### PR TITLE
[VCDA-930] Set default org name for ovdc metadata operations for k8s

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -608,16 +608,10 @@ def ovdc_group(ctx):
 \b
     Note
        All sub-commands execute in the context of organization specified
-       via --org option; it defaults to current organization-in-use
-       if --org option is not specified.
+       via --org option.
 
 \b
     Examples
-        vcd cse ovdc enablek8s 'myOrgVdc' --container-provider pks
-        --pks-plans 'plan1,plan2'
-            Enable 'myOrgVdc' for k8s deployment on container-provider
-            PKS with plans 'plan1' and 'plan2'. If no --org-name is provided,
-            organization of the logged-in user is used to find 'myOrgVdc'.
 \b
         vcd cse ovdc enablek8s 'myOrgVdc' --container-provider pks
         --pks-plans 'plan1,plan2' --org 'myOrg'
@@ -630,10 +624,6 @@ def ovdc_group(ctx):
 \b
         vcd cse ovdc disablek8s 'myOrgVdc' --org 'myOrg'
             Disable 'myOrgVdc' that backs 'myOrg' for k8s deployment.
-\b
-        vcd cse ovdc disablek8s 'myOrgVdc'
-            Disable 'myOrgVdc' that backs organization of the logged-in user
-            for k8s deployment.
 \b
         vcd cse ovdc infok8s 'myOrgVdc' --org 'myOrg'
             Displays metadata information about 'myOrgVdc' that backs
@@ -665,7 +655,7 @@ def ovdc_group(ctx):
     '--org',
     'org_name',
     default=None,
-    required=False,
+    required=True,
     metavar='[org-name]',
     help="org name")
 def enablek8s(ctx, ovdc_name, container_provider, pks_plans, org_name):
@@ -698,7 +688,7 @@ def enablek8s(ctx, ovdc_name, container_provider, pks_plans, org_name):
     '--org',
     'org_name',
     default=None,
-    required=False,
+    required=True,
     metavar='[org-name]',
     help="org name")
 def disablek8s(ctx, ovdc_name, org_name):
@@ -724,7 +714,7 @@ def disablek8s(ctx, ovdc_name, org_name):
     '--org',
     'org_name',
     default=None,
-    required=False,
+    required=True,
     metavar='[org-name]',
     help="org name")
 def infok8s(ctx, ovdc_name, org_name):

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -608,10 +608,16 @@ def ovdc_group(ctx):
 \b
     Note
        All sub-commands execute in the context of organization specified
-       via --org option.
+       via --org option; it defaults to current organization-in-use
+       if --org option is not specified.
 
 \b
     Examples
+        vcd cse ovdc enablek8s 'myOrgVdc' --container-provider pks
+        --pks-plans 'plan1,plan2'
+            Enable 'myOrgVdc' for k8s deployment on container-provider
+            PKS with plans 'plan1' and 'plan2'. If no --org-name is provided,
+            organization of the logged-in user is used to find 'myOrgVdc'.
 \b
         vcd cse ovdc enablek8s 'myOrgVdc' --container-provider pks
         --pks-plans 'plan1,plan2' --org 'myOrg'
@@ -624,6 +630,10 @@ def ovdc_group(ctx):
 \b
         vcd cse ovdc disablek8s 'myOrgVdc' --org 'myOrg'
             Disable 'myOrgVdc' that backs 'myOrg' for k8s deployment.
+\b
+        vcd cse ovdc disablek8s 'myOrgVdc'
+            Disable 'myOrgVdc' that backs organization of the logged-in user
+            for k8s deployment.
 \b
         vcd cse ovdc infok8s 'myOrgVdc' --org 'myOrg'
             Displays metadata information about 'myOrgVdc' that backs
@@ -655,7 +665,7 @@ def ovdc_group(ctx):
     '--org',
     'org_name',
     default=None,
-    required=True,
+    required=False,
     metavar='[org-name]',
     help="org name")
 def enablek8s(ctx, ovdc_name, container_provider, pks_plans, org_name):
@@ -668,6 +678,8 @@ def enablek8s(ctx, ovdc_name, container_provider, pks_plans, org_name):
             client = ctx.obj['client']
             ovdc = Ovdc(client)
             if client.is_sysadmin():
+                if org_name is None:
+                    org_name = ctx.obj['profiles'].get('org_in_use')
                 result = ovdc.enable_ovdc_for_k8s(
                     ovdc_name,
                     container_provider=container_provider,
@@ -688,7 +700,7 @@ def enablek8s(ctx, ovdc_name, container_provider, pks_plans, org_name):
     '--org',
     'org_name',
     default=None,
-    required=True,
+    required=False,
     metavar='[org-name]',
     help="org name")
 def disablek8s(ctx, ovdc_name, org_name):
@@ -698,6 +710,8 @@ def disablek8s(ctx, ovdc_name, org_name):
         client = ctx.obj['client']
         if client.is_sysadmin():
             ovdc = Ovdc(client)
+            if org_name is None:
+                org_name = ctx.obj['profiles'].get('org_in_use')
             result = ovdc.disable_ovdc_for_k8s(ovdc_name, org_name=org_name)
             stdout(result, ctx)
         else:
@@ -714,7 +728,7 @@ def disablek8s(ctx, ovdc_name, org_name):
     '--org',
     'org_name',
     default=None,
-    required=True,
+    required=False,
     metavar='[org-name]',
     help="org name")
 def infok8s(ctx, ovdc_name, org_name):
@@ -724,6 +738,8 @@ def infok8s(ctx, ovdc_name, org_name):
         client = ctx.obj['client']
         if client.is_sysadmin():
             ovdc = Ovdc(client)
+            if org_name is None:
+                org_name = ctx.obj['profiles'].get('org_in_use')
             result = ovdc.info_ovdc_for_k8s(ovdc_name, org_name=org_name)
             stdout(result, ctx)
         else:


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

- Default org-name set for info/enable/disable ovdc

- This fixes the failing ovdc metada for k8s on not providing --org-name even though there is a
   valid org set using vcs org use <org-name>. Manual testing done.

@sahithi @sompa @rocknes @harshneelmore @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/265)
<!-- Reviewable:end -->
