### PR TITLE
Comment out problematic lines in Ubuntu customization script

### DIFF
--- a/scripts/cust-ubuntu-16.04.sh
+++ b/scripts/cust-ubuntu-16.04.sh
@@ -61,8 +61,12 @@ systemctl disable nfs-kernel-server.service
 ### common
 echo 'upgrading the system'
 # apt-mark hold open-vm-tools
-apt-get -q dist-upgrade -y
-apt-get -q autoremove -y
+
+### this line results in a grub update that presents a selection menu,
+### which hangs and results in failed customization. 
+### This is a temporary change that will be fixed soon
+# apt-get -q dist-upgrade -y
+# apt-get -q autoremove -y
 
 echo -n > /etc/machine-id
 sync


### PR DESCRIPTION
`apt-get -q dist-upgrade -y` will (most of the time) result in
a grub update that presents a selection menu, which will hang
and result in failed customization. These commands are not
vital to CSE functionality, but will be looked into further.

Tested with all CSE commands.

@sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/107)
<!-- Reviewable:end -->
