### PR TITLE
VCDA-902 : Implementation of CPI id, developer-mode, removal of rp-paths

### DIFF
--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -17,10 +17,9 @@ import click
 from lxml import objectify
 from pyvcloud.vcd.api_extension import APIExtension
 from pyvcloud.vcd.client import BasicLoginCredentials
+from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.client import ResourceType
-
-from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import MissingRecordException
 from pyvcloud.vcd.org import Org
@@ -555,8 +554,7 @@ def get_ovdc_resource_pool(client, ovdc_name, org_name=None):
 
 
 def get_pvdc_id_by_name(name, vc_name_in_vcd):
-    """
-    Retrieves the pvdc identifier based on the pvdc name and vcenter name.
+    """Retrieve the pvdc identifier based on the pvdc name and vcenter name.
 
     :param str name: name of the pvdc.
     :param str vc_name_in_vcd: name of the vcenter in vcd.
@@ -576,23 +574,6 @@ def get_pvdc_id_by_name(name, vc_name_in_vcd):
         pvdc_id = href.split("/")[-1]
         return pvdc_id
     return None
-
-
-def get_datacenter_cluster_rp_path(rp_path):
-    """
-    Utility method that returns the data center name, cluster name and
-    sub resource pool path from the vCenter path of a provider vDC.
-
-    :param list rp_path: vCenter path of the provider vDC.
-
-    :return: a list of data center name, cluster name and
-    sub resource pool path.
-    """
-    fragments = rp_path[0].split("/")
-    datacenter = fragments[0]
-    cluster = fragments[1]
-    sub_rp_path = '/'.join(fragments[2:])
-    return [datacenter, cluster, sub_rp_path]
 
 
 def get_data_file(filename, logger=None):


### PR DESCRIPTION
Signed-off-by: Sompa Malakar <malakars@vmware.com>



-  Implementation of  CPI id, developer-mode, removal of rp-paths

- This PR implements logic to include CPI (Cloud Provider Id) associated with each datacenter in VC, in the new PKS configs. Removes the resource pool path field from pvdcs and adds datacenter and cluster field instead. Also adds logic to include a developer mode field 'pks_proxy_ip' to work with PKS dev set up where the PKS and VC reside in a different network than vCD's.


- @sahithi @sakthisunda @rocknes @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/252)
<!-- Reviewable:end -->
