### PR TITLE
[VCDA-500] vcd cse version should not require login

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -82,7 +82,8 @@ def cse(ctx):
     """
     if ctx.invoked_subcommand is not None:
         try:
-            restore_session(ctx)
+            if ctx.invoked_subcommand != 'version':
+                restore_session(ctx)
             if ctx.invoked_subcommand not in ['system', 'template', 'version']:
                 if not ctx.obj['profiles'].get('vdc_in_use') or \
                    not ctx.obj['profiles'].get('vdc_href'):


### PR DESCRIPTION
Signed-off-by: Harshneel More <moreh@vmware.com>

To help us process your pull request efficiently, please include: 

- This fix allows cse user to view the local version of cse libraries without user login.

- @rocknes, @sahithi, @sompa, @andrew-ni, @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/134)
<!-- Reviewable:end -->
