### PR TITLE
Restrict service permissions in ubuntu-k8s customization script

### DIFF
--- a/scripts/cust-photon-v2.sh
+++ b/scripts/cust-photon-v2.sh
@@ -17,7 +17,7 @@ RemainAfterExit=yes
 WantedBy=iptables.service
 EOF
 
-chmod 766 /etc/systemd/system/iptables-ports.service
+chmod 0644 /etc/systemd/system/iptables-ports.service
 systemctl enable iptables-ports.service
 systemctl start iptables-ports.service
 systemctl enable docker


### PR DESCRIPTION
Permissions changed from 766 to 0644. 766 allowed any user to write to the file
so an unprivileged user with local access could modify the service file to
get privileged execution. 0644 gives owner read/write access, and other users
read access

Signed-off-by: Andrew Ni <niandrew7@gmail.com>

@sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/103)
<!-- Reviewable:end -->
