### PR TITLE
changes for cse.service (Wants,After, and WantedBy)

### DIFF
--- a/cse.service
+++ b/cse.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Container Service Extension for VMware vCloud Director
-Wants=network-online.target,rabbitmq-server.service
-After=network-online.target,rabbitmq-server.service
+Wants=network-online.target rabbitmq-server.service
+After=network-online.target rabbitmq-server.service
 
 [Service]
 ExecStart=/home/vmware/cse.sh
@@ -11,4 +11,4 @@ WorkingDirectory=/home/vmware
 Restart=always
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target


### PR DESCRIPTION
There are two corrections included for the `cse.service` file:

*  `Wants` and `After` require the dependencies delimited by spaces, not commas ([systemd.syntax — General syntax of systemd configuration files](https://www.freedesktop.org/software/systemd/man/systemd.syntax.html))
*  `default.target` looks _problematic_: [user service don't start up automatically but manually](https://github.com/systemd/systemd/issues/4301)
   That's why I replaced it with `multi-user.target`

I also changed the `default.target` to `multi-user.target`, because `systemctrl get-default` reports this on a _VMware Photon OS 2.0_ system, but I'm not sure, if `default.target` raises any faults. 
