### PR TITLE
VCDA-968 - 'cse run' fails when 'pks_config' is set to an empty 'pks.…

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -349,13 +349,14 @@ def get_validated_config(config_file_name):
                                SAMPLE_SERVICE_CONFIG['service'],
                                location="config file 'service' section")
     click.secho(f"Config file '{config_file_name}' is valid", fg='green')
-    if pks_config is not None and isinstance(pks_config, str):
+    if isinstance(pks_config, str):
         check_file_permissions(pks_config)
         with open(pks_config) as f:
             pks = yaml.safe_load(f) or {}
-        click.secho(f"Validating PKS config file '{pks_config}'", fg='yellow')
+        click.secho(f"Validating PKS config file '{pks_config}'",
+                    fg='yellow')
         check_keys_and_value_types(pks, SAMPLE_PKS_CONFIG,
-                                       location='PKS config file')
+                                   location='PKS config file')
         click.secho(f"PKS Config file '{pks_config}' is valid", fg='green')
         config['pks_config'] = pks
     else:

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -338,7 +338,7 @@ def get_validated_config(config_file_name):
     """
     check_file_permissions(config_file_name)
     with open(config_file_name) as config_file:
-        config = yaml.safe_load(config_file)
+        config = yaml.safe_load(config_file) or {}
     pks_config = config.get('pks_config')
     click.secho(f"Validating config file '{config_file_name}'", fg='yellow')
     check_keys_and_value_types(config, SAMPLE_CONFIG, location='config file')
@@ -352,10 +352,10 @@ def get_validated_config(config_file_name):
     if pks_config is not None and isinstance(pks_config, str):
         check_file_permissions(pks_config)
         with open(pks_config) as f:
-            pks = yaml.safe_load(f)
+            pks = yaml.safe_load(f) or {}
         click.secho(f"Validating PKS config file '{pks_config}'", fg='yellow')
         check_keys_and_value_types(pks, SAMPLE_PKS_CONFIG,
-                                   location='PKS config file')
+                                       location='PKS config file')
         click.secho(f"PKS Config file '{pks_config}' is valid", fg='green')
         config['pks_config'] = pks
     else:

--- a/container_service_extension/cse.py
+++ b/container_service_extension/cse.py
@@ -289,9 +289,26 @@ def install(ctx, config, template, update, no_capture, ssh_key_file):
     help='Skip check')
 def run(ctx, config, skip_check):
     """Run CSE service."""
-    service = Service(config, should_check_config=not skip_check)
-    service.run()
-
-
+    try:
+        service = Service(config, should_check_config=not skip_check)
+        service.run()
+    except (KeyError, TypeError):
+        click.secho(f"Config file '{config}' is invalid. Please "
+                    f"check the logs.", fg='red')
+    except (NotAcceptableException,
+            ValueError) as err:
+        click.secho(str(err), fg='red')
+    except AmqpConnectionError as err:
+        click.secho(str(err), fg='red')
+        click.secho("check config file amqp section.", fg='red')
+    except requests.exceptions.ConnectionError:
+        click.secho("Cannot connect to vCD host (check config file vCD host).",
+                    fg='red')
+    except VcdException:
+        click.secho("vCD login failed (check config file vCD "
+                    "username/password).", fg='red')
+    except vim.fault.InvalidLogin:
+        click.secho("vCenter login failed (check config file vCenter "
+                    "username/password).", fg='red')
 if __name__ == '__main__':
     cli()

--- a/container_service_extension/cse.py
+++ b/container_service_extension/cse.py
@@ -303,7 +303,7 @@ def run(ctx, config, skip_check):
         click.secho("vCenter login failed (check config file vCenter "
                     "username/password).", fg='red')
     except Exception as err:
-        click.secho("CSE Server failure. Please check the logs.", fg='red')
         click.secho(str(err), fg='red')
+        click.secho("CSE Server failure. Please check the logs.", fg='red')
 if __name__ == '__main__':
     cli()

--- a/container_service_extension/cse.py
+++ b/container_service_extension/cse.py
@@ -164,11 +164,11 @@ def sample(ctx, output, pks_output):
          " will be validated.")
 def check(ctx, config, check_install, template):
     """Validate CSE configuration."""
+    config_dict = None
     try:
         config_dict = get_validated_config(config)
-    except (KeyError, TypeError):
-        click.secho(f"Config file '{config}' is invalid", fg='red')
-    except (NotAcceptableException, ValueError) as err:
+    except (NotAcceptableException, VcdException, ValueError,
+            KeyError, TypeError) as err:
         click.secho(str(err), fg='red')
     except AmqpConnectionError as err:
         click.secho(str(err), fg='red')
@@ -176,14 +176,11 @@ def check(ctx, config, check_install, template):
     except requests.exceptions.ConnectionError:
         click.secho("Cannot connect to vCD host (check config file vCD host).",
                     fg='red')
-    except VcdException:
-        click.secho("vCD login failed (check config file vCD "
-                    "username/password).", fg='red')
     except vim.fault.InvalidLogin:
         click.secho("vCenter login failed (check config file vCenter "
                     "username/password).", fg='red')
 
-    if not check_install:
+    if not check_install or config_dict is None:
         return
 
     try:
@@ -250,10 +247,8 @@ def install(ctx, config, template, update, no_capture, ssh_key_file):
     try:
         install_cse(ctx, config_file_name=config, template_name=template,
                     update=update, no_capture=no_capture, ssh_key=ssh_key)
-    except (KeyError, TypeError):
-        click.secho(f"Config file '{config}' is invalid", fg='red')
-    except (EntityNotFoundException, NotAcceptableException,
-            ValueError) as err:
+    except (EntityNotFoundException, NotAcceptableException, VcdException,
+            ValueError, KeyError, TypeError) as err:
         click.secho(str(err), fg='red')
     except AmqpConnectionError as err:
         click.secho(str(err), fg='red')
@@ -261,9 +256,6 @@ def install(ctx, config, template, update, no_capture, ssh_key_file):
     except requests.exceptions.ConnectionError:
         click.secho("Cannot connect to vCD host (check config file vCD host).",
                     fg='red')
-    except VcdException:
-        click.secho("vCD login failed (check config file vCD "
-                    "username/password).", fg='red')
     except vim.fault.InvalidLogin:
         click.secho("vCenter login failed (check config file vCenter "
                     "username/password).", fg='red')
@@ -310,5 +302,8 @@ def run(ctx, config, skip_check):
     except vim.fault.InvalidLogin:
         click.secho("vCenter login failed (check config file vCenter "
                     "username/password).", fg='red')
+    except Exception as err:
+        click.secho("CSE Server failure. Please check the logs.", fg='red')
+        click.secho(str(err), fg='red')
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
…yaml' file

Signed-off-by: Sompa Malakar <malakars@vmware.com>


- Fix to ensure that CSE server run does not crash abruptly when config files are empty. Handles exception from config checks and fails gracefully with a message.

- Manually tested to ensure that CSE server gracefully fails to start when empty config files are provided to the 'cse run ' command with -c option.

- @sahithi @andrew-ni @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/286)
<!-- Reviewable:end -->
