### PR TITLE
Improve how get_data_file() searches for data files

### DIFF
--- a/container_service_extension/cluster.py
+++ b/container_service_extension/cluster.py
@@ -12,6 +12,7 @@ from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.vapp import VApp
 from pyvcloud.vcd.vm import VM
 
+from container_service_extension.utils import get_data_file
 from container_service_extension.utils import get_vsphere
 
 TYPE_MASTER = 'mstr'
@@ -197,7 +198,6 @@ chmod -R go-rwx /root/.ssh
         if node_type == TYPE_NFS:
             LOGGER.debug('Enabling NFS server on %s' %
                          spec['target_vm_name'])
-            from container_service_extension.config import get_data_file
             script = get_data_file('nfsd-%s.sh' % template['name'])
             execute_script_in_nodes(config, vapp,
                                     template['admin_password'],
@@ -268,7 +268,6 @@ def get_cluster_config(config, vapp, password):
 
 
 def init_cluster(config, vapp, template):
-    from container_service_extension.config import get_data_file
     script = get_data_file('mstr-%s.sh' % template['name'])
     nodes = get_nodes(vapp, TYPE_MASTER)
     result = execute_script_in_nodes(config, vapp, template['admin_password'],
@@ -279,7 +278,6 @@ def init_cluster(config, vapp, template):
 
 
 def join_cluster(config, vapp, template, target_nodes=None):
-    from container_service_extension.config import get_data_file
     init_info = get_init_info(config, vapp, template['admin_password'])
     tmp_script = get_data_file('node-%s.sh' % template['name'])
     script = tmp_script.format(token=init_info[0], ip=init_info[1])

--- a/container_service_extension/config.py
+++ b/container_service_extension/config.py
@@ -4,7 +4,6 @@
 import hashlib
 import logging
 import os
-import site
 import stat
 import sys
 import time
@@ -34,6 +33,7 @@ from container_service_extension.broker import get_sample_broker_config
 from container_service_extension.broker import validate_broker_config_content
 from container_service_extension.broker import validate_broker_config_elements
 from container_service_extension.consumer import EXCHANGE_TYPE
+from container_service_extension.utils import get_data_file
 from container_service_extension.utils import get_vsphere
 
 LOGGER = logging.getLogger('cse.config')
@@ -318,36 +318,6 @@ def get_sha256(file):
                 break
             sha256.update(data)
     return sha256.hexdigest()
-
-
-def get_data_file(file_name):
-    path = None
-    try:
-        if os.path.isfile('./%s' % file_name):
-            path = './%s' % file_name
-        elif os.path.isfile('scripts/%s' % file_name):
-            path = 'scripts/%s' % file_name
-        elif os.path.isfile(site.getusersitepackages() + '/cse/' + file_name):
-            path = site.getusersitepackages() + '/cse/' + file_name
-        else:
-            sp = site.getsitepackages()
-            if isinstance(sp, list):
-                for item in sp:
-                    if os.path.isfile(item + '/cse/' + file_name):
-                        path = item + '/cse/' + file_name
-                        break
-            elif os.path.isfile(sp + '/cse/' + file_name):
-                path = sp + '/cse/' + file_name
-    except Exception:
-        pass
-    content = ''
-    if path is not None:
-        with open(path) as f:
-            content = f.read()
-        LOGGER.info('Reading data file: %s' % path)
-    else:
-        LOGGER.error('Data file not found: %s' % path)
-    return content
 
 
 def upload_source_ova(config, client, org, template):

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -2,12 +2,15 @@
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+import click
 import hashlib
 import logging
+import os
 import random
 import socket
 import ssl
 import string
+import sys
 from urllib.parse import urlparse
 
 from cachetools import LRUCache
@@ -21,6 +24,45 @@ from vsphere_guest_run.vsphere import VSphere
 cache = LRUCache(maxsize=1024)
 
 LOGGER = logging.getLogger('cse.utils')
+
+
+def get_data_file(filename):
+    """Used to retrieve builtin script files (as str) that users have installed
+    via pip install or setup.py. Looks inside virtualenv site-packages, cwd,
+    user/global site-packages, python libs, usr bins/Cellars, as well
+    as any subdirectories in these paths named 'scripts' or 'cse'.
+
+    :param str filename: name of file (script) we want to get
+
+    :return: the file contents as a string
+
+    :rtype: str
+    """
+    path = None
+    for base_path in sys.path:
+        possible_paths = [
+            os.path.join(base_path, filename),
+            os.path.join(base_path, 'scripts', filename),
+            os.path.join(base_path, 'cse', filename),
+        ]
+        for p in possible_paths:
+            if os.path.isfile(p):
+                path = p
+                break
+        if path is not None:
+            break
+
+    content = ''
+    if path is None:
+        LOGGER.error('Data file not found!')
+        click.secho('Data file not found!', fg='yellow')
+        return content
+
+    with open(path) as f:
+        content = f.read()
+    LOGGER.info(f"Found data file: {path}")
+    click.secho(f"Found data file: {path}", fg='green')
+    return content
 
 
 def hex_chunks(s):


### PR DESCRIPTION
Before, get_data_file() only searched in global site packages,
user site packages, current working directory, and a 'scripts'
directory in cwd. This means that if someone pip installs CSE
using a virtual environment, and runs `cse install` or other
commands while outside of the project directory, CSE would fail
to find any scripts.

This change fixes that issue, and as long as CSE was setup
correctly (pip install or python setup.py develop), get_data_file
will be able to find the script to execute.

Tested!

@sahithi @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/123)
<!-- Reviewable:end -->
