### PR TITLE
[VCDA-930] Create-compute-profile-while-enabling-ovdc

### DIFF
--- a/container_service_extension/ovdc_cache.py
+++ b/container_service_extension/ovdc_cache.py
@@ -71,7 +71,7 @@ class OvdcCache(object):
         pks_ctx[PKS_PLANS] = '' if pks_plans is None else pks_plans
         return pks_ctx
 
-    def get_ovdc_container_provider_metadata(self, ovdc_name,
+    def get_ovdc_container_provider_metadata(self, ovdc_name=None,
                                              ovdc_id=None, org_name=None,
                                              credentials_required=False):
         """Get metadata of given ovdc, pertaining to the container provider.
@@ -90,12 +90,7 @@ class OvdcCache(object):
         :raises EntityNotFoundException: if the ovdc could not be found.
         """
         # Get pvdc and pks information from oVdc metadata
-        if ovdc_id is None:
-            ovdc = get_vdc(self.client, ovdc_name, org_name=org_name,
-                           is_admin_operation=True)
-        else:
-            # TODO() - Implement this in pyvcloud
-            ovdc = self._get_vdc_by_id(ovdc_id)
+        ovdc = self.get_ovdc(ovdc_name, ovdc_id, org_name)
 
         all_metadata = utils.metadata_to_dict(ovdc.get_all_metadata())
 
@@ -112,7 +107,7 @@ class OvdcCache(object):
                         for metadata_key in self.pks_cache.get_pks_keys()}
 
             # Get the credentials from PksCache
-            pvdc_id = self._get_pvdc_id(ovdc)
+            pvdc_id = self.get_pvdc_id(ovdc)
             pvdc_info = self.pks_cache.get_pvdc_info(pvdc_id)
             metadata[PKS_PLANS] = metadata[PKS_PLANS].split(',')
             if credentials_required:
@@ -124,48 +119,29 @@ class OvdcCache(object):
         ctr_prov_details[CONTAINER_PROVIDER] = container_provider
         return ctr_prov_details
 
-    def set_ovdc_container_provider_metadata(self, ovdc_name, ovdc_id=None,
-                                             org_name=None,
-                                             container_provider=None,
-                                             pks_plans=''):
+    def set_ovdc_container_provider_metadata(self,
+                                             ovdc,
+                                             container_prov_data=None,
+                                             container_provider=None):
         """Set the container provider metadata of given ovdc.
 
-        :param str ovdc_name: name of the ovdc
-        :param str ovdc_id: unique id of the ovdc
-        :param str org_name: specific org to use if @org is not given.
-            If None, uses currently logged-in org from @client.
+        :param resource ovdc: vdc resource
+        :param dict container_prov_data: container provider context details
         :param str container_provider: name of container provider for which
             the ovdc is being enabled to deploy k8 clusters on.
-        :param str pks_plans: PKS plans for deployment. If container provider
-            is vCD or None, pks_plans are not applicable.
         """
-        metadata = dict()
-        org = get_org(self.client, org_name=org_name)
-        if ovdc_id is None:
-            ovdc = get_vdc(self.client, ovdc_name, org=org,
-                           is_admin_operation=True)
-            ovdc_id = utils.extract_id(ovdc.resource.get('id'))
-        else:
-            ovdc = self._get_vdc_by_id(ovdc_id)
-
+        ovdc_name = ovdc.resource.get('name')
+        metadata = {}
         if container_provider != CtrProvType.PKS.value:
-            LOGGER.debug(f'Remove metadata for ovdc:{ovdc_name}')
+            LOGGER.debug(f"Remove metadata for ovdc:{ovdc_name}")
             self._remove_metadata(ovdc, self.pks_cache.get_pks_keys())
             metadata[CONTAINER_PROVIDER] = container_provider or ''
+            LOGGER.debug(f'metadata for{container_provider}:{metadata}')
         else:
-            # Get pvdc and pks information from pks cache
-            org_name = org.resource.get('name')
-            pvdc_id = self._get_pvdc_id(ovdc)
-            pvdc_info = self.pks_cache.get_pvdc_info(pvdc_id)
-            pks_info = self.pks_cache.get_pks_account_details(
-                org_name, pvdc_info.vc)
+            container_prov_data.pop('username')
+            container_prov_data.pop('secret')
             metadata[CONTAINER_PROVIDER] = container_provider
-            pks_compute_profile_name = f"{org_name}-{ovdc_name}-{ovdc_id}"
-            pks_ctx = self.construct_pks_context(pks_info, pvdc_info,
-                                                 pks_compute_profile_name,
-                                                 pks_plans,
-                                                 credentials_required=False)
-            metadata.update(pks_ctx)
+            metadata.update(container_prov_data)
 
         # set ovdc metadata into Vcd
         LOGGER.debug(f"Setting below metadata on ovdc {ovdc_name}:{metadata}")
@@ -178,14 +154,23 @@ class OvdcCache(object):
             if k in metadata:
                 ovdc.remove_metadata(k, domain=MetadataDomain.SYSTEM)
 
-    def _get_vdc_by_id(self, vdc_id):
+    def get_ovdc(self, ovdc_name=None, ovdc_id=None, org_name=None):
+
+        if ovdc_id is None:
+            org = get_org(self.client, org_name=org_name)
+            return get_vdc(self.client, ovdc_name, org=org,
+                           is_admin_operation=True)
+        else:
+            return self.get_vdc_by_id(ovdc_id)
+
+    def get_vdc_by_id(self, vdc_id):
         LOGGER.debug(f"Getting vdc by id:{vdc_id}")
         admin_href = self.client.get_admin().get('href')
         ovdc_href = f'{admin_href}vdc/{vdc_id}'
         resource = self.client.get_resource(ovdc_href)
         return VDC(self.client, resource=resource)
 
-    def _get_pvdc_id(self, ovdc):
+    def get_pvdc_id(self, ovdc):
         pvdc_element = ovdc.resource.ProviderVdcReference
         # To support <= VCD 9.1 where no 'id' is present in pvdc
         # element, it has to be extracted from href. Once VCD 9.1 support
@@ -197,5 +182,12 @@ class OvdcCache(object):
         else:
             pvdc_id = pvdc_element.get('id')
             return utils.extract_id(pvdc_id)
+
+    def get_compute_profile_name(self, ovdc_id, ovdc_name):
+        return f"cp--{ovdc_id}--{ovdc_name}"
+
+
+
+
 
 

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -330,7 +330,6 @@ class PKSBroker(AbstractBroker):
         result['status'] = ACCEPTED
         return result
 
-    @exception_handler
     def create_compute_profile(self, cp_name, az_name, description, cpi,
                                datacenter_name, cluster_name, ovdc_rp_name):
         """Create a PKS compute profile that maps to a given oVdc in vCD.

--- a/container_service_extension/processor.py
+++ b/container_service_extension/processor.py
@@ -105,9 +105,7 @@ class ServiceProcessor(object):
         if body['method'] == 'GET':
             if ovdc_info_request:
                 req_spec.update({'ovdc_id': ovdc_id})
-                broker = broker_manager.get_broker_based_on_vdc()
-                reply = broker.ovdc_info_for_kubernetes()
-
+                reply = broker_manager.invoke(Operation.INFO_OVDC)
             elif spec_request:
                 reply = self.get_spec(tokens[3])
             elif config_request:
@@ -153,8 +151,7 @@ class ServiceProcessor(object):
                     reply = broker.create_nodes()
         elif body['method'] == 'PUT':
             if ovdc_info_request:
-                broker = broker_manager.get_broker_based_on_vdc()
-                reply = broker.enable_ovdc_for_kubernetes()
+                reply = broker_manager.invoke(Operation.ENABLE_OVDC)
             elif system_request:
                 reply = service.update_status(req_headers, req_spec)
             else:

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -41,7 +41,6 @@ from container_service_extension.exceptions import NFSNodeCreationError
 from container_service_extension.exceptions import NodeCreationError
 from container_service_extension.exceptions import WorkerNodeCreationError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
-from container_service_extension.ovdc_cache import OvdcCache
 from container_service_extension.server_constants import \
     CSE_NATIVE_DEPLOY_RIGHT_NAME
 from container_service_extension.utils import ACCEPTED
@@ -765,61 +764,6 @@ class VcdBroker(AbstractBroker, threading.Thread):
                 stack_trace=stack_trace)
         finally:
             self._disconnect_sys_admin()
-
-    @exception_handler
-    def enable_ovdc_for_kubernetes(self):
-        """Enable ovdc for k8-cluster deployment on given container provider.
-
-        :return: result object
-
-        :rtype: dict
-
-        :raises CseServerError: if the user is not system administrator.
-        """
-        result = dict()
-        self._connect_tenant()
-        if self.tenant_client.is_sysadmin():
-            ovdc_cache = OvdcCache(self.tenant_client)
-            task = ovdc_cache.set_ovdc_container_provider_metadata(
-                self.req_spec['ovdc_name'],
-                ovdc_id=self.req_spec.get('ovdc_id', None),
-                container_provider=
-                self.req_spec.get('container_provider', None),
-                pks_plans=self.req_spec['pks_plans'],
-                org_name=self.req_spec.get('org_name', None))
-            response_body = dict()
-            response_body['ovdc_name'] = self.req_spec['ovdc_name']
-            response_body['task_href'] = task.get('href')
-            result['body'] = response_body
-            result['status_code'] = ACCEPTED
-            return result
-        else:
-            raise CseServerError("Unauthorized Operation")
-
-    @exception_handler
-    def ovdc_info_for_kubernetes(self):
-        """Info on ovdc for k8s deployment on the given container provider.
-
-        :return: result object
-
-        :rtype: dict
-
-        :raises CseServerError: if the user is not system administrator.
-        """
-        result = dict()
-        self._connect_tenant()
-        if self.tenant_client.is_sysadmin():
-            ovdc_cache = OvdcCache(self.tenant_client)
-            metadata = ovdc_cache.get_ovdc_container_provider_metadata(
-                self.req_spec.get('ovdc_name', None),
-                ovdc_id=self.req_spec.get('ovdc_id', None),
-                org_name=self.req_spec.get('org_name', None))
-            result = dict()
-            result['status_code'] = OK
-            result['body'] = metadata
-            return result
-        else:
-            raise CseServerError("Unauthorized Operation")
 
     def node_rollback(self, node_list):
         """Rollback for node creation failure.


### PR DESCRIPTION

- PKS compute profile creation while enabling ovdc for k8s

- When container provider is 'pks', creating compute profile is also required as part of enabling ovdc for k8s. This commit includes all the changes that are necessary to create compute profile. Manual testing completed a) create new profile b) create the same profile when it already exists; this should not stop enabling ovdc parameters. 

@sahithi  @sompa @rocknes @andrew-ni @harshneelmore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/274)
<!-- Reviewable:end -->
