### PR TITLE
Fix bugs

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -108,7 +108,7 @@ class BrokerManager(object):
                 self._create_pks_compute_profile(pks_ctx)
             task = self.ovdc_cache. \
                 set_ovdc_container_provider_metadata(
-                    ovdc, pks_ctx, self.req_spec[CONTAINER_PROVIDER])
+                    ovdc, container_prov_data=pks_ctx, container_provider=self.req_spec[CONTAINER_PROVIDER])
             # TODO() Constructing response should be moved out of this layer
             result['body'] = {'task_href': task.get('href')}
             result['status_code'] = ACCEPTED
@@ -121,7 +121,7 @@ class BrokerManager(object):
         elif op == Operation.DELETE_CLUSTER:
             cluster_spec = \
                 {'cluster_name': self.req_spec.get('cluster_name', None)}
-            self._delete_cluster(**cluster_spec)
+            result['body'] = self._delete_cluster(**cluster_spec)
             result['status_code'] = ACCEPTED
         elif op == Operation.RESIZE_CLUSTER:
             # TODO(resize_cluster) Once VcdBroker.create_nodes() is hooked to

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -431,15 +431,21 @@ class BrokerManager(object):
         pks_plans = self.req_spec['pks_plans']
         ovdc = self.ovdc_cache.get_ovdc(ovdc_id=ovdc_id)
         pvdc_id = self.ovdc_cache.get_pvdc_id(ovdc)
-        pvdc_info = self.pks_cache.get_pvdc_info(pvdc_id)
-        pks_info = self.pks_cache.get_pks_account_details(
-            org_name, pvdc_info.vc)
-        pks_compute_profile_name = self. \
-            ovdc_cache.get_compute_profile_name(ovdc_id,
-                                                ovdc.resource.get('name'))
-        pks_context = OvdcCache.construct_pks_context(
-            pks_info, pvdc_info, pks_compute_profile_name,
-            pks_plans, credentials_required=True)
+
+        pks_context = None
+        if self.req_spec[CONTAINER_PROVIDER] == CtrProvType.PKS.value:
+            if self.pks_cache is None:
+                raise Exception('PKS config file does not exist')
+            pvdc_info = self.pks_cache.get_pvdc_info(pvdc_id)
+            pks_info = self.pks_cache.get_pks_account_details(
+                org_name, pvdc_info.vc)
+            pks_compute_profile_name = self. \
+                ovdc_cache.get_compute_profile_name(ovdc_id,
+                                                    ovdc.resource.get('name'))
+            pks_context = OvdcCache.construct_pks_context(
+                pks_info, pvdc_info, pks_compute_profile_name,
+                pks_plans, credentials_required=True)
+
         return pks_context, ovdc
 
     def _create_pks_compute_profile(self, pks_ctx):

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -108,7 +108,9 @@ class BrokerManager(object):
                 self._create_pks_compute_profile(pks_ctx)
             task = self.ovdc_cache. \
                 set_ovdc_container_provider_metadata(
-                    ovdc, container_prov_data=pks_ctx, container_provider=self.req_spec[CONTAINER_PROVIDER])
+                    ovdc,
+                    container_prov_data=pks_ctx,
+                    container_provider=self.req_spec[CONTAINER_PROVIDER])
             # TODO() Constructing response should be moved out of this layer
             result['body'] = {'task_href': task.get('href')}
             result['status_code'] = ACCEPTED

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -435,7 +435,7 @@ class BrokerManager(object):
         pks_context = None
         if self.req_spec[CONTAINER_PROVIDER] == CtrProvType.PKS.value:
             if self.pks_cache is None:
-                raise Exception('PKS config file does not exist')
+                raise CseServerError('PKS config file does not exist')
             pvdc_info = self.pks_cache.get_pvdc_info(pvdc_id)
             pks_info = self.pks_cache.get_pks_account_details(
                 org_name, pvdc_info.vc)

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -30,7 +30,7 @@ class Cluster(object):
             auth=None)
         return process_response(response)
 
-    def get_clusters(self, vdc):
+    def get_clusters(self, vdc=None):
         method = 'GET'
         uri = self._uri
         response = self.client._do_request_prim(
@@ -44,7 +44,7 @@ class Cluster(object):
             params={'vdc': vdc} if vdc else None)
         return process_response(response)
 
-    def get_cluster_info(self, name, vdc):
+    def get_cluster_info(self, name, vdc=None):
         method = 'GET'
         uri = '%s/%s/info' % (self._uri, name)
         response = self.client._do_request_prim(
@@ -140,10 +140,10 @@ class Cluster(object):
         return process_response(response)
 
     def resize_cluster(self,
-                       vdc,
                        network_name,
                        cluster_name,
                        node_count=1,
+                       vdc=None,
                        disable_rollback=True):
         method = 'PUT'
         uri = f"{self._uri}/{cluster_name}"
@@ -164,7 +164,7 @@ class Cluster(object):
             accept_type='application/json')
         return process_response(response)
 
-    def delete_cluster(self, cluster_name, vdc):
+    def delete_cluster(self, cluster_name, vdc=None):
         method = 'DELETE'
         uri = '%s/%s' % (self._uri, cluster_name)
         response = self.client._do_request_prim(
@@ -182,7 +182,7 @@ class Cluster(object):
                 raise e
         return result
 
-    def get_config(self, cluster_name, vdc):
+    def get_config(self, cluster_name, vdc=None):
         method = 'GET'
         uri = '%s/%s/config' % (self._uri, cluster_name)
         response = self.client._do_request_prim(

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -208,7 +208,7 @@ def list_clusters(ctx, vdc):
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
-        result = cluster.get_clusters(vdc)
+        result = cluster.get_clusters(vdc=vdc)
         stdout(result, ctx, show_id=True)
     except Exception as e:
         stderr(e, ctx)
@@ -434,10 +434,10 @@ def resize(ctx, name, node_count, network_name, vdc, disable_rollback):
         client = ctx.obj['client']
         cluster = Cluster(client)
         result = cluster.resize_cluster(
-            vdc=ctx.obj['profiles'].get('vdc_in_use') if vdc is None else vdc,
-            network_name=network_name,
-            cluster_name=name,
+            network_name,
+            name,
             node_count=node_count,
+            vdc=ctx.obj['profiles'].get('vdc_in_use') if vdc is None else vdc,
             disable_rollback=disable_rollback)
         stdout(result, ctx)
     except Exception as e:
@@ -461,7 +461,7 @@ def config(ctx, name, save, vdc):
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
-        cluster_config = cluster.get_config(name, vdc)
+        cluster_config = cluster.get_config(name, vdc=vdc)
         if os.name == 'nt':
             cluster_config = str.replace(cluster_config, '\n', '\r\n')
         if save:
@@ -488,7 +488,7 @@ def cluster_info(ctx, name, vdc):
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
-        cluster_info = cluster.get_cluster_info(name, vdc)
+        cluster_info = cluster.get_cluster_info(name, vdc=vdc)
         stdout(cluster_info, ctx, show_id=True)
     except Exception as e:
         stderr(e, ctx)
@@ -649,20 +649,13 @@ def create_node(ctx, name, node_count, cpu, memory, network_name,
 @node_group.command('list', short_help='list nodes')
 @click.pass_context
 @click.argument('name', required=True)
-@click.option(
-    '-v',
-    '--vdc',
-    'vdc',
-    required=False,
-    default=None,
-    help='Name of the virtual datacenter')
-def list_nodes(ctx, name, vdc):
+def list_nodes(ctx, name):
     """Display nodes in a Kubernetes cluster."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
-        cluster_info = cluster.get_cluster_info(name, vdc)
+        cluster_info = cluster.get_cluster_info(name)
         all_nodes = cluster_info['master_nodes'] + cluster_info['nodes']
         stdout(all_nodes, ctx, show_id=True)
     except Exception as e:

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -649,13 +649,20 @@ def create_node(ctx, name, node_count, cpu, memory, network_name,
 @node_group.command('list', short_help='list nodes')
 @click.pass_context
 @click.argument('name', required=True)
-def list_nodes(ctx, name):
+@click.option(
+    '-v',
+    '--vdc',
+    'vdc',
+    required=False,
+    default=None,
+    help='Name of the virtual datacenter')
+def list_nodes(ctx, name, vdc):
     """Display nodes in a Kubernetes cluster."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
-        cluster_info = cluster.get_cluster_info(name)
+        cluster_info = cluster.get_cluster_info(name, vdc)
         all_nodes = cluster_info['master_nodes'] + cluster_info['nodes']
         stdout(all_nodes, ctx, show_id=True)
     except Exception as e:

--- a/container_service_extension/ovdc_cache.py
+++ b/container_service_extension/ovdc_cache.py
@@ -15,6 +15,7 @@ from pyvcloud.vcd.vdc import VDC
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.pks_cache import PKS_COMPUTE_PROFILE
 from container_service_extension.pks_cache import PKS_PLANS
+from container_service_extension.pks_cache import PksCache
 from container_service_extension.utils import get_org
 from container_service_extension.utils import get_pks_cache
 from container_service_extension.utils import get_vdc
@@ -105,7 +106,7 @@ class OvdcCache(object):
         if container_provider == CtrProvType.PKS.value:
             # Filter out container provider metadata into a dict
             metadata = {metadata_key: all_metadata[metadata_key]
-                        for metadata_key in self.pks_cache.get_pks_keys()}
+                        for metadata_key in PksCache.get_pks_keys()}
 
             # Get the credentials from PksCache
             pvdc_id = self.get_pvdc_id(ovdc)
@@ -135,7 +136,7 @@ class OvdcCache(object):
         metadata = {}
         if container_provider != CtrProvType.PKS.value:
             LOGGER.debug(f"Remove existing metadata for ovdc:{ovdc_name}")
-            self._remove_metadata(ovdc, self.pks_cache.get_pks_keys())
+            self._remove_metadata(ovdc, PksCache.get_pks_keys())
             metadata[CONTAINER_PROVIDER] = container_provider or ''
             LOGGER.debug(f"Updated metadata for {container_provider}:"
                          f"{metadata}")

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -94,7 +94,7 @@ def rollback(func):
             try:
                 # arg[0] refers to the current instance of the broker thread
                 broker_instance = args[0]  # param self
-                if broker_instance.body[ROLLBACK_FLAG]:
+                if broker_instance.req_spec[ROLLBACK_FLAG]:
                     broker_instance.cluster_rollback()
             except Exception as err:
                 LOGGER.error(f"Failed to rollback cluster creation:{str(err)}")
@@ -102,7 +102,7 @@ def rollback(func):
             try:
                 broker_instance = args[0]
                 node_list = e.node_names
-                if broker_instance.body[ROLLBACK_FLAG]:
+                if broker_instance.req_spec[ROLLBACK_FLAG]:
                     broker_instance.node_rollback(node_list)
             except Exception as err:
                 LOGGER.error(f"Failed to rollback node creation:{str(err)}")
@@ -658,7 +658,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
         result = {'body': {}}
         self.cluster_name = self.req_spec['name']
         LOGGER.debug(f"About to delete nodes from cluster with name: "
-                     "{self.body['name']}")
+                     f"{self.req_spec['name']}")
 
         if len(self.req_spec['nodes']) < 1:
             raise CseServerError(f"Invalid list of nodes: "

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -619,6 +619,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
                     TaskStatus.SUCCESS,
                     message=f"Created {self.req_spec['node_count']} node(s) "
                             f"for {self.cluster_name}({self.cluster_id})")
+            elif self.req_spec['node_type'] == TYPE_NODE:
                 self.update_task(
                     TaskStatus.RUNNING,
                     message=f"Adding {self.req_spec['node_count']} node(s) to "

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cachetools >= 2.0.1
 humanfriendly >= 4.8
-pika >= 0.11.2
-pyvcloud >= 20.0.3
-vcd-cli >= 21.0.2
+pika >= 0.11.2, < 1.0.0
+pyvcloud >= 20.1.0
+vcd-cli >= 21.1.0
 vsphere-guest-run >= 0.0.7
 pyvmomi >= 6.7.0

--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -94,6 +94,21 @@ def cse_server():
                          stderr=subprocess.STDOUT)
     time.sleep(env.WAIT_INTERVAL)  # server takes a little time to set up
 
+    # enable kubernetes functionality on our ovdc
+    # by default, an ovdc cannot deploy kubernetes clusters
+    # TODO() this should be removed once this behavior is changed
+    cmd = f"login {config['vcd']['host']} {utils.SYSTEM_ORG_NAME} " \
+          f"{config['vcd']['username']} -iwp {config['vcd']['password']}"
+    result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0
+    cmd = f"org use {config['broker']['org']}"
+    result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0
+    cmd = f"cse ovdc enablek8s {config['broker']['vdc']} -c vcd"
+    result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0
+    result = env.CLI_RUNNER.invoke(vcd, 'logout', catch_exceptions=False)
+
     yield
 
     # terminate cse server subprocess
@@ -239,9 +254,11 @@ def test_0040_vcd_cse_cluster_and_node_operations(config, vcd_org_admin,
         """
         node_pattern = r'(node-\S+)'
         node_list_cmd = f"cse node list {env.TEST_CLUSTER_NAME}"
+        print(f"Running command [vcd {node_list_cmd}]...", end='')
         node_list_result = env.CLI_RUNNER.invoke(vcd, node_list_cmd.split(),
                                                  catch_exceptions=False)
         assert node_list_result.exit_code == 0
+        print('SUCCESS')
         node_list = re.findall(node_pattern, node_list_result.output)
         assert len(node_list) == num_nodes, \
             f"Test cluster has {len(node_list)} nodes, when it should have " \
@@ -250,9 +267,12 @@ def test_0040_vcd_cse_cluster_and_node_operations(config, vcd_org_admin,
 
     # vcd cse template list
     # retrieves template names to test cluster deployment against
+    cmd = 'cse template list'
+    print(f"Running command [vcd {cmd}]...", end='')
     result = env.CLI_RUNNER.invoke(vcd, ['cse', 'template', 'list'],
                                    catch_exceptions=False)
     assert result.exit_code == 0
+    print('SUCCESS')
     template_pattern = r'(True|False)\s*(\S*)'
     matches = re.findall(template_pattern, result.output)
     template_names = [match[1] for match in matches]
@@ -267,13 +287,14 @@ def test_0040_vcd_cse_cluster_and_node_operations(config, vcd_org_admin,
         cmd = f"cse cluster create {env.TEST_CLUSTER_NAME} -n " \
               f"{config['broker']['network']} -N 1 -t {template_name}"
         num_nodes += 1
+        print(f"Running command [vcd {cmd}]...", end='')
         result = env.CLI_RUNNER.invoke(vcd, cmd.split(),
                                        catch_exceptions=False)
         assert result.exit_code == 0
         assert env.vapp_exists(env.TEST_CLUSTER_NAME), \
             "Cluster doesn't exist when it should."
+        print(f"SUCCESS")
         nodes = check_node_list()
-        print(f"Command [{cmd}] successful")
 
         # `cluster config`, `cluster info`, `cluster list`, `node info`
         # only need to run once
@@ -285,39 +306,44 @@ def test_0040_vcd_cse_cluster_and_node_operations(config, vcd_org_admin,
                 f"cse node info {env.TEST_CLUSTER_NAME} {nodes[0]}"
             ]
             for cmd in cmds:
+                print(f"Running command [vcd {cmd}]...", end='')
                 result = env.CLI_RUNNER.invoke(vcd, cmd.split(),
                                                catch_exceptions=False)
                 assert result.exit_code == 0
+                print('SUCCESS')
             has_run = True
 
         # vcd cse node delete testcluster TESTNODE
         cmd = f"cse node delete {env.TEST_CLUSTER_NAME} {nodes[0]}"
         num_nodes -= 1
+        print(f"Running command [vcd {cmd}]...", end='')
         result = env.CLI_RUNNER.invoke(vcd, cmd.split(), input='y',
                                        catch_exceptions=False)
         assert result.exit_code == 0
+        print('SUCCESS')
         check_node_list()
-        print(f"Command [{cmd}] successful")
 
         # vcd cse node create testcluster -n NETWORK -t PHOTON
         cmd = f"cse node create {env.TEST_CLUSTER_NAME} -n " \
               f"{config['broker']['network']} -t {template_name}"
         num_nodes += 1
+        print(f"Running command [vcd {cmd}]...", end='')
         result = env.CLI_RUNNER.invoke(vcd, cmd.split(),
                                        catch_exceptions=False)
         assert result.exit_code == 0
+        print('SUCCESS')
         check_node_list()
-        print(f"Command [{cmd}] successful")
 
         # vcd cse cluster delete testcluster
         cmd = f"cse cluster delete {env.TEST_CLUSTER_NAME}"
+        print(f"Running command [vcd {cmd}]...", end='')
         result = env.CLI_RUNNER.invoke(vcd, cmd.split(), input='y',
                                        catch_exceptions=False)
         assert result.exit_code == 0
         assert not env.vapp_exists(env.TEST_CLUSTER_NAME), \
             "Cluster exists when it should not"
         num_nodes = 0
-        print(f"Command [{cmd}] successful")
+        print('SUCCESS')
 
 
 class TestSystemToggle:

--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -27,6 +27,8 @@ $ vcd cse cluster delete testcluster
 NOTE:
 - These tests will install CSE on vCD if CSE is not installed already.
 - Edit 'base_config.yaml' for your own vCD instance.
+- Testers MUST have an org admin user in the org with the same credentials
+    as system administrator (system administrators cannot deploy clusters).
 - Clusters are deleted on test failure, unless 'teardown_clusters'=false in
     'base_config.yaml'.
 - This test module typically takes ~20 minutes to finish per template.


### PR DESCRIPTION
This PR fixes functionality for:

- node list
- cluster rollback
- node create
- ovdc enablek8s
- cluster delete

---

**node list**
Add '--vdc' option to list nodes command
This is required to get list nodes working again.
cluster.get_cluster_info() was changed to have ovdc as
a mandatory parameter.

---

**cluster rollback**
Fix broken attribute references in vcdbroker.py 
'body' attribute was renamed to 'req_spec', but not all
instances were changed.

---

**node create**
A branching line was removed, which prevented created nodes
from being joined to the cluster. Added the line back.

---

**ovdc enablek8s/disablek8s**
enablek8s/disablek8s related functions made inappropriate and
improperly handled calls to PksCache. Users without any
PKS infrastructure could not deploy any clusters without a
valid PKS setup.

Added guarding around instances of PksCache as well as changed
a mis-use of staticmethod.

---

**cluster delete**
delete cluster task was never added to result['body'],
so delete cluster task became asynchronous.

This is unintended, as only PKS cluster deletion should be
asynchronous

---

Adjust client tests to use required commands for deployment
During cse_server fixture, we must use these commands:
$ vcd org use myorg
$ vcd cse ovdc enablek8s myovdc -c vcd

This behavior will be changed in the future to default to
vcd-enabled ovdcs, but until then we need this for tests to pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/291)
<!-- Reviewable:end -->
