### PR TITLE
[VCDA 853] Construct ovdc metada and persist in Vcd

### DIFF
--- a/container_service_extension/ovdc_cache.py
+++ b/container_service_extension/ovdc_cache.py
@@ -1,0 +1,122 @@
+from container_service_extension.utils import get_vdc
+from container_service_extension.utils import get_org
+from pyvcloud.vcd import utils
+
+
+class PvdcCacheStub(object):
+
+    def __init__(self):
+        """ Constructor for pvdc cache. Initializes pvdc and pks cache.
+
+            Always returns the canned data. This is a thrown away class
+            after actual PvdcCache is implemented
+
+        """
+        self.pvdc_cache = dict()
+        self.pks_cache = dict()
+        self._initialize_pvdc_cache()
+        self._initialize_pks_cache()
+
+    def get_pvdc_info(self, pvdc_id):
+        return self.pvdc_cache['pvdc_id']
+
+    def get_pks_info(self, org_name, vc_name):
+        return self.pks_cache['org1']['vc1']
+
+    def _initialize_pvdc_cache(self):
+        self.pvdc_cache['pvdc_id'] = dict()
+        self.pvdc_cache['pvdc_id']['name'] = 'pvdc1'
+        self.pvdc_cache['pvdc_id']['vc'] = 'vc1'
+        self.pvdc_cache['pvdc_id']['rp_path'] = ['dc1/c1/rp1', 'dc1/c1/rp2']
+
+    def _initialize_pks_cache(self):
+        self.pks1 = dict()
+        self.pks1['host'] = '10.161.148.112'
+        self.pks1['port'] = '9021'
+        self.pks1['username'] = 'cokeSvcAccount'
+        self.pks1['secret'] = 'GhujkdfRl2dEvj1_hH9wEQxDUkxO1Lcjm3'
+        self.pks1['uaac_port'] = '8443'
+        self.pks_cache['org1'] = dict()
+        self.pks_cache['org1']['vc1'] = self.pks1
+
+
+class OvdcCache(object):
+
+    def __init__(self, client):
+        """ Constructor of OvdcCache
+
+        :param pyvcloud.vcd.client.Client client:he client that will be used
+            to make REST calls to vCD.
+        """
+        self.client = client
+        self.pvdc_cache = PvdcCacheStub()
+
+    def get_ovdc_metadata(self, ovdc_name, org_name=None):
+        """Gets ovdc metadata for given ovdc name
+
+        :param str ovdc_name:
+        :param str org_name: specific org to use if @org is not given.
+            If None, uses currently logged-in org from @client.
+
+        :return: metadata of the ovdc
+
+        :rtype: dict
+
+        :raises EntityNotFoundException: if the ovdc could not be found.
+        """
+        # Get pvdc and pks information from pvdc cache
+        ovdc = get_vdc(self.client, ovdc_name, org_name=org_name, is_admin_operation=True)
+        pvdc_element = ovdc.resource.ProviderVdcReference
+        pvdc_id = pvdc_element.get('id')
+        pvdc_info = self.pvdc_cache.get_pvdc_info(pvdc_id)
+        pks_info = self.pvdc_cache.get_pks_info(ovdc.name, pvdc_info['vc'])
+
+        # Get ovdc metadata from vcd; copy the credentials from pvdc cache
+        metadata = utils.metadata_to_dict(ovdc.get_all_metadata())
+        metadata['rp_path'] = metadata['rp_path'].split(',')
+        metadata['plans'] = metadata['plans'].split(',')
+        pks_connection_details = dict()
+        pks_connection_details['host'] = metadata.pop('host')
+        pks_connection_details['port'] = metadata.pop('port')
+        pks_connection_details['uaac_port'] = metadata.pop('uaac_port')
+        pks_connection_details['username'] = pks_info['username']
+        pks_connection_details['secret'] = pks_info['secret']
+        metadata['pks_connection_details'] = pks_connection_details
+        return metadata
+
+    def set_ovdc_meta_data(self, ovdc_name, org_name=None, back_end='', plans=''):
+        """sets the backing pvdc and pks information of a given oVdc.
+
+        :param str ovdc_name: name of the ovdc
+        :param str org_name: specific org to use if @org is not given.
+            If None, uses currently logged-in org from @client.
+        :param str back_end: name of back end for which this metadata is required.
+        :param str plans: pks plan for deployment
+        """
+
+        # Get resource pool
+        org = get_org(self.client, org_name=org_name)
+        ovdc = get_vdc(self.client, ovdc_name, org=org, is_admin_operation=True)
+        ovdc_id = ovdc.resource.get('id').split(':')[-1]
+        resource_pool = f"{ovdc.name} ({ovdc_id})"
+
+        # Get pvdc and pks information from pvdc cache
+        org_name = org.resource.get('name')
+        pvdc_element = ovdc.resource.ProviderVdcReference
+        pvdc_id = pvdc_element.get('id')
+        pvdc_info = self.pvdc_cache.get_pvdc_info(pvdc_id)
+        pks_info = self.pvdc_cache.get_pks_info(org_name, pvdc_info['vc'])
+
+        # construct ovdc metadata
+        meta_data = dict()
+        meta_data['name'] = pvdc_info['name']
+        meta_data['vc'] = pvdc_info['vc']
+        meta_data['rp_path'] = ','.join(f'{rp_path}/{resource_pool}' for rp_path in pvdc_info['rp_path'])
+        meta_data['host'] = pks_info['host']
+        meta_data['port'] = pks_info['port']
+        meta_data['uaac_port'] = pks_info['uaac_port']
+        meta_data['plans'] = plans
+        meta_data['pks_compute_profile_name'] = f"{org_name}-{ovdc_name}-{ovdc_id}"
+
+        # set ovdc metadata into Vcd
+        return ovdc.set_multiple_metadata(meta_data)

--- a/container_service_extension/ovdc_cache.py
+++ b/container_service_extension/ovdc_cache.py
@@ -1,5 +1,9 @@
-from container_service_extension.utils import get_vdc
+# container-service-extension
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
 from container_service_extension.utils import get_org
+from container_service_extension.utils import get_vdc
 from pyvcloud.vcd import utils
 
 
@@ -45,16 +49,17 @@ class OvdcCache(object):
     def __init__(self, client):
         """ Constructor of OvdcCache
 
-        :param pyvcloud.vcd.client.Client client:he client that will be used
+        :param pyvcloud.vcd.client.Client client:the client that will be used
             to make REST calls to vCD.
         """
         self.client = client
         self.pvdc_cache = PvdcCacheStub()
 
-    def get_ovdc_metadata(self, ovdc_name, org_name=None):
-        """Gets ovdc metadata for given ovdc name
+    def get_ovdc_backend_metadata(self, ovdc_name, org_name=None):
+        """Gets ovdc metadata pertaining to the backend(vcd/pks),
+        this ovdc is dedicated to deploy K8 clusters on.
 
-        :param str ovdc_name:
+        :param str ovdc_name: name of the ovdc
         :param str org_name: specific org to use if @org is not given.
             If None, uses currently logged-in org from @client.
 
@@ -64,59 +69,85 @@ class OvdcCache(object):
 
         :raises EntityNotFoundException: if the ovdc could not be found.
         """
+
         # Get pvdc and pks information from pvdc cache
-        ovdc = get_vdc(self.client, ovdc_name, org_name=org_name, is_admin_operation=True)
+        ovdc = get_vdc(self.client, ovdc_name, org_name=org_name,
+                       is_admin_operation=True)
+        metadata = utils.metadata_to_dict(ovdc.get_all_metadata())
+        metadata['backend'] = metadata.get('backend', None)
+
+        if metadata['backend'] is None or metadata['backend'].lower() == 'vcd':
+            return {'backend': metadata['backend']}
+
         pvdc_element = ovdc.resource.ProviderVdcReference
         pvdc_id = pvdc_element.get('id')
         pvdc_info = self.pvdc_cache.get_pvdc_info(pvdc_id)
         pks_info = self.pvdc_cache.get_pks_info(ovdc.name, pvdc_info['vc'])
 
         # Get ovdc metadata from vcd; copy the credentials from pvdc cache
-        metadata = utils.metadata_to_dict(ovdc.get_all_metadata())
         metadata['rp_path'] = metadata['rp_path'].split(',')
-        metadata['plans'] = metadata['plans'].split(',')
-        pks_connection_details = dict()
-        pks_connection_details['host'] = metadata.pop('host')
-        pks_connection_details['port'] = metadata.pop('port')
-        pks_connection_details['uaac_port'] = metadata.pop('uaac_port')
-        pks_connection_details['username'] = pks_info['username']
-        pks_connection_details['secret'] = pks_info['secret']
-        metadata['pks_connection_details'] = pks_connection_details
+        metadata['pks_plans'] = metadata['pks_plans'].split(',')
+        metadata['username'] = pks_info['username']
+        metadata['secret'] = pks_info['secret']
         return metadata
 
-    def set_ovdc_meta_data(self, ovdc_name, org_name=None, back_end='', plans=''):
+    def set_ovdc_backend_meta_data(self, ovdc_name, org_name=None,
+                                   backend=None,
+                                   pks_plans=''):
         """sets the backing pvdc and pks information of a given oVdc.
 
         :param str ovdc_name: name of the ovdc
         :param str org_name: specific org to use if @org is not given.
             If None, uses currently logged-in org from @client.
-        :param str back_end: name of back end for which this metadata is required.
-        :param str plans: pks plan for deployment
+        :param str backend: name of back end for which this metadata is
+        required.
+        :param str pks_plans: pks plan for deployment. If backend is vcd
+            or None, plans are not used and not relevant to the context.
         """
 
-        # Get resource pool
+        metadata = dict()
         org = get_org(self.client, org_name=org_name)
-        ovdc = get_vdc(self.client, ovdc_name, org=org, is_admin_operation=True)
-        ovdc_id = ovdc.resource.get('id').split(':')[-1]
-        resource_pool = f"{ovdc.name} ({ovdc_id})"
+        ovdc = get_vdc(self.client, ovdc_name, org=org,
+                       is_admin_operation=True)
+        if backend is None:
+            self._remove_metadata(ovdc,
+                                  keys=['name', 'vc', 'rp_path', 'host',
+                                        'port',
+                                        'uaac_port', 'pks_plans',
+                                        'pks_compute_profile_name'])
+            metadata['backend'] = ''
+        else:
+            # Get resource pool
+            ovdc_id = ovdc.resource.get('id').split(':')[-1]
+            resource_pool = f"{ovdc.name} ({ovdc_id})"
 
-        # Get pvdc and pks information from pvdc cache
-        org_name = org.resource.get('name')
-        pvdc_element = ovdc.resource.ProviderVdcReference
-        pvdc_id = pvdc_element.get('id')
-        pvdc_info = self.pvdc_cache.get_pvdc_info(pvdc_id)
-        pks_info = self.pvdc_cache.get_pks_info(org_name, pvdc_info['vc'])
+            # Get pvdc and pks information from pvdc cache
+            org_name = org.resource.get('name')
+            pvdc_element = ovdc.resource.ProviderVdcReference
+            pvdc_id = pvdc_element.get('id')
+            pvdc_info = self.pvdc_cache.get_pvdc_info(pvdc_id)
+            pks_info = self.pvdc_cache.get_pks_info(org_name, pvdc_info['vc'])
 
-        # construct ovdc metadata
-        meta_data = dict()
-        meta_data['name'] = pvdc_info['name']
-        meta_data['vc'] = pvdc_info['vc']
-        meta_data['rp_path'] = ','.join(f'{rp_path}/{resource_pool}' for rp_path in pvdc_info['rp_path'])
-        meta_data['host'] = pks_info['host']
-        meta_data['port'] = pks_info['port']
-        meta_data['uaac_port'] = pks_info['uaac_port']
-        meta_data['plans'] = plans
-        meta_data['pks_compute_profile_name'] = f"{org_name}-{ovdc_name}-{ovdc_id}"
+            # construct ovdc metadata
+
+            metadata['name'] = pvdc_info['name']
+            metadata['vc'] = pvdc_info['vc']
+            metadata['rp_path'] = ','.join(
+                f'{rp_path}/{resource_pool}' for rp_path in
+                pvdc_info['rp_path'])
+            metadata['host'] = pks_info['host']
+            metadata['port'] = pks_info['port']
+            metadata['uaac_port'] = pks_info['uaac_port']
+            metadata['pks_plans'] = pks_plans
+            metadata['backend'] = backend
+            pks_compute_profile_name = f"{org_name}-{ovdc_name}-{ovdc_id}"
+            metadata['pks_compute_profile_name'] = pks_compute_profile_name
 
         # set ovdc metadata into Vcd
-        return ovdc.set_multiple_metadata(meta_data)
+        ovdc.set_multiple_metadata(metadata)
+
+    def _remove_metadata(self, ovdc, keys=[]):
+        metadata = utils.metadata_to_dict(ovdc.get_all_metadata())
+        for k in keys:
+            if k in metadata:
+                ovdc.remove_metadata(k)

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -449,7 +449,7 @@ def get_org(client, org_name=None):
     return org
 
 
-def get_vdc(client, vdc_name, org=None, org_name=None):
+def get_vdc(client, vdc_name, org=None, org_name=None, is_admin_operation=False):
     """Gets the specified VDC object.
 
     :param pyvcloud.vcd.client.Client client:
@@ -457,6 +457,8 @@ def get_vdc(client, vdc_name, org=None, org_name=None):
     :param pyvcloud.vcd.org.Org org: specific org to use.
     :param str org_name: specific org to use if @org is not given.
         If None, uses currently logged-in org from @client.
+    :param bool is_admin_operation: if set True, will return the admin
+            view of the org vdc resource.
 
     :return: pyvcloud VDC object
 
@@ -466,7 +468,7 @@ def get_vdc(client, vdc_name, org=None, org_name=None):
     """
     if org is None:
         org = get_org(client, org_name=org_name)
-    vdc = VDC(client, resource=org.get_vdc(vdc_name))
+    vdc = VDC(client, resource=org.get_vdc(vdc_name, is_admin_operation=is_admin_operation))
     return vdc
 
 


### PR DESCRIPTION
 
- Persist ovdc metadata in Vcd

- For given ovdc name and/or with org, get the backing pvdc information with associated pks
   information from pvdc cache and save it Vcd. Also, providing getter of the metadata for the given
   ovdc name and/or org-name. Tested the code manually

@sahithi @sompa @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/202)
<!-- Reviewable:end -->
