### PR TITLE
[VCDA-834] Implement flag to disable rollback for troubleshooting

### DIFF
--- a/container_service_extension/broker.py
+++ b/container_service_extension/broker.py
@@ -40,7 +40,6 @@ from container_service_extension.exceptions import MasterNodeCreationError
 from container_service_extension.exceptions import NFSNodeCreationError
 from container_service_extension.exceptions import NodeCreationError
 from container_service_extension.exceptions import WorkerNodeCreationError
-from container_service_extension.exceptions import NodeCreationError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.utils import ERROR_DESCRIPTION
 from container_service_extension.utils import ERROR_MESSAGE
@@ -65,6 +64,7 @@ OP_MESSAGE = {
 }
 
 MAX_HOST_NAME_LENGTH = 25
+ROLLBACK_FLAG = 'disable_rollback'
 
 
 def get_new_broker(config):
@@ -96,19 +96,19 @@ def rollback(func):
         except (MasterNodeCreationError, WorkerNodeCreationError,
                 NFSNodeCreationError, ClusterJoiningError,
                 ClusterInitializationError) as e:
-            LOGGER.debug('Rollback started for cluster creation exception')
             try:
                 '''arg[0] refers to the current instance of the broker thread'''
                 broker_instance = args[0]
-                broker_instance.cluster_rollback()
+                if broker_instance.body[ROLLBACK_FLAG]:
+                    broker_instance.cluster_rollback()
             except Exception as err:
                 LOGGER.error('Failed to rollback cluster creation:%s', str(err))
         except NodeCreationError as e:
-            LOGGER.debug('Rollback started for node creation exception')
             try:
                 broker_instance = args[0]
                 node_list = e.node_names
-                broker_instance.node_rollback(node_list)
+                if broker_instance.body[ROLLBACK_FLAG]:
+                    broker_instance.node_rollback(node_list)
             except Exception as err:
                 LOGGER.error('Failed to rollback node creation:%s', str(err))
     return wrapper
@@ -783,9 +783,9 @@ class DefaultBroker(threading.Thread):
 
         :param list node_list: faulty nodes to be deleted
         """
-        LOGGER.debug('About to rollback nodes from cluster with name: %s' %
+        LOGGER.info('About to rollback nodes from cluster with name: %s' %
                      self.cluster_name)
-        LOGGER.debug('Node list to be deleted:%s' % node_list)
+        LOGGER.info('Node list to be deleted:%s' % node_list)
         vapp = VApp(self.client_tenant, href=self.cluster['vapp_href'])
         template = self.get_template()
         try:
@@ -799,12 +799,11 @@ class DefaultBroker(threading.Thread):
             except Exception:
                LOGGER.warning("Couldn't undeploy VM %s" % vm_name)
         vapp.delete_vms(node_list)
-        LOGGER.debug('Successfully deleted nodes: %s' % node_list)
-
+        LOGGER.info('Successfully deleted nodes: %s' % node_list)
 
     def cluster_rollback(self):
         """Implements rollback for cluster creation failure"""
-        LOGGER.debug('About to rollback cluster with name: %s' %
+        LOGGER.info('About to rollback cluster with name: %s' %
                      self.cluster_name)
         clusters = load_from_metadata(
             self.client_tenant, name=self.cluster_name)
@@ -814,5 +813,5 @@ class DefaultBroker(threading.Thread):
         self.cluster = clusters[0]
         vdc = VDC(self.client_tenant, href=self.cluster['vdc_href'])
         vdc.delete_vapp(self.cluster['name'], force=True)
-        LOGGER.debug('Successfully deleted cluster: %s' % self.cluster_name)
+        LOGGER.info('Successfully deleted cluster: %s' % self.cluster_name)
 

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -65,7 +65,8 @@ class Cluster(object):
                        storage_profile=None,
                        ssh_key=None,
                        template=None,
-                       enable_nfs=False):
+                       enable_nfs=False,
+                       disable_rollback=True):
         """Create a new Kubernetes cluster.
 
         :param vdc: (str): The name of the vdc in which the cluster will be
@@ -85,7 +86,11 @@ class Cluster(object):
         :param template: (str): The name of the template to use to
             instantiate the nodes
         :param enable_nfs: (bool): bool value to indicate if NFS node is to be
-            created.
+            created
+        :param disable_rollback: (bool): Flag to control weather rollback should be
+            performed or not in case of errors. True to rollback,
+            False to not rollback
+
         :return: (json) A parsed json object describing the requested cluster.
         """
         method = 'POST'
@@ -100,7 +105,8 @@ class Cluster(object):
             'storage_profile': storage_profile,
             'ssh_key': ssh_key,
             'template': template,
-            'enable_nfs': enable_nfs
+            'enable_nfs': enable_nfs,
+            'disable_rollback': disable_rollback
         }
         response = self.client._do_request_prim(
             method,
@@ -167,7 +173,8 @@ class Cluster(object):
                  storage_profile=None,
                  ssh_key=None,
                  template=None,
-                 node_type=TYPE_NODE):
+                 node_type=TYPE_NODE,
+                 disable_rollback=True):
         """Add nodes to a Kubernetes cluster.
 
         :param vdc: (str): The name of the vdc that contains the cluster
@@ -185,6 +192,10 @@ class Cluster(object):
             node vms without explicitly providing passwords
         :param template: (str): The name of the catalog template to use to
             instantiate the nodes
+        :param disable_rollback: (bool): Flag to control weather rollback should be
+            performed or not in case of errors. True to rollback,
+            False to not rollback
+
         :return: (json) A parsed json object describing the requested cluster.
         """
         method = 'POST'
@@ -199,7 +210,8 @@ class Cluster(object):
             'storage_profile': storage_profile,
             'ssh_key': ssh_key,
             'template': template,
-            'node_type': node_type
+            'node_type': node_type,
+            'disable_rollback': disable_rollback
         }
         response = self.client._do_request_prim(
             method,

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -237,8 +237,15 @@ def delete(ctx, name):
     default=False,
     metavar='[enable nfs]',
     help='Creates an additional node of type NFS')
+@click.option(
+    '--disable-rollback',
+    'disable_rollback',
+    is_flag=True,
+    required=False,
+    default=True,
+    help='Disable rollback for cluster')
 def create(ctx, name, node_count, cpu, memory, network_name, storage_profile,
-           ssh_key_file, template, enable_nfs):
+           ssh_key_file, template, enable_nfs,disable_rollback):
     """Create a Kubernetes cluster."""
     try:
         restore_session(ctx, vdc_required=True)
@@ -257,7 +264,8 @@ def create(ctx, name, node_count, cpu, memory, network_name, storage_profile,
             storage_profile=storage_profile,
             ssh_key=ssh_key,
             template=template,
-            enable_nfs=enable_nfs)
+            enable_nfs=enable_nfs,
+            disable_rollback=disable_rollback)
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)
@@ -416,8 +424,15 @@ def node_info(ctx, cluster_name, node_name):
     default='node',
     type=click.Choice(['node', 'nfsd']),
     help='type of node to add')
+@click.option(
+    '--disable-rollback',
+    'disable_rollback',
+    is_flag=True,
+    required=False,
+    default=True,
+    help='Disable rollback for node')
 def create_node(ctx, name, node_count, cpu, memory, network_name,
-                storage_profile, ssh_key_file, template, node_type):
+                storage_profile, ssh_key_file, template, node_type, disable_rollback):
     """Add a node to a Kubernetes cluster."""
     try:
         restore_session(ctx)
@@ -436,7 +451,8 @@ def create_node(ctx, name, node_count, cpu, memory, network_name,
             storage_profile=storage_profile,
             ssh_key=ssh_key,
             template=template,
-            node_type=node_type)
+            node_type=node_type,
+            disable_rollback=disable_rollback)
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
- By default, rollback is enabled to disable rollback user can add the flag **--disable-rollback** to cluster/node creation.

- Tested the implementation as follows:
Created faulty clusters/nodes and allowing rollback to trigger cleanup.
Created faulty clusters/nodes with rollback disabled to not trigger cleanup.

- @sakthisunda @andrew-ni @sahithi @hodgesrm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/178)
<!-- Reviewable:end -->
