### PR TITLE
Update ova file hashing to use SHA256 instead of SHA1

### DIFF
--- a/container_service_extension/broker.py
+++ b/container_service_extension/broker.py
@@ -64,8 +64,8 @@ SAMPLE_TEMPLATE_PHOTON_V2 = {
     'photon-custom-hw11-2.0-304b817.ova',
     'source_ova':
     'http://dl.bintray.com/vmware/photon/2.0/GA/ova/photon-custom-hw11-2.0-304b817.ova',  # NOQA
-    'sha1_ova':
-    'b8c183785bbf582bcd1be7cde7c22e5758fb3f16',
+    'sha256_ova':
+    'cb51e4b6d899c3588f961e73282709a0d054bb421787e140a1d80c24d4fd89e1',
     'temp_vapp':
     'photon2-temp',
     'cleanup':
@@ -89,8 +89,8 @@ SAMPLE_TEMPLATE_UBUNTU_16_04 = {
     'ubuntu-16.04-server-cloudimg-amd64.ova',
     'source_ova':
     'https://cloud-images.ubuntu.com/releases/xenial/release-20180418/ubuntu-16.04-server-cloudimg-amd64.ova',  # NOQA
-    'sha1_ova':
-    '12014032ec640c9dd98e1839adbf5c40aca86344',
+    'sha256_ova':
+    '3c1bec8e2770af5b9b0462e20b7b24633666feedff43c099a6fb1330fcc869a9',
     'temp_vapp':
     'ubuntu1604-temp',
     'cleanup':

--- a/container_service_extension/config.py
+++ b/container_service_extension/config.py
@@ -313,15 +313,15 @@ def install_cse(ctx, config_file_name, template_name, no_capture, update,
         click.secho('Start CSE with: \'cse run %s\'' % config_file_name)
 
 
-def get_sha1(file):
-    sha1 = hashlib.sha1()
+def get_sha256(file):
+    sha256 = hashlib.sha256()
     with open(file, 'rb') as f:
         while True:
             data = f.read(BUF_SIZE)
             if not data:
                 break
-            sha1.update(data)
-    return sha1.hexdigest()
+            sha256.update(data)
+    return sha256.hexdigest()
 
 
 def get_data_file(file_name):
@@ -366,8 +366,8 @@ def upload_source_ova(config, client, org, template):
             for chunk in r.iter_content(chunk_size=SIZE_1MB):
                 fd.write(chunk)
     if os.path.exists(cse_ova_file):
-        sha1 = get_sha1(cse_ova_file)
-        assert sha1 == template['sha1_ova']
+        sha256 = get_sha256(cse_ova_file)
+        assert sha256 == template['sha256_ova']
         click.secho('Uploading %s' % template['source_ova_name'], fg='green')
         org.upload_ovf(
             config['broker']['catalog'],


### PR DESCRIPTION
SHA1 is considered unsafe, so ova file verification has been updated
to use SHA256

Tested installation, cluster commands, node commands, and system commands
to make sure nothing broke

Note: we still use SHA1 hashing in utils.get_thumbprint(). However, this
function appears to be old and is never referenced.

@sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/105)
<!-- Reviewable:end -->
