### PR TITLE
[VCDA-896] Beautify vCD setup/config file errors during installation

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -498,12 +498,18 @@ def validate_broker_config(broker_dict):
                                             "template section")
         if template['name'] == broker_dict['default_template']:
             default_exists = True
-
     if not default_exists:
-        msg = f"Default template '{broker_dict['default_template']}' not " \
-              f"found in listed templates"
-        click.secho(msg, fg='red')
-        raise ValueError(msg)
+        raise ValueError(f"Default template '{broker_dict['default_template']}"
+                         f"' not found in listed templates")
+
+    valid_ip_allocation_modes = [
+        'dhcp',
+        'pool'
+    ]
+    if broker_dict['ip_allocation_mode'] not in valid_ip_allocation_modes:
+        raise ValueError(f"IP allocation mode is "
+                         f"'{broker_dict['ip_allocation_mode']}' when it "
+                         f"should be either 'dhcp' or 'pool'")
 
 
 def check_cse_installation(config, check_template='*'):

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -46,7 +46,6 @@ from container_service_extension.utils import get_data_file
 from container_service_extension.utils import get_org
 from container_service_extension.utils import get_vdc
 from container_service_extension.utils import get_vsphere
-from container_service_extension.utils import is_cse_registered
 from container_service_extension.utils import SYSTEM_ORG_NAME
 from container_service_extension.utils import upload_ova_to_catalog
 from container_service_extension.utils import vgr_callback
@@ -324,18 +323,26 @@ def get_validated_config(config_file_name):
 
     :rtype: dict
 
-    :raises KeyError: if config file has missing properties.
-    :raises ValueError: if the value type for a config file property
+    :raises KeyError: if config file has missing or extra properties.
+    :raises TypeError: if the value type for a config file property
         is incorrect.
-    :raises AmqpConnectionError: if AMQP connection failed.
+    :raises container_service_extension.exceptions.AmqpConnectionError: if
+        AMQP connection failed (host, password, port, username,
+        vhost is invalid).
+    :raises pyvcloud.vcd.exceptions.NotAcceptableException: if 'vcd'
+        'api_version' is unsupported.
+    :raises requests.exceptions.ConnectionError: if 'vcd' 'host' is invalid.
+    :raises pyvcloud.vcd.exceptions.VcdException: if 'vcd' 'username' or
+        'password' is invalid.
+    :raises pyVmomi.vim.fault.InvalidLogin: if 'vcs' 'username' or 'password'
+        is invalid.
     """
     check_file_permissions(config_file_name)
     with open(config_file_name) as config_file:
         config = yaml.safe_load(config_file)
     pks_config = config.get('pks_config')
     click.secho(f"Validating config file '{config_file_name}'", fg='yellow')
-    check_keys_and_value_types(config, SAMPLE_CONFIG,
-                               location='config file')
+    check_keys_and_value_types(config, SAMPLE_CONFIG, location='config file')
     validate_amqp_config(config['amqp'])
     validate_vcd_and_vcs_config(config['vcd'], config['vcs'])
     validate_broker_config(config['broker'])
@@ -367,7 +374,7 @@ def validate_amqp_config(amqp_dict):
     :param dict amqp_dict: 'amqp' section of config file as a dict.
 
     :raises KeyError: if @amqp_dict has missing or extra properties.
-    :raises ValueError: if the value type for an @amqp_dict property
+    :raises TypeError: if the value type for an @amqp_dict property
         is incorrect.
     :raises AmqpConnectionError: if AMQP connection failed.
     """
@@ -406,8 +413,9 @@ def validate_vcd_and_vcs_config(vcd_dict, vcs):
 
     :raises KeyError: if @vcd_dict or a vc in @vcs has missing or
         extra properties.
-    :raises: ValueError: if the value type for a @vcd_dict or vc property
-        is incorrect, or if vCD has a VC that is not listed in the config file.
+    :raises TypeError: if the value type for a @vcd_dict or vc property
+        is incorrect.
+    :raises ValueError: if vCD has a VC that is not listed in the config file.
     """
     check_keys_and_value_types(vcd_dict, SAMPLE_VCD_CONFIG['vcd'],
                                location="config file 'vcd' section")
@@ -440,7 +448,7 @@ def validate_vcd_and_vcs_config(vcd_dict, vcs):
         for index, vc in enumerate(vcs, 1):
             check_keys_and_value_types(vc, SAMPLE_VCS_CONFIG['vcs'][0],
                                        location=f"config file 'vcs' section,"
-                                                f" "f"vc #{index}")
+                                                f" vc #{index}")
 
         # Check that all registered VCs in vCD are listed in config file
         platform = Platform(client)
@@ -475,9 +483,10 @@ def validate_broker_config(broker_dict):
     :param dict broker_dict: 'broker' section of config file as a dict.
 
     :raises KeyError: if @broker_dict has missing or extra properties.
-    :raises ValueError: if the value type for a @broker_dict property is
-        incorrect, or if 'default_template' has a value not listed in the
-        'templates' property.
+    :raises TypeError: if the value type for a @broker_dict property is
+        incorrect.
+    :raises ValueError: if 'default_template' value is not found in listed
+        'templates, or if 'ip_allocation_mode' is not 'dhcp' or 'pool'
     """
     check_keys_and_value_types(broker_dict, SAMPLE_BROKER_CONFIG['broker'],
                                location="config file 'broker' section")

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -250,8 +250,8 @@ def check_keys_and_value_types(dikt, ref_dict, location='dictionary'):
     :param str location: where this check is taking place, so error messages
         can be more descriptive.
 
-    :raises KeyError: if @dikt has missing keys
-    :raises ValueError: if the value of a property in @dikt does not match with
+    :raises KeyError: if @dikt has missing or invalid keys
+    :raises TypeError: if the value of a property in @dikt does not match with
         the value of the same property in @ref_dict
     """
     ref_keys = set(ref_dict.keys())
@@ -274,7 +274,7 @@ def check_keys_and_value_types(dikt, ref_dict, location='dictionary'):
     if missing_keys:
         raise KeyError(f"Missing and/or invalid key in {location}")
     if bad_value:
-        raise ValueError(f"Incorrect type for property value(s) in {location}")
+        raise TypeError(f"Incorrect type for property value(s) in {location}")
 
 
 def check_python_version():

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pika >= 0.11.2
 pyvcloud >= 20.0.3
 vcd-cli >= 21.0.2
 vsphere-guest-run >= 0.0.7
+pyvmomi >= 6.7.0

--- a/system_tests/test_cse_server.py
+++ b/system_tests/test_cse_server.py
@@ -230,7 +230,7 @@ def test_0050_config_invalid_value_types(config):
             get_validated_config(env.ACTIVE_CONFIG_FILEPATH)
             assert False, f"{env.ACTIVE_CONFIG_FILEPATH} passed validation " \
                           f"when it should not have"
-        except ValueError:
+        except TypeError:
             pass
 
 
@@ -238,7 +238,7 @@ def test_0060_config_valid(config):
     """Test that configs with valid keys and value types pass validation."""
     try:
         get_validated_config(env.ACTIVE_CONFIG_FILEPATH)
-    except (KeyError, ValueError):
+    except (KeyError, TypeError, ValueError):
         assert False, f"{env.ACTIVE_CONFIG_FILEPATH} did not pass validation" \
                       f" when it should have"
 


### PR DESCRIPTION
Instead of printing a full stacktrace and exception, we now swallow
any exceptions related to improper config file values or
vCD setup. The invalid setting is then printed to console, without
any stacktrace or exception details.

Made changes to install and check in cse.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/256)
<!-- Reviewable:end -->
