### PR TITLE
[VCDA-877] Retain Vcd-User-Context in pks cluster management

### DIFF
--- a/container_service_extension/abstract_broker.py
+++ b/container_service_extension/abstract_broker.py
@@ -11,11 +11,7 @@ from container_service_extension.utils import get_server_runtime_config
 from container_service_extension.utils import get_vcd_sys_admin_client
 
 
-class AbstractBroker(abc.ABC):
-
-    def __init__(self, headers, request_body):
-        self.headers = headers
-        self.request_body = request_body
+class Broker(abc.ABC):
 
     @abc.abstractmethod
     def create_cluster(self):
@@ -25,7 +21,7 @@ class AbstractBroker(abc.ABC):
 
         :rtype: dict
         """
-        pass
+    pass
 
     @abc.abstractmethod
     def delete_cluster(self):
@@ -67,6 +63,15 @@ class AbstractBroker(abc.ABC):
         :rtype: dict
         """
         pass
+
+
+class AbstractBroker(Broker):
+
+    def __init__(self, headers, request_body):
+        self.headers = headers
+        self.request_body = request_body
+        self.client_session = None
+        self.tenant_client = None
 
     def get_tenant_client_session(self):
         """Return <Session> XML object of a logged in vCD user.

--- a/container_service_extension/broker_selector.py
+++ b/container_service_extension/broker_selector.py
@@ -7,6 +7,7 @@ from container_service_extension.broker import DefaultBroker
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.ovdc_cache import OvdcCache
 from container_service_extension.pksbroker import PKSBroker
+from container_service_extension.pksbroker import PKSBrokerAdapter
 
 
 def get_new_broker(headers, request_body):
@@ -32,8 +33,8 @@ def get_new_broker(headers, request_body):
             ovdc_name=ovdc_name, org_name=org_name, credentials_required=True)
         LOGGER.debug(f"ovdc metadata for {ovdc_name}-{org_name}=>{metadata}")
         if metadata.get('container_provider') == 'pks':
-            return PKSBroker(headers, request_body,
-                             ovdc_cache=metadata)
+            return PKSBrokerAdapter(PKSBroker(headers, request_body,
+                             ovdc_cache=metadata))
         else:
             return DefaultBroker(headers, request_body)
     else:


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- User isolation of pks cluster management on same pks account

- For a given user, all CRUD operations on pks cluster management should return the cluster(s) that
  belong to the user. Since there is no automatic isolation of clusters that belong to user, the adapter
  in this commit takes care of adding unique id to the cluster that are managed by the user. 
  Tested the code with manually with pksbroker.py for given cluster and user-id on CRUD operations. 
  Also, tested with vcd cse cluster create from end-to-end.

 @sahithi @sompa @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/261)
<!-- Reviewable:end -->
