### PR TITLE
Fix enablek8s failure on VCD-9.1

### DIFF
--- a/container_service_extension/ovdc_cache.py
+++ b/container_service_extension/ovdc_cache.py
@@ -117,6 +117,13 @@ class OvdcCache(object):
             org_name = org.resource.get('name')
             pvdc_element = ovdc.resource.ProviderVdcReference
             pvdc_id = pvdc_element.get('id')
+            # To support <= VCD 9.1 where no 'id' is present in pvdc
+            # element, it has to be extracted from href. Once VCD 9.1 support
+            # is discontinued, this code is not required.
+            if pvdc_id is None:
+                pvdc_href = pvdc_element.get('href')
+                pvdc_id = pvdc_href.split("/")[-1]
+
             pvdc_info = self.pks_cache.get_pvdc_info(pvdc_id)
             pks_info = self.pks_cache.get_pks_account_details(
                 org_name, pvdc_info.vc)

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -532,8 +532,12 @@ def get_vdc(client, vdc_name, org=None, org_name=None,
     """
     if org is None:
         org = get_org(client, org_name=org_name)
-    vdc = VDC(client, resource=org.get_vdc(vdc_name,
-              is_admin_operation=is_admin_operation))
+    resource = org.get_vdc(vdc_name, is_admin_operation=is_admin_operation)
+    # TODO() org.get_vdc() should throw exception if vdc not found in the org.
+    # This should be handled in pyvcloud. For now, it is handled here.
+    if resource is None:
+        raise EntityNotFoundException(f"VDC '{vdc_name}' not found")
+    vdc = VDC(client, resource=resource)
     return vdc
 
 


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com

- Fix for extracting pvdc id from ProviderVdcReference

- ProviderVdcReference element in VDC object does not have 'id' attribute in VCD 9.1. But it is present in VCD 9.5. This fix extracts 'id' from 'href' attribute, if 'id' attribute is not found in VCD providerVdcReference.

- @sahithi @andrew-ni @harshneelmore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/259)
<!-- Reviewable:end -->
