### PR TITLE
Updated help text during cluster creation

### DIFF
--- a/container_service_extension/config.py
+++ b/container_service_extension/config.py
@@ -393,7 +393,7 @@ def install_cse(ctx, config_file_name, template_name, update, no_capture,
             configure_amqp(client, config['amqp'])
 
         register_extension(ctx, client, config, ext_install)
-        click.secho('Start CSE with: \'cse run --config %s\'' % config_file_name)
+        click.echo(f'Start CSE with: \'cse run --config {config_file_name}\'')
 
 
 def get_sha256(file):

--- a/container_service_extension/config.py
+++ b/container_service_extension/config.py
@@ -393,7 +393,7 @@ def install_cse(ctx, config_file_name, template_name, update, no_capture,
             configure_amqp(client, config['amqp'])
 
         register_extension(ctx, client, config, ext_install)
-        click.secho('Start CSE with: \'cse run %s\'' % config_file_name)
+        click.secho('Start CSE with: \'cse run --config %s\'' % config_file_name)
 
 
 def get_sha256(file):


### PR DESCRIPTION
The final line of help text after creating a cluster is missing the --config switch from it's example starting command, this change just adds the switch to avoid confusion.