### PR TITLE
[VCDA-869] Enhance-List-Cluster

### DIFF
--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -30,7 +30,7 @@ class Cluster(object):
             auth=None)
         return process_response(response)
 
-    def get_clusters(self):
+    def get_clusters(self, vdc):
         method = 'GET'
         uri = self._uri
         response = self.client._do_request_prim(
@@ -40,7 +40,8 @@ class Cluster(object):
             contents=None,
             media_type=None,
             accept_type='application/*+json',
-            auth=None)
+            auth=None,
+            params={'vdc': vdc} if vdc else None)
         return process_response(response)
 
     def get_cluster_info(self, name, vdc):

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -62,6 +62,9 @@ def cluster_group(ctx):
         vcd cse cluster list
             Displays clusters in vCD that are visible to your user status.
 \b
+        vcd cse cluster list -vdc myOvdc
+            Displays clusters residing in vdc 'myOvdc'.
+\b
         vcd cse cluster delete mycluster --yes
             Attempts to delete cluster 'mycluster' without prompting.
 \b
@@ -140,13 +143,20 @@ def list_templates(ctx):
 
 @cluster_group.command('list', short_help='list clusters')
 @click.pass_context
-def list_clusters(ctx):
+@click.option(
+    '-v',
+    '--vdc',
+    'vdc',
+    required=False,
+    default=None,
+    help='Name of the virtual datacenter')
+def list_clusters(ctx, vdc):
     """Display list of Kubernetes clusters."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
-        result = cluster.get_clusters()
+        result = cluster.get_clusters(vdc)
         stdout(result, ctx, show_id=True)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

-  List cluster enhancements
-  List cluster supports --vdc that lists the clusters based on container provider of vdc. 
    If it is set to 'pks', it gets only pks cluster list.
    If it is set to 'vcd', it get only vcd cluster list.
    'vdc' column of the result now gets populated with vdc name
    'status' column of pks gets populated with last action + status
    
    Testing: Manual testing completed with and without --vdc option.
  

@sahithi @sompa @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/279)
<!-- Reviewable:end -->
