### PR TITLE
Fixing bug with `cse check` commands and get_validated_config

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -136,7 +136,7 @@ SAMPLE_VCS_CONFIG = {
 
 SAMPLE_PKS_CONFIG_FILE_LOCATION = {
     #Path to pks config file location
-    'pks_config': 'None'
+    'pks_config': None
 }
 
 SAMPLE_PKS_CONFIG = {
@@ -304,7 +304,7 @@ def generate_sample_config(output=None, pks_output=None):
            '\n' + sample_pks_config.strip()
 
 
-def get_validated_config(config_file_name, pks_config='pks.yaml'):
+def get_validated_config(config_file_name):
     """Gets the config file as a dictionary and checks for validity.
 
     Ensures that all properties exist and all values are the expected type.
@@ -313,8 +313,6 @@ def get_validated_config(config_file_name, pks_config='pks.yaml'):
     config file.
 
     :param str config_file_name: path to config file.
-
-    :param str pks_config_file_name: path to pks config file.
 
     :return: CSE config
 
@@ -330,9 +328,8 @@ def get_validated_config(config_file_name, pks_config='pks.yaml'):
         config = yaml.safe_load(config_file)
 
     click.secho(f"Validating config file '{config_file_name}'", fg='yellow')
-    if 'pks_config' in config:
-        check_keys_and_value_types(config, SAMPLE_CONFIG_WITH_PKS,
-                                   location='config file')
+    if 'pks_config' in config and isinstance(config.get('pks_config'), str):
+        pks_config = config['pks_config']
         check_file_permissions(pks_config)
         with open(pks_config) as pks_config_file:
             pks = yaml.safe_load(pks_config_file)
@@ -342,6 +339,7 @@ def get_validated_config(config_file_name, pks_config='pks.yaml'):
         click.secho(f"PKS Config file '{pks_config}' is valid", fg='green')
         config['pks_config'] = pks
     else:
+        del config['pks_config']
         check_keys_and_value_types(config, SAMPLE_CONFIG,
                                    location='config file')
     validate_amqp_config(config['amqp'])

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -328,11 +328,11 @@ def get_validated_config(config_file_name):
         config = yaml.safe_load(config_file)
 
     click.secho(f"Validating config file '{config_file_name}'", fg='yellow')
-    if 'pks_config' in config and isinstance(config.get('pks_config'), str):
-        pks_config = config['pks_config']
+    pks_config = config.get('pks_config')
+    if isinstance(pks_config, str):
         check_file_permissions(pks_config)
-        with open(pks_config) as pks_config_file:
-            pks = yaml.safe_load(pks_config_file)
+        with open(pks_config) as f:
+            pks = yaml.safe_load(f)
         click.secho(f"Validating PKS config file '{pks_config}'", fg='yellow')
         check_keys_and_value_types(pks, SAMPLE_PKS_CONFIG,
                                    location='PKS config file')

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -248,15 +248,6 @@ SAMPLE_CONFIG = {**SAMPLE_AMQP_CONFIG, **SAMPLE_VCD_CONFIG,
                  **SAMPLE_VCS_CONFIG, **SAMPLE_SERVICE_CONFIG,
                  **SAMPLE_BROKER_CONFIG}
 
-# This allows us to compare top-level config keys and value types
-# for pks enabled customers
-SAMPLE_CONFIG_WITH_PKS = {**SAMPLE_AMQP_CONFIG, **SAMPLE_VCD_CONFIG,
-                          **SAMPLE_VCS_CONFIG,
-                          **SAMPLE_PKS_CONFIG_FILE_LOCATION,
-                          **SAMPLE_SERVICE_CONFIG,
-                          **SAMPLE_BROKER_CONFIG}
-
-
 def generate_sample_config(output=None, pks_output=None):
     """Generates sample configs for cse. If config file names are
     provided, configs are dumped into respective files.
@@ -338,9 +329,9 @@ def get_validated_config(config_file_name):
                                    location='PKS config file')
         click.secho(f"PKS Config file '{pks_config}' is valid", fg='green')
         config['pks_config'] = pks
-    else:
+    if 'pks_config' in config:
         del config['pks_config']
-        check_keys_and_value_types(config, SAMPLE_CONFIG,
+    check_keys_and_value_types(config, SAMPLE_CONFIG,
                                    location='config file')
     validate_amqp_config(config['amqp'])
     validate_vcd_and_vcs_config(config['vcd'], config['vcs'])

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -317,18 +317,9 @@ def get_validated_config(config_file_name):
     check_file_permissions(config_file_name)
     with open(config_file_name) as config_file:
         config = yaml.safe_load(config_file)
-
-    click.secho(f"Validating config file '{config_file_name}'", fg='yellow')
     pks_config = config.get('pks_config')
-    if isinstance(pks_config, str):
-        check_file_permissions(pks_config)
-        with open(pks_config) as f:
-            pks = yaml.safe_load(f)
-        click.secho(f"Validating PKS config file '{pks_config}'", fg='yellow')
-        check_keys_and_value_types(pks, SAMPLE_PKS_CONFIG,
-                                   location='PKS config file')
-        click.secho(f"PKS Config file '{pks_config}' is valid", fg='green')
-        config['pks_config'] = pks
+    #Basic validation of Configs
+    click.secho(f"Validating config file '{config_file_name}'", fg='yellow')
     if 'pks_config' in config:
         del config['pks_config']
     check_keys_and_value_types(config, SAMPLE_CONFIG,
@@ -340,6 +331,19 @@ def get_validated_config(config_file_name):
                                SAMPLE_SERVICE_CONFIG['service'],
                                location="config file 'service' section")
     click.secho(f"Config file '{config_file_name}' is valid", fg='green')
+    #Validation of optional configs if present
+    if isinstance(pks_config, str):
+        check_file_permissions(pks_config)
+        with open(pks_config) as f:
+            pks = yaml.safe_load(f)
+        click.secho(f"Validating PKS config file '{pks_config}'", fg='yellow')
+        check_keys_and_value_types(pks, SAMPLE_PKS_CONFIG,
+                                   location='PKS config file')
+        click.secho(f"PKS Config file '{pks_config}' is valid", fg='green')
+        config['pks_config'] = pks
+    else:
+        config['pks_config'] = None
+
     return config
 
 

--- a/container_service_extension/cse.py
+++ b/container_service_extension/cse.py
@@ -140,14 +140,6 @@ def sample(ctx, output, pks_output):
     default='config.yaml',
     help='Config file to use.')
 @click.option(
-    '--pks-config',
-    'pks_config',
-    type=click.Path(exists=True),
-    metavar='<pks-config-file>',
-    envvar='CSE_PKS_CONFIG',
-    default='pks.yaml',
-    help='PKS Config file to use.')
-@click.option(
     '-i',
     '--check-install',
     'check_install',
@@ -165,10 +157,10 @@ def sample(ctx, output, pks_output):
     help="If '--check-install' flag is set, validate specified template. "
          "Default value of '*' means that all templates in config file"
          " will be validated.")
-def check(ctx, config, pks_config, check_install, template):
+def check(ctx, config, check_install, template):
     """Validate CSE configuration."""
     try:
-        config_dict = get_validated_config(config, pks_config=pks_config)
+        config_dict = get_validated_config(config)
     except (KeyError, ValueError, Exception):
         # TODO() replace Exception with specific (see validate_amqp_config)
         click.secho(f"Config file '{config}' is invalid", fg='red')


### PR DESCRIPTION
Signed-off-by: Sompa Malakar <malakars@vmware.com>

- Fixes bug related to cse check command and refactors get_validated_config to accommodate removal of pks_config file param from cse check command.

Tested CSE server up is up and running with both with or without pks config file and that cse check command no longer has an option for providing pks-config file.
- @andrew-ni @sahithi @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/226)
<!-- Reviewable:end -->
