### PR TITLE
[VCDA-695] Returns the server status code when there is no server response content

### DIFF
--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -170,7 +170,14 @@ class Cluster(object):
             media_type=None,
             accept_type='application/*+json',
             auth=None)
-        return self._process_response(response)
+        try:
+            content = self._process_response(response)
+        except Exception as e:
+            if str(e) == '{}':
+                raise Exception("Invalid cluster/node name")
+            else:
+                raise e
+        return content
 
     def add_node(self,
                  vdc,


### PR DESCRIPTION
- Returns the response status code when there is empty response content.

- Command example: vcd cse node info cluster1 node-4ji\\\\0
   In case of node/cluster name with the special character in vcd cse node info <cluster-name> 
  <node-name>,  VCD server returns 500 with empty body. It does not reach CSE server.
   This fix returns the server status code to the client to let the user know server error happened.

- @rocknes @sahithi @harshneelmore @andrew-ni @sompa 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/130)
<!-- Reviewable:end -->
