### PR TITLE
[VCDA-965] List clusters as sysadmin fails if org name is not passed 

### DIFF
--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -30,9 +30,14 @@ class Cluster(object):
             auth=None)
         return process_response(response)
 
-    def get_clusters(self, vdc=None):
+    def get_clusters(self, vdc=None, org=None):
         method = 'GET'
         uri = self._uri
+        params = {}
+        if vdc:
+            params['vdc'] = vdc
+        if org:
+            params['org'] = org
         response = self.client._do_request_prim(
             method,
             uri,
@@ -41,7 +46,7 @@ class Cluster(object):
             media_type=None,
             accept_type='application/*+json',
             auth=None,
-            params={'vdc': vdc} if vdc else None)
+            params=params)
         return process_response(response)
 
     def get_cluster_info(self, name, vdc=None):

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -61,6 +61,10 @@ def cluster_group(ctx):
         vcd cse cluster list -vdc myOvdc
             Displays clusters residing in vdc 'myOvdc'.
 \b
+        vcd cse cluster list --vdc myOvdc --org myOrg
+            Displays clusters residing in vdc 'myOvdc' found in
+             org 'myOrg'.
+\b
         vcd cse cluster delete mycluster --yes
             Attempts to delete cluster 'mycluster' without prompting.
 \b
@@ -202,13 +206,25 @@ def list_templates(ctx):
     required=False,
     default=None,
     help='Name of the virtual datacenter')
-def list_clusters(ctx, vdc):
+@click.option(
+    '-o',
+    '--org',
+    'org',
+    default=None,
+    required=False,
+    metavar='<org>',
+    help='Name of the org that will define the scope of the cluster'
+    'list operation, if omitted will default to the org in use.'
+    ' This flag is only meant for System administrators.')
+def list_clusters(ctx, vdc, org):
     """Display list of Kubernetes clusters."""
     try:
         restore_session(ctx)
+        if org is None:
+            org = ctx.obj['profiles'].get('org_in_use')
         client = ctx.obj['client']
         cluster = Cluster(client)
-        result = cluster.get_clusters(vdc=vdc)
+        result = cluster.get_clusters(vdc=vdc, org=org)
         stdout(result, ctx, show_id=True)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
Currently, the org name is not passed to list clusters for sysadmin, the command fails by addition of org name to the command parameter enables the sysadmins to list clusters successfully if the org name is not passed the current org in context is used.

- Tested manually with sysadmin user and non-sysadmin user.
- Successfully ran client system test.

- @rocknes @sahithi @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/295)
<!-- Reviewable:end -->
