### PR TITLE
Node creation with wrong network name, the error is displayed on user console

### DIFF
--- a/container_service_extension/broker.py
+++ b/container_service_extension/broker.py
@@ -682,6 +682,7 @@ class DefaultBroker(threading.Thread):
         return result
 
     def create_nodes_thread(self):
+        result = {'body': {}}
         LOGGER.debug('about to add nodes to cluster with name: %s',
                      self.cluster_name)
         try:
@@ -728,6 +729,10 @@ class DefaultBroker(threading.Thread):
         except Exception as e:
             LOGGER.error(traceback.format_exc())
             self.update_task(TaskStatus.ERROR, error_message=str(e))
+            result['body'] = []
+            result['status_code'] = INTERNAL_SERVER_ERROR
+            result['message'] = str(e)
+        return result
 
     def delete_nodes(self, headers, body):
         result = {'body': {}}


### PR DESCRIPTION
- When a cse user creates a new node with an invalid network name, the error is displayed on cse user console. Earlier the error was not displayed to the user it was only visible in the cse.log.

- Reviewers - @sakthisunda  @sahithi @andrew-ni @sompa

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/129)
<!-- Reviewable:end -->
