### PR TITLE
[VCDA-520] Docstring Examples for Commands

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -22,63 +22,13 @@ from container_service_extension.service import Service
 @vcd.group(short_help='manage kubernetes clusters')
 @click.pass_context
 def cse(ctx):
-    """Work with kubernetes clusters in vCloud Director.
-
-\b
-    Description
-        The cse command works with kubernetes clusters on vCloud Director.
-\b
-        'vcd cse cluster create' creates a new kubernetes cluster in the
-        current virtual datacenter.
-\b
-        'vcd cse node create' creates new and attach new nodes to an existing
-        kubernetes cluster in the current virtual datacenter.
-\b
-        When creating clusters and nodes, the '--network' option is required,
-        as they need a network to operate and no network will be selected by
-        default if omitted.
-\b
-        Cluster names should follow the syntax for valid hostnames and can have
-        up to 25 characters .`system`, `template` and `swagger*` are reserved
-        words and cannot be used to name a cluster.
+    """Work with Kubernetes clusters in vCloud Director.
 
 \b
     Examples
-        vcd cse cluster list
-            Get list of kubernetes clusters in current virtual datacenter.
-\b
-        vcd cse cluster create dev-cluster --network net1
-            Create a kubernetes cluster in current virtual datacenter.
-\b
-        vcd cse cluster create prod-cluster --nodes 4 \\
-                    --network net1 --storage-profile '*'
-            Create a kubernetes cluster with 4 worker nodes.
-\b
-        vcd cse cluster create dev-cluster --nodes 2 \\
-                    --network net1 --enable-nfs
-            Create a kubernetes cluster with NFS support
-\b
-        vcd cse node create dev-cluster -N 2 --network net1 \\
-            Add 2 worker nodes to the cluster
-\b
-        vcd cse node create dev-cluster -N 1 --network net1 \\
-                    --type nfsd
-            Add a node of type NFS to the cluster
-\b
-        vcd cse cluster delete dev-cluster
-            Delete a kubernetes cluster by name.
-\b
-        vcd cse cluster create c1 --nodes 0 --network net1
-            Create a single node kubernetes cluster for dev/test.
-\b
-        vcd cse node list c1
-            List nodes in a cluster.
-\b
-        vcd cse template list
-            Get list of CSE templates available.
-\b
         vcd cse version
-            Display version.
+            Display CSE version. If CSE version is displayed, then vcd-cli has
+            been properly configured to run CSE commands.
     """
     if ctx.invoked_subcommand is not None:
         try:
@@ -105,7 +55,43 @@ def version(ctx):
 @cse.group('cluster', short_help='work with clusters')
 @click.pass_context
 def cluster_group(ctx):
-    """Work with kubernetes clusters."""
+    """Work with Kubernetes clusters.
+
+\b
+    Cluster names should follow the syntax for valid hostnames and can have
+    up to 25 characters .`system`, `template` and `swagger*` are reserved
+    words and cannot be used to name a cluster.
+\b
+    Examples
+        vcd cse cluster list
+            Displays clusters in vCD that are visible to your user status.
+\b
+        vcd cse cluster delete mycluster --yes
+            Attempts to delete cluster 'mycluster' without prompting.
+\b
+        vcd cse cluster create mycluster -n mynetwork
+            Attempts to create a Kubernetes cluster named 'mycluster'
+            with 2 worker nodes in the current VDC. This cluster will be
+            connected to Org VDC network 'mynetwork'. All VMs will use the
+            default template.
+\b
+        vcd cse cluster create mycluster -n mynetwork --template photon-v2 \\
+        --nodes 1 --cpu 3 --memory 1024 --storage-profile mystorageprofile \\
+        --ssh-key ~/.ssh/id_rsa.pub --enable-nfs
+            Attempts to create a Kubernetes cluster named 'mycluster' on vCD
+            with 1 worker node and 1 NFS node. This cluster will be connected
+            to Org VDC network 'mynetwork'. All VMs will use the template
+            'photon-v2'. All VMs in the cluster will have 3 vCPUs on each node
+            with 1024mb of memory each. All VMs will use the storage profile
+            'mystorageprofile'. The public ssh key at '~/.ssh/id_rsa.pub' will
+            be placed into all VMs for user accessibility.
+\b
+        vcd cse cluster config mycluster
+            Display configuration information about cluster named 'mycluster'.
+\b
+        vcd cse cluster info mycluster
+            Display detailed information about cluster named 'mycluster'.
+    """
     if ctx.invoked_subcommand is not None:
         try:
             if not ctx.obj['profiles'].get('vdc_in_use') or \
@@ -118,13 +104,21 @@ def cluster_group(ctx):
 @cse.group(short_help='work with templates')
 @click.pass_context
 def template(ctx):
-    """Work with CSE templates."""
+    """Work with CSE templates.
+
+\b
+    Examples
+        vcd cse template list
+            Displays list of available VM templates from which Kubernetes
+            cluster nodes can be instantiated.
+    """
     pass
 
 
 @template.command('list', short_help='list templates')
 @click.pass_context
 def list_templates(ctx):
+    """Display CSE templates."""
     try:
         client = ctx.obj['client']
         cluster = Cluster(client)
@@ -146,6 +140,7 @@ def list_templates(ctx):
 @cluster_group.command('list', short_help='list clusters')
 @click.pass_context
 def list_clusters(ctx):
+    """Display list of Kubernetes clusters."""
     try:
         client = ctx.obj['client']
         cluster = Cluster(client)
@@ -177,6 +172,7 @@ def list_clusters(ctx):
     expose_value=False,
     prompt='Are you sure you want to delete the cluster?')
 def delete(ctx, name):
+    """Delete a Kubernetes cluster."""
     try:
         client = ctx.obj['client']
         cluster = Cluster(client)
@@ -252,6 +248,7 @@ def delete(ctx, name):
     help='Creates an additional node of type NFS')
 def create(ctx, name, node_count, cpu, memory, network_name, storage_profile,
            ssh_key_file, template, enable_nfs):
+    """Create a Kubernetes cluster."""
     try:
         client = ctx.obj['client']
         cluster = Cluster(client)
@@ -279,6 +276,7 @@ def create(ctx, name, node_count, cpu, memory, network_name, storage_profile,
 @click.argument('name', required=True)
 @click.option('-s', '--save', is_flag=True)
 def config(ctx, name, save):
+    """Display cluster configuration info."""
     try:
         client = ctx.obj['client']
         cluster = Cluster(client)
@@ -297,6 +295,7 @@ def config(ctx, name, save):
 @click.pass_context
 @click.argument('name', required=True)
 def cluster_info(ctx, name):
+    """Display info about a Kubernetes cluster."""
     try:
         client = ctx.obj['client']
         cluster = Cluster(client)
@@ -309,7 +308,39 @@ def cluster_info(ctx, name):
 @cse.group('node', short_help='work with nodes')
 @click.pass_context
 def node_group(ctx):
-    """Work with CSE cluster nodes."""
+    """Work with CSE cluster nodes.
+
+\b
+    Examples
+        vcd cse node create mycluster -n mynetwork
+            Attempts to add a node to Kubernetes cluster named 'mycluster' on
+            vCD. The node will be connected to Org VDC network 'mynetwork' and
+            will be created from the default template.
+\b
+        vcd cse node create mycluster -n mynetwork --nodes 2 --cpu 3 \\
+        --memory 1024 --storage-profile mystorageprofile \\
+        --ssh-key ~/.ssh/id_rsa.pub --template photon-v2 --type nfsd
+            Attempts to add 2 nfsd nodes to Kubernetes cluster named
+            'mycluster' on vCD. The nodes will be connected to Org VDC
+            network 'mynetwork' and will be created from the template
+            'photon-v2'. Each node will use 3 vCPUs, have 1024mb of memory,
+            and use the storage profile 'mystorageprofile'. The public ssh
+            key at '~/.ssh/id_rsa.pub' will be placed into all VMs for
+            user accessibility.
+\b
+        vcd cse node list mycluster
+            Displays nodes in 'mycluster' that are visible to your user status.
+\b
+        vcd cse node info mycluster node-xxxx
+            Display information about 'node-xxxx' in 'mycluster', such as
+            IP address, memory, name, node type, cpu, status. If node is
+            type 'nfs', 'exports' shared will also be displayed.
+\b
+        vcd cse node delete mycluster node-xxxx --yes
+            Attempts to delete node 'node-xxxx' in 'mycluster'
+            without prompting.
+    """
+
     if ctx.invoked_subcommand is not None:
         try:
             if not ctx.obj['profiles'].get('vdc_in_use') or \
@@ -318,11 +349,13 @@ def node_group(ctx):
         except Exception as e:
             stderr(e, ctx)
 
+
 @node_group.command('info', short_help='get node info')
 @click.pass_context
 @click.argument('cluster_name', required=True)
 @click.argument('node_name', required=True)
 def node_info(ctx, cluster_name, node_name):
+    """Display info about a specific node."""
     try:
         client = ctx.obj['client']
         cluster = Cluster(client)
@@ -330,6 +363,7 @@ def node_info(ctx, cluster_name, node_name):
         stdout(node_info, ctx, show_id=True)
     except Exception as e:
         stderr(e, ctx)
+
 
 @node_group.command('create', short_help='add node(s) to cluster')
 @click.pass_context
@@ -396,6 +430,7 @@ def node_info(ctx, cluster_name, node_name):
     help='type of node to add')
 def create_node(ctx, name, node_count, cpu, memory, network_name,
                 storage_profile, ssh_key_file, template, node_type):
+    """Add a node to a Kubernetes cluster."""
     try:
         client = ctx.obj['client']
         cluster = Cluster(client)
@@ -422,6 +457,7 @@ def create_node(ctx, name, node_count, cpu, memory, network_name,
 @click.pass_context
 @click.argument('name', required=True)
 def list_nodes(ctx, name):
+    """Display nodes in a Kubernetes cluster."""
     try:
         client = ctx.obj['client']
         cluster = Cluster(client)
@@ -445,6 +481,7 @@ def list_nodes(ctx, name):
     prompt='Are you sure you want to delete the node(s)')
 @click.option('-f', '--force', is_flag=True, help='Force delete node VM(s)')
 def delete_nodes(ctx, name, node_names, force):
+    """Delete node(s) in a Kubernetes cluster."""
     try:
         client = ctx.obj['client']
         cluster = Cluster(client)
@@ -480,13 +517,29 @@ def save_config(ctx):
 @cse.group('system', short_help='work with CSE service')
 @click.pass_context
 def system_group(ctx):
-    """Work with CSE service."""
+    """Work with CSE service (system daemon).
+
+\b
+    Examples
+        vcd cse system info
+            Displays detailed information about CSE
+\b
+        vcd cse system enable --yes
+            Attempts to enable CSE system daemon without prompting
+\b
+        vcd cse system stop --yes
+            Attempts to stop CSE system daemon without prompting
+\b
+        vcd cse system disable --yes
+            Attempts to disable CSE system daemon without prompting
+    """
     pass
 
 
 @system_group.command('info', short_help='CSE system info')
 @click.pass_context
 def info(ctx):
+    """Display info about CSE."""
     try:
         client = ctx.obj['client']
         system = System(client)
@@ -506,6 +559,7 @@ def info(ctx):
     expose_value=False,
     prompt='Are you sure you want to stop the service?')
 def stop_service(ctx):
+    """Stop CSE system daemon."""
     try:
         client = ctx.obj['client']
         system = System(client)
@@ -518,6 +572,7 @@ def stop_service(ctx):
 @system_group.command('enable', short_help='enable CSE service')
 @click.pass_context
 def enable_service(ctx):
+    """Enable CSE system daemon."""
     try:
         client = ctx.obj['client']
         system = System(client)
@@ -530,6 +585,7 @@ def enable_service(ctx):
 @system_group.command('disable', short_help='disable CSE service')
 @click.pass_context
 def disable_service(ctx):
+    """Disable CSE system daemon."""
     try:
         client = ctx.obj['client']
         system = System(client)

--- a/container_service_extension/cse.py
+++ b/container_service_extension/cse.py
@@ -26,45 +26,60 @@ def cli(ctx):
     """Container Service Extension for VMware vCloud Director.
 
 \b
-    Manages CSE.
-\b
     Examples
-        cse sample
-            Generate sample config.
+        cse version
+            Display CSE version.
 \b
         cse sample > config.yaml
-            Save sample config.
+            Generate sample CSE config in a file named 'config.yaml'.
+\b
+        cse install
+            Install CSE using data from 'config.yaml'.
+\b
+        cse install -c myconfig.yaml --template photon-v2
+            Install CSE using data from 'myconfig.yaml' but only create
+            template 'photon-v2'.
+\b
+        cse install --update
+            Install CSE, and if the templates already exist in vCD, create
+            them again.
+\b
+        cse install --no-capture --ssh-key ~/.ssh/id_rsa.pub
+            Install CSE, but don't capture temporary vApps to a template.
+            Instead, leave them running for debugging purposes. Copy specified
+            SSH key into all template VMs so users with the cooresponding
+            private key have access (--ssh-key is required when --no-capture
+            is used).
+\b
+        cse install --amqp skip --ext config
+            Install CSE, but skip amqp configuration step and register CSE to
+            vCD without prompting.
 \b
         cse check
-            Validate CSE installation/configuration.
+            Checks that the info in 'config.yaml' is correct. Ensures that vCD,
+            VCs, AMQP are available, and checks that all specified templates
+            have been created.
 \b
-        cse install --config config.yaml
-            Install CSE.
+        cse check -c myconfig.yaml --template photon-v2
+            Checks that the info in 'myconfig.yaml' is correct. Ensures that
+            vCD, VCs, AMQP are available, and checks that template
+            'photon-v2' exists.
 \b
-        cse install --config config.yaml --template photon-v2
-            Install CSE. It only creates the template specified.
+        cse run
+            Run CSE Server using data from 'config.yaml', but first validate
+            that CSE was installed according to 'config.yaml'.
 \b
-        cse install --config config.yaml --no-capture --ssh-key  \\
-                    ~/.etc/id_rsa.pub
-            Install CSE. The temporary vApp specified in the config file \\
-            will be created, but the vApp will not be captured as a template \\
-            in the catalog. --ssh-key option is required if --no-capture \\
-            is used
-\b
-        cse install --config config.yaml --template photon-v2 --update \\
-                    --amqp skip --ext skip
-            Update the specified template.
-\b
-        cse version
-            Display version.
+        cse run --config myconfig.yaml --skip-check
+            Run CSE Server using data from 'myconfig.yaml' without first
+            validating that CSE was installed according to 'myconfig.yaml'.
 \b
     Environment Variables
         CSE_CONFIG
             If this environment variable is set, the commands will use the file
             indicated in the variable as the config file. The file indicated
-            with the \'--config\' option will have preference over the
+            with the '--config' option will have preference over the
             environment variable. If both are omitted, it defaults to file
-            \'config.yaml\' in the current directory.
+            'config.yaml' in the current directory.
     """
     if ctx.invoked_subcommand is None:
         click.secho(ctx.get_help())


### PR DESCRIPTION
Moved docstring examples to their respective command subgroup.
Added/Cleaned up docstring examples for commands in both `cse.py` files

Tested `-h` commands to see that docstrings are displayed nicely

@sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/133)
<!-- Reviewable:end -->
