### PR TITLE
vCDA-927: Resize cluster command; Exception handling of PksBroker; Refactoring

### DIFF
--- a/container_service_extension/abstract_broker.py
+++ b/container_service_extension/abstract_broker.py
@@ -13,9 +13,9 @@ from container_service_extension.utils import get_vcd_sys_admin_client
 
 class AbstractBroker(abc.ABC):
 
-    def __init__(self, headers, request_body):
-        self.headers = headers
-        self.request_body = request_body
+    def __init__(self, request_headers, request_spec):
+        self.req_headers = request_headers
+        self.req_spec = request_spec
 
     @abc.abstractmethod
     def create_cluster(self):
@@ -86,7 +86,7 @@ class AbstractBroker(abc.ABC):
         verify = server_config['vcd']['verify']
         self.tenant_client, self.client_session = connect_vcd_user_via_token(
             vcd_uri=host,
-            headers=self.headers,
+            headers=self.req_headers,
             verify_ssl_certs=verify)
         self.tenant_info = {
             'user_name': self.client_session.get('user'),

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -57,7 +57,7 @@ class BrokerManager(object):
 
 
     @exception_handler
-    def invoke(self, op, on_the_fly_request_body=None):
+    def invoke(self, op, on_the_fly_request_spec=None):
         """Invoke right broker(s) to perform the operation requested and do
         further (pre/post)processing on the request/result(s) if required.
 
@@ -69,7 +69,7 @@ class BrokerManager(object):
         4. Construct and return the HTTP response
 
         :param Operation op: Operation to be performed by one of the brokers.
-        :param dict on_the_fly_request_body: body constructed by processor.
+        :param dict on_the_fly_request_spec: body constructed by processor.
 
         :return result: HTTP response
 
@@ -79,8 +79,8 @@ class BrokerManager(object):
         result['body'] = []
         result['status_code'] = OK
 
-        if on_the_fly_request_body:
-            self.req_spec.update(on_the_fly_request_body)
+        if on_the_fly_request_spec:
+            self.req_spec.update(on_the_fly_request_spec)
 
         self.is_ovdc_present_in_request = self.req_spec.get('vdc', None) or \
                                           self.req_qparams.get('vdc', None)
@@ -171,7 +171,8 @@ class BrokerManager(object):
             pks_clusters = []
             pks_ctx_list = self._get_all_pks_accounts_in_org()
             for pks_ctx in pks_ctx_list:
-                pks_broker = PKSBroker(self.req_headers, self.req_spec, pks_ctx)
+                pks_broker = PKSBroker(self.req_headers, self.req_spec,
+                                       pks_ctx)
                 for cluster in pks_broker.list_clusters():
                     pks_cluster = {k: cluster.get(k, None) for k in
                                    common_cluster_properties}
@@ -280,20 +281,21 @@ class BrokerManager(object):
 
         return pks_ctx_dict.values()
 
-    def get_broker_based_on_vdc(self, on_the_fly_request_body=None):
+    def get_broker_based_on_vdc(self, on_the_fly_request_spec=None):
         """Gets the broker based on ovdc.
 
-        :param on_the_fly_request_body: New or modified HTTP request body by
+        :param on_the_fly_request_spec: New or modified HTTP request body by
         CSE {container_service_extension.processor.ServiceProcessor}
         :return: broker
 
         :rtype: container_service_extension.abstract_broker.AbstractBroker
         """
 
-        if on_the_fly_request_body:
-            self.req_spec.update(on_the_fly_request_body)
+        if on_the_fly_request_spec:
+            self.req_spec.update(on_the_fly_request_spec)
 
-        ovdc_name = self.req_spec.get('vdc', None) or self.req_qparams.get('vdc', None)
+        ovdc_name = self.req_spec.get('vdc', None) or \
+                    self.req_qparams.get('vdc', None)
         org_name = self.session.get('org')
         LOGGER.debug(f"org_name={org_name};vdc_name=\'{ovdc_name}\'")
 

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -253,6 +253,9 @@ class BrokerManager(object):
 
         :return:
         """
+        if self.pks_cache is None:
+            return []
+
         if self.vcd_client.is_sysadmin():
             pks_acc_list = self.pks_cache.get_all_pks_accounts_in_system()
             pks_ctx_list = [OvdcCache.construct_pks_context(

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -82,6 +82,9 @@ class BrokerManager(object):
         if on_the_fly_request_body:
             self.body.update(on_the_fly_request_body)
 
+        self.is_ovdc_present_in_request = self.body.get('vdc', None) or \
+                                          self.params.get('vdc', None)
+
         if op == Operation.GET_CLUSTER:
             result['body'] = \
                 self._get_cluster_info(self.body['cluster_name'])[0]
@@ -129,11 +132,7 @@ class BrokerManager(object):
         Returns a tuple of (cluster and the broker instance used to find the
         cluster)
         """
-        vdc = self.params.get('vdc', None)
-        print(f'vdc: {vdc}')
-        is_ovdc_present_in_request = self.body.get('vdc', None) or self.params.get('vdc', None)
-        if is_ovdc_present_in_request:
-            print('inside ovdc blcok')
+        if self.is_ovdc_present_in_request:
             broker = self.get_broker_based_on_vdc()
             return broker.get_cluster_info(cluster_name), broker
         else:
@@ -155,8 +154,7 @@ class BrokerManager(object):
             Post-process the result returned by each broker.
             Aggregate all the results into one.
         """
-        is_ovdc_present_in_request = self.body.get('vdc', None) or self.params.get('vdc', None)
-        if is_ovdc_present_in_request:
+        if self.is_ovdc_present_in_request:
             broker = self.get_broker_based_on_vdc()
             return broker.list_clusters()
         else:

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -64,7 +64,7 @@ class BrokerManager(object):
 
 
     @exception_handler
-    def invoke(self, op, on_the_fly_request_spec=None):
+    def invoke(self, op):
         """Invoke right broker(s) to perform the operation requested and do
         further (pre/post)processing on the request/result(s) if required.
 
@@ -76,7 +76,6 @@ class BrokerManager(object):
         4. Construct and return the HTTP response
 
         :param Operation op: Operation to be performed by one of the brokers.
-        :param dict on_the_fly_request_spec: body constructed by processor.
 
         :return result: HTTP response
 
@@ -85,9 +84,6 @@ class BrokerManager(object):
         result = {}
         result['body'] = []
         result['status_code'] = OK
-
-        if on_the_fly_request_spec:
-            self.req_spec.update(on_the_fly_request_spec)
 
         self.is_ovdc_present_in_request = self.req_spec.get('vdc', None) or \
                                           self.req_qparams.get('vdc', None)
@@ -300,19 +296,13 @@ class BrokerManager(object):
 
         return pks_ctx_dict.values()
 
-    def get_broker_based_on_vdc(self, on_the_fly_request_spec=None):
+    def get_broker_based_on_vdc(self):
         """Get the broker based on ovdc.
 
-        :param on_the_fly_request_spec: New or modified HTTP request body by
-        CSE {container_service_extension.processor.ServiceProcessor}
         :return: broker
 
         :rtype: container_service_extension.abstract_broker.AbstractBroker
         """
-
-        if on_the_fly_request_spec:
-            self.req_spec.update(on_the_fly_request_spec)
-
         ovdc_name = self.req_spec.get('vdc', None) or \
                     self.req_qparams.get('vdc', None)
         org_name = self.session.get('org')

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -105,7 +105,7 @@ class BrokerManager(object):
             result['status_code'] = ACCEPTED
         elif op == Operation.RESIZE_CLUSTER:
             # TODO(resize_cluster) Once VcdBroker.create_nodes() is hooked to
-            #  broker_manager, ensure vcdbroker.resize_cluster returns only
+            #  broker_manager, ensure broker.resize_cluster returns only
             #  response body. Construct the remainder of the response here.
             #  This cannot be done at the moment as @exception_handler cannot
             #  be removed on create_nodes() as of today (Mar 15, 2019).

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -87,12 +87,14 @@ class BrokerManager(object):
                                           self.req_qparams.get('vdc', None)
 
         if op == Operation.GET_CLUSTER:
-            cluster_spec = {'cluster_name': self.req_spec.get('name', None)}
+            cluster_spec = \
+                {'cluster_name': self.req_spec.get('cluster_name', None)}
             result['body'] = self._get_cluster_info(**cluster_spec)[0]
         elif op == Operation.LIST_CLUSTERS:
             result['body'] = self._list_clusters()
         elif op == Operation.DELETE_CLUSTER:
-            cluster_spec = {'cluster_name': self.req_spec.get('name', None)}
+            cluster_spec = \
+                {'cluster_name': self.req_spec.get('cluster_name', None)}
             self._delete_cluster(**cluster_spec)
             result['status_code'] = ACCEPTED
         elif op == Operation.RESIZE_CLUSTER:
@@ -101,9 +103,10 @@ class BrokerManager(object):
             #  response body. Construct the remainder of the response here.
             #  This cannot be done at the moment as @exception_handler cannot
             #  be removed on create_nodes() as of today (Mar 15, 2019).
-            cluster_spec = {'cluster_name': self.req_spec.get('name', None),
-                            'node_count': self.req_spec.get('node_count', None)
-                            }
+            cluster_spec = \
+                {'cluster_name': self.req_spec.get('cluster_name', None),
+                 'node_count': self.req_spec.get('node_count', None)
+                 }
             result = self._resize_cluster(**cluster_spec)
         elif op == Operation.CREATE_CLUSTER:
             # TODO(ClusterSpec) Create an inner class "ClusterSpec"
@@ -112,7 +115,8 @@ class BrokerManager(object):
             #  Method 'Create_cluster' in VcdBroker and PksBroker should take
             #  ClusterSpec either as a param (or)
             #  read from instance variable (if needed only).
-            cluster_spec = {'cluster_name': self.req_spec.get('name', None),
+            cluster_spec = {'cluster_name':
+                                self.req_spec.get('cluster_name', None),
                             'vdc_name': self.req_spec.get('vdc', None),
                             'node_count':
                                 self.req_spec.get('node_count', None),
@@ -290,7 +294,7 @@ class BrokerManager(object):
         return pks_ctx_dict.values()
 
     def get_broker_based_on_vdc(self, on_the_fly_request_spec=None):
-        """Gets the broker based on ovdc.
+        """Get the broker based on ovdc.
 
         :param on_the_fly_request_spec: New or modified HTTP request body by
         CSE {container_service_extension.processor.ServiceProcessor}

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -229,7 +229,6 @@ class BrokerManager(object):
         except Exception as err:
             LOGGER.debug(f"Get cluster info on {cluster_name} failed "
                          f"on vCD with error: {err}")
-            pass
 
         pks_ctx_list = self._get_all_pks_accounts_in_org()
         for pks_ctx in pks_ctx_list:
@@ -240,7 +239,6 @@ class BrokerManager(object):
             except Exception as err:
                 LOGGER.debug(f"Get cluster info on {cluster_name} failed "
                              f"on {pks_ctx['host']} with error: {err}")
-                pass
 
         return None, None
 

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -42,6 +42,12 @@ class Operation(Enum):
 
 
 class BrokerManager(object):
+    """Manage calls to vCD and PKS brokers.
+
+    Handles:
+    Pre-processing of requests to brokers
+    Post-processing of results from brokers.
+    """
     def __init__(self, request_headers, request_query_params, request_spec):
         self.req_headers = request_headers
         self.req_qparams = request_query_params

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -43,7 +43,7 @@ class Cluster(object):
             auth=None)
         return process_response(response)
 
-    def get_cluster_info(self, name):
+    def get_cluster_info(self, name, vdc):
         method = 'GET'
         uri = '%s/%s/info' % (self._uri, name)
         response = self.client._do_request_prim(
@@ -53,7 +53,8 @@ class Cluster(object):
             contents=None,
             media_type=None,
             accept_type='application/*+json',
-            auth=None)
+            auth=None,
+            params={'vdc': vdc} if vdc else None)
         try:
             result = process_response(response)
         except VcdResponseError as e:
@@ -125,14 +126,15 @@ class Cluster(object):
             accept_type='application/*+json')
         return process_response(response)
 
-    def delete_cluster(self, cluster_name):
+    def delete_cluster(self, cluster_name, vdc):
         method = 'DELETE'
         uri = '%s/%s' % (self._uri, cluster_name)
         response = self.client._do_request_prim(
             method,
             uri,
             self.client._session,
-            accept_type='application/*+json')
+            accept_type='application/*+json',
+            params={'vdc': vdc} if vdc else None)
         try:
             result = process_response(response)
         except VcdResponseError as e:

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -133,10 +133,11 @@ class Cluster(object):
                        node_count=1,
                        disable_rollback=True):
         method = 'PUT'
-        uri = f"{self.uri}/{cluster_name}"
+        uri = f"{self._uri}/{cluster_name}"
         data = {
             'name': cluster_name,
             'node_count': node_count,
+            'node_type': TYPE_NODE,
             'vdc': vdc,
             'network': network_name,
             'disable_rollback': disable_rollback

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -147,8 +147,8 @@ class Cluster(object):
             uri,
             self.client._session,
             contents=data,
-            media_type=None,
-            accept_type='application/*+json')
+            media_type='application/json',
+            accept_type='application/json')
         return process_response(response)
 
     def delete_cluster(self, cluster_name, vdc):

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -126,6 +126,30 @@ class Cluster(object):
             accept_type='application/*+json')
         return process_response(response)
 
+    def resize_cluster(self,
+                       vdc,
+                       network_name,
+                       cluster_name,
+                       node_count=1,
+                       disable_rollback=True):
+        method = 'PUT'
+        uri = f"{self.uri}/{cluster_name}"
+        data = {
+            'name': cluster_name,
+            'node_count': node_count,
+            'vdc': vdc,
+            'network': network_name,
+            'disable_rollback': disable_rollback
+        }
+        response = self.client._do_request_prim(
+            method,
+            uri,
+            self.client._session,
+            contents=data,
+            media_type=None,
+            accept_type='application/*+json')
+        return process_response(response)
+
     def delete_cluster(self, cluster_name, vdc):
         method = 'DELETE'
         uri = '%s/%s' % (self._uri, cluster_name)

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -282,7 +282,8 @@ def create(ctx, name, node_count, cpu, memory, network_name, storage_profile,
     except Exception as e:
         stderr(e, ctx)
 
-@cluster_group.command(short_help='create cluster')
+
+@cluster_group.command(short_help='resize cluster')
 @click.pass_context
 @click.argument('name', required=True)
 @click.option(
@@ -298,7 +299,7 @@ def create(ctx, name, node_count, cpu, memory, network_name, storage_profile,
     '--network',
     'network_name',
     default=None,
-    required=True,
+    required=False,
     help='Network name')
 @click.option(
     '--disable-rollback',

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -176,6 +176,9 @@ def delete(ctx, name, vdc):
         client = ctx.obj['client']
         cluster = Cluster(client)
         result = cluster.delete_cluster(name, vdc)
+        # result is empty for delete cluster operation on PKS-managed clusters.
+        # In that specific case, below check helps to print out a meaningful
+        # message to users.
         if len(result) == 0:
             click.secho(f"Delete cluster operation has been initiated on "
                         f"{name}, please check the status using"

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -65,6 +65,11 @@ def cluster_group(ctx):
         vcd cse cluster delete mycluster --yes
             Attempts to delete cluster 'mycluster' without prompting.
 \b
+        vcd cse cluster delete mycluster -vdc myOvdc
+            Deletes cluster residing in vdc 'myOvdc'. Specifying optional
+            param --vdc lets CSE server to efficiently locate and
+            delete the cluster.
+\b
         vcd cse cluster create mycluster -n mynetwork
             Attempts to create a Kubernetes cluster named 'mycluster'
             with 2 worker nodes in the current VDC. This cluster will be
@@ -87,6 +92,11 @@ def cluster_group(ctx):
 \b
         vcd cse cluster info mycluster
             Display detailed information about cluster named 'mycluster'.
+\b
+        vcd cse cluster info mycluster --vdc myOvdc
+            Display detailed information on cluster 'mycluster', which is
+            residing in vdc 'myOvdc'. Specifying optional param --vdc
+            lets CSE server to efficiently locate the cluster.
     """
     pass
 
@@ -168,7 +178,8 @@ def delete(ctx, name, vdc):
         result = cluster.delete_cluster(name, vdc)
         if len(result) == 0:
             click.secho(f"Delete cluster operation has been initiated on "
-                        f"{name}, please check the status using 'vcd cse cluster info {name}'.")
+                        f"{name}, please check the status using"
+                        f" 'vcd cse cluster info {name}'.", fg='yellow')
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -90,6 +90,11 @@ def cluster_group(ctx):
              range of locating the cluster to 'myOvdc' only (improves
              turnaround time of the command).
 \b
+        vcd cse cluster resize mycluster -N 10 --disable-rollback
+            Attempts to resize the cluster size to 10 worker nodes. On any
+            failure of creation of nodes, it leaves the nodes as-is in an error
+            state for admins to troubleshoot.
+\b
         vcd cse cluster delete mycluster --yes
             Attempts to delete cluster 'mycluster' without prompting.
 \b
@@ -331,7 +336,8 @@ def create(ctx, name, node_count, cpu, memory, network_name, storage_profile,
     is_flag=True,
     required=False,
     default=True,
-    help='Disable rollback for node (applicable only for vCD-powered clusters')
+    help='Disable rollback for failed node creation '
+         '(applicable only for vCD-powered clusters')
 def resize(ctx, name, node_count, network_name, vdc, disable_rollback):
     """Resize the cluster to specified worker node count.
 

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -89,7 +89,6 @@ def cluster_group(ctx):
              optional param --vdc forces CSE server to narrow down the search
              range of locating the cluster to 'myOvdc' only (improves
              turnaround time of the command).
-
 \b
         vcd cse cluster delete mycluster --yes
             Attempts to delete cluster 'mycluster' without prompting.

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -303,7 +303,8 @@ def create(ctx, name, node_count, cpu, memory, network_name, storage_profile,
     'network_name',
     default=None,
     required=False,
-    help='Network name')
+    help='Network name (mandatory for vCD-powered clusters; '
+         'optional for PKS-powered clusters')
 @click.option(
     '--disable-rollback',
     'disable_rollback',

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -146,19 +146,29 @@ def list_clusters(ctx):
 @click.pass_context
 @click.argument('name', required=True)
 @click.option(
+    '-v',
+    '--vdc',
+    'vdc',
+    required=False,
+    default=None,
+    help='Name of the virtual datacenter')
+@click.option(
     '-y',
     '--yes',
     is_flag=True,
     callback=abort_if_false,
     expose_value=False,
     prompt='Are you sure you want to delete the cluster?')
-def delete(ctx, name):
+def delete(ctx, name, vdc):
     """Delete a Kubernetes cluster."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
-        result = cluster.delete_cluster(name)
+        result = cluster.delete_cluster(name, vdc)
+        if len(result) == 0:
+            click.secho(f"Delete cluster operation has been initiated on "
+                        f"{name}, please check the status using 'vcd cse cluster info {name}'.")
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)
@@ -286,13 +296,20 @@ def config(ctx, name, save):
 @cluster_group.command('info', short_help='get cluster info')
 @click.pass_context
 @click.argument('name', required=True)
-def cluster_info(ctx, name):
+@click.option(
+    '-v',
+    '--vdc',
+    'vdc',
+    required=False,
+    default=None,
+    help='Name of the virtual datacenter')
+def cluster_info(ctx, name, vdc):
     """Display info about a Kubernetes cluster."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
-        cluster_info = cluster.get_cluster_info(name)
+        cluster_info = cluster.get_cluster_info(name, vdc)
         stdout(cluster_info, ctx, show_id=True)
     except Exception as e:
         stderr(e, ctx)

--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -90,6 +90,15 @@ class VcdResponseError(Exception):
 class PksServerError(CseServerError):
     """Raised when error is received from PKS"""
 
+    def __init__(self, status, reason, body):
+        self.status = status
+        self.reason = reason
+        self.body = body
+
+    def __str__(self):
+        return f"PKS error\n status: {self.status}\n reason: {self.reason}\n" \
+            f" body: {self.body}"
+
 
 class PksConnectionError(PksServerError):
     """Raised when connection establishment to PKS fails"""

--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -90,14 +90,12 @@ class VcdResponseError(Exception):
 class PksServerError(CseServerError):
     """Raised when error is received from PKS"""
 
-    def __init__(self, status, reason, body):
+    def __init__(self, status, body):
         self.status = status
-        self.reason = reason
         self.body = body
 
     def __str__(self):
-        return f"PKS error\n status: {self.status}\n reason: {self.reason}\n" \
-            f" body: {self.body}"
+        return f"PKS error\n status: {self.status}\n body: {self.body}\n"
 
 
 class PksConnectionError(PksServerError):

--- a/container_service_extension/ovdc_cache.py
+++ b/container_service_extension/ovdc_cache.py
@@ -111,6 +111,7 @@ class OvdcCache(object):
             # Get the credentials from PksCache
             pvdc_element = ovdc.resource.ProviderVdcReference
             pvdc_id = pvdc_element.get('id')
+            pvdc_id = pvdc_id.split(':')[-1]
             pvdc_info = self.pks_cache.get_pvdc_info(pvdc_id)
             metadata[PKS_PLANS] = metadata[PKS_PLANS].split(',')
             if credentials_required:
@@ -155,6 +156,7 @@ class OvdcCache(object):
             org_name = org.resource.get('name')
             pvdc_element = ovdc.resource.ProviderVdcReference
             pvdc_id = pvdc_element.get('id')
+            pvdc_id = pvdc_id.split(':')[-1]
             # To support <= VCD 9.1 where no 'id' is present in pvdc
             # element, it has to be extracted from href. Once VCD 9.1 support
             # is discontinued, this code is not required.

--- a/container_service_extension/ovdc_cache.py
+++ b/container_service_extension/ovdc_cache.py
@@ -111,7 +111,6 @@ class OvdcCache(object):
             # Get the credentials from PksCache
             pvdc_element = ovdc.resource.ProviderVdcReference
             pvdc_id = pvdc_element.get('id')
-            pvdc_id = pvdc_id.split(':')[-1]
             pvdc_info = self.pks_cache.get_pvdc_info(pvdc_id)
             metadata[PKS_PLANS] = metadata[PKS_PLANS].split(',')
             if credentials_required:
@@ -156,7 +155,6 @@ class OvdcCache(object):
             org_name = org.resource.get('name')
             pvdc_element = ovdc.resource.ProviderVdcReference
             pvdc_id = pvdc_element.get('id')
-            pvdc_id = pvdc_id.split(':')[-1]
             # To support <= VCD 9.1 where no 'id' is present in pvdc
             # element, it has to be extracted from href. Once VCD 9.1 support
             # is discontinued, this code is not required.

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -107,6 +107,7 @@ class PKSBroker(AbstractBroker):
         try:
             clusters = cluster_api.list_clusters()
         except Exception as err:
+            LOGGER.debug(f'Listing PKS clusters failed with error:\n {err}')
             raise PksServerError(err.status, err.body)
 
         list_of_cluster_dicts = []
@@ -162,6 +163,8 @@ class PKSBroker(AbstractBroker):
         try:
             cluster = cluster_api.add_cluster(cluster_request)
         except Exception as err:
+            LOGGER.debug(f'Creating cluster {cluster_name} in PKS failed with '
+                         f'error:\n {err}')
             raise PksServerError(err.status, err.body)
         cluster_dict = cluster.to_dict()
         # Flattening the dictionary
@@ -187,6 +190,8 @@ class PKSBroker(AbstractBroker):
         try:
             cluster = cluster_api.get_cluster(cluster_name=cluster_name)
         except Exception as err:
+            LOGGER.debug(f'Getting cluster info on {cluster_name} failed with '
+                         f'error:\n {err}')
             raise PksServerError(err.status, err.body)
         cluster_dict = cluster.to_dict()
         cluster_params_dict = cluster_dict.pop('parameters')
@@ -209,6 +214,8 @@ class PKSBroker(AbstractBroker):
         try:
             cluster_api.delete_cluster(cluster_name=cluster_name)
         except Exception as err:
+            LOGGER.debug(f'Deleting cluster {cluster_name} failed with '
+                         f'error:\n {err}')
             raise PksServerError(err.status, err.body)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to delete'
@@ -233,6 +240,8 @@ class PKSBroker(AbstractBroker):
         try:
             cluster_api.update_cluster(cluster_name, body=resize_params)
         except Exception as err:
+            LOGGER.debug(f'Resizing cluster {cluster_name} failed with '
+                         f'error:\n {err}')
             raise PksServerError(err.status, err.body)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to resize'
@@ -299,6 +308,8 @@ class PKSBroker(AbstractBroker):
         try:
             profile_api.add_compute_profile(body=cp_request)
         except Exception as err:
+            LOGGER.debug(f'Creating compute-profile {cp_name} in PKS failed '
+                         f'with error:\n {err}')
             raise PksServerError(err.status, err.body)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} created the compute profile: '
@@ -306,10 +317,10 @@ class PKSBroker(AbstractBroker):
         return result
 
     @exception_handler
-    def get_compute_profile(self, name):
+    def get_compute_profile(self, cp_name):
         """Get the details of compute profile.
 
-        :param str name: Name of the compute profile
+        :param str cp_name: Name of the compute profile
         :return: Details of the compute profile as body of the result
 
         :rtype: dict
@@ -320,15 +331,18 @@ class PKSBroker(AbstractBroker):
         profile_api = ProfileApi(api_client=self.pks_client)
 
         LOGGER.debug(f'Sending request to PKS:{self.pks_host_uri} to get the '
-                     f'compute profile: {name} ')
+                     f'compute profile: {cp_name} ')
 
         try:
-            compute_profile = profile_api.get_compute_profile(profile_name=name)
+            compute_profile = \
+                profile_api.get_compute_profile(profile_name=cp_name)
         except Exception as err:
+            LOGGER.debug(f'Creating compute-profile {cp_name} in PKS failed '
+                         f'with error:\n {err}')
             raise PksServerError(err.status, err.body)
 
         LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} on '
-                     f'compute-profile: {name} with details: '
+                     f'compute-profile: {cp_name} with details: '
                      f'{compute_profile.to_dict()}')
 
         result['body'] = compute_profile.to_dict()
@@ -352,6 +366,8 @@ class PKSBroker(AbstractBroker):
         try:
             cp_list = profile_api.list_compute_profiles()
         except Exception as err:
+            LOGGER.debug(f'Listing compute-profiles in PKS failed '
+                         f'with error:\n {err}')
             raise PksServerError(err.status, err.body)
 
         list_of_cp_dicts = [cp.to_dict() for cp in cp_list]
@@ -362,10 +378,10 @@ class PKSBroker(AbstractBroker):
         return result
 
     @exception_handler
-    def delete_compute_profile(self, name):
+    def delete_compute_profile(self, cp_name):
         """Delete the compute profile with a given name.
 
-        :param str name: Name of the compute profile
+        :param str cp_name: Name of the compute profile
         :return: result
 
         :rtype: dict
@@ -376,15 +392,17 @@ class PKSBroker(AbstractBroker):
         profile_api = ProfileApi(api_client=self.pks_client)
 
         LOGGER.debug(f'Sending request to PKS:{self.pks_host_uri} to delete '
-                     f'the compute profile: {name}')
+                     f'the compute profile: {cp_name}')
 
         try:
-            profile_api.delete_compute_profile(profile_name=name)
+            profile_api.delete_compute_profile(profile_name=cp_name)
         except Exception as err:
+            LOGGER.debug(f'Deleting compute-profile {cp_name} in PKS failed '
+                         f'with error:\n {err}')
             raise PksServerError(err.status, err.body)
 
         LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} that'
-                     f' it deleted the compute profile: {name}')
+                     f' it deleted the compute profile: {cp_name}')
 
         return result
 

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -34,15 +34,15 @@ class PKSBroker(AbstractBroker):
     It performs CRUD operations on Kubernetes clusters.
     """
 
-    def __init__(self, headers, request_body, pks_ctx=None):
+    def __init__(self, request_headers, request_spec, pks_ctx=None):
         """Initialize PKS broker.
 
         :param pks_ctx: ovdc cache (subject to change) is used to
         initialize PKS broker.
         """
-        super().__init__(headers, request_body)
-        self.headers = headers
-        self.body = request_body
+        super().__init__(request_headers, request_spec)
+        self.req_headers = request_headers
+        self.req_spec = request_spec
         self.username = pks_ctx['username']
         self.secret = pks_ctx['secret']
         self.pks_host_uri = \
@@ -208,12 +208,11 @@ class PKSBroker(AbstractBroker):
         return
 
     @exception_handler
-    def resize_cluster(self, name, num_worker_nodes):
+    def resize_cluster(self, name, num_worker_nodes, **kwargs):
         """Resize the cluster of a given name to given number of worker nodes.
 
         :param str name: Name of the cluster
         :param int num_worker_nodes: New size of the worker nodes
-        (should be greater than the current number).
         """
         cluster_api = ClusterApi(api_client=self.pks_client)
 

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -201,7 +201,7 @@ class PKSBroker(AbstractBroker):
         LOGGER.debug(f'Sending request to PKS: {self.pks_host_uri} to delete '
                      f'the cluster with name: {name}')
 
-        cluster_api.delete_cluster(cluster_name=name)
+        #cluster_api.delete_cluster(cluster_name=name)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to delete'
                      f' the cluster: {name}')

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -201,7 +201,7 @@ class PKSBroker(AbstractBroker):
         LOGGER.debug(f'Sending request to PKS: {self.pks_host_uri} to delete '
                      f'the cluster with name: {name}')
 
-        #cluster_api.delete_cluster(cluster_name=name)
+        cluster_api.delete_cluster(cluster_name=name)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to delete'
                      f' the cluster: {name}')

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -8,6 +8,7 @@ import json
 from container_service_extension.abstract_broker import AbstractBroker
 from container_service_extension.exceptions import CseServerError
 from container_service_extension.exceptions import PksConnectionError
+from container_service_extension.exceptions import PksServerError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.pks_cache import PKS_COMPUTE_PROFILE
 from container_service_extension.pksclient.api.cluster_api import ClusterApi
@@ -103,8 +104,11 @@ class PKSBroker(AbstractBroker):
 
         LOGGER.debug(f'Sending request to PKS: {self.pks_host_uri} '
                      f'to list all clusters')
+        try:
+            clusters = cluster_api.list_clusters()
+        except Exception as err:
+            raise PksServerError(err.status, err.reason, err.body)
 
-        clusters = cluster_api.list_clusters()
         list_of_cluster_dicts = []
         for cluster in clusters:
             cluster_dict = {
@@ -157,8 +161,10 @@ class PKSBroker(AbstractBroker):
 
         LOGGER.debug(f'Sending request to PKS: {self.pks_host_uri} to create '
                      f'cluster of name: {cluster_name}')
-
-        cluster = cluster_api.add_cluster(cluster_request)
+        try:
+            cluster = cluster_api.add_cluster(cluster_request)
+        except Exception as err:
+            raise PksServerError(err.status, err.reason, err.body)
         cluster_dict = cluster.to_dict()
         # Flattening the dictionary
         cluster_params_dict = cluster_dict.pop('parameters')
@@ -180,8 +186,10 @@ class PKSBroker(AbstractBroker):
 
         LOGGER.debug(f'Sending request to PKS: {self.pks_host_uri} to get '
                      f'details of cluster with name: {cluster_name}')
-
-        cluster = cluster_api.get_cluster(cluster_name=cluster_name)
+        try:
+            cluster = cluster_api.get_cluster(cluster_name=cluster_name)
+        except Exception as err:
+            raise PksServerError(err.status, err.reason, err.body)
         cluster_dict = cluster.to_dict()
         cluster_params_dict = cluster_dict.pop('parameters')
         cluster_dict.update(cluster_params_dict)
@@ -200,8 +208,10 @@ class PKSBroker(AbstractBroker):
 
         LOGGER.debug(f'Sending request to PKS: {self.pks_host_uri} to delete '
                      f'the cluster with name: {cluster_name}')
-
-        cluster_api.delete_cluster(cluster_name=cluster_name)
+        try:
+            cluster_api.delete_cluster(cluster_name=cluster_name)
+        except Exception as err:
+            raise PksServerError(err.status, err.reason, err.body)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to delete'
                      f' the cluster: {cluster_name}')
@@ -222,7 +232,10 @@ class PKSBroker(AbstractBroker):
 
         resize_params = UpdateClusterParameters(
             kubernetes_worker_instances=node_count)
-        cluster_api.update_cluster(cluster_name, body=resize_params)
+        try:
+            cluster_api.update_cluster(cluster_name, body=resize_params)
+        except Exception as err:
+            raise PksServerError(err.status, err.reason, err.body)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to resize'
                      f' the cluster: {cluster_name}')
@@ -285,8 +298,10 @@ class PKSBroker(AbstractBroker):
 
         LOGGER.debug(f'Sending request to PKS:{self.pks_host_uri} to create '
                      f'the compute profile: {cp_name} for ovdc {ovdc_rp_name}')
-
-        profile_api.add_compute_profile(body=cp_request)
+        try:
+            profile_api.add_compute_profile(body=cp_request)
+        except Exception as err:
+            raise PksServerError(err.status, err.reason, err.body)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} created the compute profile: '
                      f'{cp_name} for ovdc {ovdc_rp_name}')
@@ -309,7 +324,10 @@ class PKSBroker(AbstractBroker):
         LOGGER.debug(f'Sending request to PKS:{self.pks_host_uri} to get the '
                      f'compute profile: {name} ')
 
-        compute_profile = profile_api.get_compute_profile(profile_name=name)
+        try:
+            compute_profile = profile_api.get_compute_profile(profile_name=name)
+        except Exception as err:
+            raise PksServerError(err.status, err.reason, err.body)
 
         LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} on '
                      f'compute-profile: {name} with details: '
@@ -333,10 +351,12 @@ class PKSBroker(AbstractBroker):
 
         LOGGER.debug(f'Sending request to PKS:{self.pks_host_uri} to get the '
                      f'list of compute profiles')
+        try:
+            cp_list = profile_api.list_compute_profiles()
+        except Exception as err:
+            raise PksServerError(err.status, err.reason, err.body)
 
-        cp_list = profile_api.list_compute_profiles()
         list_of_cp_dicts = [cp.to_dict() for cp in cp_list]
-
         LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} on '
                      f'list of compute profiles: {list_of_cp_dicts}')
 
@@ -360,7 +380,10 @@ class PKSBroker(AbstractBroker):
         LOGGER.debug(f'Sending request to PKS:{self.pks_host_uri} to delete '
                      f'the compute profile: {name}')
 
-        profile_api.delete_compute_profile(profile_name=name)
+        try:
+            profile_api.delete_compute_profile(profile_name=name)
+        except Exception as err:
+            raise PksServerError(err.status, err.reason, err.body)
 
         LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} that'
                      f' it deleted the compute profile: {name}')

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -168,10 +168,10 @@ class PKSBroker(AbstractBroker):
                      f' cluster: {cluster_name}')
         return cluster_dict
 
-    def get_cluster_info(self, name):
-        """Get the details of a cluster with a given name in PKS environment.
+    def get_cluster_info(self, cluster_name):
+        """Get the details of a cluster with a given cluster_name in PKS environment.
 
-        :param str name: Name of the cluster
+        :param str cluster_name: Name of the cluster
         :return: Details of the cluster.
 
         :rtype: dict
@@ -179,53 +179,53 @@ class PKSBroker(AbstractBroker):
         cluster_api = ClusterApi(api_client=self.pks_client)
 
         LOGGER.debug(f'Sending request to PKS: {self.pks_host_uri} to get '
-                     f'details of cluster with name: {name}')
+                     f'details of cluster with name: {cluster_name}')
 
-        cluster = cluster_api.get_cluster(cluster_name=name)
+        cluster = cluster_api.get_cluster(cluster_name=cluster_name)
         cluster_dict = cluster.to_dict()
         cluster_params_dict = cluster_dict.pop('parameters')
         cluster_dict.update(cluster_params_dict)
 
         LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} on '
-                     f'cluster: {name} with details: {cluster_dict}')
+                     f'cluster: {cluster_name} with details: {cluster_dict}')
 
         return cluster_dict
 
-    def delete_cluster(self, name):
+    def delete_cluster(self, cluster_name):
         """Delete the cluster with a given name in PKS environment.
 
-        :param str name: Name of the cluster
+        :param str cluster_name: Name of the cluster
         """
         cluster_api = ClusterApi(api_client=self.pks_client)
 
         LOGGER.debug(f'Sending request to PKS: {self.pks_host_uri} to delete '
-                     f'the cluster with name: {name}')
+                     f'the cluster with name: {cluster_name}')
 
-        cluster_api.delete_cluster(cluster_name=name)
+        cluster_api.delete_cluster(cluster_name=cluster_name)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to delete'
-                     f' the cluster: {name}')
+                     f' the cluster: {cluster_name}')
         return
 
     @exception_handler
-    def resize_cluster(self, name, num_worker_nodes, **kwargs):
+    def resize_cluster(self, cluster_name, node_count, **kwargs):
         """Resize the cluster of a given name to given number of worker nodes.
 
-        :param str name: Name of the cluster
-        :param int num_worker_nodes: New size of the worker nodes
+        :param str cluster_name: Name of the cluster
+        :param int node_count: New size of the worker nodes
         """
         cluster_api = ClusterApi(api_client=self.pks_client)
 
         LOGGER.debug(f'Sending request to PKS:{self.pks_host_uri} to resize '
-                     f'the cluster with name: {name} to '
-                     f'{num_worker_nodes} worker nodes')
+                     f'the cluster with name: {cluster_name} to '
+                     f'{node_count} worker nodes')
 
         resize_params = UpdateClusterParameters(
-            kubernetes_worker_instances=num_worker_nodes)
-        cluster_api.update_cluster(name, body=resize_params)
+            kubernetes_worker_instances=node_count)
+        cluster_api.update_cluster(cluster_name, body=resize_params)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to resize'
-                     f' the cluster: {name}')
+                     f' the cluster: {cluster_name}')
         return
 
     @exception_handler

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -94,7 +94,7 @@ class PKSBroker(AbstractBroker):
         return self.pks_client
 
     def list_clusters(self):
-        """Get list of clusters ((TODO)for a given vCD user) in PKS environment.
+        """Get list of clusters in PKS environment.
 
         :return: a list of cluster-dictionaries
 
@@ -107,7 +107,7 @@ class PKSBroker(AbstractBroker):
         try:
             clusters = cluster_api.list_clusters()
         except Exception as err:
-            raise PksServerError(err.status, err.reason, err.body)
+            raise PksServerError(err.status, err.body)
 
         list_of_cluster_dicts = []
         for cluster in clusters:
@@ -140,14 +140,12 @@ class PKSBroker(AbstractBroker):
 
         :rtype: dict
         """
-        # TODO(ClusterParams) Create an inner class "ClusterParams"
+        # TODO(ClusterSpec) Create an inner class "ClusterSpec"
         #  in abstract_broker.py and have subclasses define and use it
         #  as instance variable.
         #  Method 'Create_cluster' in VcdBroker and PksBroker should take
-        #  ClusterParams either as a param (or)
+        #  ClusterSpec either as a param (or)
         #  read from instance variable (if needed only).
-
-        # TODO() Invalidate cluster names containing '-' character.
 
         compute_profile = compute_profile \
             if compute_profile else self.compute_profile
@@ -164,7 +162,7 @@ class PKSBroker(AbstractBroker):
         try:
             cluster = cluster_api.add_cluster(cluster_request)
         except Exception as err:
-            raise PksServerError(err.status, err.reason, err.body)
+            raise PksServerError(err.status, err.body)
         cluster_dict = cluster.to_dict()
         # Flattening the dictionary
         cluster_params_dict = cluster_dict.pop('parameters')
@@ -189,7 +187,7 @@ class PKSBroker(AbstractBroker):
         try:
             cluster = cluster_api.get_cluster(cluster_name=cluster_name)
         except Exception as err:
-            raise PksServerError(err.status, err.reason, err.body)
+            raise PksServerError(err.status, err.body)
         cluster_dict = cluster.to_dict()
         cluster_params_dict = cluster_dict.pop('parameters')
         cluster_dict.update(cluster_params_dict)
@@ -211,7 +209,7 @@ class PKSBroker(AbstractBroker):
         try:
             cluster_api.delete_cluster(cluster_name=cluster_name)
         except Exception as err:
-            raise PksServerError(err.status, err.reason, err.body)
+            raise PksServerError(err.status, err.body)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to delete'
                      f' the cluster: {cluster_name}')
@@ -235,7 +233,7 @@ class PKSBroker(AbstractBroker):
         try:
             cluster_api.update_cluster(cluster_name, body=resize_params)
         except Exception as err:
-            raise PksServerError(err.status, err.reason, err.body)
+            raise PksServerError(err.status, err.body)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to resize'
                      f' the cluster: {cluster_name}')
@@ -301,7 +299,7 @@ class PKSBroker(AbstractBroker):
         try:
             profile_api.add_compute_profile(body=cp_request)
         except Exception as err:
-            raise PksServerError(err.status, err.reason, err.body)
+            raise PksServerError(err.status, err.body)
 
         LOGGER.debug(f'PKS: {self.pks_host_uri} created the compute profile: '
                      f'{cp_name} for ovdc {ovdc_rp_name}')
@@ -327,7 +325,7 @@ class PKSBroker(AbstractBroker):
         try:
             compute_profile = profile_api.get_compute_profile(profile_name=name)
         except Exception as err:
-            raise PksServerError(err.status, err.reason, err.body)
+            raise PksServerError(err.status, err.body)
 
         LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} on '
                      f'compute-profile: {name} with details: '
@@ -354,7 +352,7 @@ class PKSBroker(AbstractBroker):
         try:
             cp_list = profile_api.list_compute_profiles()
         except Exception as err:
-            raise PksServerError(err.status, err.reason, err.body)
+            raise PksServerError(err.status, err.body)
 
         list_of_cp_dicts = [cp.to_dict() for cp in cp_list]
         LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} on '
@@ -383,7 +381,7 @@ class PKSBroker(AbstractBroker):
         try:
             profile_api.delete_compute_profile(profile_name=name)
         except Exception as err:
-            raise PksServerError(err.status, err.reason, err.body)
+            raise PksServerError(err.status, err.body)
 
         LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} that'
                      f' it deleted the compute profile: {name}')

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -14,6 +14,7 @@ from container_service_extension.exceptions import PksConnectionError
 from container_service_extension.exceptions import PksServerError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.pks_cache import PKS_COMPUTE_PROFILE
+from container_service_extension.pksclient.rest import ApiException
 from container_service_extension.pksclient.api.cluster_api import ClusterApi
 from container_service_extension.pksclient.api.profile_api import ProfileApi
 from container_service_extension.pksclient.api_client import ApiClient
@@ -179,7 +180,7 @@ class PKSBroker(AbstractBroker):
                      f'to list all clusters')
         try:
             clusters = cluster_api.list_clusters()
-        except Exception as err:
+        except ApiException as err:
             LOGGER.debug(f'Listing PKS clusters failed with error:\n {err}')
             raise PksServerError(err.status, err.body)
 
@@ -236,7 +237,7 @@ class PKSBroker(AbstractBroker):
                      f'cluster of name: {cluster_name}')
         try:
             cluster = cluster_api.add_cluster(cluster_request)
-        except Exception as err:
+        except ApiException as err:
             LOGGER.debug(f'Creating cluster {cluster_name} in PKS failed with '
                          f'error:\n {err}')
             raise PksServerError(err.status, err.body)
@@ -264,7 +265,7 @@ class PKSBroker(AbstractBroker):
                      f'details of cluster with name: {cluster_name}')
         try:
             cluster = cluster_api.get_cluster(cluster_name=cluster_name)
-        except Exception as err:
+        except ApiException as err:
             LOGGER.debug(f'Getting cluster info on {cluster_name} failed with '
                          f'error:\n {err}')
             raise PksServerError(err.status, err.body)
@@ -289,7 +290,7 @@ class PKSBroker(AbstractBroker):
                      f'the cluster with name: {cluster_name}')
         try:
             cluster_api.delete_cluster(cluster_name=cluster_name)
-        except Exception as err:
+        except ApiException as err:
             LOGGER.debug(f'Deleting cluster {cluster_name} failed with '
                          f'error:\n {err}')
             raise PksServerError(err.status, err.body)
@@ -318,7 +319,7 @@ class PKSBroker(AbstractBroker):
             kubernetes_worker_instances=node_count)
         try:
             cluster_api.update_cluster(cluster_name, body=resize_params)
-        except Exception as err:
+        except ApiException as err:
             LOGGER.debug(f'Resizing cluster {cluster_name} failed with '
                          f'error:\n {err}')
             raise PksServerError(err.status, err.body)
@@ -388,7 +389,7 @@ class PKSBroker(AbstractBroker):
                      f'the compute profile: {cp_name} for ovdc {ovdc_rp_name}')
         try:
             profile_api.add_compute_profile(body=cp_request)
-        except Exception as err:
+        except ApiException as err:
             LOGGER.debug(f'Creating compute-profile {cp_name} in PKS failed '
                          f'with error:\n {err}')
             raise PksServerError(err.status, err.body)
@@ -417,7 +418,7 @@ class PKSBroker(AbstractBroker):
         try:
             compute_profile = \
                 profile_api.get_compute_profile(profile_name=cp_name)
-        except Exception as err:
+        except ApiException as err:
             LOGGER.debug(f'Creating compute-profile {cp_name} in PKS failed '
                          f'with error:\n {err}')
             raise PksServerError(err.status, err.body)
@@ -446,7 +447,7 @@ class PKSBroker(AbstractBroker):
                      f'list of compute profiles')
         try:
             cp_list = profile_api.list_compute_profiles()
-        except Exception as err:
+        except ApiException as err:
             LOGGER.debug(f'Listing compute-profiles in PKS failed '
                          f'with error:\n {err}')
             raise PksServerError(err.status, err.body)
@@ -477,7 +478,7 @@ class PKSBroker(AbstractBroker):
 
         try:
             profile_api.delete_compute_profile(profile_name=cp_name)
-        except Exception as err:
+        except ApiException as err:
             LOGGER.debug(f'Deleting compute-profile {cp_name} in PKS failed '
                          f'with error:\n {err}')
             raise PksServerError(err.status, err.body)

--- a/container_service_extension/processor.py
+++ b/container_service_extension/processor.py
@@ -6,6 +6,7 @@ import base64
 import json
 import sys
 import traceback
+from urllib.parse import parse_qsl
 
 from pkg_resources import resource_string
 import yaml
@@ -77,10 +78,15 @@ class ServiceProcessor(object):
                         sys.getfilesystemencoding()))
             except Exception:
                 LOGGER.error(traceback.format_exc())
-                request_body = None
+                request_body = {}
         else:
-            request_body = None
+            request_body = {}
         LOGGER.debug('request body: %s' % json.dumps(request_body))
+
+        query_params = {}
+        if body['queryString']:
+            query_params = dict(parse_qsl(body['queryString']))
+        LOGGER.debug(f'Query params in the request: {query_params}')
 
         from container_service_extension.service import Service
         service = Service()
@@ -89,7 +95,8 @@ class ServiceProcessor(object):
                                  'Contact the System Administrator.')
 
         from container_service_extension.broker_manager import BrokerManager
-        broker_manager = BrokerManager(body['headers'], request_body)
+        broker_manager = BrokerManager(body['headers'], query_params,
+                                       request_body)
         from container_service_extension.broker_manager import Operation
 
         if body['method'] == 'GET':

--- a/container_service_extension/processor.py
+++ b/container_service_extension/processor.py
@@ -104,9 +104,8 @@ class ServiceProcessor(object):
 
         if body['method'] == 'GET':
             if ovdc_info_request:
-                on_the_fly_request_spec = {'ovdc_id': ovdc_id}
-                broker = broker_manager.get_broker_based_on_vdc(
-                    on_the_fly_request_spec)
+                req_spec.update({'ovdc_id': ovdc_id})
+                broker = broker_manager.get_broker_based_on_vdc()
                 reply = broker.ovdc_info_for_kubernetes()
 
             elif spec_request:
@@ -133,9 +132,8 @@ class ServiceProcessor(object):
                 result['status_code'] = 200
                 reply = result
             elif cluster_info_request:
-                on_the_fly_request_spec = {'cluster_name': cluster_name}
-                reply = broker_manager.invoke(Operation.GET_CLUSTER,
-                                              on_the_fly_request_spec)
+                req_spec.update({'cluster_name': cluster_name})
+                reply = broker_manager.invoke(Operation.GET_CLUSTER)
             elif node_info_request:
                 broker = broker_manager.get_broker_based_on_vdc()
                 reply = broker.get_node_info(cluster_name, node_name)
@@ -160,17 +158,15 @@ class ServiceProcessor(object):
             elif system_request:
                 reply = service.update_status(req_headers, req_spec)
             else:
-                on_the_fly_request_spec = {'cluster_name': cluster_name}
-                reply = broker_manager.invoke(Operation.RESIZE_CLUSTER,
-                                              on_the_fly_request_spec)
+                req_spec.update({'cluster_name': cluster_name})
+                reply = broker_manager.invoke(Operation.RESIZE_CLUSTER)
         elif body['method'] == 'DELETE':
             if node_request:
                 broker = broker_manager.get_broker_based_on_vdc()
                 reply = broker.delete_nodes()
             else:
-                on_the_fly_request_spec = {'cluster_name': cluster_name}
-                reply = broker_manager.invoke(Operation.DELETE_CLUSTER,
-                                              on_the_fly_request_spec)
+                req_spec.update({'cluster_name': cluster_name})
+                reply = broker_manager.invoke(Operation.DELETE_CLUSTER)
 
         LOGGER.debug('reply: %s' % str(reply))
         return reply

--- a/container_service_extension/processor.py
+++ b/container_service_extension/processor.py
@@ -93,6 +93,7 @@ class ServiceProcessor(object):
         if not system_request and not service.is_enabled:
             raise CseServerError('CSE service is disabled. '
                                  'Contact the System Administrator.')
+
         req_headers = deepcopy(body['headers'])
         req_query_params = deepcopy(query_params)
         req_spec = deepcopy(request_body)

--- a/container_service_extension/processor.py
+++ b/container_service_extension/processor.py
@@ -6,6 +6,7 @@ import base64
 import json
 import sys
 import traceback
+from copy import deepcopy
 from urllib.parse import parse_qsl
 
 from pkg_resources import resource_string
@@ -95,8 +96,9 @@ class ServiceProcessor(object):
                                  'Contact the System Administrator.')
 
         from container_service_extension.broker_manager import BrokerManager
-        broker_manager = BrokerManager(body['headers'], query_params,
-                                       request_body)
+        broker_manager = BrokerManager(deepcopy(body['headers']),
+                                       deepcopy(query_params),
+                                       deepcopy(request_body))
         from container_service_extension.broker_manager import Operation
 
         if body['method'] == 'GET':

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -124,11 +124,11 @@ def task_callback(task):
 
 
 class VcdBroker(AbstractBroker, threading.Thread):
-    def __init__(self, headers, request_body):
-        super().__init__(headers, request_body)
+    def __init__(self, request_headers, request_spec):
+        super().__init__(request_headers, request_spec)
         threading.Thread.__init__(self)
-        self.headers = headers
-        self.body = request_body
+        self.req_headers = request_headers
+        self.req_spec = request_spec
 
         self.tenant_client = None
         self.client_session = None
@@ -198,8 +198,9 @@ class VcdBroker(AbstractBroker, threading.Thread):
     def get_template(self, name=None):
         server_config = get_server_runtime_config()
         if name is None:
-            if 'template' in self.body and self.body['template'] is not None:
-                name = self.body['template']
+            if 'template' in self.req_spec and \
+                    self.req_spec['template'] is not None:
+                name = self.req_spec['template']
             else:
                 name = server_config['broker']['default_template']
         for template in server_config['broker']['templates']:
@@ -232,7 +233,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
             })
         return clusters
 
-    def get_cluster_info(self, name):
+    def get_cluster_info(self, cluster_name):
         """Get the info of the cluster.
 
         :param cluster_name: (str): Name of the cluster
@@ -240,9 +241,9 @@ class VcdBroker(AbstractBroker, threading.Thread):
         :return: (dict): Info of the cluster.
         """
         self._connect_tenant()
-        clusters = load_from_metadata(self.tenant_client, name=name)
+        clusters = load_from_metadata(self.tenant_client, name=cluster_name)
         if len(clusters) == 0:
-            raise CseServerError('Cluster \'%s\' not found.' % name)
+            raise CseServerError('Cluster \'%s\' not found.' % cluster_name)
         cluster = clusters[0]
         vapp = VApp(self.tenant_client, href=clusters[0]['vapp_href'])
         vms = vapp.get_all_vms()
@@ -384,7 +385,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
 
     @rollback
     def create_cluster_thread(self):
-        network_name = self.body['network']
+        network_name = self.req_spec['network']
         try:
             clusters = load_from_metadata(
                 self.tenant_client, name=self.cluster_name)
@@ -393,7 +394,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
                                                 "already exists.")
             org_resource = self.tenant_client.get_org()
             org = Org(self.tenant_client, resource=org_resource)
-            vdc_resource = org.get_vdc(self.body['vdc'])
+            vdc_resource = org.get_vdc(self.req_spec['vdc'])
             vdc = VDC(self.tenant_client, resource=vdc_resource)
             template = self.get_template()
             self.update_task(
@@ -430,7 +431,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
             server_config = get_server_runtime_config()
             try:
                 add_nodes(1, template, TYPE_MASTER, server_config,
-                          self.tenant_client, org, vdc, vapp, self.body)
+                          self.tenant_client, org, vdc, vapp, self.req_spec)
             except Exception as e:
                 raise MasterNodeCreationError(
                     "Error while adding master node:", str(e))
@@ -445,16 +446,16 @@ class VcdBroker(AbstractBroker, threading.Thread):
             task = vapp.set_metadata('GENERAL', 'READWRITE', 'cse.master.ip',
                                      master_ip)
             self.tenant_client.get_task_monitor().wait_for_status(task)
-            if self.body['node_count'] > 0:
+            if self.req_spec['node_count'] > 0:
                 self.update_task(
                     TaskStatus.RUNNING,
                     message='Creating %s node(s) for %s(%s)' %
-                    (self.body['node_count'], self.cluster_name,
+                    (self.req_spec['node_count'], self.cluster_name,
                      self.cluster_id))
                 try:
-                    add_nodes(self.body['node_count'], template, TYPE_NODE,
+                    add_nodes(self.req_spec['node_count'], template, TYPE_NODE,
                               server_config, self.tenant_client, org, vdc,
-                              vapp, self.body)
+                              vapp, self.req_spec)
                 except Exception as e:
                     raise WorkerNodeCreationError(
                         "Error while creating worker node:", str(e))
@@ -462,11 +463,11 @@ class VcdBroker(AbstractBroker, threading.Thread):
                 self.update_task(
                     TaskStatus.RUNNING,
                     message='Adding %s node(s) to %s(%s)' %
-                    (self.body['node_count'], self.cluster_name,
+                    (self.req_spec['node_count'], self.cluster_name,
                      self.cluster_id))
                 vapp.reload()
                 join_cluster(server_config, vapp, template)
-            if self.body['enable_nfs']:
+            if self.req_spec['enable_nfs']:
                 self.update_task(
                     TaskStatus.RUNNING,
                     message='Creating NFS node for %s(%s)' %
@@ -475,7 +476,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
                 try:
                     add_nodes(1, template, TYPE_NFS,
                               server_config, self.tenant_client, org, vdc,
-                              vapp, self.body)
+                              vapp, self.req_spec)
                 except Exception as e:
                     raise NFSNodeCreationError(
                         "Error while creating NFS node:", str(e))
@@ -569,13 +570,14 @@ class VcdBroker(AbstractBroker, threading.Thread):
     @secure(required_rights=[CSE_NATIVE_DEPLOY_RIGHT_NAME])
     def create_nodes(self):
         result = {'body': {}}
-        self.cluster_name = self.body['name']
-        LOGGER.debug(f"About to add {self.body['node_count']} nodes to cluster"
-                     " {self.cluster_name} on VDC {self.body['vdc']}, "
-                     "sp={self.body['storage_profile']}")
-        if self.body['node_count'] < 1:
+        self.cluster_name = self.req_spec['name']
+        LOGGER.debug(f"About to add {self.req_spec['node_count']} nodes to "
+                     f"cluster {self.cluster_name} on VDC "
+                     f"{self.req_spec['vdc']}, "
+                     f"sp={self.req_spec['storage_profile']}")
+        if self.req_spec['node_count'] < 1:
             raise CseServerError(f"Invalid node count: "
-                                 f"{self.body['node_count']}.")
+                                 f"{self.req_spec['node_count']}.")
         self._connect_tenant()
         self._connect_sys_admin()
         clusters = load_from_metadata(
@@ -588,7 +590,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
         self.cluster_id = self.cluster['cluster_id']
         self.update_task(
             TaskStatus.RUNNING,
-            message=f"Adding {self.body['node_count']} node(s) to cluster "
+            message=f"Adding {self.req_spec['node_count']} node(s) to cluster "
                     "{self.cluster_name}({self.cluster_id})")
         self.daemon = True
         self.start()
@@ -613,25 +615,25 @@ class VcdBroker(AbstractBroker, threading.Thread):
             self.update_task(
                 TaskStatus.RUNNING,
                 message='Creating %s node(s) for %s(%s)' %
-                        (self.body['node_count'],
+                        (self.req_spec['node_count'],
                          self.cluster_name,
                          self.cluster_id))
-            new_nodes = add_nodes(self.body['node_count'], template,
-                                  self.body['node_type'],
+            new_nodes = add_nodes(self.req_spec['node_count'], template,
+                                  self.req_spec['node_type'],
                                   server_config, self.tenant_client,
-                                  org, vdc, vapp, self.body)
-            if self.body['node_type'] == TYPE_NFS:
+                                  org, vdc, vapp, self.req_spec)
+            if self.req_spec['node_type'] == TYPE_NFS:
                 self.update_task(
                     TaskStatus.SUCCESS,
                     message='Created %s node(s) for %s(%s)' %
-                            (self.body['node_count'],
+                            (self.req_spec['node_count'],
                              self.cluster_name,
                              self.cluster_id))
-            elif self.body['node_type'] == TYPE_NODE:
+            elif self.req_spec['node_type'] == TYPE_NODE:
                 self.update_task(
                     TaskStatus.RUNNING,
                     message='Adding %s node(s) to %s(%s)' %
-                            (self.body['node_count'],
+                            (self.req_spec['node_count'],
                              self.cluster_name,
                              self.cluster_id))
                 target_nodes = []
@@ -642,7 +644,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
                 self.update_task(
                     TaskStatus.SUCCESS,
                     message='Added %s node(s) to cluster %s(%s)' %
-                            (self.body['node_count'],
+                            (self.req_spec['node_count'],
                              self.cluster_name,
                              self.cluster_id))
         except NodeCreationError as e:
@@ -669,14 +671,14 @@ class VcdBroker(AbstractBroker, threading.Thread):
     @secure(required_rights=[CSE_NATIVE_DEPLOY_RIGHT_NAME])
     def delete_nodes(self):
         result = {'body': {}}
-        self.cluster_name = self.body['name']
+        self.cluster_name = self.req_spec['name']
         LOGGER.debug(f"About to delete nodes from cluster with name: "
                      "{self.body['name']}")
 
-        if len(self.body['nodes']) < 1:
+        if len(self.req_spec['nodes']) < 1:
             raise CseServerError(f"Invalid list of nodes: "
-                                 f"{self.body['nodes']}.")
-        for node in self.body['nodes']:
+                                 f"{self.req_spec['nodes']}.")
+        for node in self.req_spec['nodes']:
             if node.startswith(TYPE_MASTER):
                 raise CseServerError(
                     'Can\'t delete a master node: \'%s\'.' % node)
@@ -692,8 +694,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
         self.cluster_id = self.cluster['cluster_id']
         self.update_task(
             TaskStatus.RUNNING,
-            message=f"Deleting {len(self.body['nodes'])} node(s) from cluster "
-                    "{self.cluster_name}({self.cluster_id})")
+            message=f"Deleting {len(self.req_spec['nodes'])} node(s) from "
+            f"cluster {self.cluster_name}({self.cluster_id})")
         self.daemon = True
         self.start()
         response_body = {}
@@ -712,22 +714,24 @@ class VcdBroker(AbstractBroker, threading.Thread):
             self.update_task(
                 TaskStatus.RUNNING,
                 message='Deleting %s node(s) from %s(%s)' %
-                (len(self.body['nodes']), self.cluster_name, self.cluster_id))
+                (len(self.req_spec['nodes']), self.cluster_name,
+                 self.cluster_id))
             try:
                 server_config = get_server_runtime_config()
                 delete_nodes_from_cluster(server_config,
                                           vapp,
                                           template,
-                                          self.body['nodes'],
-                                          self.body['force'])
+                                          self.req_spec['nodes'],
+                                          self.req_spec['force'])
             except Exception:
-                LOGGER.error(f"Couldn't delete node {self.body['nodes']} from "
-                             "cluster:{self.cluster_name}")
+                LOGGER.error(f"Couldn't delete node {self.req_spec['nodes']} "
+                             f"from cluster:{self.cluster_name}")
             self.update_task(
                 TaskStatus.RUNNING,
                 message='Undeploying %s node(s) for %s(%s)' %
-                (len(self.body['nodes']), self.cluster_name, self.cluster_id))
-            for vm_name in self.body['nodes']:
+                (len(self.req_spec['nodes']), self.cluster_name,
+                 self.cluster_id))
+            for vm_name in self.req_spec['nodes']:
                 vm = VM(self.tenant_client, resource=vapp.get_vm(vm_name))
                 try:
                     task = vm.undeploy()
@@ -737,13 +741,15 @@ class VcdBroker(AbstractBroker, threading.Thread):
             self.update_task(
                 TaskStatus.RUNNING,
                 message='Deleting %s VM(s) for %s(%s)' %
-                (len(self.body['nodes']), self.cluster_name, self.cluster_id))
-            task = vapp.delete_vms(self.body['nodes'])
+                (len(self.req_spec['nodes']), self.cluster_name,
+                 self.cluster_id))
+            task = vapp.delete_vms(self.req_spec['nodes'])
             self.tenant_client.get_task_monitor().wait_for_status(task)
             self.update_task(
                 TaskStatus.SUCCESS,
                 message='Deleted %s node(s) to cluster %s(%s)' %
-                (len(self.body['nodes']), self.cluster_name, self.cluster_id))
+                (len(self.req_spec['nodes']), self.cluster_name,
+                 self.cluster_id))
         except Exception as e:
             LOGGER.error(traceback.format_exc())
             error_obj = error_to_json(e)
@@ -770,13 +776,14 @@ class VcdBroker(AbstractBroker, threading.Thread):
         if self.tenant_client.is_sysadmin():
             ovdc_cache = OvdcCache(self.tenant_client)
             task = ovdc_cache.set_ovdc_container_provider_metadata(
-                self.body['ovdc_name'],
-                ovdc_id=self.body.get('ovdc_id', None),
-                container_provider=self.body.get('container_provider', None),
-                pks_plans=self.body['pks_plans'],
-                org_name=self.body.get('org_name', None))
+                self.req_spec['ovdc_name'],
+                ovdc_id=self.req_spec.get('ovdc_id', None),
+                container_provider=
+                self.req_spec.get('container_provider', None),
+                pks_plans=self.req_spec['pks_plans'],
+                org_name=self.req_spec.get('org_name', None))
             response_body = dict()
-            response_body['ovdc_name'] = self.body['ovdc_name']
+            response_body['ovdc_name'] = self.req_spec['ovdc_name']
             response_body['task_href'] = task.get('href')
             result['body'] = response_body
             result['status_code'] = ACCEPTED
@@ -799,9 +806,9 @@ class VcdBroker(AbstractBroker, threading.Thread):
         if self.tenant_client.is_sysadmin():
             ovdc_cache = OvdcCache(self.tenant_client)
             metadata = ovdc_cache.get_ovdc_container_provider_metadata(
-                self.body.get('ovdc_name', None),
-                ovdc_id=self.body.get('ovdc_id', None),
-                org_name=self.body.get('org_name', None))
+                self.req_spec.get('ovdc_name', None),
+                ovdc_id=self.req_spec.get('ovdc_id', None),
+                org_name=self.req_spec.get('org_name', None))
             result = dict()
             result['status_code'] = OK
             result['body'] = metadata
@@ -850,6 +857,26 @@ class VcdBroker(AbstractBroker, threading.Thread):
         vdc.delete_vapp(self.cluster['name'], force=True)
         LOGGER.info(f"Successfully deleted cluster: {self.cluster_name}")
 
-    # TODO() as part of vcd cse cluster resize implementation
-    def resize_cluster(self):
+    def resize_cluster(self, cluster_name, num_worker_nodes,
+                       cluster_spec=None):
+        """Resize the cluster of a given name to given number of worker nodes.
+
+        :param str name: Name of the cluster
+        :param int num_worker_nodes: New size of the worker nodes
+        (should be greater than the current number).
+        :param dict cluster_spec: Current properties of the cluster
+
+        """
+        if cluster_spec:
+            curr_worker_count = len(cluster_spec['nodes'])
+        else:
+            cluster = self.get_cluster_info(cluster_name=cluster_name)
+            curr_worker_count = len(cluster['nodes'])
+
+        if curr_worker_count > num_worker_nodes:
+            raise CseServerError(f"Scale down is not supported via 'resize' "
+                                 f"operation. Use 'vcd cse delete node' "
+                                 f"command.")
+        self.req_spec['node_count'] = num_worker_nodes-curr_worker_count
+        self.create_nodes()
         raise NotImplementedError('resize cluster')

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -863,8 +863,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
         LOGGER.info(f"Successfully deleted cluster: {self.cluster_name}")
 
     @secure(required_rights=[CSE_NATIVE_DEPLOY_RIGHT_NAME])
-    def resize_cluster(self, cluster_name, node_count,
-                       curr_cluster_info=None):
+    def resize_cluster(self, cluster_name, node_count, curr_cluster_info=None):
         """Resize the cluster of a given name to given number of worker nodes.
 
         :param str name: Name of the cluster
@@ -889,7 +888,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
                                  f"vCD powered K8 clusters. Use "
                                  f"'vcd cse delete node' command.")
         elif curr_worker_count == node_count:
-            raise CseServerError(f"Cluster: {cluster_name} is already at the "
+            raise CseServerError(f"Cluster - {cluster_name} is already at the "
                                  f"size of {curr_worker_count}.")
 
         self.req_spec['node_count'] = node_count - curr_worker_count

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -508,11 +508,11 @@ class VcdBroker(AbstractBroker, threading.Thread):
             self._disconnect_sys_admin()
 
     @secure(required_rights=[CSE_NATIVE_DEPLOY_RIGHT_NAME])
-    def delete_cluster(self, name):
+    def delete_cluster(self, cluster_name):
 
-        LOGGER.debug(f"About to delete cluster with name: {name}")
+        LOGGER.debug(f"About to delete cluster with name: {cluster_name}")
 
-        self.cluster_name = name
+        self.cluster_name = cluster_name
         self._connect_tenant()
         self._connect_sys_admin()
         self.op = OP_DELETE_CLUSTER
@@ -885,7 +885,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
 
         if curr_worker_count > node_count:
             raise CseServerError(f"Automatic scale down is not supported for "
-                                 f"vCD powered K8 clusters. Use "
+                                 f"vCD powered Kubernetes clusters. Use "
                                  f"'vcd cse delete node' command.")
         elif curr_worker_count == node_count:
             raise CseServerError(f"Cluster - {cluster_name} is already at the "

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -889,8 +889,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
                                  f"vCD powered K8 clusters. Use "
                                  f"'vcd cse delete node' command.")
         elif curr_worker_count == node_count:
-            raise CseServerError(f"{cluster_name} is already at the size of "
-                                 f"{curr_worker_count}")
+            raise CseServerError(f"Cluster: {cluster_name} is already at the "
+                                 f"size of {curr_worker_count}.")
 
         self.req_spec['node_count'] = node_count - curr_worker_count
         response = self.create_nodes()


### PR DESCRIPTION
This change-set has below:
1. Both client and server side implementation of resize command.
2. Exception handling for PksBroker.
3. Refactored the way we pass/leak HTTP request body to brokers. I modified the code in processor.py to deepcopy the request before we pass it to rest of the CSE engine(brokers), so that contents of the request is protected from any unexpected modifications by brokers (or) CSE engine. I had to do this as part of this change because "resize" implementation requires modification of the "body[node_count]".
The idea or design here is that we construct and pass the "request_spec" instead of "body" to broker_manager. Then broker_manager either updates or uses the "request_spec" as-is depending on certain factors. The responsibility of broker_manager also includes construction of "cluster_spec" before passing it on to actual brokers.
Data flow goes something like this:
HTTP_body -> request_spec -> cluster_spec

In future, our goal should be to create a separate class for ClusterSpec and have it implemented by both the brokers. That way we can avoid tight contract between broker_manager and brokers to pass the dictionaries around with correct "keys".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/275)
<!-- Reviewable:end -->
