### PR TITLE
Add missing requirement for click

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cachetools >= 2.0.1
-click >= 7.0
+click >= 6.7
 humanfriendly >= 4.8
 pika >= 0.11.2
 pyvcloud >= 20.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cachetools >= 2.0.1
+click >= 7.0
 humanfriendly >= 4.8
 pika >= 0.11.2
 pyvcloud >= 20.0.1


### PR DESCRIPTION
The code requires click>=7.0 as a requirement

Discovered this while installing the scripts in an empty python container.

Signed-off-by: Glenn McElhoe <gmcelhoe@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/224)
<!-- Reviewable:end -->
