### PR TITLE
[VCDA-833] Delete faulty/unregistered node from cse

### DIFF
--- a/container_service_extension/broker.py
+++ b/container_service_extension/broker.py
@@ -732,8 +732,11 @@ class DefaultBroker(threading.Thread):
                 TaskStatus.RUNNING,
                 message='Deleting %s node(s) from %s(%s)' %
                 (len(self.body['nodes']), self.cluster_name, self.cluster_id))
-            delete_nodes_from_cluster(self.config, vapp, template,
+            try:
+                delete_nodes_from_cluster(self.config, vapp, template,
                                       self.body['nodes'], self.body['force'])
+            except Exception:
+                LOGGER.error("Couldn't delete node %s from cluster:%s" % (self.body['nodes'], self.cluster_name))
             self.update_task(
                 TaskStatus.RUNNING,
                 message='Undeploying %s node(s) for %s(%s)' %


### PR DESCRIPTION
- The user can successfully delete nodes not registered with CSE.
- Tested manually by creating a faulty node and using cse node delete CLUSTER-NAME NODE-NAME

- @sahithi @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/173)
<!-- Reviewable:end -->
