### PR TITLE
Fix CVE-2019-5736 (runc vulnerability) for Ubuntu and Photon vApp templates

### DIFF
--- a/scripts/cust-photon-v2.sh
+++ b/scripts/cust-photon-v2.sh
@@ -20,12 +20,19 @@ EOF
 chmod 0644 /etc/systemd/system/iptables-ports.service
 systemctl enable iptables-ports.service
 systemctl start iptables-ports.service
-systemctl enable docker
-systemctl start docker
-while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
+
+# update repo info (needed for docker update)
+tdnf makecache -q
 
 echo 'installing kuberentes'
 tdnf install -yq wget kubernetes-1.10.11-1.ph2 kubernetes-kubeadm-1.10.11-1.ph2
+
+echo 'install docker'
+tdnf install -yq wget docker-17.06.0-9.ph2
+
+systemctl enable docker
+systemctl start docker
+while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
 
 echo 'downloading container images'
 docker pull gcr.io/google_containers/kube-controller-manager-amd64:v1.10.11

--- a/scripts/cust-ubuntu-16.04.sh
+++ b/scripts/cust-ubuntu-16.04.sh
@@ -24,7 +24,7 @@ deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get -q update
-apt-get -q install -y docker-ce=18.03.0~ce-0~ubuntu
+apt-get -q install -y docker-ce=18.06.2~ce~3-0~ubuntu
 apt-get -q install -y kubelet=1.10.11-00 kubeadm=1.10.11-00 kubectl=1.10.11-00 kubernetes-cni=0.6.0-00 --allow-unauthenticated
 apt-get -q autoremove -y
 systemctl restart docker

--- a/system_tests/scripts/CUST-PHOTON.sh
+++ b/system_tests/scripts/CUST-PHOTON.sh
@@ -20,12 +20,19 @@ EOF
 chmod 0644 /etc/systemd/system/iptables-ports.service
 systemctl enable iptables-ports.service
 systemctl start iptables-ports.service
-systemctl enable docker
-systemctl start docker
-while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
+
+# update repo info (needed for docker update)
+tdnf makecache -q
 
 echo 'installing kuberentes'
 tdnf install -yq wget kubernetes-1.10.11-1.ph2 kubernetes-kubeadm-1.10.11-1.ph2
+
+echo 'install docker'
+tdnf install -yq wget docker-17.06.0-9.ph2
+
+systemctl enable docker
+systemctl start docker
+while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
 
 echo 'downloading container images'
 docker pull gcr.io/google_containers/kube-controller-manager-amd64:v1.10.11

--- a/system_tests/scripts/CUST-UBUNTU.sh
+++ b/system_tests/scripts/CUST-UBUNTU.sh
@@ -24,7 +24,7 @@ deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get -q update
-apt-get -q install -y docker-ce=18.03.0~ce-0~ubuntu
+apt-get -q install -y docker-ce=18.06.2~ce~3-0~ubuntu
 apt-get -q install -y kubelet=1.10.11-00 kubeadm=1.10.11-00 kubectl=1.10.11-00 kubernetes-cni=0.6.0-00 --allow-unauthenticated
 apt-get -q autoremove -y
 systemctl restart docker


### PR DESCRIPTION
Ubuntu template has been upgraded to use Docker 18.06.2 (from Docker 18.03.0)
Photon template has been upgraded to use Docker 17.06.0-9 (from default Photon2 Docker version. 17.06.0-?)

Both Docker versions have been validated to fix CVE-2019-5736

Testing done:
- Server and client system tests
- Manually deployed Kubernetes applications onto clusters using kubectl

- *CUST-PHOTON.sh* and *CUST-UBUNTU.sh* are static files used by our system tests that are copies of the actual customization scripts we use

---

Relevant links:
- Secure Docker versions for Photon: <https://github.com/vmware/photon/wiki/Security-Updates-2-129>
- Vulnerability info: <https://seclists.org/oss-sec/2019/q1/119>
- Docker release notes: <https://github.com/docker/docker-ce/releases>

Closes #231

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/237)
<!-- Reviewable:end -->
