### PR TITLE
[VCDA-964] Create-Cluster-As-SysAdmin-Fails

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -174,7 +174,7 @@ class BrokerManager(object):
         if self.vcd_client.is_sysadmin():
             org_resource_list = self.vcd_client.get_org_list()
         else:
-            org_resource_list= list(self.vcd_client.get_org())
+            org_resource_list = list(self.vcd_client.get_org())
 
         ovdc_list = []
         for org_resource in org_resource_list:
@@ -185,10 +185,11 @@ class BrokerManager(object):
                     self.ovdc_cache.get_ovdc_container_provider_metadata(
                         ovdc_name=vdc['name'], org_name=org.get_name(),
                         credentials_required=False)
-                vdc_dict = {'org':org.get_name(),
-                            'name': vdc['name'],
-                            CONTAINER_PROVIDER:ctr_prov_ctx[CONTAINER_PROVIDER]
-                            }
+                vdc_dict = {
+                    'org': org.get_name(),
+                    'name': vdc['name'],
+                    CONTAINER_PROVIDER: ctr_prov_ctx[CONTAINER_PROVIDER]
+                }
                 ovdc_list.append(vdc_dict)
         return ovdc_list
 
@@ -217,7 +218,7 @@ class BrokerManager(object):
                                    f'either in vCD or PKS')
 
     def _get_cluster_config(self, **cluster_spec):
-        """Gets the cluster configuration.
+        """Get the cluster configuration.
 
         :param str cluster_name: Name of cluster.
 
@@ -280,7 +281,7 @@ class BrokerManager(object):
     def _delete_cluster(self, **cluster_spec):
         cluster_name = cluster_spec['cluster_name']
         broker = self._get_cluster_info(**cluster_spec)[1]
-        return broker.delete_cluster(cluster_name)
+        return broker.delete_cluster(cluster_name=cluster_name)
 
     def _create_cluster(self, **cluster_spec):
         cluster_name = cluster_spec['cluster_name']
@@ -392,7 +393,10 @@ class BrokerManager(object):
         """
         ovdc_name = self.req_spec.get('vdc', None) or \
             self.req_qparams.get('vdc', None)
-        org_name = self.session.get('org')
+        org_name = self.req_spec.get('org', None) or \
+            self.req_qparams.get('vdc', None) or \
+            self.session.get('org', None)
+
         LOGGER.debug(f"org_name={org_name};vdc_name=\'{ovdc_name}\'")
 
         # Get the ovdc metadata from the logged-in org and ovdc.
@@ -408,10 +412,12 @@ class BrokerManager(object):
             if ctr_prov_ctx.get('container_provider') == CtrProvType.PKS.value:
                 return PKSBroker(self.req_headers, self.req_spec,
                                  pks_ctx=ctr_prov_ctx)
-            elif ctr_prov_ctx.get('container_provider') == CtrProvType.VCD.value:
+            elif ctr_prov_ctx.get('container_provider') \
+                    == CtrProvType.VCD.value:
                 return VcdBroker(self.req_headers, self.req_spec)
             else:
-                raise CseServerError(f"Vdc '{ovdc_name}' is not enabled for Kubernetes "
+                raise CseServerError(f"Vdc '{ovdc_name}' "
+                                     f"is not enabled for Kubernetes "
                                      f"cluster deployment")
         else:
             # TODO() - This call should be based on a boolean flag

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -78,7 +78,8 @@ class Cluster(object):
                        enable_nfs=False,
                        disable_rollback=True,
                        pks_ext_host=None,
-                       pks_plan=None):
+                       pks_plan=None,
+                       org=None):
         """Create a new Kubernetes cluster.
 
         :param vdc: (str): The name of the vdc in which the cluster will be
@@ -106,6 +107,8 @@ class Cluster(object):
         API for PKS.
         :param pks_plan: (str): Preconfigured PKS plan to use for deploying the
         cluster.
+        :param org: (str): name of the organization in which the vdc to be
+        used for cluster creation.
 
         :return: (json) A parsed json object describing the requested cluster.
         """
@@ -124,7 +127,8 @@ class Cluster(object):
             'enable_nfs': enable_nfs,
             'disable_rollback': disable_rollback,
             'pks_ext_host': pks_ext_host,
-            'pks_plan': pks_plan
+            'pks_plan': pks_plan,
+            'org': org
         }
         response = self.client._do_request_prim(
             method,

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -114,15 +114,25 @@ def cluster_group(ctx):
         vcd cse cluster create mycluster --pks-external-hostname api.pks.local
         --pks-plan 'myPlan'
             Attempts to create a Kubernetes cluster named 'mycluster' with
-            external host name as 'api.pks.local' and available PKS-plan 'myPlan
-            using the VDC in context explicitly dedicated for PKS cluster creation.
+            external host name as 'api.pks.local' and available PKS-plan
+            'myPlan' using the VDC in context explicitly dedicated for PKS
+            cluster creation.
 
 \b
         vcd cse cluster create mycluster --pks-external-hostname api.pks.local
         --pks-plan 'myPlan' --vdc 'myVdc'
             Attempts to create a Kubernetes cluster named 'mycluster' with
-            external host name as 'api.pks.local' and available PKS-plan 'myPlan
-            in the given VDC dedicated explicitly for PKS cluster creation.
+            external host name as 'api.pks.local' and available PKS-plan
+            'myPlan' in the given VDC dedicated explicitly for PKS cluster
+            creation.
+
+\b
+        vcd cse cluster create mycluster --pks-external-hostname api.pks.local
+        --pks-plan 'myPlan' --vdc 'myVdc' --org 'myOrg'
+            Attempts to create a Kubernetes cluster named 'mycluster' with
+            external host name as 'api.pks.local' and available PKS-plan
+            'myPlan' in the given VDC 'myVdc' found in the give org 'myOrg'.
+
 \b
         vcd cse cluster config mycluster
             Display configuration information about cluster named 'mycluster'.
@@ -334,17 +344,29 @@ def delete(ctx, name, vdc):
     default=None,
     help='Preconfigured PKS plan to use for deploying the cluster. '
          'Required for deploying PKS clusters. Optional otherwise.')
-def create(ctx, name, vdc, node_count, cpu, memory, network_name, storage_profile,
-           ssh_key_file, template, enable_nfs, disable_rollback,
-           pks_ext_host, pks_plan):
+@click.option(
+    '-o',
+    '--org',
+    'org_name',
+    default=None,
+    required=False,
+    metavar='<org-name>',
+    help='Name of the org in which the cluster is to be created. If not '
+         'specified, use the org-in-context. This flag is meant only for'
+         ' system administrators.')
+def create(ctx, name, vdc, node_count, cpu, memory, network_name,
+           storage_profile, ssh_key_file, template, enable_nfs,
+           disable_rollback, pks_ext_host, pks_plan, org_name):
     """Create a Kubernetes cluster."""
     try:
-        restore_session(ctx, vdc_required=True)
+        restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
         ssh_key = None
         vdc_to_use = vdc if vdc is not None \
             else ctx.obj['profiles'].get('vdc_in_use')
+        if org_name is None:
+            org_name = ctx.obj['profiles'].get('org_in_use')
         if ssh_key_file is not None:
             ssh_key = ssh_key_file.read()
         result = cluster.create_cluster(
@@ -360,7 +382,8 @@ def create(ctx, name, vdc, node_count, cpu, memory, network_name, storage_profil
             enable_nfs=enable_nfs,
             disable_rollback=disable_rollback,
             pks_ext_host=pks_ext_host,
-            pks_plan=pks_plan)
+            pks_plan=pks_plan,
+            org=org_name)
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)
@@ -818,10 +841,11 @@ def ovdc_group(ctx):
     """
     pass
 
+
 @ovdc_group.command('list', short_help='list ovdcs')
 @click.pass_context
 def list(ctx):
-    """List ovdcs in a given Org or System"""
+    """List ovdcs in a given Org or System."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

To help us process your pull request efficiently, please include: 

- Fixes the failing cluster creation as system administrator

- Creating cluster as sysadmin using System org would always fail. To handle this use case, new option --org-name is included as part of this command. If no org-name provided, org-in-use from the profiles gets used to find the ovdc. Also, fixed delete cluster not having named argument cluster-name before calling the broker.delete_cluster()

- Testing completed for create and delete cluster as sys-admin with and with no --org. flake8 errors fixed.

@sahithi @rocknes @sompa @harshneelmore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/285)
<!-- Reviewable:end -->
