### PR TITLE
[VCD-743] Documentation fix on incorrect command usage example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -544,7 +544,7 @@ $ vcd cse node create mycluster --nodes 1 --type nfsd --network intranet --ssh-k
                                 --storage-profile Development
 
 # info on a given node. If the node is of type nfsd, it displays info about Exports.
-$ vcd cse node info nfsd-xxxx mycluster
+$ vcd cse node info mycluster nfsd-dj3s
 
 # delete 2 nodes from a cluster
 $ vcd cse node delete mycluster node-dj3s node-b4rt --yes


### PR DESCRIPTION
- Documentation fix for viewing node info on a node with given cluster name

-  The usage example for cse node info is corrected. Verified in the installation that the command usage appears correctly and the usage works fine when gets executed in the local setup.

-  @sahithi @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/127)
<!-- Reviewable:end -->
