### PR TITLE
[VCDA-877] Vcd-User-Context-In-Pks-Cluster-Management

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -133,9 +133,10 @@ class BrokerManager(object):
         Returns a tuple of (cluster and the broker instance used to find the
         cluster)
         """
+
         if self.is_ovdc_present_in_request:
             broker = self.get_broker_based_on_vdc()
-            return broker.get_cluster_info(cluster_name), broker
+            return broker.get_cluster_info(cluster_name=cluster_name), broker
         else:
             cluster, broker = self._find_cluster_in_org(cluster_name)
             if cluster is not None:
@@ -181,12 +182,12 @@ class BrokerManager(object):
 
     def _resize_cluster(self, cluster_name, node_count):
         broker = self._get_cluster_info(cluster_name)[1]
-        return broker.resize_cluster(name=cluster_name,
+        return broker.resize_cluster(cluster_name=cluster_name,
                                      num_worker_nodes=node_count)
 
     def _delete_cluster(self, cluster_name):
         broker = self._get_cluster_info(cluster_name)[1]
-        return broker.delete_cluster(cluster_name)
+        return broker.delete_cluster(cluster_name=cluster_name)
 
     def _create_cluster(self, **kwargs):
         cluster_name = kwargs['cluster_name']
@@ -219,10 +220,11 @@ class BrokerManager(object):
         for pks_ctx in pks_ctx_list:
             pksbroker = PKSBroker(self.headers, self.body, pks_ctx)
             try:
-                return pksbroker.get_cluster_info(cluster_name), pksbroker
+                return pksbroker.get_cluster_info(cluster_name=cluster_name),\
+                       pksbroker
             except Exception as err:
                 LOGGER.debug(f"Get cluster info on {cluster_name} failed "
-                             f"on {pks_ctx['host']} with error: {err}")
+                             f"on {pks_ctx['host']} with error: {err}")pks_ctx
                 pass
 
         return None, None

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -224,7 +224,7 @@ class BrokerManager(object):
                        pksbroker
             except Exception as err:
                 LOGGER.debug(f"Get cluster info on {cluster_name} failed "
-                             f"on {pks_ctx['host']} with error: {err}")pks_ctx
+                             f"on {pks_ctx['host']} with error: {err}")
                 pass
 
         return None, None

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -2,8 +2,10 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-
+import functools
 import json
+
+from pyvcloud.vcd.utils import extract_id
 
 from container_service_extension.abstract_broker import AbstractBroker
 from container_service_extension.exceptions import CseServerError
@@ -23,9 +25,69 @@ from container_service_extension.pksclient.models.compute_profile_request \
 from container_service_extension.pksclient.models.update_cluster_parameters\
     import UpdateClusterParameters
 from container_service_extension.uaaclient.uaaclient import UaaClient
-from container_service_extension.utils import ACCEPTED
 from container_service_extension.utils import exception_handler
 from container_service_extension.utils import OK
+
+
+def add_vcd_user_context(qualify_params=['cluster_name'],
+                         filter_list_by_user_id=False):
+    """Qualify cluster's name with the user's id who owns it.
+
+    And subsequently strip the id off before serving the result back
+    to client.
+
+    :param list qualify_params: params that need to be qualified with
+    user-id
+
+    :param bool filter_list_by_user_id: whether to filter the result list.
+
+    :return: results from the decorated function after post processing
+    """
+    def decorator(pks_function):
+        @functools.wraps(pks_function)
+        def wrapper(*args, **kwargs):
+
+            def get_user_id():
+                # Return user id associated with client-session
+                # arg[0] is represents 'self' which is instance of PKSBroker
+                broker_instance = args[0]
+                session = broker_instance.get_tenant_client_session()
+                return extract_id(session.get('userId'))
+
+            def strip_user_id(cluster_info):
+                is_user_id_stripped = False
+
+                if type(cluster_info) is not dict:
+                    return is_user_id_stripped
+
+                # Process every value from the cluster information
+                # Return true if any stripping happened
+                for key, val in cluster_info.items():
+                    if type(val) is str and user_id in val:
+                        cluster_info.update(
+                            {key: val.replace(f'-{user_id}', '')})
+                        is_user_id_stripped = True
+
+                return is_user_id_stripped
+
+            user_id = get_user_id()
+
+            for param in qualify_params:
+                if kwargs.get(param) is not None:
+                    kwargs[param] += f'-{user_id}'
+
+            result = pks_function(*args, **kwargs)
+
+            # Get updated result after filtering
+            if filter_list_by_user_id:
+                filtered_list = [cluster_dict for cluster_dict in result
+                                 if strip_user_id(cluster_dict)]
+                return filtered_list
+
+            strip_user_id(result)
+            return result
+        return wrapper
+    return decorator
 
 
 class PKSBroker(AbstractBroker):
@@ -54,6 +116,7 @@ class PKSBroker(AbstractBroker):
         self.compute_profile = pks_ctx.get(PKS_COMPUTE_PROFILE, None)
         self.verify = False  # TODO(pks.yaml) pks_config['pks']['verify']
         self.pks_client = self._get_pks_client()
+        self.client_session = None
 
     def _get_pks_config(self):
         """Connect to UAA server and construct PKS configuration.
@@ -92,8 +155,9 @@ class PKSBroker(AbstractBroker):
         self.pks_client = ApiClient(configuration=pks_config)
         return self.pks_client
 
+    @add_vcd_user_context(filter_list_by_user_id=True)
     def list_clusters(self):
-        """Get list of clusters ((TODO)for a given vCD user) in PKS environment.
+        """Get list of clusters in PKS environment.
 
         :return: a list of cluster-dictionaries
 
@@ -121,6 +185,7 @@ class PKSBroker(AbstractBroker):
                      f' list of clusters: {list_of_cluster_dicts}')
         return list_of_cluster_dicts
 
+    @add_vcd_user_context(qualify_params=['cluster_name'])
     def create_cluster(self, cluster_name, node_count, pks_plan, pks_ext_host,
                        compute_profile=None, **kwargs):
         """Create cluster in PKS environment.
@@ -168,7 +233,8 @@ class PKSBroker(AbstractBroker):
                      f' cluster: {cluster_name}')
         return cluster_dict
 
-    def get_cluster_info(self, name):
+    @add_vcd_user_context(qualify_params=['cluster_name'])
+    def get_cluster_info(self, cluster_name):
         """Get the details of a cluster with a given name in PKS environment.
 
         :param str name: Name of the cluster
@@ -179,19 +245,20 @@ class PKSBroker(AbstractBroker):
         cluster_api = ClusterApi(api_client=self.pks_client)
 
         LOGGER.debug(f'Sending request to PKS: {self.pks_host_uri} to get '
-                     f'details of cluster with name: {name}')
+                     f'details of cluster with name: {cluster_name}')
 
-        cluster = cluster_api.get_cluster(cluster_name=name)
+        cluster = cluster_api.get_cluster(cluster_name=cluster_name)
         cluster_dict = cluster.to_dict()
         cluster_params_dict = cluster_dict.pop('parameters')
         cluster_dict.update(cluster_params_dict)
 
         LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} on '
-                     f'cluster: {name} with details: {cluster_dict}')
+                     f'cluster: {cluster_name} with details: {cluster_dict}')
 
         return cluster_dict
 
-    def delete_cluster(self, name):
+    @add_vcd_user_context(qualify_params=['cluster_name'])
+    def delete_cluster(self, cluster_name):
         """Delete the cluster with a given name in PKS environment.
 
         :param str name: Name of the cluster
@@ -199,16 +266,17 @@ class PKSBroker(AbstractBroker):
         cluster_api = ClusterApi(api_client=self.pks_client)
 
         LOGGER.debug(f'Sending request to PKS: {self.pks_host_uri} to delete '
-                     f'the cluster with name: {name}')
+                     f'the cluster with name: {cluster_name}')
 
-        cluster_api.delete_cluster(cluster_name=name)
+        cluster_api.delete_cluster(cluster_name=cluster_name)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to delete'
-                     f' the cluster: {name}')
+                     f' the cluster: {cluster_name}')
         return
 
     @exception_handler
-    def resize_cluster(self, name, num_worker_nodes):
+    @add_vcd_user_context(qualify_params=['cluster_name'])
+    def resize_cluster(self, cluster_name, num_worker_nodes):
         """Resize the cluster of a given name to given number of worker nodes.
 
         :param str name: Name of the cluster
@@ -218,15 +286,15 @@ class PKSBroker(AbstractBroker):
         cluster_api = ClusterApi(api_client=self.pks_client)
 
         LOGGER.debug(f'Sending request to PKS:{self.pks_host_uri} to resize '
-                     f'the cluster with name: {name} to '
+                     f'the cluster with name: {cluster_name} to '
                      f'{num_worker_nodes} worker nodes')
 
         resize_params = UpdateClusterParameters(
             kubernetes_worker_instances=num_worker_nodes)
-        cluster_api.update_cluster(name, body=resize_params)
+        cluster_api.update_cluster(cluster_name, body=resize_params)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to resize'
-                     f' the cluster: {name}')
+                     f' the cluster: {cluster_name}')
         return
 
     @exception_handler

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+from collections import Iterable
 import functools
 import json
 
@@ -31,7 +32,7 @@ from container_service_extension.utils import OK
 
 def add_vcd_user_context(qualify_params=['cluster_name'],
                          filter_list_by_user_id=False):
-    """Qualify cluster's name with the user's id who owns it.
+    """Qualify the values of parameters passed in qualify_params with user_id.
 
     And subsequently strip the id off before serving the result back
     to client.
@@ -55,6 +56,10 @@ def add_vcd_user_context(qualify_params=['cluster_name'],
                 return extract_id(session.get('userId'))
 
             def strip_user_id(cluster_info):
+                # NOTE: Current implementation works only if the method
+                # argument is a dict item. Any change in the requirement needs
+                # this logic to be revisited
+
                 is_user_id_stripped = False
 
                 if type(cluster_info) is not dict:
@@ -79,7 +84,7 @@ def add_vcd_user_context(qualify_params=['cluster_name'],
             result = pks_function(*args, **kwargs)
 
             # Get updated result after filtering
-            if filter_list_by_user_id:
+            if filter_list_by_user_id and isinstance(result, Iterable):
                 filtered_list = [cluster_dict for cluster_dict in result
                                  if strip_user_id(cluster_dict)]
                 return filtered_list

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -507,11 +507,11 @@ class VcdBroker(AbstractBroker, threading.Thread):
             self._disconnect_sys_admin()
 
     @secure(required_rights=[CSE_NATIVE_DEPLOY_RIGHT_NAME])
-    def delete_cluster(self, name):
+    def delete_cluster(self, cluster_name):
 
-        LOGGER.debug(f"About to delete cluster with name: {name}")
+        LOGGER.debug(f"About to delete cluster with name: {cluster_name}")
 
-        self.cluster_name = name
+        self.cluster_name = cluster_name
         self._connect_tenant()
         self._connect_sys_admin()
         self.op = OP_DELETE_CLUSTER


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

-  Retains user level cluster context in PKS cluster management

-  PKS cluster management allows multiple users to manage clusters with same service account. This
    by default, allow an user to see other users's cluster information who are sharing the 
    service account.

    In this pull request, changes are made to allow user level isolation of cluster management by doing
    pre and post processing of cluster information to make them unique to the user doing the cluster 
    operation. Manual testing completed for CRUD operations 

@sahithi @rocknes @sompa @andrew-ni @harsh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/269)
<!-- Reviewable:end -->
