### PR TITLE
Add missing requirement for click

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cachetools >= 2.0.1
+click >= 7.0
 humanfriendly >= 4.8
 pika >= 0.11.2
 pyvcloud >= 20.0.1


### PR DESCRIPTION
The code requires click>=7.0 as a requirement

Discovered this while working on a container version of the tool