### PR TITLE
[VCDA-893] Remove '--ext-install' option from CSE installation

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -633,8 +633,7 @@ def check_cse_installation(config, check_template='*'):
 
 
 def install_cse(ctx, config_file_name='config.yaml', template_name='*',
-                update=False, no_capture=False, ssh_key=None,
-                ext_install='prompt'):
+                update=False, no_capture=False, ssh_key=None):
     """Handle logistics for CSE installation.
 
     Handles decision making for configuring AMQP exchange/settings,
@@ -649,9 +648,6 @@ def install_cse(ctx, config_file_name='config.yaml', template_name='*',
     :param bool no_capture: if True, temporary vApp will not be captured or
         destroyed, so the user can ssh into and debug the VM.
     :param str ssh_key: public ssh key to place into template vApp(s).
-    :param str ext_install: 'prompt' asks the user if CSE should be registered
-        to vCD. 'skip' does not register CSE to vCD. 'config' registers CSE
-        to vCD without asking the user.
 
     :raises AmqpError: if AMQP exchange could not be created.
     """
@@ -685,23 +681,19 @@ def install_cse(ctx, config_file_name='config.yaml', template_name='*',
                              amqp['vhost'], amqp['ssl'], amqp['username'],
                              amqp['password'])
 
-        # register cse as extension to vCD
-        if should_register_cse(client, routing_key=amqp['routing_key'],
-                               exchange=amqp['exchange'],
-                               ext_install=ext_install):
-            register_cse(client, amqp['routing_key'], amqp['exchange'])
+        # register or update cse on vCD
+        register_cse(client, amqp['routing_key'], amqp['exchange'])
 
         # register rights to vCD
         # TODO() should also remove rights when unregistering CSE
-        if is_cse_registered(client):
-            register_right(client, right_name=CSE_NATIVE_DEPLOY_RIGHT_NAME,
-                           description=CSE_NATIVE_DEPLOY_RIGHT_DESCRIPTION,
-                           category=CSE_NATIVE_DEPLOY_RIGHT_CATEGORY,
-                           bundle_key=CSE_NATIVE_DEPLOY_RIGHT_BUNDLE_KEY)
-            register_right(client, right_name=CSE_PKS_DEPLOY_RIGHT_NAME,
-                           description=CSE_PKS_DEPLOY_RIGHT_DESCRIPTION,
-                           category=CSE_PKS_DEPLOY_RIGHT_CATEGORY,
-                           bundle_key=CSE_PKS_DEPLOY_RIGHT_BUNDLE_KEY)
+        register_right(client, right_name=CSE_NATIVE_DEPLOY_RIGHT_NAME,
+                       description=CSE_NATIVE_DEPLOY_RIGHT_DESCRIPTION,
+                       category=CSE_NATIVE_DEPLOY_RIGHT_CATEGORY,
+                       bundle_key=CSE_NATIVE_DEPLOY_RIGHT_BUNDLE_KEY)
+        register_right(client, right_name=CSE_PKS_DEPLOY_RIGHT_NAME,
+                       description=CSE_PKS_DEPLOY_RIGHT_DESCRIPTION,
+                       category=CSE_PKS_DEPLOY_RIGHT_CATEGORY,
+                       bundle_key=CSE_PKS_DEPLOY_RIGHT_BUNDLE_KEY)
 
         # set up cse catalog
         org = get_org(client, org_name=config['broker']['org'])
@@ -805,7 +797,6 @@ def create_template(ctx, client, config, template_config, update=False,
     except EntityNotFoundException:
         temp_vapp_exists = False
 
-    # flag is used to hide previous try/except error if an error occurs below
     if not temp_vapp_exists:
         if catalog_item_exists(org, catalog_name, ova_name):
             msg = f"Found ova file '{ova_name}' in catalog '{catalog_name}'"
@@ -1110,79 +1101,6 @@ def create_amqp_exchange(exchange_name, host, port, vhost, use_ssl,
     msg = f"AMQP exchange '{exchange_name}' is ready"
     click.secho(msg, fg='green')
     LOGGER.info(msg)
-
-
-def should_register_cse(client, routing_key, exchange, ext_install='prompt'):
-    """Decides if CSE installation should register CSE to vCD.
-
-    Returns False if @ext_install='skip' or if user declines
-    registration/update. Will print relevant information about CSE on vCD
-    if it is already registered.
-
-    :param pyvcloud.vcd.client.Client client:
-    :param str routing_key: routing_key to use for CSE
-    :param str exchange: exchange to use for CSE
-    :param str ext_install: 'skip' skips registration,
-        'config' allows registration without prompting user,
-        'prompt' asks user before registration.
-
-    :return: boolean that signals whether we should register CSE to vCD.
-
-    :rtype: bool
-    """
-    ext_config = {
-        'routingKey': routing_key,
-        'exchange': exchange
-    }
-
-    ext = APIExtension(client)
-    cse_info = None
-    try:
-        cse_info = ext.get_extension_info(CSE_SERVICE_NAME,
-                                          namespace=CSE_SERVICE_NAMESPACE)
-    except MissingRecordException:
-        pass
-
-    if cse_info is None:
-        msg = 'Register CSE to vCD?'
-        if ext_install == 'skip' \
-                or (ext_install == 'prompt' and not click.confirm(msg)):
-            msg = 'CSE is not registered to vCD. Skipping API extension ' \
-                  'registration'
-            click.secho(msg, fg='yellow')
-            LOGGER.warning(msg)
-            return False
-        return True
-
-    # cse is already registered to vCD, but settings might be off
-    diff_settings = [p for p, v in ext_config.items() if cse_info[p] != v]
-    if diff_settings:
-        msg = 'CSE on vCD has different settings than config file' \
-              '\n\nCurrent CSE settings on vCD:'
-        for setting in diff_settings:
-            msg += f"\n{setting}: {cse_info[setting]}"
-
-        msg += '\n\nCurrent config file settings:'
-        for setting in diff_settings:
-            msg += f"\n{setting}: {ext_config[setting]}"
-        click.echo(msg)
-        LOGGER.info(msg)
-
-        msg = '\nUpdate CSE on vCD to match config file settings?'
-        if ext_install == 'skip' \
-                or (ext_install == 'prompt' and not click.confirm(msg)):
-            msg = 'Skipping CSE registration to vCD. CSE on vCD has ' \
-                  'different settings than config file'
-            click.secho(msg, fg='yellow')
-            LOGGER.warning(msg)
-            return False
-        return True
-
-    # cse is already registered to vCD, and the settings match with config file
-    msg = 'CSE is registered to vCD and has same settings as config file'
-    click.secho(msg, fg='green')
-    LOGGER.info(msg)
-    return False
 
 
 def register_cse(client, routing_key, exchange):

--- a/container_service_extension/cse.py
+++ b/container_service_extension/cse.py
@@ -216,15 +216,7 @@ def check(ctx, config, check_install, template):
     type=click.File('r'),
     help='SSH public key to connect to the guest OS on the VM'
 )
-@click.option(
-    '-e',
-    '--ext',
-    'ext_install',
-    default='prompt',
-    type=click.Choice(['prompt', 'skip', 'config']),
-    help='API Extension configuration')
-def install(ctx, config, template, update, no_capture, ssh_key_file,
-            ext_install):
+def install(ctx, config, template, update, no_capture, ssh_key_file):
     """Install CSE on vCloud Director."""
     if no_capture and ssh_key_file is None:
         click.echo('Must provide ssh-key file (using --ssh-key OR -k) if '
@@ -235,8 +227,7 @@ def install(ctx, config, template, update, no_capture, ssh_key_file,
         if ssh_key_file is not None:
             ssh_key = ssh_key_file.read()
         install_cse(ctx, config_file_name=config, template_name=template,
-                    update=update, no_capture=no_capture, ssh_key=ssh_key,
-                    ext_install=ext_install)
+                    update=update, no_capture=no_capture, ssh_key=ssh_key)
 
 
 @cli.command(short_help='run service')

--- a/container_service_extension/system_test_framework/environment.py
+++ b/container_service_extension/system_test_framework/environment.py
@@ -255,3 +255,13 @@ def is_cse_registration_valid(routing_key, exchange):
         return False
 
     return True
+
+
+def check_cse_registration(routing_key, exchange):
+    cse_is_registered = is_cse_registered()
+    assert cse_is_registered, \
+        'CSE is not registered as an extension when it should be.'
+    if cse_is_registered:
+        assert is_cse_registration_valid(routing_key, exchange), \
+            'CSE is registered as an extension, but the extension settings ' \
+            'on vCD are not the same as config settings.'

--- a/docs/CSE_ADMIN.md
+++ b/docs/CSE_ADMIN.md
@@ -412,7 +412,7 @@ instances in parallel.
 To update a template rerun the `cse install` command as follows:
 
 ```sh
-cse install -c config.yaml --template photon-v2 --update --amqp skip --ext skip
+cse install -c config.yaml --template photon-v2 --update
 ```
 
 Updating a template increases `versionNumber` of the corresponding
@@ -446,9 +446,8 @@ in [Software Installation](/INSTALLATION.html).  Once this is done
 you can invoke server setup using the `cse install` command.  The
 example below shows a typical command.
 
-```sh
-cse install -c config.yaml --ssh-key=$HOME/.ssh/id_rsa.pub \
- --ext config --amqp config
+```bash
+cse install -c config.yaml --ssh-key ~/.ssh/id_rsa.pub
 ```
 
 The following diagram illustrates installation steps visually.

--- a/docs/CSE_ADMIN.md
+++ b/docs/CSE_ADMIN.md
@@ -464,7 +464,6 @@ The `cse install` command supports the following options:
 | \--update     | -u    | n/a                      | Recreate templates during installation                                                                                                                     | False                                         |
 | \--no-capture | -n    | n/a                      | Don't capture the temporary vApp as a template   (Leaves it standing for debugging purposes)                                                               | False                                         |
 | \--ssh-key    | -k    | path/to/ssh-key.pub      | ssh-key file to use for vm access   (root password ssh access is disabled for security reasons)                                                            | None                                          |
-| \--ext        | -e    | prompt OR skip OR config | **prompt**: ask before registering CSE<br>**skip**: do not register CSE<br>**config**: register CSE without asking for confirmation                        | prompt                                        |
 
 To monitor the vApp customization process, you can ssh into the temporary vApp. In the temporary vApp, the output of the customization script is captured in `/tmp/FILENAME.out` as well as `/tmp/FILENAME.err`:
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -27,7 +27,7 @@ Action required (by Admins and Users)
 * Cloud Admin:
     * Update CSE to 1.2.7
     * Update the templates
-    * Command for updating template -> cse install -c config.yaml --template template-name --update --amqp skip --ext skip
+    * Command for updating template -> cse install -c config.yaml --template template-name --update --ext skip
 
 * Tenant Users:
     * Delete clusters that were created with older templates. Recreate clusters with new templates

--- a/system_tests/test_cse_server.py
+++ b/system_tests/test_cse_server.py
@@ -11,7 +11,8 @@ $ cse check --config cse_test_config.yaml (incorrect value types)
 $ cse check --config cse_test_config.yaml -i (cse not installed yet)
 
 $ cse install --config cse_test_config.yaml --template photon-v2
-    --ext skip --ssh-key ~/.ssh/id_rsa.pub --no-capture
+    --ssh-key ~/.ssh/id_rsa.pub --no-capture
+
 $ cse install --config cse_test_config.yaml --template photon-v2
 $ cse install --config cse_test_config.yaml --ssh-key ~/.ssh/id_rsa.pub
     --update --no-capture
@@ -257,20 +258,19 @@ def test_0070_check_invalid_installation(config):
 def test_0080_install_no_capture(config, blank_cust_scripts, unregister_cse):
     """Test install.
 
-    Installation options: '--config', '--template', '--ext skip',
-        '--ssh-key', '--no-capture'.
+    Installation options: '--config', '--template', '--ssh-key',
+        '--no-capture'.
 
     Tests that installation:
     - downloads/uploads ova file,
     - creates photon temp vapp,
-    - skips cse registration,
     - skips temp vapp capture.
 
     command: cse install --config cse_test_config.yaml --template photon-v2
-        --ext skip --ssh-key ~/.ssh/id_rsa.pub --no-capture
+        --ssh-key ~/.ssh/id_rsa.pub --no-capture
     required files: ~/.ssh/id_rsa.pub, cse_test_config.yaml,
         photon-v2 init, photon-v2 cust (blank)
-    expected: cse not registered, catalog exists, photon-v2 ova exists,
+    expected: cse registered, catalog exists, photon-v2 ova exists,
         temp vapp does not exist, template does not exist.
     """
     template_config = testutils.get_default_template_config(config)
@@ -279,15 +279,13 @@ def test_0080_install_no_capture(config, blank_cust_scripts, unregister_cse):
                                    ['install',
                                     '--config', env.ACTIVE_CONFIG_FILEPATH,
                                     '--ssh-key', env.SSH_KEY_FILEPATH,
-                                    '--template', template_config['name'],
-                                    '--ext', 'skip',
+                                    '--template', env.PHOTON_TEMPLATE_NAME,
                                     '--no-capture'],
                                    catch_exceptions=False)
     assert result.exit_code == 0
 
-    # check that cse was not registered
-    assert not env.is_cse_registered(), \
-        'CSE is registered as an extension when it should not be.'
+    # check that cse was registered correctly
+    env.check_cse_registration(config['routing_key'], config['exchange'])
 
     # check that source ova file exists in catalog
     assert env.catalog_item_exists(template_config['source_ova_name']), \
@@ -307,7 +305,6 @@ def test_0090_install_temp_vapp_already_exists(config, blank_cust_scripts,
     """Test installation when temp vapp already exists.
 
     Tests that installation:
-    - skips cse registration (answering no to prompt),
     - captures temp vapp as template correctly,
     - does not delete temp_vapp when config file 'cleanup' property is false.
 
@@ -324,17 +321,15 @@ def test_0090_install_temp_vapp_already_exists(config, blank_cust_scripts,
 
     testutils.dict_to_yaml_file(config, env.ACTIVE_CONFIG_FILEPATH)
 
-    res = env.CLI_RUNNER.invoke(cli,
-                                ['install',
-                                 '--config', env.ACTIVE_CONFIG_FILEPATH,
-                                 '--template', template_config['name']],
-                                input='N',
-                                catch_exceptions=False)
-    assert res.exit_code == 0
+    result = env.CLI_RUNNER.invoke(cli,
+                                   ['install',
+                                    '--config', env.ACTIVE_CONFIG_FILEPATH,
+                                    '--template', env.PHOTON_TEMPLATE_NAME],
+                                   catch_exceptions=False)
+    assert result.exit_code == 0
 
-    # check that cse was not registered
-    assert not env.is_cse_registered(), \
-        'CSE is registered as an extension when it should not be.'
+    # check that cse was registered correctly
+    env.check_cse_registration(config['routing_key'], config['exchange'])
 
     # check that vapp template exists in catalog
     assert env.catalog_item_exists(template_config['catalog_item']), \
@@ -349,7 +344,6 @@ def test_0100_install_update(config, unregister_cse):
     """Tests installation option: '--update'.
 
     Tests that installation:
-    - registers cse (when answering yes to prompt),
     - creates all templates correctly,
     - customizes temp vapps correctly.
 
@@ -366,21 +360,13 @@ def test_0100_install_update(config, unregister_cse):
                                     '--ssh-key', env.SSH_KEY_FILEPATH,
                                     '--update',
                                     '--no-capture'],
-                                   input='y',
                                    catch_exceptions=False)
     assert result.exit_code == 0
 
     vdc = VDC(env.CLIENT, href=env.VDC_HREF)
 
     # check that cse was registered correctly
-    is_cse_registered = env.is_cse_registered()
-    assert is_cse_registered, \
-        'CSE is not registered as an extension when it should be.'
-    if is_cse_registered:
-        assert env.is_cse_registration_valid(config['amqp']['routing_key'],
-                                             config['amqp']['exchange']), \
-            'CSE is registered as an extension, but the extension settings ' \
-            'on vCD are not the same as config settings.'
+    env.check_cse_registration(config['routing_key'], config['exchange'])
 
     # ssh into vms to check for installed software
     ssh_client = paramiko.SSHClient()
@@ -428,8 +414,6 @@ def test_0100_install_update(config, unregister_cse):
 def test_0110_install_cleanup_true(config, blank_cust_scripts, unregister_cse):
     """Tests that installation deletes temp vapps when 'cleanup' is True.
 
-    Also tests that '--ext config' registers cse.
-
     command: cse install --config cse_test_config.yaml
     expected: temp vapps are deleted
     """
@@ -440,20 +424,12 @@ def test_0110_install_cleanup_true(config, blank_cust_scripts, unregister_cse):
 
     result = env.CLI_RUNNER.invoke(cli,
                                    ['install',
-                                    '--config', env.ACTIVE_CONFIG_FILEPATH,
-                                    '--ext', 'config'],
+                                    '--config', env.ACTIVE_CONFIG_FILEPATH],
                                    catch_exceptions=False)
     assert result.exit_code == 0
 
     # check that cse was registered correctly
-    is_cse_registered = env.is_cse_registered()
-    assert is_cse_registered, \
-        'CSE is not registered as an extension when it should be.'
-    if is_cse_registered:
-        assert env.is_cse_registration_valid(config['amqp']['routing_key'],
-                                             config['amqp']['exchange']), \
-            'CSE is registered as an extension, but the extension settings ' \
-            'on vCD are not the same as config settings.'
+    env.check_cse_registration(config['routing_key'], config['exchange'])
 
     for template_config in config['broker']['templates']:
         # check that vapp templates exists

--- a/system_tests/test_cse_server.py
+++ b/system_tests/test_cse_server.py
@@ -279,13 +279,14 @@ def test_0080_install_no_capture(config, blank_cust_scripts, unregister_cse):
                                    ['install',
                                     '--config', env.ACTIVE_CONFIG_FILEPATH,
                                     '--ssh-key', env.SSH_KEY_FILEPATH,
-                                    '--template', env.PHOTON_TEMPLATE_NAME,
+                                    '--template', template_config['name'],
                                     '--no-capture'],
                                    catch_exceptions=False)
     assert result.exit_code == 0
 
     # check that cse was registered correctly
-    env.check_cse_registration(config['routing_key'], config['exchange'])
+    env.check_cse_registration(config['amqp']['routing_key'],
+                               config['amqp']['exchange'])
 
     # check that source ova file exists in catalog
     assert env.catalog_item_exists(template_config['source_ova_name']), \
@@ -324,12 +325,13 @@ def test_0090_install_temp_vapp_already_exists(config, blank_cust_scripts,
     result = env.CLI_RUNNER.invoke(cli,
                                    ['install',
                                     '--config', env.ACTIVE_CONFIG_FILEPATH,
-                                    '--template', env.PHOTON_TEMPLATE_NAME],
+                                    '--template', template_config['name']],
                                    catch_exceptions=False)
     assert result.exit_code == 0
 
     # check that cse was registered correctly
-    env.check_cse_registration(config['routing_key'], config['exchange'])
+    env.check_cse_registration(config['amqp']['routing_key'],
+                               config['amqp']['exchange'])
 
     # check that vapp template exists in catalog
     assert env.catalog_item_exists(template_config['catalog_item']), \
@@ -366,7 +368,8 @@ def test_0100_install_update(config, unregister_cse):
     vdc = VDC(env.CLIENT, href=env.VDC_HREF)
 
     # check that cse was registered correctly
-    env.check_cse_registration(config['routing_key'], config['exchange'])
+    env.check_cse_registration(config['amqp']['routing_key'],
+                               config['amqp']['exchange'])
 
     # ssh into vms to check for installed software
     ssh_client = paramiko.SSHClient()
@@ -429,7 +432,8 @@ def test_0110_install_cleanup_true(config, blank_cust_scripts, unregister_cse):
     assert result.exit_code == 0
 
     # check that cse was registered correctly
-    env.check_cse_registration(config['routing_key'], config['exchange'])
+    env.check_cse_registration(config['amqp']['routing_key'],
+                               config['amqp']['exchange'])
 
     for template_config in config['broker']['templates']:
         # check that vapp templates exists


### PR DESCRIPTION
- Adjusted CSE installation to not use `--ext-install` option. Now CSE always registers or updates the extension info on vCD

- Removed testing for the option in `system_tests/test_cse_server.py`

- Removed mention of the option in documentation

Tested against server and client test suite

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/251)
<!-- Reviewable:end -->
