### PR TITLE
[VCDA-789] Refactor CSE Installation - AMQP, registration, catalog

### DIFF
--- a/container_service_extension/config.py
+++ b/container_service_extension/config.py
@@ -39,6 +39,8 @@ from container_service_extension.utils import get_data_file
 from container_service_extension.utils import get_sha256
 from container_service_extension.utils import get_vsphere
 from container_service_extension.utils import get_sha256
+from container_service_extension.utils import register_extension
+
 
 LOGGER = logging.getLogger('cse.config')
 
@@ -566,7 +568,9 @@ def install_cse(ctx, config_file_name, template_name, update, no_capture,
                                config['amqp']['username'],
                                config['amqp']['password'])
 
-        register_extension(ctx, client, config, ext_install)
+        if should_register_cse(client, ext_install):
+            register_extension(client, 'cse', config['amqp']['exchange'])
+
         click.echo(f'Start CSE with: \'cse run --config {config_file_name}\'')
 
 
@@ -913,25 +917,30 @@ def create_amqp_exchange(exchange_name, username, password, host, port, vhost,
     click.echo(f"AMQP exchange '{exchange_name}' created")
 
 
-def register_extension(ctx, client, config, ext_install):
+def should_register_cse(client, ext_install):
+    """Decides if CSE should be registered, depending on user inputs.
+
+    Returns False if CSE is already registered, or if the user declines
+    registration.
+
+    :param pyvcloud.vcd.client.Client client:
+    :param str ext_install: 'skip' skips registration,
+        'config' allows registration without prompting user,
+        'prompt' asks user before registration.
+
+    :rtype: bool
+    """
     if ext_install == 'skip':
-        click.secho('Extension configuration: skipped')
-        return
+        return False
+
     ext = APIExtension(client)
     try:
-        name = 'cse'
-        cse_ext = ext.get_extension_info(name)
-        click.secho('Find extension \'%s\', enabled=%s: %s' %
-                    (name, cse_ext['enabled'], bool_to_msg(True)))
-    except Exception:
-        if ext_install == 'prompt':
-            if not click.confirm('Do you want to register CSE as an API '
-                                 'extension in vCD?'):
-                click.secho('CSE not registered')
-                return
-        amqp = config['amqp']
-        exchange = amqp['exchange']
-        patterns = '/api/cse,/api/cse/.*,/api/cse/.*/.*'
-        ext.add_extension(name, name, name, exchange, patterns.split(','))
-        click.secho('Registered extension \'%s\': %s' % (name,
-                                                         bool_to_msg(True)))
+        cse_info_dict = ext.get_extension_info('cse')
+        click.echo(f"Found cse', enabled={cse_info_dict['enabled']}")
+        return False
+    except MissingRecordException:
+        prompt_msg = "Register 'cse' as an API extension in vCD?"
+        if ext_install == 'prompt' and not click.confirm(prompt_msg):
+            return False
+
+    return True

--- a/container_service_extension/config.py
+++ b/container_service_extension/config.py
@@ -38,6 +38,7 @@ from container_service_extension.utils import CSE_EXT_NAMESPACE
 from container_service_extension.utils import get_data_file
 from container_service_extension.utils import get_sha256
 from container_service_extension.utils import get_vsphere
+from container_service_extension.utils import get_sha256
 
 LOGGER = logging.getLogger('cse.config')
 

--- a/container_service_extension/consumer.py
+++ b/container_service_extension/consumer.py
@@ -12,10 +12,9 @@ import traceback
 import pika
 
 from container_service_extension.processor import ServiceProcessor
+from container_service_extension.utils import EXCHANGE_TYPE
 
 LOGGER = logging.getLogger('cse.consumer')
-
-EXCHANGE_TYPE = 'direct'
 
 
 class MessageConsumer(object):

--- a/container_service_extension/cse.py
+++ b/container_service_extension/cse.py
@@ -222,8 +222,9 @@ def install(ctx, config, template, update, no_capture, ssh_key_file,
         ssh_key = None
         if ssh_key_file is not None:
             ssh_key = ssh_key_file.read()
-        install_cse(ctx, config, template, update, no_capture, ssh_key,
-                    amqp_install, ext_install)
+        install_cse(ctx, config_file_name=config, template_name=template,
+                    update=update, no_capture=no_capture, ssh_key=ssh_key,
+                    amqp_install=amqp_install, ext_install=ext_install)
 
 
 @cli.command(short_help='run service')

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import click
-import hashlib
 import logging
 import os
 import pathlib
@@ -212,24 +211,10 @@ def get_data_file(filename):
     return path.read_text()
 
 
-def hex_chunks(s):
-    return [s[i:i + 2] for i in range(0, len(s), 2)]
-
-
-def get_thumbprint(host, port):
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.settimeout(10)
-    wrappedSocket = ssl.wrap_socket(sock)
-    wrappedSocket.connect((host, port))
-    der_cert_bin = wrappedSocket.getpeercert(True)
-    thumb_sha1 = hashlib.sha1(der_cert_bin).hexdigest()
-    wrappedSocket.close()
-    return ':'.join(map(str, hex_chunks(thumb_sha1))).upper()
-
-
-def random_word(length):
-    letters = string.ascii_lowercase
-    return ''.join(random.choice(letters) for i in range(length))
+def bool_to_msg(b):
+    if b:
+        return 'success'
+    return 'fail'
 
 
 def get_vsphere(config, vapp, vm_name):
@@ -272,3 +257,29 @@ def get_vsphere(config, vapp, vm_name):
                 cache[vm_id]['password'], cache[vm_id]['port'])
 
     return v
+
+
+# unused functions, unsure what to do with these
+# import hashlib
+# import random
+# import socket
+# import ssl
+# import string
+# def hex_chunks(s):
+#     return [s[i:i + 2] for i in range(0, len(s), 2)]
+
+
+# def get_thumbprint(host, port):
+#     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+#     sock.settimeout(10)
+#     wrappedSocket = ssl.wrap_socket(sock)
+#     wrappedSocket.connect((host, port))
+#     der_cert_bin = wrappedSocket.getpeercert(True)
+#     thumb_sha1 = hashlib.sha1(der_cert_bin).hexdigest()
+#     wrappedSocket.close()
+#     return ':'.join(map(str, hex_chunks(thumb_sha1))).upper()
+
+
+# def random_word(length):
+#     letters = string.ascii_lowercase
+#     return ''.join(random.choice(letters) for i in range(length))

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -19,6 +19,7 @@ import click
 import pika
 from cachetools import LRUCache
 from pyvcloud.vcd.amqp import AmqpService
+from pyvcloud.vcd.api_extension import APIExtension
 from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.exceptions import EntityNotFoundException
@@ -214,6 +215,27 @@ def get_data_file(filename):
     LOGGER.info(f"Found data file: {path}")
     click.secho(f"Found data file: {path}", fg='green')
     return path.read_text()
+
+
+def register_extension(client, ext_name, exchange_name, patterns=None):
+    """Registers an API extension in vCD.
+
+    :param pyvcloud.vcd.client.Client client:
+    :param str ext_name: extension name
+    :param str exchange_name: AMQP exchange name
+    :param list patterns: list of urls that map to this API extension
+    """
+    ext = APIExtension(client)
+    if patterns is None:
+        patterns = [
+            f'/api/{ext_name}',
+            f'/api/{ext_name}/.*',
+            f'/api/{ext_name}/.*/.*'
+        ]
+
+    ext.add_extension(ext_name, ext_name, ext_name, exchange_name, patterns)
+    click.secho(f"Registered extension {ext_name} as an API extension in vCD.",
+                fg='green')
 
 
 def configure_vcd_amqp(client, exchange_name, host, port, prefix,

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import click
+import hashlib
 import logging
 import os
 import pathlib
@@ -215,6 +216,17 @@ def bool_to_msg(b):
     if b:
         return 'success'
     return 'fail'
+
+
+def get_sha256(file):
+    sha256 = hashlib.sha256()
+    with open(file, 'rb') as f:
+        while True:
+            data = f.read(BUF_SIZE)
+            if not data:
+                break
+            sha256.update(data)
+    return sha256.hexdigest()
 
 
 def get_vsphere(config, vapp, vm_name):

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -176,12 +176,12 @@ def check_file_permissions(filename):
 
 
 def get_data_file(filename):
-    """Searches paths from sys.path to retrieve file contents
+    """Retrieves CSE script file content as a string.
 
-    Looks for @filename at paths listed by sys.path, as well as any
-    subdirectory named container_service_extension_scripts.
-    Paths along sys.path include: virtualenv site-packages, cwd,
-    user/global site-packages, python libs, usr bins/Cellars.
+    Used to retrieve builtin script files that users have installed
+    via pip install or setup.py. Looks inside virtualenv site-packages, cwd,
+    user/global site-packages, python libs, usr bins/Cellars, as well
+    as any subdirectories in these paths named 'scripts' or 'cse'.
 
     :param str filename: name of file (script) we want to get.
 
@@ -217,13 +217,50 @@ def get_data_file(filename):
     return path.read_text()
 
 
+def catalog_exists(org, catalog_name):
+    try:
+        org.get_catalog(catalog_name)
+        return True
+    except EntityNotFoundException:
+        return False
+
+
+def create_and_share_catalog(org, catalog_name, catalog_desc=''):
+    """Creates and shares specified catalog.
+
+    If catalog does not exist in vCD, create it. Share the specified catalog
+    to all orgs.
+
+    :param pyvcloud.vcd.org.Org org:
+    :param str catalog_name:
+    :param str catalog_desc:
+
+    :return: XML representation of specified catalog.
+
+    :rtype: lxml.objectify.ObjectifiedElement
+
+    :raises pyvcloud.vcd.exceptions.EntityNotFoundException: if catalog sharing
+        fails due to catalog creation failing.
+    """
+    if catalog_exists(org, catalog_name):
+        click.secho(f"Found catalog '{catalog_name}'", fg='green')
+    else:
+        click.secho(f"Creating catalog '{catalog_name}'", fg='yellow')
+        org.create_catalog(catalog_name, catalog_desc)
+        click.secho(f"Created catalog '{catalog_name}'", fg='green')
+        org.reload()
+    org.share_catalog(catalog_name)
+    org.reload()
+    return org.get_catalog(catalog_name)
+
+
 def register_extension(client, ext_name, exchange_name, patterns=None):
     """Registers an API extension in vCD.
 
     :param pyvcloud.vcd.client.Client client:
-    :param str ext_name: extension name
-    :param str exchange_name: AMQP exchange name
-    :param list patterns: list of urls that map to this API extension
+    :param str ext_name: extension name.
+    :param str exchange_name: AMQP exchange name.
+    :param list patterns: list of urls that map to this API extension.
     """
     ext = APIExtension(client)
     if patterns is None:
@@ -234,7 +271,7 @@ def register_extension(client, ext_name, exchange_name, patterns=None):
         ]
 
     ext.add_extension(ext_name, ext_name, ext_name, exchange_name, patterns)
-    click.secho(f"Registered extension {ext_name} as an API extension in vCD.",
+    click.secho(f"Registered extension {ext_name} as an API extension in vCD",
                 fg='green')
 
 
@@ -243,15 +280,17 @@ def configure_vcd_amqp(client, exchange_name, host, port, prefix,
     """Configures vCD AMQP settings/exchange using parameter values.
 
     :param pyvcloud.vcd.client.Client client:
-    :param str exchange_name: name of exchange
-    :param str host: AMQP host name
-    :param str password: AMQP password
-    :param int port: AMQP port
+    :param str exchange_name: name of exchange.
+    :param str host: AMQP host name.
+    :param str password: AMQP password.
+    :param int port: AMQP port.
     :param str prefix:
     :param bool ssl_accept_all:
-    :param bool use_ssl: Enable ssl
-    :param str username: AMQP username
-    :param str vhost: AMQP vhost
+    :param bool use_ssl: Enable ssl.
+    :param str username: AMQP username.
+    :param str vhost: AMQP vhost.
+
+    :raises Exception: if could not set AMQP configuration.
     """
     amqp_service = AmqpService(client)
     amqp = {
@@ -272,9 +311,12 @@ def configure_vcd_amqp(client, exchange_name, host, port, prefix,
                 fg='yellow')
     if result['Valid'].text == 'true':
         amqp_service.set_config(amqp, password)
-        click.secho('Updated vCD AMQP configuration.', fg='green')
+        click.secho("Updated vCD AMQP configuration", fg='green')
     else:
-        click.secho("Couldn't set vCD AMQP configuration.", fg='red')
+        msg = "Couldn't set vCD AMQP configuration"
+        click.secho(msg, fg='red')
+        # TODO replace raw exception with specific
+        raise Exception(msg)
 
 
 def create_amqp_exchange(exchange_name, host, port, vhost, use_ssl,
@@ -283,28 +325,29 @@ def create_amqp_exchange(exchange_name, host, port, vhost, use_ssl,
 
     If specified AMQP exchange exists already, does nothing.
 
-    :param str exchange_name: The AMQP exchange name to check for or create
-    :param str host: AMQP host name
-    :param str password: AMQP password
-    :param int port: AMQP port number
-    :param bool use_ssl: Enable ssl
-    :param str username: AMQP username
-    :param str vhost: AMQP vhost
+    :param str exchange_name: The AMQP exchange name to check for or create.
+    :param str host: AMQP host name.
+    :param str password: AMQP password.
+    :param int port: AMQP port number.
+    :param bool use_ssl: Enable ssl.
+    :param str username: AMQP username.
+    :param str vhost: AMQP vhost.
+
+    :raises Exception: if AMQP exchange could not be created.
     """
     click.secho(f"Checking for AMQP exchange '{exchange_name}'", fg='yellow')
     credentials = pika.PlainCredentials(username, password)
     parameters = pika.ConnectionParameters(host, port, vhost, credentials,
                                            ssl=use_ssl, connection_attempts=3,
                                            retry_delay=2, socket_timeout=5)
-    connection = pika.BlockingConnection(parameters)
-    click.secho(f"Connected to AMQP server: {host}:{port}", fg='green')
-
-    channel = connection.channel()
     try:
+        connection = pika.BlockingConnection(parameters)
+        click.secho(f"Connected to AMQP server: {host}:{port}", fg='green')
+        channel = connection.channel()
         channel.exchange_declare(exchange=exchange_name,
                                  exchange_type=EXCHANGE_TYPE,
                                  durable=True, auto_delete=False)
-    except Exception:
+    except Exception:  # TODO replace with specific exception
         LOGGER.error(traceback.format_exc())
         click.secho(f"Couldn't create exchange '{exchange_name}'", fg='red')
         raise

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -12,14 +12,10 @@ import ssl
 import stat
 import string
 import sys
-import traceback
 from urllib.parse import urlparse
 
 import click
-import pika
 from cachetools import LRUCache
-from pyvcloud.vcd.amqp import AmqpService
-from pyvcloud.vcd.api_extension import APIExtension
 from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.exceptions import EntityNotFoundException
@@ -254,108 +250,6 @@ def create_and_share_catalog(org, catalog_name, catalog_desc=''):
     return org.get_catalog(catalog_name)
 
 
-def register_extension(client, ext_name, exchange_name, patterns=None):
-    """Registers an API extension in vCD.
-
-    :param pyvcloud.vcd.client.Client client:
-    :param str ext_name: extension name.
-    :param str exchange_name: AMQP exchange name.
-    :param list patterns: list of urls that map to this API extension.
-    """
-    ext = APIExtension(client)
-    if patterns is None:
-        patterns = [
-            f'/api/{ext_name}',
-            f'/api/{ext_name}/.*',
-            f'/api/{ext_name}/.*/.*'
-        ]
-
-    ext.add_extension(ext_name, ext_name, ext_name, exchange_name, patterns)
-    click.secho(f"Registered extension {ext_name} as an API extension in vCD",
-                fg='green')
-
-
-def configure_vcd_amqp(client, exchange_name, host, port, prefix,
-                       ssl_accept_all, use_ssl, vhost, username, password):
-    """Configures vCD AMQP settings/exchange using parameter values.
-
-    :param pyvcloud.vcd.client.Client client:
-    :param str exchange_name: name of exchange.
-    :param str host: AMQP host name.
-    :param str password: AMQP password.
-    :param int port: AMQP port.
-    :param str prefix:
-    :param bool ssl_accept_all:
-    :param bool use_ssl: Enable ssl.
-    :param str username: AMQP username.
-    :param str vhost: AMQP vhost.
-
-    :raises Exception: if could not set AMQP configuration.
-    """
-    amqp_service = AmqpService(client)
-    amqp = {
-        'AmqpExchange': exchange_name,
-        'AmqpHost': host,
-        'AmqpPort': port,
-        'AmqpPrefix': prefix,
-        'AmqpSslAcceptAll': ssl_accept_all,
-        'AmqpUseSSL': use_ssl,
-        'AmqpUsername': username,
-        'AmqpVHost': vhost
-    }
-
-    # This block sets the AMQP setting values on the
-    # vCD "System Administration Extensibility page"
-    result = amqp_service.test_config(amqp, password)
-    click.secho(f"AMQP test settings, result: {result['Valid'].text}",
-                fg='yellow')
-    if result['Valid'].text == 'true':
-        amqp_service.set_config(amqp, password)
-        click.secho("Updated vCD AMQP configuration", fg='green')
-    else:
-        msg = "Couldn't set vCD AMQP configuration"
-        click.secho(msg, fg='red')
-        # TODO replace raw exception with specific
-        raise Exception(msg)
-
-
-def create_amqp_exchange(exchange_name, host, port, vhost, use_ssl,
-                         username, password):
-    """Creates the specified AMQP exchange if it does not exist.
-
-    If specified AMQP exchange exists already, does nothing.
-
-    :param str exchange_name: The AMQP exchange name to check for or create.
-    :param str host: AMQP host name.
-    :param str password: AMQP password.
-    :param int port: AMQP port number.
-    :param bool use_ssl: Enable ssl.
-    :param str username: AMQP username.
-    :param str vhost: AMQP vhost.
-
-    :raises Exception: if AMQP exchange could not be created.
-    """
-    click.secho(f"Checking for AMQP exchange '{exchange_name}'", fg='yellow')
-    credentials = pika.PlainCredentials(username, password)
-    parameters = pika.ConnectionParameters(host, port, vhost, credentials,
-                                           ssl=use_ssl, connection_attempts=3,
-                                           retry_delay=2, socket_timeout=5)
-    try:
-        connection = pika.BlockingConnection(parameters)
-        click.secho(f"Connected to AMQP server: {host}:{port}", fg='green')
-        channel = connection.channel()
-        channel.exchange_declare(exchange=exchange_name,
-                                 exchange_type=EXCHANGE_TYPE,
-                                 durable=True, auto_delete=False)
-    except Exception:  # TODO replace with specific exception
-        LOGGER.error(traceback.format_exc())
-        click.secho(f"Couldn't create exchange '{exchange_name}'", fg='red')
-        raise
-    finally:
-        connection.close()
-    click.secho(f"AMQP exchange '{exchange_name}' is ready", fg='green')
-
-
 def bool_to_msg(b):
     if b:
         return 'success'
@@ -413,29 +307,3 @@ def get_vsphere(config, vapp, vm_name):
                 cache[vm_id]['password'], cache[vm_id]['port'])
 
     return v
-
-
-# unused functions, unsure what to do with these
-# import hashlib
-# import random
-# import socket
-# import ssl
-# import string
-# def hex_chunks(s):
-#     return [s[i:i + 2] for i in range(0, len(s), 2)]
-
-
-# def get_thumbprint(host, port):
-#     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-#     sock.settimeout(10)
-#     wrappedSocket = ssl.wrap_socket(sock)
-#     wrappedSocket.connect((host, port))
-#     der_cert_bin = wrappedSocket.getpeercert(True)
-#     thumb_sha1 = hashlib.sha1(der_cert_bin).hexdigest()
-#     wrappedSocket.close()
-#     return ':'.join(map(str, hex_chunks(thumb_sha1))).upper()
-
-
-# def random_word(length):
-#     letters = string.ascii_lowercase
-#     return ''.join(random.choice(letters) for i in range(length))


### PR DESCRIPTION
Generalized AMQP configuration and CSE registration
- `install_cse()` uses `should_configure_amqp()` and `should_register_cse()` to decide whether or not to configure amqp settings or register extension based on existing settings and user input

Cleaned up `config.py` and `utils.py`
- `config.py` should only include code specific to the config file and cse installation
- `utils.py` should include general use code
- General functions `get_sha256()`, `bool_to_msg()`, `configure_vcd_amqp()`, `create_amqp_exchange()`, `register_extension()` have all been moved to `utils.py`
- AMQP configuration and CSE registration has been moved to occur before template creation, since template creation takes the longest and is most prone to failure. This way, CSE installation can just finish after template creation.
- Moved catalog creation/sharing up to isolate from template creation step

Tested CSE installation :)

@rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/141)
<!-- Reviewable:end -->
