### PR TITLE
Fix static data file installation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,23 +24,6 @@ classifier =
 
 requires-python = >=3
 
-[files]
-packages =
-    container_service_extension
-data_files =
-    ./cse = scripts/init-photon-v2.sh
-    ./cse = scripts/cust-photon-v2.sh
-    ./cse = scripts/mstr-photon-v2.sh
-    ./cse = scripts/node-photon-v2.sh
-    ./cse = scripts/init-ubuntu-16.04.sh
-    ./cse = scripts/cust-ubuntu-16.04.sh
-    ./cse = scripts/mstr-ubuntu-16.04.sh
-    ./cse = scripts/node-ubuntu-16.04.sh
-    ./cse = scripts/nfsd-ubuntu-16.04.sh
-    . = LICENSE.txt
-    . = NOTICE.txt
-    . = open_source_license_container-service-extension_1.2.0_GA.txt
-
 [entry_points]
 console_scripts =
     cse = container_service_extension.cse:cli

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,29 @@
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-from setuptools import setup
+from setuptools import setup, find_packages
+import pathlib
+
+osl = 'open_source_license_container-service-extension_1.2.0_GA.txt'
+cse_scripts_dir = '/container_service_extension_scripts'
 
 setup(
     setup_requires=['pbr>=1.9', 'setuptools>=17.1'],
-    package_data = {'':['swagger/swagger.yaml']},
+    package_data={'': ['swagger/swagger.yaml']},
+    packages=find_packages(),
+    data_files=[
+        (str(pathlib.Path(cse_scripts_dir)), ['scripts/init-photon-v2.sh',
+                                              'scripts/cust-photon-v2.sh',
+                                              'scripts/mstr-photon-v2.sh',
+                                              'scripts/node-photon-v2.sh',
+                                              'scripts/init-ubuntu-16.04.sh',
+                                              'scripts/cust-ubuntu-16.04.sh',
+                                              'scripts/mstr-ubuntu-16.04.sh',
+                                              'scripts/node-ubuntu-16.04.sh',
+                                              'scripts/nfsd-ubuntu-16.04.sh']),
+        (str(pathlib.Path('.')), ['LICENSE.txt',
+                                  'NOTICE.txt',
+                                  osl]),
+    ],
     pbr=True,
 )


### PR DESCRIPTION
**setup.cfg** had unintuitive placement of static data files
(such as scripts, license, notice). Without a virtual
environment active, these scripts would be installed to
somewhere like `usr/local/bin/Python3.7/`. With a virtual
environment active, these scripts would be installed to
the virtual environment's home directory, somewhere like
`~/.virtualenvs/myvenv/`. To standardize this behavior,
script files are now installed to the Python environment's
`site-packages` folder in the `container_service_extension_scripts` 
directory. LICENSE.txt, NOTICE.txt, and OSL install to Python
base directory or the virtualenv's base directory.

Updated get_data_file() to use pathlib. No longer checks for
potential 'cse' subdirectory. Now only checks for potential
'scripts' subdirectory.

Tested get_data_file(), works as expected independent of virtualenv

Fixes vmware/container-service-extension#145

@rocknes 
