### PR TITLE
[VCDA-906] Redact sensitive information in CSE logs

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -337,11 +337,9 @@ class BrokerManager(object):
         org_name = self.session.get('org')
         LOGGER.debug(f"org_name={org_name};vdc_name=\'{ovdc_name}\'")
 
-        """
-        Get the ovdc metadata from the logged-in org and ovdc.
-        Create the right broker based on value of 'container_provider'.
-        Fall back to DefaultBroker for missing ovdc or org.
-        """
+        # Get the ovdc metadata from the logged-in org and ovdc.
+        # Create the right broker based on value of 'container_provider'.
+        # Fall back to DefaultBroker for missing ovdc or org.
         if ovdc_name and org_name:
             ctr_prov_ctx = \
                 self.ovdc_cache.get_ovdc_container_provider_metadata(

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -17,8 +17,6 @@ import yaml
 from container_service_extension.client.cluster import Cluster
 from container_service_extension.client.ovdc import Ovdc
 from container_service_extension.client.system import System
-# TODO()
-# from container_service_extension.logger import configure_client_logger
 from container_service_extension.service import Service
 
 
@@ -33,8 +31,6 @@ def cse(ctx):
             Display CSE version. If CSE version is displayed, then vcd-cli has
             been properly configured to run CSE commands.
     """
-    # TODO() client logging is set up, but need to write log statements
-    # configure_client_logger()
 
 
 @cse.command(short_help='show version')
@@ -376,6 +372,7 @@ def resize(ctx, name, node_count, network_name, vdc, disable_rollback):
     except Exception as e:
         stderr(e, ctx)
 
+
 @cluster_group.command(short_help='get cluster config')
 @click.pass_context
 @click.argument('name', required=True)
@@ -569,6 +566,7 @@ def create_node(ctx, name, node_count, cpu, memory, network_name,
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)
+
 
 @node_group.command('list', short_help='list nodes')
 @click.pass_context

--- a/container_service_extension/cluster.py
+++ b/container_service_extension/cluster.py
@@ -31,14 +31,12 @@ def wait_until_tools_ready(vm):
         try:
             status = vm.guest.toolsRunningStatus
             if 'guestToolsRunning' == status:
-                LOGGER.debug('vm tools %s are ready' % vm)
+                LOGGER.debug(f"vm tools {vm} are ready")
                 return
-            LOGGER.debug('waiting for vm tools %s to be ready (%s)' % (vm,
-                                                                       status))
+            LOGGER.debug(f"waiting for vm tools {vm} to be ready ({status})")
             time.sleep(1)
         except Exception:
-            LOGGER.debug('waiting for vm tools %s to be ready (%s)* ' %
-                         (vm, status))
+            LOGGER.debug(f"waiting for vm tools {vm} to be ready ({status})* ")
             time.sleep(1)
 
 
@@ -195,8 +193,8 @@ def add_nodes(qty, template, node_type, config, client, org, vdc, vapp, body):
                 check_tools=True,
                 wait=False)
             if node_type == TYPE_NFS:
-                LOGGER.debug('Enabling NFS server on %s' %
-                             spec['target_vm_name'])
+                LOGGER.debug(
+                    f"enabling NFS server on {spec['target_vm_name']}")
                 script = get_data_file('nfsd-%s.sh' % template['name'])
                 exec_results = execute_script_in_nodes(
                     config, vapp,
@@ -222,15 +220,15 @@ def get_nodes(vapp, node_type):
 
 
 def wait_for_tools_ready_callback(message, exception=None):
-    LOGGER.debug('waiting for guest tools, status: %s' % message)
+    LOGGER.debug(f"waiting for guest tools, status: {message}")
     if exception is not None:
-        LOGGER.error('exception: %s' % str(exception))
+        LOGGER.error(f"exception: {str(exception)}")
 
 
 def wait_for_guest_execution_callback(message, exception=None):
     LOGGER.debug(message)
     if exception is not None:
-        LOGGER.error('exception: %s' % str(exception))
+        LOGGER.error(f"exception: {str(exception)}")
 
 
 def get_init_info(config, vapp, password):
@@ -246,7 +244,7 @@ ip route get 1 | awk '{print $NF;exit}'
 
 
 def get_master_ip(config, vapp, template):
-    LOGGER.debug('getting master IP for vapp: %s' % vapp.resource.get('name'))
+    LOGGER.debug(f"getting master IP for vapp: {vapp.resource.get('name')}")
     script = \
 """#!/usr/bin/env bash
 ip route get 1 | awk '{print $NF;exit}'
@@ -260,8 +258,8 @@ ip route get 1 | awk '{print $NF;exit}'
         nodes,
         check_tools=False)
     master_ip = result[0][1].content.decode().split()[0]
-    LOGGER.debug('getting master IP for vapp: %s, ip: %s' %
-                 (vapp.resource.get('name'), master_ip))
+    LOGGER.debug(f"getting master IP for vapp: {vapp.resource.get('name')}, "
+                 f"ip: {master_ip}")
     return master_ip
 
 
@@ -326,9 +324,9 @@ uname -a
             if result[0] == 0:
                 ready = True
                 break
-            raise Exception('script returned %s' % result[0])
+            raise Exception(f"script returned {result[0]}")
         except Exception:
-            LOGGER.info('VM is not ready to execute scripts, yet')
+            LOGGER.info("VM is not ready to execute scripts, yet")
             time.sleep(2)
     if not ready:
         raise CseServerError('VM is not ready to execute scripts')
@@ -348,19 +346,19 @@ def execute_script_in_nodes(config,
             debug_script = p.sub(':***\"', script)
         else:
             debug_script = script
-        LOGGER.debug('will try to execute script on %s:\n%s' %
-                     (node.get('name'), debug_script))
+        LOGGER.debug(f"will try to execute script on {node.get('name')}:\n"
+                     f"{debug_script}")
         vs = get_vsphere(config, vapp, node.get('name'))
         vs.connect()
         moid = vapp.get_vm_moid(node.get('name'))
         vm = vs.get_vm_by_moid(moid)
         if check_tools:
-            LOGGER.debug('waiting for tools on %s' % node.get('name'))
+            LOGGER.debug(f"waiting for tools on {node.get('name')}")
             vs.wait_until_tools_ready(
                 vm, sleep=5, callback=wait_for_tools_ready_callback)
             wait_until_ready_to_exec(vs, vm, password)
-        LOGGER.debug('about to execute script on %s (vm=%s), wait=%s' %
-                     (node.get('name'), vm, wait))
+        LOGGER.debug(f"about to execute script on {node.get('name')} (vm={vm})"
+                     f", wait={wait}")
         if wait:
             result = vs.execute_script_in_guest(
                 vm,
@@ -402,7 +400,7 @@ def get_file_from_nodes(config,
                         check_tools=True):
     all_results = []
     for node in nodes:
-        LOGGER.debug('getting file from node %s' % node.get('name'))
+        LOGGER.debug(f"getting file from node {node.get('name')}")
         vs = get_vsphere(config, vapp, node.get('name'))
         vs.connect()
         moid = vapp.get_vm_moid(node.get('name'))

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -992,7 +992,7 @@ def _customize_vm(ctx, config, vapp, vm_name, cust_script, is_photon=False):
         # unsure all errors execute_script_in_guest can result in
         # Docker TLS handshake timeout can occur when internet is slow
         click.secho("Failed VM customization. Check CSE install log", fg='red')
-        LOGGER.error(f"Failed VM customization with error: f{err}",
+        LOGGER.error(f"Failed VM customization with error: {err}",
                      exc_info=True)
         raise
 
@@ -1164,7 +1164,7 @@ def register_right(client, right_name, description, category, bundle_key):
         system_org.get_right_record(right_name_in_vcd)
         msg = f"Right: {right_name} already exists in vCD"
         click.secho(msg, fg='green')
-        LOGGER.debug(msg)
+        LOGGER.info(msg)
         # Presence of the right in vCD is not guarantee that the right will be
         # assigned to system org.
         rights_in_system = system_org.list_rights_of_org()
@@ -1175,12 +1175,12 @@ def register_right(client, right_name, description, category, bundle_key):
                 msg = f"Right: {right_name} already assigned to System " \
                     f"organization."
                 click.secho(msg, fg='green')
-                LOGGER.debug(msg)
+                LOGGER.info(msg)
                 return
         # Since the right is not assigned to system org, we need to add it.
         msg = f"Assigning Right: {right_name} to System organization."
         click.secho(msg, fg='green')
-        LOGGER.debug(msg)
+        LOGGER.info(msg)
         system_org.add_rights([right_name_in_vcd])
     except EntityNotFoundException:
         # Registering a right via api extension end point auto assigns it to

--- a/container_service_extension/logger.py
+++ b/container_service_extension/logger.py
@@ -7,6 +7,8 @@ import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
+from container_service_extension.security import RedactingFilter
+
 # max size for log files (8MB)
 _MAX_BYTES = 2**23
 _BACKUP_COUNT = 10
@@ -78,6 +80,7 @@ def setup_log_file_directory():
 def configure_install_logger():
     """Configure cse install logger if it is not configured."""
     setup_log_file_directory()
+    INSTALL_LOGGER.addFilter(RedactingFilter())
     INSTALL_LOGGER.setLevel(logging.DEBUG)
     file_handler = logging.FileHandler(INSTALL_LOG_FILEPATH)
     file_handler.setFormatter(DEBUG_LOG_FORMATTER)
@@ -98,6 +101,7 @@ def configure_client_logger():
                                              backupCount=_BACKUP_COUNT)
     debug_file_handler.setFormatter(DEBUG_LOG_FORMATTER)
 
+    CLIENT_LOGGER.addFilter(RedactingFilter())
     CLIENT_LOGGER.setLevel(logging.DEBUG)
     CLIENT_LOGGER.addHandler(info_file_handler)
     CLIENT_LOGGER.addHandler(debug_file_handler)
@@ -117,11 +121,13 @@ def configure_server_logger():
                                              backupCount=_BACKUP_COUNT)
     debug_file_handler.setFormatter(DEBUG_LOG_FORMATTER)
 
+    SERVER_LOGGER.addFilter(RedactingFilter())
     SERVER_LOGGER.setLevel(logging.DEBUG)
     SERVER_LOGGER.addHandler(info_file_handler)
     SERVER_LOGGER.addHandler(debug_file_handler)
 
     pika_logger = logging.getLogger('pika')
+    pika_logger.addFilter(RedactingFilter())
     pika_logger.setLevel(logging.WARNING)
     pika_logger.addHandler(info_file_handler)
     pika_logger.addHandler(debug_file_handler)

--- a/container_service_extension/ovdc_cache.py
+++ b/container_service_extension/ovdc_cache.py
@@ -133,10 +133,11 @@ class OvdcCache(object):
         ovdc_name = ovdc.resource.get('name')
         metadata = {}
         if container_provider != CtrProvType.PKS.value:
-            LOGGER.debug(f"Remove metadata for ovdc:{ovdc_name}")
+            LOGGER.debug(f"Remove existing metadata for ovdc:{ovdc_name}")
             self._remove_metadata(ovdc, self.pks_cache.get_pks_keys())
             metadata[CONTAINER_PROVIDER] = container_provider or ''
-            LOGGER.debug(f'metadata for{container_provider}:{metadata}')
+            LOGGER.debug(f"Updated metadata for {container_provider}:"
+                         f"{metadata}")
         else:
             container_prov_data.pop('username')
             container_prov_data.pop('secret')
@@ -144,7 +145,7 @@ class OvdcCache(object):
             metadata.update(container_prov_data)
 
         # set ovdc metadata into Vcd
-        LOGGER.debug(f"Setting below metadata on ovdc {ovdc_name}:{metadata}")
+        LOGGER.debug(f"On ovdc:{ovdc_name}, setting metadata:{metadata}")
         return ovdc.set_multiple_metadata(metadata, MetadataDomain.SYSTEM,
                                           MetadataVisibility.PRIVATE)
 
@@ -185,9 +186,3 @@ class OvdcCache(object):
 
     def get_compute_profile_name(self, ovdc_id, ovdc_name):
         return f"cp--{ovdc_id}--{ovdc_name}"
-
-
-
-
-
-

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -14,7 +14,6 @@ from container_service_extension.exceptions import PksConnectionError
 from container_service_extension.exceptions import PksServerError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.pks_cache import PKS_COMPUTE_PROFILE
-from container_service_extension.pksclient.rest import ApiException
 from container_service_extension.pksclient.api.cluster_api import ClusterApi
 from container_service_extension.pksclient.api.profile_api import ProfileApi
 from container_service_extension.pksclient.api_client import ApiClient
@@ -27,6 +26,7 @@ from container_service_extension.pksclient.models.compute_profile_request \
     import ComputeProfileRequest
 from container_service_extension.pksclient.models.update_cluster_parameters\
     import UpdateClusterParameters
+from container_service_extension.pksclient.rest import ApiException
 from container_service_extension.uaaclient.uaaclient import UaaClient
 from container_service_extension.utils import ACCEPTED
 from container_service_extension.utils import exception_handler
@@ -176,12 +176,12 @@ class PKSBroker(AbstractBroker):
         """
         cluster_api = ClusterApi(api_client=self.pks_client)
 
-        LOGGER.debug(f'Sending request to PKS: {self.pks_host_uri} '
-                     f'to list all clusters')
+        LOGGER.debug(f"Sending request to PKS: {self.pks_host_uri} "
+                     f"to list all clusters")
         try:
             clusters = cluster_api.list_clusters()
         except ApiException as err:
-            LOGGER.debug(f'Listing PKS clusters failed with error:\n {err}')
+            LOGGER.debug(f"Listing PKS clusters failed with error:\n {err}")
             raise PksServerError(err.status, err.body)
 
         list_of_cluster_dicts = []
@@ -196,8 +196,8 @@ class PKSBroker(AbstractBroker):
             }
             list_of_cluster_dicts.append(cluster_dict)
 
-        LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} on the'
-                     f' list of clusters: {list_of_cluster_dicts}')
+        LOGGER.debug(f"Received response from PKS: {self.pks_host_uri} on the"
+                     f" list of clusters: {list_of_cluster_dicts}")
         return list_of_cluster_dicts
 
     @add_vcd_user_context(qualify_params=['cluster_name'])
@@ -233,21 +233,21 @@ class PKSBroker(AbstractBroker):
                                          parameters=cluster_params,
                                          compute_profile_name=compute_profile)
 
-        LOGGER.debug(f'Sending request to PKS: {self.pks_host_uri} to create '
-                     f'cluster of name: {cluster_name}')
+        LOGGER.debug(f"Sending request to PKS: {self.pks_host_uri} to create "
+                     f"cluster of name: {cluster_name}")
         try:
             cluster = cluster_api.add_cluster(cluster_request)
         except ApiException as err:
-            LOGGER.debug(f'Creating cluster {cluster_name} in PKS failed with '
-                         f'error:\n {err}')
+            LOGGER.debug(f"Creating cluster {cluster_name} in PKS failed with "
+                         f"error:\n {err}")
             raise PksServerError(err.status, err.body)
         cluster_dict = cluster.to_dict()
         # Flattening the dictionary
         cluster_params_dict = cluster_dict.pop('parameters')
         cluster_dict.update(cluster_params_dict)
 
-        LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to create'
-                     f' cluster: {cluster_name}')
+        LOGGER.debug(f"PKS: {self.pks_host_uri} accepted the request to create"
+                     f" cluster: {cluster_name}")
         return cluster_dict
 
     @add_vcd_user_context(qualify_params=['cluster_name'])
@@ -261,20 +261,20 @@ class PKSBroker(AbstractBroker):
         """
         cluster_api = ClusterApi(api_client=self.pks_client)
 
-        LOGGER.debug(f'Sending request to PKS: {self.pks_host_uri} to get '
-                     f'details of cluster with name: {cluster_name}')
+        LOGGER.debug(f"Sending request to PKS: {self.pks_host_uri} to get "
+                     f"details of cluster with name: {cluster_name}")
         try:
             cluster = cluster_api.get_cluster(cluster_name=cluster_name)
         except ApiException as err:
-            LOGGER.debug(f'Getting cluster info on {cluster_name} failed with '
-                         f'error:\n {err}')
+            LOGGER.debug(f"Getting cluster info on {cluster_name} failed with "
+                         f"error:\n {err}")
             raise PksServerError(err.status, err.body)
         cluster_dict = cluster.to_dict()
         cluster_params_dict = cluster_dict.pop('parameters')
         cluster_dict.update(cluster_params_dict)
 
-        LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} on '
-                     f'cluster: {cluster_name} with details: {cluster_dict}')
+        LOGGER.debug(f"Received response from PKS: {self.pks_host_uri} on "
+                     f"cluster: {cluster_name} with details: {cluster_dict}")
 
         return cluster_dict
 
@@ -286,17 +286,17 @@ class PKSBroker(AbstractBroker):
         """
         cluster_api = ClusterApi(api_client=self.pks_client)
 
-        LOGGER.debug(f'Sending request to PKS: {self.pks_host_uri} to delete '
-                     f'the cluster with name: {cluster_name}')
+        LOGGER.debug(f"Sending request to PKS: {self.pks_host_uri} to delete "
+                     f"the cluster with name: {cluster_name}")
         try:
             cluster_api.delete_cluster(cluster_name=cluster_name)
         except ApiException as err:
-            LOGGER.debug(f'Deleting cluster {cluster_name} failed with '
-                         f'error:\n {err}')
+            LOGGER.debug(f"Deleting cluster {cluster_name} failed with "
+                         f"error:\n {err}")
             raise PksServerError(err.status, err.body)
 
-        LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to delete'
-                     f' the cluster: {cluster_name}')
+        LOGGER.debug(f"PKS: {self.pks_host_uri} accepted the request to delete"
+                     f" the cluster: {cluster_name}")
         return
 
     @exception_handler
@@ -311,21 +311,21 @@ class PKSBroker(AbstractBroker):
         result['body'] = []
 
         cluster_api = ClusterApi(api_client=self.pks_client)
-        LOGGER.debug(f'Sending request to PKS:{self.pks_host_uri} to resize '
-                     f'the cluster with name: {cluster_name} to '
-                     f'{node_count} worker nodes')
+        LOGGER.debug(f"Sending request to PKS:{self.pks_host_uri} to resize "
+                     f"the cluster with name: {cluster_name} to "
+                     f"{node_count} worker nodes")
 
         resize_params = UpdateClusterParameters(
             kubernetes_worker_instances=node_count)
         try:
             cluster_api.update_cluster(cluster_name, body=resize_params)
         except ApiException as err:
-            LOGGER.debug(f'Resizing cluster {cluster_name} failed with '
-                         f'error:\n {err}')
+            LOGGER.debug(f"Resizing cluster {cluster_name} failed with "
+                         f"error:\n {err}")
             raise PksServerError(err.status, err.body)
 
-        LOGGER.debug(f'PKS: {self.pks_host_uri} accepted the request to resize'
-                     f' the cluster: {cluster_name}')
+        LOGGER.debug(f"PKS: {self.pks_host_uri} accepted the request to resize"
+                     f" the cluster: {cluster_name}")
 
         result['status'] = ACCEPTED
         return result
@@ -384,17 +384,17 @@ class PKSBroker(AbstractBroker):
                                            description=description,
                                            parameters=cp_params_json_str)
 
-        LOGGER.debug(f'Sending request to PKS:{self.pks_host_uri} to create '
-                     f'the compute profile: {cp_name} for ovdc {ovdc_rp_name}')
+        LOGGER.debug(f"Sending request to PKS:{self.pks_host_uri} to create "
+                     f"the compute profile: {cp_name} for ovdc {ovdc_rp_name}")
         try:
             profile_api.add_compute_profile(body=cp_request)
         except ApiException as err:
-            LOGGER.debug(f'Creating compute-profile {cp_name} in PKS failed '
-                         f'with error:\n {err}')
+            LOGGER.debug(f"Creating compute-profile {cp_name} in PKS failed "
+                         f"with error:\n {err}")
             raise PksServerError(err.status, err.body)
 
-        LOGGER.debug(f'PKS: {self.pks_host_uri} created the compute profile: '
-                     f'{cp_name} for ovdc {ovdc_rp_name}')
+        LOGGER.debug(f"PKS: {self.pks_host_uri} created the compute profile: "
+                     f"{cp_name} for ovdc {ovdc_rp_name}")
         return result
 
     @exception_handler
@@ -411,20 +411,20 @@ class PKSBroker(AbstractBroker):
         result['status_code'] = OK
         profile_api = ProfileApi(api_client=self.pks_client)
 
-        LOGGER.debug(f'Sending request to PKS:{self.pks_host_uri} to get the '
-                     f'compute profile: {cp_name} ')
+        LOGGER.debug(f"Sending request to PKS:{self.pks_host_uri} to get the "
+                     f"compute profile: {cp_name}")
 
         try:
             compute_profile = \
                 profile_api.get_compute_profile(profile_name=cp_name)
         except ApiException as err:
-            LOGGER.debug(f'Creating compute-profile {cp_name} in PKS failed '
-                         f'with error:\n {err}')
+            LOGGER.debug(f"Creating compute-profile {cp_name} in PKS failed "
+                         f"with error:\n {err}")
             raise PksServerError(err.status, err.body)
 
-        LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} on '
-                     f'compute-profile: {cp_name} with details: '
-                     f'{compute_profile.to_dict()}')
+        LOGGER.debug(f"Received response from PKS: {self.pks_host_uri} on "
+                     f"compute-profile: {cp_name} with details: "
+                     f"{compute_profile.to_dict()}")
 
         result['body'] = compute_profile.to_dict()
         return result
@@ -442,18 +442,18 @@ class PKSBroker(AbstractBroker):
         result['status_code'] = OK
         profile_api = ProfileApi(api_client=self.pks_client)
 
-        LOGGER.debug(f'Sending request to PKS:{self.pks_host_uri} to get the '
-                     f'list of compute profiles')
+        LOGGER.debug(f"Sending request to PKS:{self.pks_host_uri} to get the "
+                     f"list of compute profiles")
         try:
             cp_list = profile_api.list_compute_profiles()
         except ApiException as err:
-            LOGGER.debug(f'Listing compute-profiles in PKS failed '
-                         f'with error:\n {err}')
+            LOGGER.debug(f"Listing compute-profiles in PKS failed "
+                         f"with error:\n {err}")
             raise PksServerError(err.status, err.body)
 
         list_of_cp_dicts = [cp.to_dict() for cp in cp_list]
-        LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} on '
-                     f'list of compute profiles: {list_of_cp_dicts}')
+        LOGGER.debug(f"Received response from PKS: {self.pks_host_uri} on "
+                     f"list of compute profiles: {list_of_cp_dicts}")
 
         result['body'] = list_of_cp_dicts
         return result
@@ -472,18 +472,18 @@ class PKSBroker(AbstractBroker):
         result['status_code'] = OK
         profile_api = ProfileApi(api_client=self.pks_client)
 
-        LOGGER.debug(f'Sending request to PKS:{self.pks_host_uri} to delete '
-                     f'the compute profile: {cp_name}')
+        LOGGER.debug(f"Sending request to PKS:{self.pks_host_uri} to delete "
+                     f"the compute profile: {cp_name}")
 
         try:
             profile_api.delete_compute_profile(profile_name=cp_name)
         except ApiException as err:
-            LOGGER.debug(f'Deleting compute-profile {cp_name} in PKS failed '
-                         f'with error:\n {err}')
+            LOGGER.debug(f"Deleting compute-profile {cp_name} in PKS failed "
+                         f"with error:\n {err}")
             raise PksServerError(err.status, err.body)
 
-        LOGGER.debug(f'Received response from PKS: {self.pks_host_uri} that'
-                     f' it deleted the compute profile: {cp_name}')
+        LOGGER.debug(f"Received response from PKS: {self.pks_host_uri} that"
+                     f" it deleted the compute profile: {cp_name}")
 
         return result
 

--- a/container_service_extension/processor.py
+++ b/container_service_extension/processor.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import base64
+from copy import deepcopy
 import json
 import sys
 import traceback
-from copy import deepcopy
 from urllib.parse import parse_qsl
 
 from pkg_resources import resource_string
@@ -25,7 +25,7 @@ INTERNAL_SERVER_ERROR = 500
 
 class ServiceProcessor(object):
     def process_request(self, body):
-        LOGGER.debug('body: %s' % json.dumps(body))
+        LOGGER.debug(f"body: {json.dumps(body)}")
         reply = {}
         tokens = body['requestUri'].split('/')
         cluster_name = None
@@ -82,7 +82,7 @@ class ServiceProcessor(object):
                 request_body = {}
         else:
             request_body = {}
-        LOGGER.debug('request body: %s' % json.dumps(request_body))
+        LOGGER.debug(f"request body: {json.dumps(request_body)}")
 
         query_params = {}
         if body['queryString']:
@@ -165,7 +165,7 @@ class ServiceProcessor(object):
                 req_spec.update({'cluster_name': cluster_name})
                 reply = broker_manager.invoke(Operation.DELETE_CLUSTER)
 
-        LOGGER.debug('reply: %s' % str(reply))
+        LOGGER.debug(f"reply: {str(reply)}")
         return reply
 
     def get_spec(self, format):

--- a/container_service_extension/security.py
+++ b/container_service_extension/security.py
@@ -198,6 +198,18 @@ def _test_redaction_filter():
     msg = base_str + str(dikt1) + "," + str(dikt2)
     logger.debug(msg)
 
+    # Case 11 : Real world example
+    # note : the secret is invalid but has the correct format
+    msg = "ovdc metadata for cse-org-vdc-cse-org=>{'pks_plans': ['Plan 1'], " \
+        "'host': 'api.pks.local', 'account_name': 'cse-org-service-account', "\
+        "'uaac_port': '8443', 'cluster': 'kubo-az-1', 'datacenter': " \
+        "'kubo-dc', 'pks_compute_profile_name': 'cp--c1f22cc3-6238-40ec-925" \
+        "2-4162b7c5f1f8--cse-org-vdc', 'proxy': '10.161.67.157', 'port': " \
+        "'9021', 'vc': 'vc1', 'cpi': 'b0f29ab638499e84db21', 'pvdc_name': " \
+        "'vc1-TestbedCluster-20:37:43', 'username': 'admin', 'secret': " \
+        "'S2syTXN6T2JTaV9EbkhzbmdRZVZJemVBaG9lMTFrMnU=', " \
+        "'container_provider': 'pks'}"
+    logger.debug(msg)
 
 if __name__ == "__main__":
     _test_redaction_filter()

--- a/container_service_extension/security.py
+++ b/container_service_extension/security.py
@@ -113,7 +113,7 @@ class RedactingFilter(logging.Filter):
 
 
 def _test_redaction_filter():
-    logger = logging.getLogger("a.b.c")
+    logger = logging.getLogger("random1.2.3")
     logger.addFilter(RedactingFilter())
     logger.setLevel(logging.DEBUG)
     logger.addHandler(logging.FileHandler('test.log'))

--- a/container_service_extension/security.py
+++ b/container_service_extension/security.py
@@ -1,5 +1,5 @@
 # container-service-extension
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 import logging

--- a/container_service_extension/security.py
+++ b/container_service_extension/security.py
@@ -1,0 +1,201 @@
+# container-service-extension
+# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import logging
+import re
+
+
+class RedactingFilter(logging.Filter):
+    """Filter class to redact sensitive infomarion in logs.
+
+    This filter looks for certain sensitive keys and if a match is found, the
+    value will be redacted. The value are expected to be strings. If they are
+    dictionaries or iterables, resulting redaction will be partial. Generally
+    the values for the sesitive key will be plain strings.
+    """
+
+    _SENSITIVE_KEYS = ['authorization',
+                       'x-vcloud-authorization',
+                       'x-vmware-vcloud-access-token',
+                       'username',
+                       'secret',
+                       'password']
+
+    _REDACTED_MSG = r"[REDACTED]"
+
+    def __init__(self):
+        """."""
+        super(RedactingFilter, self).__init__()
+
+        pattern_key = r""
+        # concatenate all sensitive keys with | symbol
+        for key in self._SENSITIVE_KEYS:
+            pattern_key += key + r"|"
+        # remove the last | symbol
+        pattern_key = pattern_key[:-1]
+
+        # The following pattern will match key-value pairs as follows
+        # key: value
+        # key: 'value'
+        # 'key': value
+        # 'key': 'value'
+        # where key is one of the keys defined in the list of sensitive keys
+        # and value will be accessible as group 1
+        # Regex explanation :
+        #   1. Look for a match with one of the keys
+        #   2. Look for 0 or 1 instance of '
+        #   3. Look for a colon
+        #   4. Look for 1 or more instances of space
+        #   5. Look for 0 or 1 instance of '
+        #   5. Put everything that is not ', space or } in a group,
+        #      this group must be atleast of length 1.
+        self._pattern = r"((" + pattern_key + r")'?:\s+[{\[]*'?)([^',}]+)"
+
+    def filter(self, record):
+        """Overridden filter method to redact log records.
+
+        record.msg is always a string, record.args is the arg list from which
+        the formatter will pick values if necessary and hence should be
+        redacted too.
+
+        :param logRecord record: logRecord object that needs redaction
+
+        :returns: True, which forces the filter chain processing to continue.
+
+        :rtype: boolean
+        """
+        record.msg = self.redact(record.msg)
+        if len(record.args) != 0:
+            record.args = self.redact(record.args)
+        return True
+
+    def redact(self, obj):
+        """Redact sensitive data in an object.
+
+        The redaction algorithm will preserve dictionary structure. Iterables
+        like list etc. will be converted to n-tuple. Everything else will be
+        converted to string.
+
+        :param object obj: the object which contains sensitive data to be
+            redacted.
+
+        :return: the redacted version of the object.
+
+        :rtype: object
+        """
+        if obj is None:
+            return obj
+
+        is_iterable = True
+        try:
+            iter(theElement)
+        except (NameError, TypeError):
+            is_iterable = False
+
+        if isinstance(obj, dict):
+            result = {}
+            for k in obj.keys():
+                if k in self._SENSITIVE_KEYS:
+                    result[k] = self._REDACTED_MSG
+                else:
+                    result[k] = self.redact(obj[k])
+            return result
+        elif is_iterable:
+            return tuple(self.redact(item) for item in obj)
+        else:
+            msg_str = str(obj)
+            redacted_msg = re.sub(pattern=self._pattern,
+                                  string=msg_str,
+                                  repl=r"\1" + self._REDACTED_MSG,
+                                  flags=re.IGNORECASE)
+            return redacted_msg
+
+
+def _test_redaction_filter():
+    logger = logging.getLogger("a.b.c")
+    logger.addFilter(RedactingFilter())
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(logging.FileHandler('test.log'))
+
+    base_str = "This is just a test string."
+
+    # Case 1 : key : value
+    dikt = {1: 2}
+    msg = base_str + str(dikt)
+    logger.debug(msg)
+
+    # Case 2 : key : 'value'
+    dikt = {1: '2'}
+    msg = base_str + str(dikt)
+    logger.debug(msg)
+
+    # Case 3 : 'key' : value
+    dikt1 = {'normal_key': 123}
+    dikt2 = {'username': 345}
+    msg = base_str + str(dikt1) + "," + str(dikt2)
+    logger.debug(msg)
+
+    # Case 4 : 'key' : 'value'
+    dikt1 = {'normal_key': 123}
+    dikt2 = {'username': 'super secret user name'}
+    msg = base_str + str(dikt1) + "," + str(dikt2)
+    logger.debug(msg)
+
+    # Case 5 : Ignore case
+    dikt1 = {'normal_key': 123}
+    dikt2 = {'usERname': 'super secret user name'}
+    msg = base_str + str(dikt1) + "," + str(dikt2)
+    logger.debug(msg)
+
+    # Case 6 : Multiple matches
+    dikt1 = {'password': 'super secret password'}
+    dikt2 = {'username': 'super secret user name'}
+    msg = base_str + str(dikt1) + "," + str(dikt2)
+    logger.debug(msg)
+
+    # Case 7 : Empty value
+    dikt1 = {'password': 'super secret password'}
+    dikt2 = {'username': ''}
+    # expected no redaction for empty value
+    msg = base_str + str(dikt1) + "," + str(dikt2)
+    logger.debug(msg)
+
+    # Case 8 : Nested dictionaries with bad value
+    dikt1 = {'normal_key': 'normal_value'}
+    dikt2 = {'password': dikt1}
+    # expected - improper redaction - since value is not string
+    msg = base_str + str(dikt1) + "," + str(dikt2)
+    logger.debug(msg)
+
+    # Case 9 : dictionary with multiple sensitive keys
+    dikt = {
+        'password': 'super secret password',
+        'normal_key': 'normal_value',
+        'username': 'super secret username'
+    }
+    msg = base_str + str(dikt)
+    logger.debug(msg)
+
+    # Case 10 : Battle Royale
+    dikt1 = {
+        'Authorization': 'Base 64 encoded string',
+        'PasswOrd': 'super secret password',
+        'normal_key': ['', 'sshhh'],
+        'username': '',
+        'secret': 'shhh'
+    }
+    dikt2 = {
+        'Authorization': 'Base 64 encoded string',
+        'PasswOrd': 'super secret password',
+        'normal_key': '',
+        'username': '',
+        'secret': dikt1
+    }
+    # expected - improper redaction - since value is not always string
+    msg = base_str + str(dikt1) + "," + str(dikt2)
+    logger.debug(msg)
+
+
+if __name__ == "__main__":
+    _test_redaction_filter()

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -16,7 +16,6 @@ from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 import requests
 
-from container_service_extension.pks_cache import PksCache
 from container_service_extension.configure_cse import check_cse_installation
 from container_service_extension.configure_cse import get_validated_config
 from container_service_extension.consumer import MessageConsumer
@@ -25,6 +24,7 @@ from container_service_extension.logger import SERVER_DEBUG_LOG_FILEPATH
 from container_service_extension.logger import SERVER_DEBUG_WIRELOG_FILEPATH
 from container_service_extension.logger import SERVER_INFO_LOG_FILEPATH
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
+from container_service_extension.pks_cache import PksCache
 from container_service_extension.utils import connect_vcd_user_via_token
 from container_service_extension.utils import SYSTEM_ORG_NAME
 
@@ -46,10 +46,10 @@ def signal_handler(signal, frame):
 
 def consumer_thread(c):
     try:
-        LOGGER.info('About to start consumer_thread %s.', c)
+        LOGGER.info(f"About to start consumer_thread {c}.")
         c.run()
     except Exception:
-        click.echo('About to stop consumer_thread.')
+        click.echo("About to stop consumer_thread.")
         LOGGER.error(traceback.format_exc())
         c.stop()
 
@@ -74,9 +74,9 @@ class Service(object, metaclass=Singleton):
     def get_sys_admin_client(self):
         if self.config is not None:
             if not self.config['vcd']['verify']:
-                LOGGER.warning('InsecureRequestWarning: Unverified HTTPS '
-                               'request is being made. Adding certificate '
-                               'verification is strongly advised.')
+                LOGGER.warning("InsecureRequestWarning: Unverified HTTPS "
+                               "request is being made. Adding certificate "
+                               "verification is strongly advised.")
                 requests.packages.urllib3.disable_warnings()
             client = Client(
                 uri=self.config['vcd']['host'],
@@ -199,9 +199,10 @@ class Service(object, metaclass=Singleton):
         click.secho(message)
         LOGGER.info(message)
         if self.config.get('pks_config'):
-            self.pks_cache = PksCache(self.config.get('pks_config').get('orgs'),
-                                    self.config.get('pks_config').get('pks_accounts'),
-                                    self.config.get('pks_config').get('pvdcs'))
+            self.pks_cache = PksCache(
+                self.config.get('pks_config').get('orgs'),
+                self.config.get('pks_config').get('pks_accounts'),
+                self.config.get('pks_config').get('pvdcs'))
         amqp = self.config['amqp']
         num_consumers = self.config['service']['listeners']
 
@@ -215,7 +216,7 @@ class Service(object, metaclass=Singleton):
                 t = Thread(name=name, target=consumer_thread, args=(c, ))
                 t.daemon = True
                 t.start()
-                LOGGER.info('started thread %s', t.ident)
+                LOGGER.info("Started thread {t.ident}")
                 self.threads.append(t)
                 self.consumers.append(c)
                 time.sleep(0.25)
@@ -224,7 +225,7 @@ class Service(object, metaclass=Singleton):
             except Exception:
                 print(traceback.format_exc())
 
-        LOGGER.info('num of threads started: %s', len(self.threads))
+        LOGGER.info(f"Number of threads started: {len(self.threads)}")
 
         self.is_enabled = True
 
@@ -239,11 +240,11 @@ class Service(object, metaclass=Singleton):
                 click.secho(traceback.format_exc())
                 sys.exit(1)
 
-        LOGGER.info('stop detected')
-        LOGGER.info('closing connections...')
+        LOGGER.info("Stop detected")
+        LOGGER.info("Closing connections...")
         for c in self.consumers:
             try:
                 c.stop()
             except Exception:
                 pass
-        LOGGER.info('done')
+        LOGGER.info("Done")

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -72,9 +72,9 @@ GATEWAY_TIMEOUT = 504
 
 def connect_vcd_user_via_token(vcd_uri, headers, verify_ssl_certs=True):
     if not verify_ssl_certs:
-        LOGGER.warning('InsecureRequestWarning: Unverified HTTPS request is '
-                       'being made. Adding certificate verification is '
-                       'strongly advised.')
+        LOGGER.warning("InsecureRequestWarning: Unverified HTTPS request is "
+                       "being made. Adding certificate verification is "
+                       "strongly advised.")
         requests.packages.urllib3.disable_warnings()
     token = headers.get('x-vcloud-authorization')
     accept_header = headers.get('Accept')

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -105,20 +105,20 @@ def rollback(func):
                 if broker_instance.body[ROLLBACK_FLAG]:
                     broker_instance.node_rollback(node_list)
             except Exception as err:
-                LOGGER.error('Failed to rollback node creation:%s', str(err))
+                LOGGER.error(f"Failed to rollback node creation:{str(err)}")
     return wrapper
 
 
 def task_callback(task):
-    message = '\x1b[2K\r{}: {}, status: {}'.format(
-        task.get('operationName'), task.get('operation'), task.get('status'))
+    message = f"\x1b[2K\r{task.get('operationName')}: " \
+              f"{task.get('operation')}, status: {task.get('status')}"
     if hasattr(task, 'Progress'):
-        message += ', progress: %s%%' % task.Progress
+        message += f", progress: {task.Progress}%"
     if task.get('status').lower() in [
             TaskStatus.QUEUED.value, TaskStatus.PENDING.value,
             TaskStatus.PRE_RUNNING.value, TaskStatus.RUNNING.value
     ]:
-        message += ' %s ' % spinner.next()
+        message += f" {spinner.next()} "
     click.secho(message)
 
 
@@ -174,7 +174,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
             operation_name=self.op,
             details='',
             progress=None,
-            owner_href='urn:cse:cluster:%s' % self.cluster_id,
+            owner_href=f"urn:cse:cluster:{self.cluster_id}",
             owner_name=self.cluster_name,
             owner_type='application/vcloud.cse.cluster+xml',
             user_href=self.tenant_info['user_id'],
@@ -191,7 +191,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
             return False
         if name[-1] == '.':
             name = name[:-1]
-        allowed = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+        allowed = re.compile(r"(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
         return all(allowed.match(x) for x in name.split("."))
 
     def get_template(self, name=None):
@@ -205,10 +205,10 @@ class VcdBroker(AbstractBroker, threading.Thread):
         for template in server_config['broker']['templates']:
             if template['name'] == name:
                 return template
-        raise Exception('Template %s not found' % name)
+        raise Exception(f"Template {name} not found.")
 
     def run(self):
-        LOGGER.debug('thread started op=%s' % self.op)
+        LOGGER.debug(f"Thread started for operation={self.op}")
         if self.op == OP_CREATE_CLUSTER:
             self.create_cluster_thread()
         elif self.op == OP_DELETE_CLUSTER:
@@ -242,7 +242,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
         self._connect_tenant()
         clusters = load_from_metadata(self.tenant_client, name=cluster_name)
         if len(clusters) == 0:
-            raise CseServerError('Cluster \'%s\' not found.' % cluster_name)
+            raise CseServerError(f"Cluster '{cluster_name}' not found.")
         cluster = clusters[0]
         vapp = VApp(self.tenant_client, href=clusters[0]['vapp_href'])
         vms = vapp.get_all_vms()
@@ -255,8 +255,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
                 node_info['ipAddress'] = vapp.get_primary_ip(
                     vm.get('name'))
             except Exception:
-                LOGGER.debug(
-                    'cannot get ip address for node %s' % vm.get('name'))
+                LOGGER.debug(f"Unable to get ip address of node "
+                             f"{vm.get('name')}")
             if vm.get('name').startswith(TYPE_MASTER):
                 cluster.get('master_nodes').append(node_info)
             elif vm.get('name').startswith(TYPE_NODE):
@@ -304,8 +304,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
                     node_info['ipAddress'] = vapp.get_primary_ip(
                         vm.get('name'))
                 except Exception:
-                    LOGGER.debug('cannot get ip address '
-                                 'for node %s' % vm.get('name'))
+                    LOGGER.debug(f"Unable to get ip address of node "
+                                 f"{vm.get('name')}")
                 if vm.get('name').startswith(TYPE_MASTER):
                     node_info['node_type'] = 'master'
                 elif vm.get('name').startswith(TYPE_NODE):
@@ -317,8 +317,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
                                                     vm)
                     node_info['exports'] = exports
         if node_info is None:
-            raise CseServerError('Node \'%s\' not found in cluster \'%s\''
-                                 % (node_name, cluster_name))
+            raise CseServerError(f"Node '{node_name}' not found in cluster "
+                                 f"'{cluster_name}'")
         result['body'] = node_info
         return result
 
@@ -338,7 +338,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
         # the template from which nfs node was created.
         server_config = get_server_runtime_config()
         template = server_config['broker']['templates'][0]
-        script = '#!/usr/bin/env bash\nshowmount -e %s' % ip
+        script = f"#!/usr/bin/env bash\nshowmount -e {ip}"
         result = execute_script_in_nodes(
             server_config, vapp, template['admin_password'],
             script, nodes=[node], check_tools=False)
@@ -360,11 +360,11 @@ class VcdBroker(AbstractBroker, threading.Thread):
         #  ClusterParams either as a param (or)
         #  read from instance variable (if needed only).
 
-        LOGGER.debug('About to create cluster %s on %s with %s nodes, sp=%s',
-                     cluster_name, vdc_name, node_count, storage_profile)
+        LOGGER.debug(f"About to create cluster {cluster_name} on {vdc_name} "
+                     f"with {node_count} nodes, sp={storage_profile}")
 
         if not self.is_valid_name(cluster_name):
-            raise CseServerError(f"Invalid cluster name \'{cluster_name}\'")
+            raise CseServerError(f"Invalid cluster name '{cluster_name}'")
         self._connect_tenant()
         self._connect_sys_admin()
         self.cluster_name = cluster_name
@@ -372,8 +372,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
         self.op = OP_CREATE_CLUSTER
         self.update_task(
             TaskStatus.RUNNING,
-            message='Creating cluster %s(%s)' % (cluster_name,
-                                                 self.cluster_id))
+            message=f"Creating cluster {cluster_name}({self.cluster_id})")
         self.daemon = True
         self.start()
         result = {}
@@ -398,17 +397,17 @@ class VcdBroker(AbstractBroker, threading.Thread):
             template = self.get_template()
             self.update_task(
                 TaskStatus.RUNNING,
-                message='Creating cluster vApp %s(%s)' % (self.cluster_name,
-                                                          self.cluster_id))
+                message=f"Creating cluster vApp {self.cluster_name}"
+                        f"({self.cluster_id})")
             try:
                 vapp_resource = vdc.create_vapp(
                     self.cluster_name,
-                    description='cluster %s' % self.cluster_name,
+                    description=f"cluster {self.cluster_name}",
                     network=network_name,
                     fence_mode='bridged')
             except Exception as e:
                 raise ClusterOperationError(
-                    'Error while creating vApp:', str(e))
+                    "Error while creating vApp:", str(e))
 
             self.tenant_client.get_task_monitor().wait_for_status(
                 vapp_resource.Tasks.Task[0])
@@ -423,8 +422,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
                 self.tenant_client.get_task_monitor().wait_for_status(task)
             self.update_task(
                 TaskStatus.RUNNING,
-                message='Creating master node for %s(%s)' % (self.cluster_name,
-                                                             self.cluster_id))
+                message=f"Creating master node for {self.cluster_name}"
+                        f"({self.cluster_id})")
             vapp.reload()
 
             server_config = get_server_runtime_config()
@@ -437,8 +436,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
 
             self.update_task(
                 TaskStatus.RUNNING,
-                message='Initializing cluster %s(%s)' % (self.cluster_name,
-                                                         self.cluster_id))
+                message=f"Initializing cluster {self.cluster_name}"
+                        f"({self.cluster_id})")
             vapp.reload()
             init_cluster(server_config, vapp, template)
             master_ip = get_master_ip(server_config, vapp, template)
@@ -448,9 +447,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
             if self.req_spec['node_count'] > 0:
                 self.update_task(
                     TaskStatus.RUNNING,
-                    message='Creating %s node(s) for %s(%s)' %
-                    (self.req_spec['node_count'], self.cluster_name,
-                     self.cluster_id))
+                    message=f"Creating {self.req_spec['node_count']} node(s) "
+                            f"for {self.cluster_name}({self.cluster_id})")
                 try:
                     add_nodes(self.req_spec['node_count'], template, TYPE_NODE,
                               server_config, self.tenant_client, org, vdc,
@@ -461,17 +459,15 @@ class VcdBroker(AbstractBroker, threading.Thread):
 
                 self.update_task(
                     TaskStatus.RUNNING,
-                    message='Adding %s node(s) to %s(%s)' %
-                    (self.req_spec['node_count'], self.cluster_name,
-                     self.cluster_id))
+                    message=f"Adding {self.req_spec['node_count']} node(s) to "
+                            f"{self.cluster_name}({self.cluster_id})")
                 vapp.reload()
                 join_cluster(server_config, vapp, template)
             if self.req_spec['enable_nfs']:
                 self.update_task(
                     TaskStatus.RUNNING,
-                    message='Creating NFS node for %s(%s)' %
-                            (self.cluster_name,
-                             self.cluster_id))
+                    message=f"Creating NFS node for {self.cluster_name}"
+                            f"({self.cluster_id})")
                 try:
                     add_nodes(1, template, TYPE_NFS,
                               server_config, self.tenant_client, org, vdc,
@@ -482,8 +478,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
 
             self.update_task(
                 TaskStatus.SUCCESS,
-                message='Created cluster %s(%s)' % (self.cluster_name,
-                                                    self.cluster_id))
+                message=f"Created cluster {self.cluster_name}"
+                        f"({self.cluster_id})")
         except (MasterNodeCreationError, WorkerNodeCreationError,
                 NFSNodeCreationError, ClusterJoiningError,
                 ClusterInitializationError, ClusterOperationError) as e:
@@ -508,7 +504,6 @@ class VcdBroker(AbstractBroker, threading.Thread):
 
     @secure(required_rights=[CSE_NATIVE_DEPLOY_RIGHT_NAME])
     def delete_cluster(self, cluster_name):
-
         LOGGER.debug(f"About to delete cluster with name: {cluster_name}")
 
         self.cluster_name = cluster_name
@@ -523,8 +518,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
         self.cluster_id = self.cluster['cluster_id']
         self.update_task(
             TaskStatus.RUNNING,
-            message='Deleting cluster %s(%s)' % (self.cluster_name,
-                                                 self.cluster_id))
+            message=f"Deleting cluster {self.cluster_name}"
+                    f"({self.cluster_id})")
         self.daemon = True
         self.start()
         result = {}
@@ -533,16 +528,15 @@ class VcdBroker(AbstractBroker, threading.Thread):
         return result
 
     def delete_cluster_thread(self):
-        LOGGER.debug('About to delete cluster with name: %s',
-                     self.cluster_name)
+        LOGGER.debug(f"About to delete cluster with name: {self.cluster_name}")
         try:
             vdc = VDC(self.tenant_client, href=self.cluster['vdc_href'])
             task = vdc.delete_vapp(self.cluster['name'], force=True)
             self.tenant_client.get_task_monitor().wait_for_status(task)
             self.update_task(
                 TaskStatus.SUCCESS,
-                message='Deleted cluster %s(%s)' % (self.cluster_name,
-                                                    self.cluster_id))
+                message=f"Deleted cluster {self.cluster_name}"
+                        f"({self.cluster_id})")
         except Exception as e:
             LOGGER.error(traceback.format_exc())
             self.update_task(TaskStatus.ERROR, error_message=str(e))
@@ -556,7 +550,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
         clusters = load_from_metadata(
             self.tenant_client, name=cluster_name)
         if len(clusters) != 1:
-            raise CseServerError('Cluster \'%s\' not found' % cluster_name)
+            raise CseServerError(f"Cluster '{cluster_name}' not found")
         vapp = VApp(self.tenant_client, href=clusters[0]['vapp_href'])
         template = self.get_template(name=clusters[0]['template'])
         server_config = get_server_runtime_config()
@@ -587,8 +581,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
         clusters = load_from_metadata(
             self.tenant_client, name=self.cluster_name)
         if len(clusters) != 1:
-            raise CseServerError(
-                'Cluster \'%s\' not found.' % self.cluster_name)
+            raise CseServerError(f"Cluster '{self.cluster_name}' not found.")
         self.cluster = clusters[0]
         self.op = OP_CREATE_NODES
         self.cluster_id = self.cluster['cluster_id']
@@ -607,8 +600,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
 
     @rollback
     def create_nodes_thread(self):
-        LOGGER.debug('About to add nodes to cluster with name: %s',
-                     self.cluster_name)
+        LOGGER.debug(f"About to add nodes to cluster with name: "
+                     f"{self.cluster_name}")
         try:
             server_config = get_server_runtime_config()
             org_resource = self.tenant_client.get_org()
@@ -618,10 +611,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
             template = self.get_template()
             self.update_task(
                 TaskStatus.RUNNING,
-                message='Creating %s node(s) for %s(%s)' %
-                        (self.req_spec['node_count'],
-                         self.cluster_name,
-                         self.cluster_id))
+                message=f"Creating {self.req_spec['node_count']} node(s) for "
+                        f"{self.cluster_name}({self.cluster_id})")
             new_nodes = add_nodes(self.req_spec['node_count'], template,
                                   self.req_spec['node_type'],
                                   server_config, self.tenant_client,
@@ -629,17 +620,12 @@ class VcdBroker(AbstractBroker, threading.Thread):
             if self.req_spec['node_type'] == TYPE_NFS:
                 self.update_task(
                     TaskStatus.SUCCESS,
-                    message='Created %s node(s) for %s(%s)' %
-                            (self.req_spec['node_count'],
-                             self.cluster_name,
-                             self.cluster_id))
-            elif self.req_spec['node_type'] == TYPE_NODE:
+                    message=f"Created {self.req_spec['node_count']} node(s) "
+                            f"for {self.cluster_name}({self.cluster_id})")
                 self.update_task(
                     TaskStatus.RUNNING,
-                    message='Adding %s node(s) to %s(%s)' %
-                            (self.req_spec['node_count'],
-                             self.cluster_name,
-                             self.cluster_id))
+                    message=f"Adding {self.req_spec['node_count']} node(s) to "
+                            f"cluster {self.cluster_name}({self.cluster_id})")
                 target_nodes = []
                 for spec in new_nodes['specs']:
                     target_nodes.append(spec['target_vm_name'])
@@ -647,10 +633,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
                 join_cluster(server_config, vapp, template, target_nodes)
                 self.update_task(
                     TaskStatus.SUCCESS,
-                    message='Added %s node(s) to cluster %s(%s)' %
-                            (self.req_spec['node_count'],
-                             self.cluster_name,
-                             self.cluster_id))
+                    message=f"Added {self.req_spec['node_count']} node(s) to "
+                            f"cluster {self.cluster_name}({self.cluster_id})")
         except NodeCreationError as e:
             error_obj = error_to_json(e)
             LOGGER.error(traceback.format_exc())
@@ -684,15 +668,13 @@ class VcdBroker(AbstractBroker, threading.Thread):
                                  f"{self.req_spec['nodes']}.")
         for node in self.req_spec['nodes']:
             if node.startswith(TYPE_MASTER):
-                raise CseServerError(
-                    'Can\'t delete a master node: \'%s\'.' % node)
+                raise CseServerError(f"Can't delete a master node: '{node}'.")
         self._connect_tenant()
         self._connect_sys_admin()
         clusters = load_from_metadata(
             self.tenant_client, name=self.cluster_name)
         if len(clusters) != 1:
-            raise CseServerError(
-                'Cluster \'%s\' not found.' % self.cluster_name)
+            raise CseServerError(f"Cluster '{self.cluster_name}' not found.")
         self.cluster = clusters[0]
         self.op = OP_DELETE_NODES
         self.cluster_id = self.cluster['cluster_id']
@@ -710,16 +692,15 @@ class VcdBroker(AbstractBroker, threading.Thread):
         return result
 
     def delete_nodes_thread(self):
-        LOGGER.debug('About to delete nodes from cluster with name: %s',
-                     self.cluster_name)
+        LOGGER.debug(f"About to delete nodes from cluster with name: "
+                     f"{self.cluster_name}")
         try:
             vapp = VApp(self.tenant_client, href=self.cluster['vapp_href'])
             template = self.get_template()
             self.update_task(
                 TaskStatus.RUNNING,
-                message='Deleting %s node(s) from %s(%s)' %
-                (len(self.req_spec['nodes']), self.cluster_name,
-                 self.cluster_id))
+                message=f"Deleting {len(self.req_spec['nodes'])} node(s) from "
+                        f"{self.cluster_name}({self.cluster_id})")
             try:
                 server_config = get_server_runtime_config()
                 delete_nodes_from_cluster(server_config,
@@ -732,28 +713,25 @@ class VcdBroker(AbstractBroker, threading.Thread):
                              f"from cluster:{self.cluster_name}")
             self.update_task(
                 TaskStatus.RUNNING,
-                message='Undeploying %s node(s) for %s(%s)' %
-                (len(self.req_spec['nodes']), self.cluster_name,
-                 self.cluster_id))
+                message=f"Undeploying {len(self.req_spec['nodes'])} node(s) "
+                        f"for {self.cluster_name}({self.cluster_id})")
             for vm_name in self.req_spec['nodes']:
                 vm = VM(self.tenant_client, resource=vapp.get_vm(vm_name))
                 try:
                     task = vm.undeploy()
                     self.tenant_client.get_task_monitor().wait_for_status(task)
                 except Exception:
-                    LOGGER.warning('couldn\'t undeploy VM %s' % vm_name)
+                    LOGGER.warning(f"Couldn't undeploy VM {vm_name}")
             self.update_task(
                 TaskStatus.RUNNING,
-                message='Deleting %s VM(s) for %s(%s)' %
-                (len(self.req_spec['nodes']), self.cluster_name,
-                 self.cluster_id))
+                message=f"Deleting {len(self.req_spec['nodes'])} VM(s) for "
+                        f"{self.cluster_name}({self.cluster_id})")
             task = vapp.delete_vms(self.req_spec['nodes'])
             self.tenant_client.get_task_monitor().wait_for_status(task)
             self.update_task(
                 TaskStatus.SUCCESS,
-                message='Deleted %s node(s) to cluster %s(%s)' %
-                (len(self.req_spec['nodes']), self.cluster_name,
-                 self.cluster_id))
+                message=f"Deleted {len(self.req_spec['nodes'])} node(s) to "
+                        f"cluster {self.cluster_name}({self.cluster_id})")
         except Exception as e:
             LOGGER.error(traceback.format_exc())
             error_obj = error_to_json(e)
@@ -799,7 +777,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
         clusters = load_from_metadata(
             self.tenant_client, name=self.cluster_name)
         if len(clusters) != 1:
-            LOGGER.debug('Cluster %s not found.' % self.cluster_name)
+            LOGGER.debug(f"Cluster {self.cluster_name} not found.")
             return
         self.cluster = clusters[0]
         vdc = VDC(self.tenant_client, href=self.cluster['vdc_href'])


### PR DESCRIPTION
* Added a new logFilter to redact all log messages.
* Standardized all log messages in CSE to use f-strings and "
* Fixed flake8 errors in the editted files.
* Added some unit tests for the regex matcher

Testing done:
* Ran CSE commands and verified that server wire logs are getting redacted properly
2019-03-26 10:29:07,163 | DEBUG | cse-logs/cse-se | client          | _log_request | Response headers: {'Date': 'Tue, 26 Mar 2019 17:29:07 GMT', 'X-VMWARE-VCLOUD-REQUEST-ID': 'efdfb252-50c0-45f2-a1c3-373eb9ffeaf0', 'X-VMWARE-VCLOUD-CEIP-ID': '176ee7a0-7e79-45d1-a1a8-9d27c1a75930', 'X-VMWARE-VCLOUD-ACCESS-TOKEN': '[REDACTED]', 'X-VMWARE-VCLOUD-TOKEN-TYPE': 'Bearer', 'x-vcloud-authorization': '[REDACTED]', 'Content-Type': 'application/vnd.vmware.vcloud.session+xml;version=31.0', 'X-VMWARE-VCLOUD-REQUEST-EXECUTION-TIME': '411', 'Cache-Control': 'no-store, must-revalidate', 'Vary': 'Accept-Encoding, User-Agent', 'Content-Length': '2890'}

* Ran test cases to verify other real world log message e.g. ovdc metadata are getting redacted properly
ovdc metadata for cse-org-vdc-cse-org=>{'pks_plans': ['Plan 1'], 'host': 'api.pks.local', 'account_name': 'cse-org-service-account', 'uaac_port': '8443', 'cluster': 'kubo-az-1', 'datacenter': 'kubo-dc', 'pks_compute_profile_name': 'cp--c1f22cc3-6238-40ec-9252-4162b7c5f1f8--cse-org-vdc', 'proxy': '10.161.67.157', 'port': '9021', 'vc': 'vc1', 'cpi': 'b0f29ab638499e84db21', 'pvdc_name': 'vc1-TestbedCluster-20:37:43', 'username': '[REDACTED]', 'secret': '[REDACTED]', 'container_provider': 'pks'}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/283)
<!-- Reviewable:end -->
