### PR TITLE
Fix cluster config command and node rollback

### DIFF
--- a/container_service_extension/broker.py
+++ b/container_service_extension/broker.py
@@ -598,7 +598,8 @@ class DefaultBroker(AbstractBroker, threading.Thread):
             raise CseServerError('Cluster \'%s\' not found' % cluster_name)
         vapp = VApp(self.tenant_client, href=clusters[0]['vapp_href'])
         template = self.get_template(name=clusters[0]['template'])
-        result['body'] = get_cluster_config(self.config, vapp,
+        server_config = get_server_runtime_config()
+        result['body'] = get_cluster_config(server_config, vapp,
                                             template['admin_password'])
         result['status_code'] = OK
         return result
@@ -804,7 +805,8 @@ class DefaultBroker(AbstractBroker, threading.Thread):
         vapp = VApp(self.tenant_client, href=self.cluster['vapp_href'])
         template = self.get_template()
         try:
-            delete_nodes_from_cluster(self.config, vapp, template,
+            server_config = get_server_runtime_config()
+            delete_nodes_from_cluster(server_config, vapp, template,
                                       node_list, force=True)
         except Exception:
             LOGGER.warning("Couldn't delete node {node_list} from cluster:"


### PR DESCRIPTION
PR 208 (https://github.com/vmware/container-service-extension/pull/208) missed few instances of self.config in broker.py. These leftover references to self.config is the cause behind broken vcd cse cluster config command and failures seen during node rollback.

As a fix, replaced the instances of self.config with server config obtained from Service class.

Testing done:
1. With the fix in, deployed a cluster and ran vcd cse cluster config 'cluster name' to check that the configuration of the K8 cluster is being returned properly by CSE.
2. Tried to add a node with >1TB memory requirement. The operation failed as expected. Checked server debug logs to make sure that node-rollback was launched on the above failure and no additional failures were observed during the node rollback operation.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/227)
<!-- Reviewable:end -->
