### PR TITLE
[VCDA-904] Document action on sys admin to share catalog to non admin users

### DIFF
--- a/docs/CSE_ADMIN.md
+++ b/docs/CSE_ADMIN.md
@@ -515,6 +515,31 @@ this command to work.
 ```sh
 vcd system extension create cse cse cse vcdext '/api/cse, /api/cse/.*, /api/cse/.*/.*'
 ```
+
+### Sharing CSE catalog with non organization administrator users
+
+CSE installation creates a catalog to store all the VM templates that are later 
+used to deploy Kubernetes clusters. This catalog is by default shared with all 
+organization administrators. However if users who are not organization 
+administrator want to access this catalog (cluster creation requires access to 
+this catalog), the catalog needs to be explicitly shared with such users by 
+System administrators. The following commands can be run by a System 
+administrator to do so,
+
+```sh
+# login as system administrator
+vcd login vcd.serviceprovider.com system administrator --password passw0rd -w -i
+
+# switch over to the organization holding the catalog viz. cse-org
+vcd org use cse-org
+
+# share the catalog viz. cse-cat with the non org admin users in the org holding the catalog
+vcd catalog acl add cse-cat 'org:cse-org:ReadOnly'
+
+# share the catalog cse-cat to a second organization viz. test-org
+vcd catalog acl add cse-cat 'org:test-org:ReadOnly'
+```
+
 ---
 <a name="serveroperation"></a>
 ## Server Operation

--- a/docs/RBAC.md
+++ b/docs/RBAC.md
@@ -50,7 +50,7 @@ the above mentioned right to vCloud Director. The right belongs to the hidden
 visibility of it.
 
 Cloud Administrator turns on the role based access control for CSE
-- sets the 'enable_authorization' flag to 'true' under 'service' section of the
+- sets the 'enforce_authorization' flag to 'true' under 'service' section of the
   configuration file
 - restarts the CSE server
 


### PR DESCRIPTION
Currently when CSE installation shares the catalog, it just shares with org-admins of all orgs. Non org admin users don't have access to the catalog yet. To grant them access, sys admin needs to share the catalog explicitly with them. This PR documents the action item on sys admin.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/235)
<!-- Reviewable:end -->
