### PR TITLE
[VCDA-903] Upgrade Kubernetes templates from v1.10.11 to v1.13.5

### DIFF
--- a/scripts/cust-ubuntu-16.04.sh
+++ b/scripts/cust-ubuntu-16.04.sh
@@ -24,19 +24,19 @@ deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get -q update
-apt-get -q install -y docker-ce=18.06.2~ce~3-0~ubuntu
-apt-get -q install -y kubelet=1.10.11-00 kubeadm=1.10.11-00 kubectl=1.10.11-00 kubernetes-cni=0.6.0-00 --allow-unauthenticated
+apt-get -q install -y docker-ce=18.06.3~ce~3-0~ubuntu
+apt-get -q install -y kubelet=1.13.5-00 kubeadm=1.13.5-00 kubectl=1.13.5-00 kubernetes-cni=0.7.5-00 --allow-unauthenticated
 apt-get -q autoremove -y
 systemctl restart docker
 while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
 
 echo 'downloading container images'
-docker pull k8s.gcr.io/kube-apiserver-amd64:v1.10.11
-docker pull k8s.gcr.io/kube-controller-manager-amd64:v1.10.11
-docker pull k8s.gcr.io/kube-proxy-amd64:v1.10.11
-docker pull k8s.gcr.io/kube-scheduler-amd64:v1.10.11
+docker pull k8s.gcr.io/kube-apiserver-amd64:v1.13.5
+docker pull k8s.gcr.io/kube-controller-manager-amd64:v1.13.5
+docker pull k8s.gcr.io/kube-proxy-amd64:v1.13.5
+docker pull k8s.gcr.io/kube-scheduler-amd64:v1.13.5
 
-docker pull k8s.gcr.io/etcd-amd64:3.1.12
+docker pull k8s.gcr.io/etcd-amd64:3.2.24
 docker pull k8s.gcr.io/pause-amd64:3.1
 
 docker pull k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.8

--- a/scripts/mstr-ubuntu-16.04.sh
+++ b/scripts/mstr-ubuntu-16.04.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
-kubeadm init --kubernetes-version=v1.10.11 > /root/kubeadm-init.out
+kubeadm init --kubernetes-version=v1.13.5 > /root/kubeadm-init.out
 mkdir -p /root/.kube
 cp -f /etc/kubernetes/admin.conf /root/.kube/config
 chown $(id -u):$(id -g) /root/.kube/config


### PR DESCRIPTION
Upgrade Kubernetes from v1.10.11 to v1.13.5 for Ubuntu 16.04

-Tested manually by doing a fresh installation of CSE and created a cluster with master and slave nodes.
-Tested using system_tests framework for CSE
- Tested by deploying a Kubernetes guestbook application on the cluster 

- @sahithi @andrew-ni @rocknes @yilmi-vmw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/276)
<!-- Reviewable:end -->
