### PR TITLE
Add os import back to utils.py

### DIFF
--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -5,6 +5,7 @@
 import click
 import hashlib
 import logging
+import os
 import pathlib
 import random
 import socket


### PR DESCRIPTION
I caused a bug when merging in two PRs at once. PR #146 removed the **os** import from **utils.py**, which PR #136 requires. Both PRs worked as expected, but after merging the first, I should have updated the second to be equal to **vmware:master**.

Tested to make sure nothing else was affected. config file processing/data file searching/cse installation all work as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/155)
<!-- Reviewable:end -->
