### PR TITLE
Fix 'cse sample' bug if user had click<7.0

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -24,7 +24,6 @@ import yaml
 
 from container_service_extension.exceptions import AmqpConnectionError
 from container_service_extension.exceptions import AmqpError
-
 from container_service_extension.logger import configure_install_logger
 from container_service_extension.logger import INSTALL_LOG_FILEPATH
 from container_service_extension.logger import INSTALL_LOGGER as LOGGER
@@ -36,7 +35,6 @@ from container_service_extension.server_constants import \
     CSE_PKS_DEPLOY_RIGHT_BUNDLE_KEY, CSE_PKS_DEPLOY_RIGHT_CATEGORY, \
     CSE_PKS_DEPLOY_RIGHT_DESCRIPTION, CSE_PKS_DEPLOY_RIGHT_NAME, \
     CSE_SERVICE_NAME, CSE_SERVICE_NAMESPACE  # noqa
-
 from container_service_extension.utils import catalog_exists
 from container_service_extension.utils import catalog_item_exists
 from container_service_extension.utils import check_file_permissions
@@ -59,8 +57,8 @@ from container_service_extension.utils import wait_until_tools_ready
 TEMP_VAPP_NETWORK_ADAPTER_TYPE = 'vmxnet3'
 TEMP_VAPP_FENCE_MODE = FenceMode.BRIDGED.value
 
-INSTRUCTIONS_FOR_PKS_CONFIG_FILE = '''#Config file for PKS enabled CSE Server to be filled by the administrator.
-#This config file has the following three sections:
+INSTRUCTIONS_FOR_PKS_CONFIG_FILE = '''# Config file for PKS enabled CSE Server to be filled by the administrator.
+# This config file has the following three sections:
 #   1. pks_accounts:
 #       a. Cloud Admins can specify PKS service account for every (PKS managed) vCenter in vCD
 #          i.e. a common PKS account per vCenter will be used for all the
@@ -70,28 +68,28 @@ INSTRUCTIONS_FOR_PKS_CONFIG_FILE = '''#Config file for PKS enabled CSE Server to
 #          admins need to ensure that PKS accounts are correctly mapped to
 #          their respective organization in the 'orgs' section of this
 #          config file.
-#   2. orgs: [OPTIONAL SECTION for admins who chose 1a above.]
+#   2. orgs: [OPTIONAL SECTION for admins who chose 1a above]
 #       a. If cloud admin chooses to define PKS service account per
 #          organization per vCenter, include the organization and respective
 #          pks_account names in this section, else should be left blank with empty values.
 #   3. pvdcs:
-#        a. List of Provider vDCs dedicated for PKS enabled CSE set up only\n
-#Each PKS service account needs to have the following information fields to be filled in:
+#       a. List of Provider vDCs dedicated for PKS enabled CSE set up only\n
+# Each PKS service account needs to have the following information fields to be filled in:
 #       1. PKS account name
 #       2. vCenter name in vCD for this PKS account
 #       3. PKS server host
 #       4. PKS server port
 #       5. PKS UAAC account information
-#For more information, please refer to CSE documentation page :
-#               https://vmware.github.io/container-service-extension/INSTALLATION.html\n'''
+# For more information, please refer to CSE documentation page:
+#       https://vmware.github.io/container-service-extension/INSTALLATION.html\n'''  # noqa
 
-NOTE_FOR_PKS_KEY_IN_CONFIG_FILE = '''#Filling out this key for regular CSE set up is optional and should be left as is.
-#Only for CSE set up enabled for PKS container provider, this value needs to point to a valid PKS config file name. 
-'''
-PKS_CONFIG_NOTE = '''#[OPTIONAL] PKS CONFIGS
-#These configs are required only for customers with PKS enabled CSE. Regular CSE users with 
+NOTE_FOR_PKS_KEY_IN_CONFIG_FILE = '''# Filling out this key for regular CSE set up is optional and should be left as is.
+# Only for CSE set up enabled for PKS container provider, this value needs to point to a valid PKS config file name.
+'''  # noqa
+PKS_CONFIG_NOTE = '''# [OPTIONAL] PKS CONFIGS
+# These configs are required only for customers with PKS enabled CSE. Regular CSE users with
 # no PKS container provider do not need these configs to be filled out in a separate yaml file.
-'''
+'''  # noqa
 
 SAMPLE_AMQP_CONFIG = {
     'amqp': {
@@ -121,76 +119,90 @@ SAMPLE_VCD_CONFIG = {
 }
 
 SAMPLE_VCS_CONFIG = {
-    'vcs': [{
-        'name': 'vc1',
-        'username': 'cse_user@vsphere.local',
-        'password': 'my_secret_password',
-        'verify': False
-    }, {
-        'name': 'vc2',
-        'username': 'cse_user@vsphere.local',
-        'password': 'my_secret_password',
-        'verify': False
-    }]
+    'vcs': [
+        {
+            'name': 'vc1',
+            'username': 'cse_user@vsphere.local',
+            'password': 'my_secret_password',
+            'verify': False
+        },
+        {
+            'name': 'vc2',
+            'username': 'cse_user@vsphere.local',
+            'password': 'my_secret_password',
+            'verify': False
+        }
+    ]
 }
 
 SAMPLE_PKS_CONFIG_FILE_LOCATION = {
-    #Path to pks config file location
+    # Path to pks config file location
     'pks_config': None
 }
 
 SAMPLE_PKS_CONFIG = {
-    'orgs': [{
-        'name': 'Org1',
-        'pks_accounts': ['Org1ServiceAccount1', 'Org1ServiceAccount2']
-    }, {
-        'name': 'Org2',
-        'pks_accounts': ['Org2ServiceAccount']
-    }],
-    'pks_accounts' : [{
-        'name' : 'Org1ServiceAccount1',
-        'vc' : 'vc1',
-        'host' : 'https://deadend-12345.eng.vmware.com',
-        'port' : '9021',
-        'uaac' : {
-            'port' : '8443',
-            'secret' : 'secret',
-            'username' : 'org1Admin'
+    'orgs': [
+        {
+            'name': 'Org1',
+            'pks_accounts': ['Org1ServiceAccount1', 'Org1ServiceAccount2']
+        },
+        {
+            'name': 'Org2',
+            'pks_accounts': ['Org2ServiceAccount']
         }
-    },{
-        'name' : 'Org1ServiceAccount2',
-        'vc' : 'vc2',
-        'host' : 'https://deadend-12345.eng.vmware.com',
-        'port' : '9021',
-        'uaac' : {
-            'port' : '8443',
-            'secret' : 'secret',
-            'username' : 'org1Admin'
+    ],
+    'pks_accounts': [
+        {
+            'name': 'Org1ServiceAccount1',
+            'vc': 'vc1',
+            'host': 'https://deadend-12345.eng.vmware.com',
+            'port': '9021',
+            'uaac': {
+                'port': '8443',
+                'secret': 'secret',
+                'username': 'org1Admin'
+            }
+        },
+        {
+            'name': 'Org1ServiceAccount2',
+            'vc': 'vc2',
+            'host': 'https://deadend-12345.eng.vmware.com',
+            'port': '9021',
+            'uaac': {
+                'port': '8443',
+                'secret': 'secret',
+                'username': 'org1Admin'
+            }
+        },
+        {
+            'name': 'Org2ServiceAccount',
+            'vc': 'vc1',
+            'host': 'https://deadend-12345.eng.vmware.com',
+            'port': '9021',
+            'uaac': {
+                'port': '8443',
+                'secret': 'secret',
+                'username': 'org2Admin'
+            }
         }
-    },{
-        'name' : 'Org2ServiceAccount',
-        'vc' : 'vc1',
-        'host' : 'https://deadend-12345.eng.vmware.com',
-        'port' : '9021',
-        'uaac' : {
-            'port' : '8443',
-            'secret' : 'secret',
-            'username' : 'org2Admin'
+    ],
+    'pvdcs': [
+        {
+            'name': 'pvdc1',
+            'vc': 'vc1',
+            'rp_paths': ['datacenter1/cluster1/rp1']
+        },
+        {
+            'name': 'pvdc2',
+            'vc': 'vc1',
+            'rp_paths': ['HA_datacenter/HA_cluster1/gold_rp/sub-rp']
+        },
+        {
+            'name': 'pvdc3',
+            'vc': 'vc2',
+            'rp_paths': ['datacenter/cluster1/rp1/sub-rp1/sub-rp2']
         }
-    }],
-    'pvdcs':[{
-        'name' : 'pvdc1',
-        'vc' : 'vc1',
-        'rp_paths': ['datacenter1/cluster1/rp1']
-    },{
-        'name' : 'pvdc2',
-        'vc': 'vc1',
-        'rp_paths' : ['HA_datacenter/HA_cluster1/gold_rp/sub-rp']
-    },{
-        'name' : 'pvdc3',
-        'vc' : 'vc2',
-        'rp_paths' : ['datacenter/cluster1/rp1/sub-rp1/sub-rp2']
-    }]
+    ]
 }
 
 SAMPLE_SERVICE_CONFIG = {
@@ -248,8 +260,11 @@ SAMPLE_CONFIG = {**SAMPLE_AMQP_CONFIG, **SAMPLE_VCD_CONFIG,
                  **SAMPLE_VCS_CONFIG, **SAMPLE_SERVICE_CONFIG,
                  **SAMPLE_BROKER_CONFIG}
 
+
 def generate_sample_config(output=None, pks_output=None):
-    """Generates sample configs for cse. If config file names are
+    """Generate sample configs for cse.
+
+    If config file names are
     provided, configs are dumped into respective files.
 
     :param str output: name of the config file to dump the CSE configs.
@@ -266,37 +281,31 @@ def generate_sample_config(output=None, pks_output=None):
                                     default_flow_style=False) + '\n'
     sample_config += yaml.safe_dump(SAMPLE_VCS_CONFIG,
                                     default_flow_style=False) + '\n'
-
     sample_config += yaml.safe_dump(SAMPLE_SERVICE_CONFIG,
                                     default_flow_style=False) + '\n'
     sample_config += yaml.safe_dump(SAMPLE_BROKER_CONFIG,
                                     default_flow_style=False) + '\n'
     sample_config += NOTE_FOR_PKS_KEY_IN_CONFIG_FILE
     sample_config += yaml.safe_dump(SAMPLE_PKS_CONFIG_FILE_LOCATION,
-                                        default_flow_style=False) + '\n'
-    sample_pks_config = yaml.safe_dump(
-            SAMPLE_PKS_CONFIG, default_flow_style=False) + '\n'
+                                    default_flow_style=False) + '\n'
+    sample_pks_config = yaml.safe_dump(SAMPLE_PKS_CONFIG,
+                                       default_flow_style=False)
+
     if output is not None:
         with open(output, 'w') as f:
             f.write(sample_config)
-            click.secho(f"Config file '{output}' is generated.",
-                        fg='green')
-            if pks_output is None:
-                return
     if pks_output is not None:
-        sample_pks_config = yaml.safe_dump(
-            SAMPLE_PKS_CONFIG, default_flow_style=False) + '\n'
         with open(pks_output, 'w') as f:
-            f.write(f"{INSTRUCTIONS_FOR_PKS_CONFIG_FILE}\n{sample_pks_config}")
-            click.secho(f"PKS config file '{pks_output}' is "
-                        f"generated.", fg='green')
-        return
-    return sample_config.strip() + '\n\n' + PKS_CONFIG_NOTE + \
-           '\n' + sample_pks_config.strip()
+            pks_config_string = yaml.safe_dump(SAMPLE_PKS_CONFIG,
+                                               default_flow_style=False)
+            f.write(f"{INSTRUCTIONS_FOR_PKS_CONFIG_FILE}\n{pks_config_string}")
+
+    return sample_config.strip() + '\n\n' + PKS_CONFIG_NOTE + '\n' + \
+        sample_pks_config.strip()
 
 
 def get_validated_config(config_file_name):
-    """Gets the config file as a dictionary and checks for validity.
+    """Get the config file as a dictionary and check for validity.
 
     Ensures that all properties exist and all values are the expected type.
     Checks that AMQP connection is available, and vCD/VCs are valid.
@@ -318,12 +327,12 @@ def get_validated_config(config_file_name):
     with open(config_file_name) as config_file:
         config = yaml.safe_load(config_file)
     pks_config = config.get('pks_config')
-    #Basic validation of Configs
+    # Basic validation of Configs
     click.secho(f"Validating config file '{config_file_name}'", fg='yellow')
     if 'pks_config' in config:
         del config['pks_config']
     check_keys_and_value_types(config, SAMPLE_CONFIG,
-                                   location='config file')
+                               location='config file')
     validate_amqp_config(config['amqp'])
     validate_vcd_and_vcs_config(config['vcd'], config['vcs'])
     validate_broker_config(config['broker'])
@@ -331,7 +340,7 @@ def get_validated_config(config_file_name):
                                SAMPLE_SERVICE_CONFIG['service'],
                                location="config file 'service' section")
     click.secho(f"Config file '{config_file_name}' is valid", fg='green')
-    #Validation of optional configs if present
+    # Validation of optional configs if present
     if isinstance(pks_config, str):
         check_file_permissions(pks_config)
         with open(pks_config) as f:


### PR DESCRIPTION
`cse sample` command now always returns the sample string (prints cse sample config to console)

This bug was caused by click<7.0 not being able to handle `click.echo(None)` properly, resulting in an error.


Also updated formatting to comply with flake8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/236)
<!-- Reviewable:end -->
