### PR TITLE
Fix paths in data section of setup.cfg for windows

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,18 +28,18 @@ requires-python = >=3
 packages =
     container_service_extension
 data_files =
-    /cse = scripts/init-photon-v2.sh
-    /cse = scripts/cust-photon-v2.sh
-    /cse = scripts/mstr-photon-v2.sh
-    /cse = scripts/node-photon-v2.sh
-    /cse = scripts/init-ubuntu-16.04.sh
-    /cse = scripts/cust-ubuntu-16.04.sh
-    /cse = scripts/mstr-ubuntu-16.04.sh
-    /cse = scripts/node-ubuntu-16.04.sh
-    /cse = scripts/nfsd-ubuntu-16.04.sh
-    / = LICENSE.txt
-    / = NOTICE.txt
-    / = open_source_license_container-service-extension_1.2.0_GA.txt
+    ./cse = scripts/init-photon-v2.sh
+    ./cse = scripts/cust-photon-v2.sh
+    ./cse = scripts/mstr-photon-v2.sh
+    ./cse = scripts/node-photon-v2.sh
+    ./cse = scripts/init-ubuntu-16.04.sh
+    ./cse = scripts/cust-ubuntu-16.04.sh
+    ./cse = scripts/mstr-ubuntu-16.04.sh
+    ./cse = scripts/node-ubuntu-16.04.sh
+    ./cse = scripts/nfsd-ubuntu-16.04.sh
+    . = LICENSE.txt
+    . = NOTICE.txt
+    . = open_source_license_container-service-extension_1.2.0_GA.txt
 
 [entry_points]
 console_scripts =


### PR DESCRIPTION
Currently ``python setup.py sdist bdist_wheel`` fails on windows
setup.cfg has data paths that uses / which windows will treat as \ only if they are not absolute path.

As a fix converted all / to ./

This fix is similar to https://github.com/vmware/pyvcloud/commit/5c7fdefcd9a7555b19327189e6386dd3e7ec668c#diff-380c6a8ebbbce17d55d50ef17d3cf906
and 
https://github.com/vmware/vcd-cli/commit/00769daf4403e2687b0a1ed60cefea8dcf65db14#diff-380c6a8ebbbce17d55d50ef17d3cf906


Signed-off-by: Aritra Sen <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/125)
<!-- Reviewable:end -->
