### PR TITLE
Client side changes - Task update with stacktrace

### DIFF
--- a/container_service_extension/broker.py
+++ b/container_service_extension/broker.py
@@ -213,6 +213,8 @@ class DefaultBroker(threading.Thread):
             return {'message': str(e)}
 
     def update_task(self, status, message=None, error_message=None, stack_trace=''):
+        if not self.client_tenant.is_sysadmin():
+            stack_trace = ''
         if not hasattr(self, 'task'):
             self.task = Task(self.client_sysadmin)
         if message is None:
@@ -542,17 +544,13 @@ class DefaultBroker(threading.Thread):
                 ClusterInitializationError, ClusterOperationError) as e:
             LOGGER.error(traceback.format_exc())
             error_obj = error_to_json(e)
-            stack_trace = ''
-            if self.client_tenant.is_sysadmin():
-                stack_trace = ''.join(error_obj[ERROR_MESSAGE][ERROR_STACKTRACE])
+            stack_trace = ''.join(error_obj[ERROR_MESSAGE][ERROR_STACKTRACE])
             self.update_task(TaskStatus.ERROR, error_message=error_obj[ERROR_MESSAGE][ERROR_DESCRIPTION], stack_trace=stack_trace)
             raise e
         except Exception as e:
             LOGGER.error(traceback.format_exc())
             error_obj = error_to_json(e)
-            stack_trace = ''
-            if self.client_tenant.is_sysadmin():
-                stack_trace = ''.join(error_obj[ERROR_MESSAGE][ERROR_STACKTRACE])
+            stack_trace = ''.join(error_obj[ERROR_MESSAGE][ERROR_STACKTRACE])
             self.update_task(TaskStatus.ERROR, error_message=error_obj[ERROR_MESSAGE][ERROR_DESCRIPTION], stack_trace=stack_trace)
 
     @exception_handler
@@ -700,17 +698,13 @@ class DefaultBroker(threading.Thread):
         except NodeCreationError as e:
             error_obj = error_to_json(e)
             LOGGER.error(traceback.format_exc())
-            stack_trace = ''
-            if self.client_tenant.is_sysadmin():
-                stack_trace = ''.join(error_obj[ERROR_MESSAGE][ERROR_STACKTRACE])
+            stack_trace = ''.join(error_obj[ERROR_MESSAGE][ERROR_STACKTRACE])
             self.update_task(TaskStatus.ERROR, error_message=error_obj[ERROR_MESSAGE][ERROR_DESCRIPTION], stack_trace=stack_trace)
             raise
         except Exception as e:
             error_obj = error_to_json(e)
             LOGGER.error(traceback.format_exc())
-            stack_trace = ''
-            if self.client_tenant.is_sysadmin():
-                stack_trace = ''.join(error_obj[ERROR_MESSAGE][ERROR_STACKTRACE])
+            stack_trace = ''.join(error_obj[ERROR_MESSAGE][ERROR_STACKTRACE])
             self.update_task(TaskStatus.ERROR, error_message=error_obj[ERROR_MESSAGE][ERROR_DESCRIPTION], stack_trace=stack_trace)
 
     @exception_handler
@@ -790,9 +784,7 @@ class DefaultBroker(threading.Thread):
         except Exception as e:
             LOGGER.error(traceback.format_exc())
             error_obj = error_to_json(e)
-            stack_trace = ''
-            if self.client_tenant.is_sysadmin():
-                stack_trace = ''.join(error_obj[ERROR_MESSAGE][ERROR_STACKTRACE])
+            stack_trace = ''.join(error_obj[ERROR_MESSAGE][ERROR_STACKTRACE])
             self.update_task(TaskStatus.ERROR, error_message=error_obj[ERROR_MESSAGE][ERROR_DESCRIPTION], stack_trace=stack_trace)
 
     def node_rollback(self, node_list):


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

-  Update the task with stacktrace information
-  Pyvcloud new commit supports task update with stacktrace. To keep in sync, update the task from 
   client (caller).  
    with stacktrace.
-  Manually tested and verified

@rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/192)
<!-- Reviewable:end -->
