### PR TITLE
Fixed new validation error after updating flake8 to v3.7.2

### DIFF
--- a/container_service_extension/authorization.py
+++ b/container_service_extension/authorization.py
@@ -95,7 +95,7 @@ def secure(required_rights=[]):
         def decorator_wrapper(*args, **kwargs):
             sys_admin_client = None
             try:
-                is_authorized = True;
+                is_authorized = True
                 server_config = get_server_runtime_config()
                 if server_config['service']['enforce_authorization']:
                     sys_admin_client = get_vcd_sys_admin_client()

--- a/container_service_extension/cluster.py
+++ b/container_service_extension/cluster.py
@@ -127,7 +127,7 @@ def add_nodes(qty, template, node_type, config, client, org, vdc, vapp, body):
     chmod -R go-rwx /root/.ssh
     """.format(ssh_key=body['ssh_key'])  # NOQA
 
-        if cust_script_common is '':
+        if cust_script_common == '':
             cust_script = None
         else:
             cust_script = cust_script_init + cust_script_common + \

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -11,10 +11,12 @@ CSE_SERVICE_NAMESPACE = 'cse'
 # DEPLOY RIGHTS
 # used by authorization framework to weed out unauthorized calls.
 CSE_NATIVE_DEPLOY_RIGHT_NAME = 'CSE NATIVE DEPLOY RIGHT'
-CSE_NATIVE_DEPLOY_RIGHT_DESCRIPTION = 'Right necessary to deploy kubernetes cluster via vCD apis in CSE'
+CSE_NATIVE_DEPLOY_RIGHT_DESCRIPTION = 'Right necessary to deploy kubernetes ' \
+    'cluster via vCD apis in CSE'
 CSE_NATIVE_DEPLOY_RIGHT_CATEGORY = 'cseRight'
 CSE_NATIVE_DEPLOY_RIGHT_BUNDLE_KEY = 'cseBundleKey'
 CSE_PKS_DEPLOY_RIGHT_NAME = 'PKS DEPLOY RIGHT'
-CSE_PKS_DEPLOY_RIGHT_DESCRIPTION = 'Right necessary to deploy kubernetes cluster via vSphere apis in PKS'
+CSE_PKS_DEPLOY_RIGHT_DESCRIPTION = 'Right necessary to deploy kubernetes ' \
+    'cluster via vSphere apis in PKS'
 CSE_PKS_DEPLOY_RIGHT_CATEGORY = 'pksRight'
 CSE_PKS_DEPLOY_RIGHT_BUNDLE_KEY = 'pksBundleKey'

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from pathlib import Path
+
 from setuptools import setup
 
 osl = 'open_source_license_container-service-extension_1.2.0_GA.txt'


### PR DESCRIPTION
Flake8 has been updated to v3.7.2 on pypi .
The updated version of flake8 is stricter than v3.6.0. This PR fixes all the new validation errors found in CSE barring errors like D401, W605.

Testing done:
Ran flake8 on the affected files and made sure the reported errors were fixed.