### PR TITLE
[VCDA-875] Broker instance selection based on container-provider

### DIFF
--- a/container_service_extension/abstract_broker.py
+++ b/container_service_extension/abstract_broker.py
@@ -4,21 +4,21 @@
 
 import abc
 
+from pyvcloud.vcd.client import _WellKnownEndpoint
+
+from container_service_extension.utils import connect_vcd_user_via_token
+from container_service_extension.utils import get_server_runtime_config
+from container_service_extension.utils import get_vcd_sys_admin_client
+
 
 class AbstractBroker(abc.ABC):
-    @abc.abstractmethod
-    def get_tenant_client_session(self):
-        """Return <Session> XML object of a logged in vCD user.
 
-        :return: the session of the tenant user.
-
-        :rtype: lxml.objectify.ObjectifiedElement containing <Session> XML
-            data.
-        """
-        pass
+    def __init__(self, headers, request_body):
+        self.headers = headers
+        self.request_body = request_body
 
     @abc.abstractmethod
-    def create_cluster(self, *args, **kwargs):
+    def create_cluster(self):
         """Create cluster.
 
         :return: response object
@@ -28,17 +28,7 @@ class AbstractBroker(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def create_nodes(self, *args, **kwargs):
-        """Create nodes from the cluster.
-
-        :return: response object
-
-        :rtype: dict
-        """
-        pass
-
-    @abc.abstractmethod
-    def delete_cluster(self, *args, **kwargs):
+    def delete_cluster(self):
         """Delete the given cluster.
 
         :return: response object
@@ -48,28 +38,7 @@ class AbstractBroker(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_nodes(self, *args, **kwargs):
-        """Create nodes from the cluster.
-
-        :return: response object
-
-        :rtype: dict
-        """
-        pass
-
-    @abc.abstractmethod
-    def get_cluster_config(self, name):
-        """Get the configuration of cluster.
-
-        :return: response object
-
-        :rtype: dict
-
-        """
-        pass
-
-    @abc.abstractmethod
-    def get_cluster_info(self, name):
+    def get_cluster_info(self):
         """Get the information about the cluster.
 
         :return: response object
@@ -79,8 +48,8 @@ class AbstractBroker(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_node_info(self, cluster_name, node_name):
-        """Get information of node in the given cluster.
+    def list_clusters(self):
+        """Get the list of clusters.
 
         :return: response object
 
@@ -90,11 +59,47 @@ class AbstractBroker(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def list_clusters(self):
-        """List clusters.
+    def resize_cluster(self):
+        """Scale the cluster.
 
         :return: response object
 
         :rtype: dict
         """
         pass
+
+    def get_tenant_client_session(self):
+        """Return <Session> XML object of a logged in vCD user.
+
+        :return: the session of the tenant user.
+
+        :rtype: lxml.objectify.ObjectifiedElement containing <Session> XML
+            data.
+        """
+        if self.client_session is None:
+            self._connect_tenant()
+        return self.client_session
+
+    def _connect_tenant(self):
+        server_config = get_server_runtime_config()
+        host = server_config['vcd']['host']
+        verify = server_config['vcd']['verify']
+        self.tenant_client, self.client_session = connect_vcd_user_via_token(
+            vcd_uri=host,
+            headers=self.headers,
+            verify_ssl_certs=verify)
+        self.tenant_info = {
+            'user_name': self.client_session.get('user'),
+            'user_id': self.client_session.get('userId'),
+            'org_name': self.client_session.get('org'),
+            'org_href': self.tenant_client._get_wk_endpoint(
+                _WellKnownEndpoint.LOGGED_IN_ORG)
+        }
+
+    def _connect_sys_admin(self):
+        self.sys_admin_client = get_vcd_sys_admin_client()
+
+    def _disconnect_sys_admin(self):
+        if self.sys_admin_client is not None:
+            self.sys_admin_client.logout()
+            self.sys_admin_client = None

--- a/container_service_extension/abstract_broker.py
+++ b/container_service_extension/abstract_broker.py
@@ -16,3 +16,85 @@ class AbstractBroker(abc.ABC):
             data.
         """
         pass
+
+    @abc.abstractmethod
+    def create_cluster(self, *args, **kwargs):
+        """Create cluster.
+
+        :return: response object
+
+        :rtype: dict
+        """
+        pass
+
+    @abc.abstractmethod
+    def create_nodes(self, *args, **kwargs):
+        """Create nodes from the cluster.
+
+        :return: response object
+
+        :rtype: dict
+        """
+        pass
+
+    @abc.abstractmethod
+    def delete_cluster(self, *args, **kwargs):
+        """Delete the given cluster.
+
+        :return: response object
+
+        :rtype: dict
+        """
+        pass
+
+    @abc.abstractmethod
+    def delete_nodes(self, *args, **kwargs):
+        """Create nodes from the cluster.
+
+        :return: response object
+
+        :rtype: dict
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_cluster_config(self, name):
+        """Get the configuration of cluster.
+
+        :return: response object
+
+        :rtype: dict
+
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_cluster_info(self, name):
+        """Get the information about the cluster.
+
+        :return: response object
+
+        :rtype: dict
+
+        """
+
+    @abc.abstractmethod
+    def get_node_info(self, cluster_name, node_name):
+        """Get information of node in the given cluster.
+
+        :return: response object
+
+        :rtype: dict
+
+        """
+        pass
+
+    @abc.abstractmethod
+    def list_clusters(self):
+        """List clusters.
+
+        :return: response object
+
+        :rtype: dict
+        """
+        pass

--- a/container_service_extension/broker_selector.py
+++ b/container_service_extension/broker_selector.py
@@ -2,13 +2,37 @@
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+from vcd_cli.profiles import Profiles
+
+from container_service_extension import utils
 from container_service_extension.broker import DefaultBroker
-from container_service_extension.utils import get_server_runtime_config
+from container_service_extension.logger import SERVER_LOGGER as LOGGER
+from container_service_extension.ovdc_cache import OvdcCache
+from container_service_extension.pksbroker import PKSBroker
 
 
 def get_new_broker(headers, request_body):
-    server_config = get_server_runtime_config()
-    if server_config['broker']['type'] == 'default':
-        return DefaultBroker(headers, request_body)
+
+    profiles = Profiles.load()
+    ovdc_name = profiles.get('vdc_in_use')
+    org_name = profiles.get('org_in_use')
+    LOGGER.debug(f"org_name={org_name};vdc_name=\'{ovdc_name}\'")
+
+    """
+    Get the ovdc metadata from the logged-in org and ovdc.
+    Create the right broker based on value of 'container_provider'.
+    Fall back to DefaultBroker for missing ovdc or org.
+    """
+    if ovdc_name and org_name:
+        admin_client = utils.get_vcd_sys_admin_client()
+        ovdc_cache = OvdcCache(admin_client)
+        metadata = ovdc_cache.get_ovdc_container_provider_metadata(
+            ovdc_name=ovdc_name, org_name=org_name)
+        LOGGER.debug(f"ovdc metadata for {ovdc_name}-{org_name}=>{metadata}")
+        if metadata.get('container_provider') == 'pks':
+            return PKSBroker(headers, request_body,
+                             ovdc_cache=ovdc_cache)
+        else:
+            return DefaultBroker(headers, request_body)
     else:
-        return None
+        return DefaultBroker(headers, request_body)

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -2,8 +2,10 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+
 import json
 
+from container_service_extension.abstract_broker import AbstractBroker
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.pksclient.api.cluster_api import ClusterApi
 from container_service_extension.pksclient.api.profile_api import ProfileApi
@@ -23,18 +25,19 @@ from container_service_extension.utils import exception_handler
 from container_service_extension.utils import OK
 
 
-class PKSBroker(object):
+class PKSBroker(AbstractBroker):
     """PKSBroker makes API calls to PKS server.
 
     It performs CRUD operations on Kubernetes clusters.
     """
 
-    def __init__(self, ovdc_cache=None):
+    def __init__(self, headers, request_body, ovdc_cache=None):
         """Initialize PKS broker.
 
         :param ovdc_cache: ovdc cache (subject to change) is used to
         initialize PKS broker.
         """
+
         self.username = ovdc_cache['username']
         self.secret = ovdc_cache['secret']
         self.pks_host_uri = \
@@ -240,6 +243,7 @@ class PKSBroker(object):
         result['status_code'] = ACCEPTED
         return result
 
+
     @exception_handler
     def create_compute_profile(self, cp_name, az_name, description, cpi,
                                datacenter_name, cluster_name, ovdc_rp_name):
@@ -378,3 +382,4 @@ class PKSBroker(object):
                      f'deleted the compute profile: {name}')
 
         return result
+

--- a/container_service_extension/pksclient/api/cluster_api.py
+++ b/container_service_extension/pksclient/api/cluster_api.py
@@ -126,7 +126,7 @@ class ClusterApi(object):
             files=local_var_files,
             response_type='Cluster',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -223,7 +223,7 @@ class ClusterApi(object):
             files=local_var_files,
             response_type='object',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -316,7 +316,7 @@ class ClusterApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -409,7 +409,7 @@ class ClusterApi(object):
             files=local_var_files,
             response_type='Cluster',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -494,7 +494,7 @@ class ClusterApi(object):
             files=local_var_files,
             response_type='list[Cluster]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -595,7 +595,7 @@ class ClusterApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/container_service_extension/pksclient/api/plans_api.py
+++ b/container_service_extension/pksclient/api/plans_api.py
@@ -112,7 +112,7 @@ class PlansApi(object):
             files=local_var_files,
             response_type='list[Plan]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/container_service_extension/pksclient/api/profile_api.py
+++ b/container_service_extension/pksclient/api/profile_api.py
@@ -126,7 +126,7 @@ class ProfileApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -225,7 +225,7 @@ class ProfileApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -318,7 +318,7 @@ class ProfileApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -411,7 +411,7 @@ class ProfileApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -504,7 +504,7 @@ class ProfileApi(object):
             files=local_var_files,
             response_type='ComputeProfile',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -597,7 +597,7 @@ class ProfileApi(object):
             files=local_var_files,
             response_type='NetworkProfile',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -682,7 +682,7 @@ class ProfileApi(object):
             files=local_var_files,
             response_type='list[ComputeProfile]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -767,7 +767,7 @@ class ProfileApi(object):
             files=local_var_files,
             response_type='list[NetworkProfile]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/container_service_extension/pksclient/api/users_api.py
+++ b/container_service_extension/pksclient/api/users_api.py
@@ -124,7 +124,7 @@ class UsersApi(object):
             files=local_var_files,
             response_type='object',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            is_async=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/container_service_extension/pksclient/api_client.py
+++ b/container_service_extension/pksclient/api_client.py
@@ -51,7 +51,7 @@ class ApiClient(object):
     PRIMITIVE_TYPES = (float, bool, bytes, six.text_type) + six.integer_types
     NATIVE_TYPES_MAPPING = {
         'int': int,
-        'long': int if six.PY3 else long,  # noqa: F821
+        'long': int,  # noqa: F821
         'float': float,
         'str': str,
         'bool': bool,
@@ -274,7 +274,7 @@ class ApiClient(object):
     def call_api(self, resource_path, method,
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
-                 response_type=None, auth_settings=None, async=None,
+                 response_type=None, auth_settings=None, is_async=None,
                  _return_http_data_only=None, collection_formats=None,
                  _preload_content=True, _request_timeout=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
@@ -313,7 +313,7 @@ class ApiClient(object):
             If parameter async is False or missing,
             then the method will return the response directly.
         """
-        if not async:
+        if not is_async:
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,


### PR DESCRIPTION

Broker instance abstraction for cluster CRUD operations

- Changes that are required to select the right broker instance based on container-provider that is part of ovdc metadata.
- Currently, supported container-providers: 'pks' and 'vcd'.
- Manually tested cluster commands for the already existing vcd broker.
- Partially tested to check, if the container provider is 'pks', the broker selection and execution happens on PKSBroker.
- This pull request also has fixes for the pksclient and api_client code to unblock the testing.

@sahithi @sompa @rocknes @andrew-ni @harshneelmore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/233)
<!-- Reviewable:end -->
