### PR TITLE
[VCDA-946] Updated logic to check for presence of PKS/CSE right in vCD/System org.

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -10,7 +10,6 @@ from pyvcloud.vcd.api_extension import APIExtension
 from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.client import FenceMode
-from pyvcloud.vcd.exceptions import BadRequestException
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import MissingRecordException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
@@ -1159,7 +1158,7 @@ def register_right(client, right_name, description, category, bundle_key):
     org = Org(client, resource=client.get_org())
     try:
         right_name_in_vcd = f"{{{CSE_SERVICE_NAME}}}:{right_name}"
-        result = org.get_right_record(right_name_in_vcd)
+        org.get_right_record(right_name_in_vcd)
         msg = f"Right: {right_name} already exists in vCD"
         click.secho(msg, fg='green')
         LOGGER.debug(msg)
@@ -1179,7 +1178,9 @@ def register_right(client, right_name, description, category, bundle_key):
         click.secho(msg, fg='green')
         LOGGER.debug(msg)
         org.add_rights([right_name_in_vcd])
-    except EntityNotFoundException as e:
+    except EntityNotFoundException:
+        # registering a right via api extension end point auto assigns it to
+        # System org.
         ext.add_service_right(right_name, CSE_SERVICE_NAME,
                               CSE_SERVICE_NAMESPACE, description, category,
                               bundle_key)

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -1156,7 +1156,14 @@ def register_right(client, right_name, description, category, bundle_key):
         exists in vCD.
     """
     ext = APIExtension(client)
+    org = Org(client, resource=client.get_org())
     try:
+        right_name_in_vcd = f"{{{CSE_SERVICE_NAME}}}:{right_name}"
+        org.get_right_record(right_name_in_vcd)
+        msg = f"Right: {right_name} already exists in vCD"
+        click.secho(msg, fg='green')
+        LOGGER.debug(msg)
+    except EntityNotFoundException as e:
         ext.add_service_right(right_name, CSE_SERVICE_NAME,
                               CSE_SERVICE_NAMESPACE, description, category,
                               bundle_key)
@@ -1164,13 +1171,3 @@ def register_right(client, right_name, description, category, bundle_key):
         msg = f"Register {right_name} as a Right in vCD"
         click.secho(msg, fg='green')
         LOGGER.info(msg)
-    except BadRequestException as err:
-        # TODO() replace string matching logic to look for specific right
-        right_exists_msg = f'Right with name "{{{CSE_SERVICE_NAME}}}:' \
-                           f'{right_name}" already exists'
-        if right_exists_msg in str(err):
-            msg = f"Right: {right_name} already exists in vCD"
-            click.secho(msg, fg='green')
-            LOGGER.debug(msg)
-        else:
-            raise err


### PR DESCRIPTION
During CSE installation we always try to add the CSE/PKS rights and if the operation fails we look for a specific error message in the response body to infer that the right already exists in vCD. However the specific error message we are looking for is in English, which means any non English vCD installation will send us a response that will not match our criteria and the exception will leak out causing CSE installation to fail.

As a fix, we will get away from inferring the existence of the right via string matching on error messages, rather we will invoke vCD REST api to look for it directly. If the result comes back positive, we don't register the new rights, else we register them.

Also, it can be possible that the right is present in vCD but not granted to System org. Added logic to cover those cases too.

Testing done:
1. Ran cse install on an existing setup and checked the on screen messages to make sure that CSE is not trying to re-register the rights
2. Removed the rights from ssytem org via vcd-cli. Re-ran cse install command. The rights were assigned back to system org.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/267)
<!-- Reviewable:end -->
