### PR TITLE
VCDA-912: Revisit config validation checks to relax checks for additional keys

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -324,7 +324,7 @@ def get_validated_config(config_file_name):
 
     :rtype: dict
 
-    :raises KeyError: if config file has missing or extra properties.
+    :raises KeyError: if config file has missing properties.
     :raises ValueError: if the value type for a config file property
         is incorrect.
     :raises AmqpConnectionError: if AMQP connection failed.
@@ -334,8 +334,6 @@ def get_validated_config(config_file_name):
         config = yaml.safe_load(config_file)
     pks_config = config.get('pks_config')
     click.secho(f"Validating config file '{config_file_name}'", fg='yellow')
-    if 'pks_config' in config:
-        del config['pks_config']
     check_keys_and_value_types(config, SAMPLE_CONFIG,
                                location='config file')
     validate_amqp_config(config['amqp'])
@@ -345,24 +343,14 @@ def get_validated_config(config_file_name):
                                SAMPLE_SERVICE_CONFIG['service'],
                                location="config file 'service' section")
     click.secho(f"Config file '{config_file_name}' is valid", fg='green')
-    if isinstance(pks_config, str):
+    if pks_config is not None and isinstance(pks_config, str):
         check_file_permissions(pks_config)
         with open(pks_config) as f:
             pks = yaml.safe_load(f)
-        pks_proxies = dict()
-        if 'pks_accounts' in pks:
-            for i, account in enumerate(pks['pks_accounts']):
-                if 'proxy' in account:
-                    pks_proxies[account['name']] = account['proxy']
-                    del pks['pks_accounts'][i]['proxy']
         click.secho(f"Validating PKS config file '{pks_config}'", fg='yellow')
         check_keys_and_value_types(pks, SAMPLE_PKS_CONFIG,
                                    location='PKS config file')
         click.secho(f"PKS Config file '{pks_config}' is valid", fg='green')
-        for i, account_name in enumerate(pks_proxies):
-            if pks['pks_accounts'][i]['name'] == account_name:
-                pks['pks_accounts'][i]['proxy'] = \
-                    pks_proxies[account_name]
         config['pks_config'] = pks
     else:
         config['pks_config'] = None

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -250,7 +250,7 @@ def check_keys_and_value_types(dikt, ref_dict, location='dictionary'):
     :param str location: where this check is taking place, so error messages
         can be more descriptive.
 
-    :raises KeyError: if @dikt has missing or invalid keys
+    :raises KeyError: if @dikt has missing keys
     :raises ValueError: if the value of a property in @dikt does not match with
         the value of the same property in @ref_dict
     """
@@ -258,13 +258,9 @@ def check_keys_and_value_types(dikt, ref_dict, location='dictionary'):
     keys = set(dikt.keys())
 
     missing_keys = ref_keys - keys
-    invalid_keys = keys - ref_keys
 
     if missing_keys:
         click.secho(f"Missing keys in {location}: {missing_keys}", fg='red')
-    if invalid_keys:
-        click.secho(f"Invalid keys in {location}: {invalid_keys}", fg='red')
-
     bad_value = False
     for k in ref_keys:
         if k not in keys:
@@ -275,7 +271,7 @@ def check_keys_and_value_types(dikt, ref_dict, location='dictionary'):
                         f"'{_type_to_string[value_type]}'", fg='red')
             bad_value = True
 
-    if missing_keys or invalid_keys:
+    if missing_keys:
         raise KeyError(f"Missing and/or invalid key in {location}")
     if bad_value:
         raise ValueError(f"Incorrect type for property value(s) in {location}")

--- a/system_tests/test_cse_server.py
+++ b/system_tests/test_cse_server.py
@@ -169,20 +169,17 @@ def test_0030_cse_check(config):
     assert result.exit_code == 0
 
 
-def test_0040_config_invalid_keys(config):
-    """Test that config files with invalid/extra keys don't pass validation."""
+def test_0040_config_missing_keys(config):
+    """Test that config files with missing keys don't pass validation."""
     bad_key_config1 = testutils.yaml_to_dict(env.ACTIVE_CONFIG_FILEPATH)
     del bad_key_config1['amqp']
-    bad_key_config1['extra_section'] = True
 
     bad_key_config2 = testutils.yaml_to_dict(env.ACTIVE_CONFIG_FILEPATH)
     del bad_key_config2['vcs'][0]['username']
-    bad_key_config2['vcs'][0]['extra_property'] = 'a'
 
     bad_key_config3 = testutils.yaml_to_dict(env.ACTIVE_CONFIG_FILEPATH)
     del bad_key_config3['broker']['templates'][0]['mem']
     del bad_key_config3['broker']['templates'][0]['name']
-    bad_key_config3['broker']['templates'][0]['extra_property'] = 0
 
     configs = [
         bad_key_config1,


### PR DESCRIPTION


Signed-off-by: Sompa Malakar <malakars@vmware.com>

- This PR relaxes the validation checks for additional config keys in CSE.
Current CSE implementation mandates the check for both missing and invalid keys and fails if either of the keys are missing or there is presence of additional keys other than what is expected in the configs.
Since we anyway safe load the config file contents at the start of any other operation relating to configs, simply removing the invalid keys from  `check_keys_and_value_types` serves our purpose and relaxes the check for `pks_config` or developer/test mode keys like `proxy` or `test`.

- Manually tested the get_validated_config method to see that the check_keys_and_value_types skip additional keys added to the config (example in case : pks_config, proxy)

- @sahithi @sakthisunda @rocknes @harshneelmore @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/263)
<!-- Reviewable:end -->
