### PR TITLE
[VCDA-924] Upgrade Photon OS 2.0 from Kubernetes from v1.10.11 to v1.12.7

### DIFF
--- a/scripts/cust-photon-v2.sh
+++ b/scripts/cust-photon-v2.sh
@@ -25,7 +25,7 @@ systemctl start iptables-ports.service
 tdnf makecache -q
 
 echo 'installing kuberentes'
-tdnf install -yq wget kubernetes-1.10.11-1.ph2 kubernetes-kubeadm-1.10.11-1.ph2
+tdnf install -yq wget kubernetes-1.12.7-1.ph2 kubernetes-kubeadm-1.12.7-1.ph2
 
 echo 'install docker'
 tdnf install -yq wget docker-17.06.0-9.ph2
@@ -35,10 +35,10 @@ systemctl start docker
 while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
 
 echo 'downloading container images'
-docker pull gcr.io/google_containers/kube-controller-manager-amd64:v1.10.11
-docker pull gcr.io/google_containers/kube-scheduler-amd64:v1.10.11
-docker pull gcr.io/google_containers/kube-apiserver-amd64:v1.10.11
-docker pull gcr.io/google_containers/kube-proxy-amd64:v1.10.11
+docker pull gcr.io/google_containers/kube-controller-manager-amd64:v1.12.7
+docker pull gcr.io/google_containers/kube-scheduler-amd64:v1.12.7
+docker pull gcr.io/google_containers/kube-apiserver-amd64:v1.12.7
+docker pull gcr.io/google_containers/kube-proxy-amd64:v1.12.7
 docker pull gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7
 docker pull gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7
 docker pull gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7

--- a/scripts/mstr-photon-v2.sh
+++ b/scripts/mstr-photon-v2.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
-kubeadm init --kubernetes-version=v1.10.11 > /root/kubeadm-init.out
+kubeadm init --kubernetes-version=v1.12.7 > /root/kubeadm-init.out
 mkdir -p /root/.kube
 cp -f /etc/kubernetes/admin.conf /root/.kube/config
 chown $(id -u):$(id -g) /root/.kube/config

--- a/system_tests/scripts/CUST-PHOTON.sh
+++ b/system_tests/scripts/CUST-PHOTON.sh
@@ -25,7 +25,7 @@ systemctl start iptables-ports.service
 tdnf makecache -q
 
 echo 'installing kuberentes'
-tdnf install -yq wget kubernetes-1.10.11-1.ph2 kubernetes-kubeadm-1.10.11-1.ph2
+tdnf install -yq wget kubernetes-1.12.7-1.ph2 kubernetes-kubeadm-1.12.7-1.ph2
 
 echo 'install docker'
 tdnf install -yq wget docker-17.06.0-9.ph2
@@ -35,10 +35,10 @@ systemctl start docker
 while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
 
 echo 'downloading container images'
-docker pull gcr.io/google_containers/kube-controller-manager-amd64:v1.10.11
-docker pull gcr.io/google_containers/kube-scheduler-amd64:v1.10.11
-docker pull gcr.io/google_containers/kube-apiserver-amd64:v1.10.11
-docker pull gcr.io/google_containers/kube-proxy-amd64:v1.10.11
+docker pull gcr.io/google_containers/kube-controller-manager-amd64:v1.12.7
+docker pull gcr.io/google_containers/kube-scheduler-amd64:v1.12.7
+docker pull gcr.io/google_containers/kube-apiserver-amd64:v1.12.7
+docker pull gcr.io/google_containers/kube-proxy-amd64:v1.12.7
 docker pull gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7
 docker pull gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7
 docker pull gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7

--- a/system_tests/scripts/cust-photon-v2.sh
+++ b/system_tests/scripts/cust-photon-v2.sh
@@ -25,7 +25,7 @@ systemctl start iptables-ports.service
 tdnf makecache -q
 
 echo 'installing kuberentes'
-tdnf install -yq wget kubernetes-1.10.11-1.ph2 kubernetes-kubeadm-1.10.11-1.ph2
+tdnf install -yq wget kubernetes-1.12.7-1.ph2 kubernetes-kubeadm-1.12.7-1.ph2
 
 echo 'install docker'
 tdnf install -yq wget docker-17.06.0-9.ph2
@@ -35,10 +35,10 @@ systemctl start docker
 while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
 
 echo 'downloading container images'
-docker pull gcr.io/google_containers/kube-controller-manager-amd64:v1.10.11
-docker pull gcr.io/google_containers/kube-scheduler-amd64:v1.10.11
-docker pull gcr.io/google_containers/kube-apiserver-amd64:v1.10.11
-docker pull gcr.io/google_containers/kube-proxy-amd64:v1.10.11
+docker pull gcr.io/google_containers/kube-controller-manager-amd64:v1.12.7
+docker pull gcr.io/google_containers/kube-scheduler-amd64:v1.12.7
+docker pull gcr.io/google_containers/kube-apiserver-amd64:v1.12.7
+docker pull gcr.io/google_containers/kube-proxy-amd64:v1.12.7
 docker pull gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7
 docker pull gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7
 docker pull gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7


### PR DESCRIPTION
Upgrade Kubernetes from v1.10.11 to v1.12.7 for Photon OS 2.0

-Tested manually by doing a fresh installation of CSE and created a cluster with master and slave nodes.
-Tested using system_tests framework for CSE
- Tested by deploying a Kubernetes guestbook application on the cluster

@andrew-ni @sahithi @yilmi-vmw @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/290)
<!-- Reviewable:end -->
