### PR TITLE
[VCDA-975] Beautify CLI documentation

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -13,12 +13,12 @@ from container_service_extension.exceptions import ClusterNotFoundError
 from container_service_extension.exceptions import CseServerError
 from container_service_extension.exceptions import PksServerError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
-from container_service_extension.ovdc_cache import CONTAINER_PROVIDER_KEY
-from container_service_extension.ovdc_cache import CtrProvType
 from container_service_extension.ovdc_cache import OvdcCache
 from container_service_extension.pks_cache import PKS_CLUSTER_DOMAIN_KEY
 from container_service_extension.pks_cache import PKS_PLANS_KEY
 from container_service_extension.pksbroker import PKSBroker
+from container_service_extension.server_constants import K8S_PROVIDER_KEY
+from container_service_extension.server_constants import K8sProviders
 from container_service_extension.utils import ACCEPTED
 from container_service_extension.utils import connect_vcd_user_via_token
 from container_service_extension.utils import exception_handler
@@ -108,13 +108,13 @@ class BrokerManager(object):
             result['status_code'] = OK
         elif op == Operation.ENABLE_OVDC:
             pks_ctx, ovdc = self._get_ovdc_params()
-            if self.req_spec[CONTAINER_PROVIDER_KEY] == CtrProvType.PKS.value:
+            if self.req_spec[K8S_PROVIDER_KEY] == K8sProviders.PKS:
                 self._create_pks_compute_profile(pks_ctx)
             task = self.ovdc_cache. \
                 set_ovdc_container_provider_metadata(
                     ovdc,
                     container_prov_data=pks_ctx,
-                    container_provider=self.req_spec[CONTAINER_PROVIDER_KEY])
+                    container_provider=self.req_spec[K8S_PROVIDER_KEY])
             # TODO() Constructing response should be moved out of this layer
             result['body'] = {'task_href': task.get('href')}
             result['status_code'] = ACCEPTED
@@ -191,10 +191,9 @@ class BrokerManager(object):
                         ovdc_name=vdc['name'], org_name=org.get_name(),
                         credentials_required=False)
                 vdc_dict = {
-                    'org': org.get_name(),
                     'name': vdc['name'],
-                    CONTAINER_PROVIDER_KEY:
-                        ctr_prov_ctx[CONTAINER_PROVIDER_KEY]
+                    'org': org.get_name(),
+                    K8S_PROVIDER_KEY: ctr_prov_ctx[K8S_PROVIDER_KEY]
                 }
                 ovdc_list.append(vdc_dict)
         return ovdc_list
@@ -269,7 +268,7 @@ class BrokerManager(object):
             for cluster in vcd_broker.list_clusters():
                 vcd_cluster = {k: cluster.get(k, None) for k in
                                common_cluster_properties}
-                vcd_cluster[CONTAINER_PROVIDER_KEY] = CtrProvType.VCD.value
+                vcd_cluster[K8S_PROVIDER_KEY] = K8sProviders.NATIVE
                 vcd_clusters.append(vcd_cluster)
 
             pks_clusters = []
@@ -280,7 +279,7 @@ class BrokerManager(object):
                 for cluster in pks_broker.list_clusters():
                     pks_cluster = self._get_truncated_cluster_info(
                         cluster, pks_broker, common_cluster_properties)
-                    pks_cluster[CONTAINER_PROVIDER_KEY] = CtrProvType.PKS.value
+                    pks_cluster[K8S_PROVIDER_KEY] = K8sProviders.PKS
                     pks_clusters.append(pks_cluster)
             return vcd_clusters + pks_clusters
 
@@ -299,7 +298,7 @@ class BrokerManager(object):
         if not cluster:
             ctr_prov_ctx = self._get_ctr_prov_ctx_from_ovdc_metadata()
             if ctr_prov_ctx.get(
-                    CONTAINER_PROVIDER_KEY) == CtrProvType.PKS.value:
+                    K8S_PROVIDER_KEY) == K8sProviders.PKS:
                 cluster_spec['pks_plan'] = ctr_prov_ctx[PKS_PLANS_KEY][0]
                 cluster_spec['pks_ext_host'] = f"{cluster_name}." \
                     f"{ctr_prov_ctx[PKS_CLUSTER_DOMAIN_KEY]}"
@@ -387,8 +386,7 @@ class BrokerManager(object):
                     self.ovdc_cache.get_ovdc_container_provider_metadata(
                         ovdc_name=vdc_name, org_name=org_name,
                         credentials_required=True)
-                if ctr_prov_ctx[CONTAINER_PROVIDER_KEY] == \
-                        CtrProvType.PKS.value:
+                if ctr_prov_ctx[K8S_PROVIDER_KEY] == K8sProviders.PKS:
                     pks_ctx_dict[ctr_prov_ctx['vc']] = ctr_prov_ctx
 
             pks_ctx_list = list(pks_ctx_dict.values())
@@ -429,8 +427,8 @@ class BrokerManager(object):
 
     def _get_broker_based_on_ctr_prov_ctx(self, ctr_prov_ctx):
 
-        if ctr_prov_ctx and ctr_prov_ctx.get(
-                CONTAINER_PROVIDER_KEY) == CtrProvType.PKS.value:
+        if ctr_prov_ctx \
+                and ctr_prov_ctx.get(K8S_PROVIDER_KEY) == K8sProviders.PKS:
             return PKSBroker(self.req_headers, self.req_spec,
                              pks_ctx=ctr_prov_ctx)
         else:
@@ -468,7 +466,7 @@ class BrokerManager(object):
         pvdc_id = self.ovdc_cache.get_pvdc_id(ovdc)
 
         pks_context = None
-        if self.req_spec[CONTAINER_PROVIDER_KEY] == CtrProvType.PKS.value:
+        if self.req_spec[K8S_PROVIDER_KEY] == K8sProviders.PKS:
             if not self.pks_cache:
                 raise CseServerError('PKS config file does not exist')
             pvdc_info = self.pks_cache.get_pvdc_info(pvdc_id)

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -136,7 +136,7 @@ class Cluster(object):
             uri,
             self.client._session,
             contents=data,
-            media_type=None,
+            media_type='application/json',
             accept_type='application/*+json')
         return process_response(response)
 
@@ -280,7 +280,7 @@ class Cluster(object):
             uri,
             self.client._session,
             contents=data,
-            media_type=None,
+            media_type='application/json',
             accept_type='application/*+json')
         return process_response(response)
 

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -171,22 +171,20 @@ def list_templates(ctx):
 @click.option(
     '-o',
     '--org',
-    'org',
+    'org_name',
     default=None,
     required=False,
-    metavar='<org>',
-    help='Name of the org that will define the scope of the cluster'
-    'list operation, if omitted will default to the org in use.'
-    ' This flag is only meant for System administrators.')
-def list_clusters(ctx, vdc, org):
+    metavar='ORGNAME',
+    help="Org to use. Defaults to currently logged-in org")
+def list_clusters(ctx, vdc, org_name):
     """Display clusters in vCD that are visible to your user status."""
     try:
         restore_session(ctx)
-        if org is None:
-            org = ctx.obj['profiles'].get('org_in_use')
+        if org_name is None:
+            org_name = ctx.obj['profiles'].get('org_in_use')
         client = ctx.obj['client']
         cluster = Cluster(client)
-        result = cluster.get_clusters(vdc=vdc, org=org)
+        result = cluster.get_clusters(vdc=vdc, org=org_name)
         stdout(result, ctx, show_id=True)
     except Exception as e:
         stderr(e, ctx)

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -98,12 +98,6 @@ Examples
         Resize the cluster size to 10 worker nodes. On resize failure,
         cluster will be left cluster in error state for troubleshooting.
 \b
-    vcd cse cluster create mycluster --pks-external-hostname api.pks.local
-    --pks-plan 'myPlan'
-        Create a Kubernetes cluster named 'mycluster' with external host name
-        as 'api.pks.local' and available PKS-plan 'myPlan' using the VDC in
-        context explicitly dedicated for PKS cluster creation.
-\b
     vcd cse cluster config mycluster > ~/.kube/config
         Write cluster config details into '~/.kube/config' to manage cluster
         using kubectl.
@@ -780,25 +774,14 @@ Currently supported Kubernetes-providers:
 
 \b
 Examples
-        vcd cse ovdc enablek8s 'myOrgVdc' --container-provider pks
-        --pks-plan 'plan1' --pks-cluster-domain 'org.com'
-            Enable 'myOrgVdc' for k8s deployment on container-provider
-            PKS with plan 'plan1' with cluster domain 'org.com'.
-            If no --org-name is provided, organization of the logged-in user
-            is used to find 'myOrgVdc'.
-\b
-        vcd cse ovdc enablek8s 'myOrgVdc' --container-provider pks
-        --pks-plan 'plan1' --pks-cluster-domain 'org.com' --org 'myOrg'
-            Enable 'myOrgVdc' that backs organization 'myOrg', for k8s
-            deployment on PKS with plan 'plan1' with cluster domain 'org.com'.
-\b
     vcd cse ovdc enable ovdc1 --k8s-provider native
-        Set 'ovdc1' Kubernetes provider to be native (vCD)
+        Set 'ovdc1' Kubernetes provider to be native (vCD).
 \b
     vcd cse ovdc enable ovdc2 --k8s-provider ent-pks \\
-    --pks-plans 'plan1,plan2' ?
+    --pks-plan 'plan1' --pks-cluster-domain 'myorg.com'
         Set 'ovdc2' Kubernetes provider to be ent-pks.
-        Use pks plans 'plan1' and 'plan2' for 'ovdc2'.
+        Use pks plan 'plan1' for 'ovdc2'.
+        Set cluster domain to be 'myorg.com'.
 \b
     vcd cse ovdc disable ovdc3
         Set 'ovdc3' Kubernetes provider to be none,
@@ -839,22 +822,23 @@ def list_ovdcs(ctx):
     'k8s_provider',
     required=True,
     type=click.Choice([K8sProviders.NATIVE, K8sProviders.PKS]),
-    help="Name of the Kubernetes provider")
+    help="Name of the Kubernetes provider to use for this org VDC")
 @click.option(
     '-p',
     '--pks-plan',
     'pks_plan',
     required=False,
-    metavar='plan1,plan2',
-    help=f"PKS plans to use. (Required if --k8s-provider={K8sProviders.PKS})")
+    metavar='PLAN_NAME',
+    help=f"PKS plan to use for all cluster deployments in this org VDC "
+         f"(Exclusive to --k8s-provider={K8sProviders.PKS}) (Required)")
 @click.option(
     '-d',
     '--pks-cluster-domain',
     'pks_cluster_domain',
     required=False,
-    help="Suffix of the domain name, which will be used to construct FQDN of "
-         "clusters that get deployed in this ovdc. This is a required "
-         "argument, if --container-provider is set to 'pks'")
+    help=f"Domain name suffix used to construct FQDN of deployed clusters "
+         f"in this org VDC "
+         f"(Exclusive to --k8s-provider={K8sProviders.PKS}) (Required)")
 @click.option(
     '-o',
     '--org',
@@ -863,10 +847,11 @@ def list_ovdcs(ctx):
     required=False,
     metavar='ORG_NAME',
     help="Org to use. Defaults to currently logged-in org")
-def ovdc_enable(ctx, ovdc_name, k8s_provider, pks_plans, pks_cluster_domain, org_name):
+def ovdc_enable(ctx, ovdc_name, k8s_provider, pks_plan, pks_cluster_domain,
+                org_name):
     """Set Kubernetes provider for an org VDC."""
     if k8s_provider == K8sProviders.PKS and \
-            (pks_plans is None or pks_cluster_domain is None):
+            (pks_plan is None or pks_cluster_domain is None):
         click.secho("One or both of the required params (--pks-plan,"
                     " --pks-cluster-domain) are missing", fg='yellow')
         return
@@ -881,7 +866,7 @@ def ovdc_enable(ctx, ovdc_name, k8s_provider, pks_plans, pks_cluster_domain, org
             result = ovdc.enable_ovdc_for_k8s(
                 ovdc_name,
                 k8s_provider=k8s_provider,
-                pks_plans=pks_plans,
+                pks_plan=pks_plan,
                 pks_cluster_domain=pks_cluster_domain,
                 org_name=org_name)
         else:

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -10,7 +10,6 @@ import click
 from vcd_cli.utils import restore_session
 from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
-from vcd_cli.vcd import abort_if_false
 from vcd_cli.vcd import vcd
 import yaml
 
@@ -20,23 +19,23 @@ from container_service_extension.client.system import System
 from container_service_extension.service import Service
 
 
-@vcd.group(short_help='manage kubernetes clusters')
+@vcd.group(short_help='Manage kubernetes clusters')
 @click.pass_context
 def cse(ctx):
-    """Work with Kubernetes clusters in vCloud Director.
+    """Manage Kubernetes clusters in vCloud Director.
 
 \b
-    Examples
-        vcd cse version
-            Display CSE version. If CSE version is displayed, then vcd-cli has
-            been properly configured to run CSE commands.
+Examples
+    vcd cse version
+        Display CSE version. If CSE version is displayed, then vcd-cli has
+        been properly configured to run CSE commands.
     """
 
 
-@cse.command(short_help='show version')
+@cse.command(short_help='Display CSE version')
 @click.pass_context
 def version(ctx):
-    """Show CSE version."""
+    """Display CSE version."""
     ver_obj = Service.version()
     ver_str = '%s, %s, version %s' % (ver_obj['product'],
                                       ver_obj['description'],
@@ -44,138 +43,100 @@ def version(ctx):
     stdout(ver_obj, ctx, ver_str)
 
 
-@cse.group('cluster', short_help='work with clusters')
+@cse.group('cluster', short_help='Manage Kubernetes clusters')
 @click.pass_context
 def cluster_group(ctx):
-    """Work with Kubernetes clusters.
+    """Manage Kubernetes clusters.
 
 \b
-    Cluster names should follow the syntax for valid hostnames and can have
-    up to 25 characters .`system`, `template` and `swagger*` are reserved
-    words and cannot be used to name a cluster.
+Cluster names should follow the syntax for valid hostnames and can have
+up to 25 characters .`system`, `template` and `swagger*` are reserved
+words and cannot be used to name a cluster.
 \b
-    Examples
-        vcd cse cluster list
-            Displays clusters in vCD that are visible to your user status.
+Examples
+    vcd cse cluster list
+        Display clusters in vCD that are visible to your user status.
 \b
-        vcd cse cluster list -vdc myOvdc
-            Displays clusters residing in vdc 'myOvdc'.
+    vcd cse cluster list -vdc ovdc1
+        Display clusters residing in vdc 'ovdc1'.
 \b
-        vcd cse cluster list --vdc myOvdc --org myOrg
-            Displays clusters residing in vdc 'myOvdc' found in
-             org 'myOrg'.
+    vcd cse cluster create mycluster -n mynetwork
+        Create a Kubernetes cluster named 'mycluster'.
+        The cluster will have 2 worker nodes.
+        The cluster will be connected to org VDC network 'mynetwork'.
+        All VMs will use the default template.
+        On create failure, the invalid cluster is deleted.
+        '--network' is only applicable for clusters using native (vCD)
+        Kubernetes provider.
 \b
-        vcd cse cluster delete mycluster --yes
-            Attempts to delete cluster 'mycluster' without prompting.
+    vcd cse cluster create mycluster --nodes 1 --enable-nfs \\
+    --network mynetwork --template photon-v2 --cpu 3 --memory 1024 \\
+    --storage-profile mystorageprofile --ssh-key ~/.ssh/id_rsa.pub \\
+    --disable-rollback --vdc othervdc
+        Create a Kubernetes cluster named 'mycluster' on org VDC 'othervdc'.
+        The cluster will have 1 worker node and 1 NFS node.
+        The cluster will be connected to org VDC network 'mynetwork'.
+        All VMs will use the template 'photon-v2'.
+        All VMs in the cluster will have 3 vCPUs on each node with 1024mb
+        of memory each.
+        All VMs will use the storage profile 'mystorageprofile'.
+        The public ssh key at '~/.ssh/id_rsa.pub' will be placed into all
+        VMs for user accessibility.
+        On create failure, leaves cluster in error state for troubleshooting.
+        All of these options except for '--nodes' and '--vdc' are only
+        applicable for clusters using native (vCD) Kubernetes provider.
 \b
-        vcd cse cluster delete mycluster -vdc myOvdc
-            Deletes cluster residing in vdc 'myOvdc'. Specifying optional
-            param --vdc lets CSE server to efficiently locate and
-            delete the cluster.
+    vcd cse cluster resize mycluster --network mynetwork
+        Resize the cluster to have 1 worker node. On resize failure,
+        returns cluster to original state.
+        '--network' is only applicable for clusters using
+        native (vCD) Kubernetes provider.
+        '--vdc' option can be used for faster command execution.
 \b
-        vcd cse cluster create mycluster -n mynetwork
-            Attempts to create a Kubernetes cluster named 'mycluster'
-            with 2 worker nodes in the current VDC. This cluster will be
-            connected to Org VDC network 'mynetwork'. All VMs will use the
-            default template.
+    vcd cse cluster resize mycluster -N 10 --disable-rollback
+        Resize the cluster size to 10 worker nodes. On resize failure,
+        leaves cluster in error state for troubleshooting.
 \b
-        vcd cse cluster create mycluster -n mynetwork --template photon-v2 \\
-        --nodes 1 --cpu 3 --memory 1024 --storage-profile mystorageprofile \\
-        --ssh-key ~/.ssh/id_rsa.pub --enable-nfs
-            Attempts to create a Kubernetes cluster named 'mycluster' on vCD
-            with 1 worker node and 1 NFS node. This cluster will be connected
-            to Org VDC network 'mynetwork'. All VMs will use the template
-            'photon-v2'. All VMs in the cluster will have 3 vCPUs on each node
-            with 1024mb of memory each. All VMs will use the storage profile
-            'mystorageprofile'. The public ssh key at '~/.ssh/id_rsa.pub' will
-            be placed into all VMs for user accessibility.
+    vcd cse cluster create mycluster --pks-external-hostname api.pks.local
+    --pks-plan 'myPlan'
+        Create a Kubernetes cluster named 'mycluster' with external host name
+        as 'api.pks.local' and available PKS-plan 'myPlan' using the VDC in
+        context explicitly dedicated for PKS cluster creation.
 \b
-        vcd cse cluster resize mycluster -N 10 --network mynetwork
-            Attempts to resize the cluster size to 10 worker nodes. The Option
-             "--network" is mandatory if the cluster is vCD-powered and
-             it is optional if the cluster is PKS-powered.
+    vcd cse cluster config mycluster > ~/.kube/config
+        Send cluster config details into '~/.kube/config' to manage cluster
+        using kubectl.
+        '--vdc' option can be used for faster command execution.
 \b
-        vcd cse cluster resize mycluster -N 10 --vcd myovdc
-            Attempts to resize the cluster size to 10 worker nodes. Specifying
-             optional param --vdc forces CSE server to narrow down the search
-             range of locating the cluster to 'myOvdc' only (improves
-             turnaround time of the command).
+    vcd cse cluster info mycluster
+        Display detailed information about cluster 'mycluster'.
+        '--vdc' option can be used for faster command execution.
 \b
-        vcd cse cluster resize mycluster -N 10 --disable-rollback
-            Attempts to resize the cluster size to 10 worker nodes. On any
-            failure of creation of nodes, it leaves the nodes as-is in an error
-            state for admins to troubleshoot.
-\b
-        vcd cse cluster delete mycluster --yes
-            Attempts to delete cluster 'mycluster' without prompting.
-\b
-        vcd cse cluster delete mycluster -vdc myOvdc
-            Deletes cluster residing in vdc 'myOvdc'. Specifying optional param
-             --vdc forces CSE server to narrow down the search range of
-             locating the cluster to 'myOvdc' only. (improves turnaround time
-             of the command).
-\b
-        vcd cse cluster create mycluster
-            If ovdc in context is dedicated for PKS deployments, it attempts to
-             create a Kubernetes cluster 'mycluster' with external host name as
-              'mycluster.<pks_cluster_domain set on ovdc>', using PKS-plan
-              associated with that ovdc.
-
-\b
-        vcd cse cluster create mycluster --vdc 'myVdc'
-            Attempts to create a Kubernetes cluster named 'mycluster' with
-            external host name as 'mycluster.<pks_cluster_domain set on ovdc>',
-             using PKS-plan associated with given VDC dedicated explicitly for
-             PKS cluster creation.
-
-\b
-        vcd cse cluster create mycluster --vdc 'myVdc' --org 'myOrg'
-            Attempts to create a Kubernetes cluster named 'mycluster' with
-            external host name as 'mycluster.<pks_cluster_domain set on ovdc>',
-             using PKS-plan associated with given VDC 'myVdc'
-             of the given org 'myOrg'.
-
-\b
-        vcd cse cluster config mycluster
-            Display configuration information about cluster named 'mycluster'.
-
-\b
-        vcd cse cluster config mycluster --vdc myVdc
-            Display configuration information about cluster named 'mycluster'.
-            Specifying optional param --vdc lets CSE server to efficiently
-            locate and retrieve the cluster configuration.
-
-\b
-        vcd cse cluster info mycluster
-            Display detailed information about cluster named 'mycluster'.
-\b
-        vcd cse cluster info mycluster --vdc myOvdc
-            Display detailed information on cluster 'mycluster', which is
-            residing in vdc 'myOvdc'. Specifying optional param --vdc
-            forces CSE server to narrow down the search range of locating the
-            cluster to 'myOvdc' only. (improves turnaround time of the command)
+    vcd cse cluster delete mycluster --yes
+        Delete cluster 'mycluster' without prompting.
+        '--vdc' option can be used for faster command execution.
     """
     pass
 
 
-@cse.group(short_help='work with templates')
+@cse.group(short_help='Manage native Kubernetes provider templates')
 @click.pass_context
 def template(ctx):
-    """Work with CSE templates.
+    """Manage native Kubernetes provider templates.
 
 \b
-    Examples
-        vcd cse template list
-            Displays list of available VM templates from which Kubernetes
-            cluster nodes can be instantiated.
+Examples
+    vcd cse template list
+        Display templates that can be used by native Kubernetes provider.
     """
     pass
 
 
-@template.command('list', short_help='list templates')
+@template.command('list',
+                  short_help='List native Kubernetes provider templates')
 @click.pass_context
 def list_templates(ctx):
-    """Display CSE templates."""
+    """Display templates that can be used by native Kubernetes provider."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
@@ -195,7 +156,9 @@ def list_templates(ctx):
         stderr(e, ctx)
 
 
-@cluster_group.command('list', short_help='list clusters')
+@cluster_group.command('list',
+                       short_help='Display clusters in vCD that are visible '
+                                  'to your user status')
 @click.pass_context
 @click.option(
     '-v',
@@ -203,7 +166,8 @@ def list_templates(ctx):
     'vdc',
     required=False,
     default=None,
-    help='Name of the virtual datacenter')
+    metavar='VDCNAME',
+    help='Org VDC to use. Defaults to currently logged-in org VDC')
 @click.option(
     '-o',
     '--org',
@@ -215,7 +179,7 @@ def list_templates(ctx):
     'list operation, if omitted will default to the org in use.'
     ' This flag is only meant for System administrators.')
 def list_clusters(ctx, vdc, org):
-    """Display list of Kubernetes clusters."""
+    """Display clusters in vCD that are visible to your user status."""
     try:
         restore_session(ctx)
         if org is None:
@@ -228,23 +192,20 @@ def list_clusters(ctx, vdc, org):
         stderr(e, ctx)
 
 
-@cluster_group.command(short_help='delete cluster')
+@cluster_group.command('delete',
+                       short_help='Delete a Kubernetes cluster')
 @click.pass_context
 @click.argument('name', required=True)
+@click.confirmation_option(prompt='Are you sure you want to delete the '
+                                  'cluster?')
 @click.option(
     '-v',
     '--vdc',
     'vdc',
     required=False,
     default=None,
-    help='Name of the virtual datacenter')
-@click.option(
-    '-y',
-    '--yes',
-    is_flag=True,
-    callback=abort_if_false,
-    expose_value=False,
-    prompt='Are you sure you want to delete the cluster?')
+    metavar='VDCNAME',
+    help='Org VDC to use. Defaults to currently logged-in org VDC')
 def delete(ctx, name, vdc):
     """Delete a Kubernetes cluster."""
     try:
@@ -264,7 +225,7 @@ def delete(ctx, name, vdc):
         stderr(e, ctx)
 
 
-@cluster_group.command(short_help='create cluster')
+@cluster_group.command(short_help='Create a Kubernetes cluster')
 @click.pass_context
 @click.argument('name', required=True)
 @click.option(
@@ -273,7 +234,8 @@ def delete(ctx, name, vdc):
     'vdc',
     required=False,
     default=None,
-    help='Name of the virtual datacenter')
+    metavar='VDCNAME',
+    help='Org VDC to use. Defaults to currently logged-in org VDC')
 @click.option(
     '-N',
     '--nodes',
@@ -289,7 +251,8 @@ def delete(ctx, name, vdc):
     required=False,
     default=None,
     type=click.INT,
-    help='Number of virtual CPUs on each node')
+    help='Number of virtual CPUs on each node '
+         '(Exclusive to native Kubernetes provider)')
 @click.option(
     '-m',
     '--memory',
@@ -297,23 +260,23 @@ def delete(ctx, name, vdc):
     required=False,
     default=None,
     type=click.INT,
-    help='Amount of memory (in MB) on each node')
+    help='Megabytes of memory on each node '
+         '(Exclusive to native Kubernetes provider)')
 @click.option(
     '-n',
     '--network',
     'network_name',
     default=None,
     required=False,
-    help='Network name (Mandatory field to be '
-         'specified for vCD powered clusters. '
-         'Optional for PKS backed clusters)')
+    help='Network name (Exclusive to native Kubernetes provider) (Required)')
 @click.option(
     '-s',
     '--storage-profile',
     'storage_profile',
     required=False,
     default=None,
-    help='Name of the storage profile for the nodes')
+    help='Name of the storage profile for the nodes '
+         '(Exclusive to native Kubernetes provider)')
 @click.option(
     '-k',
     '--ssh-key',
@@ -321,39 +284,40 @@ def delete(ctx, name, vdc):
     required=False,
     default=None,
     type=click.File('r'),
-    help='SSH public key to connect to the guest OS on the VM')
+    help='SSH public key to connect to the guest OS on the VM '
+         '(Exclusive to native Kubernetes provider)')
 @click.option(
     '-t',
     '--template',
     'template',
     required=False,
     default=None,
-    help='Name of the template to instantiate nodes from')
+    help='Name of the template to instantiate nodes from '
+         '(Exclusive to native Kubernetes provider)')
 @click.option(
     '--enable-nfs',
     'enable_nfs',
     is_flag=True,
     required=False,
     default=False,
-    metavar='[enable nfs]',
-    help='Creates an additional node of type NFS')
+    help='Create an additional NFS node '
+         '(Exclusive to native Kubernetes provider)')
 @click.option(
     '--disable-rollback',
     'disable_rollback',
     is_flag=True,
     required=False,
     default=True,
-    help='Disable rollback for cluster')
+    help='Disable rollback on failed cluster creation '
+         '(Exclusive to native Kubernetes provider)')
 @click.option(
     '-o',
     '--org',
     'org_name',
     default=None,
     required=False,
-    metavar='<org-name>',
-    help='Name of the org in which the cluster is to be created. If not '
-         'specified, use the org-in-context. This flag is meant only for'
-         ' system administrators.')
+    metavar='ORGNAME',
+    help='Org to use. Defaults to currently logged-in org')
 def create(ctx, name, vdc, node_count, cpu, memory, network_name,
            storage_profile, ssh_key_file, template, enable_nfs,
            disable_rollback, org_name):
@@ -387,7 +351,9 @@ def create(ctx, name, vdc, node_count, cpu, memory, network_name,
         stderr(e, ctx)
 
 
-@cluster_group.command(short_help='resize cluster')
+@cluster_group.command('resize',
+                       short_help='Resize the cluster to contain the '
+                                  'specified number of worker nodes')
 @click.pass_context
 @click.argument('name', required=True)
 @click.option(
@@ -404,28 +370,28 @@ def create(ctx, name, vdc, node_count, cpu, memory, network_name,
     'network_name',
     default=None,
     required=False,
-    help='Network name (mandatory for vCD-powered clusters; '
-         'optional for PKS-powered clusters')
+    help='Network name (Exclusive to native Kubernetes provider) (Required)')
 @click.option(
     '-v',
     '--vdc',
     'vdc',
     required=False,
     default=None,
-    help='Name of the virtual datacenter')
+    metavar='VDCNAME',
+    help='Org VDC to use. Defaults to currently logged-in org VDC')
 @click.option(
     '--disable-rollback',
     'disable_rollback',
     is_flag=True,
     required=False,
     default=True,
-    help='Disable rollback for failed node creation '
-         '(applicable only for vCD-powered clusters')
+    help='Disable rollback on failed node creation '
+         '(Exclusive to native Kubernetes provider)')
 def resize(ctx, name, node_count, network_name, vdc, disable_rollback):
-    """Resize the cluster to specified worker node count.
+    """Resize the cluster to contain the specified number of worker nodes.
 
-    Automatic scale down is not supported on vCD powered Kubernetes clusters.
-    Use 'vcd cse node delete' command to do so.
+    Clusters that use native Kubernetes provider can not be sized down
+    (use 'vcd cse node delete' command to do so).
     """
     try:
         restore_session(ctx)
@@ -442,7 +408,7 @@ def resize(ctx, name, node_count, network_name, vdc, disable_rollback):
         stderr(e, ctx)
 
 
-@cluster_group.command(short_help='get cluster config')
+@cluster_group.command('config', short_help='Display cluster configuration')
 @click.pass_context
 @click.argument('name', required=True)
 @click.option('-s', '--save', is_flag=True)
@@ -452,9 +418,10 @@ def resize(ctx, name, node_count, network_name, vdc, disable_rollback):
     'vdc',
     required=False,
     default=None,
-    help='Name of the virtual datacenter')
+    metavar='VDCNAME',
+    help='Org VDC to use. Defaults to currently logged-in org VDC')
 def config(ctx, name, save, vdc):
-    """Display cluster configuration info."""
+    """Display cluster configuration."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
@@ -470,7 +437,8 @@ def config(ctx, name, save, vdc):
         stderr(e, ctx)
 
 
-@cluster_group.command('info', short_help='get cluster info')
+@cluster_group.command('info',
+                       short_help='Display info about a Kubernetes cluster')
 @click.pass_context
 @click.argument('name', required=True)
 @click.option(
@@ -479,7 +447,8 @@ def config(ctx, name, save, vdc):
     'vdc',
     required=False,
     default=None,
-    help='Name of the virtual datacenter')
+    metavar='VDCNAME',
+    help='Org VDC to use. Defaults to currently logged-in org VDC')
 def cluster_info(ctx, name, vdc):
     """Display info about a Kubernetes cluster."""
     try:
@@ -492,50 +461,57 @@ def cluster_info(ctx, name, vdc):
         stderr(e, ctx)
 
 
-@cse.group('node', short_help='work with nodes')
+@cse.group('node',
+           short_help='Manage nodes of clusters created by native '
+                      'Kubernetes provider')
 @click.pass_context
 def node_group(ctx):
-    """Work with CSE cluster nodes.
+    """Manage nodes of clusters created by native Kubernetes provider.
+
+These commands will only work with clusters created by native
+Kubernetes provider.
 
 \b
-    Examples
-        vcd cse node create mycluster -n mynetwork
-            Attempts to add a node to Kubernetes cluster named 'mycluster' on
-            vCD. The node will be connected to Org VDC network 'mynetwork' and
-            will be created from the default template.
+Examples
+    vcd cse node create mycluster -n mynetwork
+        Add 1 node to vApp named 'mycluster' on vCD.
+        The node will be connected to org VDC network 'mynetwork'.
+        The VM will use the default template.
+        rollback?
 \b
-        vcd cse node create mycluster -n mynetwork --nodes 2 --cpu 3 \\
-        --memory 1024 --storage-profile mystorageprofile \\
-        --ssh-key ~/.ssh/id_rsa.pub --template photon-v2 --type nfsd
-            Attempts to add 2 nfsd nodes to Kubernetes cluster named
-            'mycluster' on vCD. The nodes will be connected to Org VDC
-            network 'mynetwork' and will be created from the template
-            'photon-v2'. Each node will use 3 vCPUs, have 1024mb of memory,
-            and use the storage profile 'mystorageprofile'. The public ssh
-            key at '~/.ssh/id_rsa.pub' will be placed into all VMs for
-            user accessibility.
+    vcd cse node create mycluster --nodes 2 --type nfsd -n mynetwork \\
+    --template photon-v2 --cpu 3 --memory 1024 \\
+    --storage-profile mystorageprofile --ssh-key ~/.ssh/id_rsa.pub \\
+    --disable-rollback?
+        Add 2 nfsd nodes to vApp named 'mycluster' on vCD.
+        The nodes will be connected to org VDC network 'mynetwork'.
+        All VMs will use the template 'photon-v2'.
+        All VMs will have 3 vCPUs, each with 1024mb of memory.
+        All VMs will use the storage profile 'mystorageprofile'.
+        The public ssh key at '~/.ssh/id_rsa.pub' will be placed into all
+        VMs for user accessibility.
 \b
-        vcd cse node list mycluster
-            Displays nodes in 'mycluster' that are visible to your user status.
+    vcd cse node list mycluster
+        Displays nodes in 'mycluster' that are visible to your user status.
 \b
-        vcd cse node info mycluster node-xxxx
-            Display information about 'node-xxxx' in 'mycluster', such as
-            IP address, memory, name, node type, cpu, status. If node is
-            type 'nfs', 'exports' shared will also be displayed.
+    vcd cse node info mycluster node-xxxx
+        Display detailed information about node 'node-xxxx' in cluster
+        'mycluster'.
 \b
-        vcd cse node delete mycluster node-xxxx --yes
-            Attempts to delete node 'node-xxxx' in 'mycluster'
-            without prompting.
+    vcd cse node delete mycluster node-xxxx --yes
+        Delete node 'node-xxxx' in cluster 'mycluster' without prompting.
     """
     pass
 
 
-@node_group.command('info', short_help='get node info')
+@node_group.command('info',
+                    short_help='Display info about a node in a cluster that '
+                               'was created with native Kubernetes provider')
 @click.pass_context
 @click.argument('cluster_name', required=True)
 @click.argument('node_name', required=True)
 def node_info(ctx, cluster_name, node_name):
-    """Display info about a specific node."""
+    """Display info about a node in a native Kubernetes provider cluster."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
@@ -546,7 +522,9 @@ def node_info(ctx, cluster_name, node_name):
         stderr(e, ctx)
 
 
-@node_group.command('create', short_help='add node(s) to cluster')
+@node_group.command('create',
+                    short_help='Add node(s) to a cluster that was created '
+                               'with native Kubernetes provider')
 @click.pass_context
 @click.argument('name', required=True)
 @click.option(
@@ -572,7 +550,7 @@ def node_info(ctx, cluster_name, node_name):
     required=False,
     default=None,
     type=click.INT,
-    help='Amount of memory (in MB) on each node')
+    help='Megabytes of memory on each node')
 @click.option(
     '-n',
     '--network',
@@ -608,7 +586,7 @@ def node_info(ctx, cluster_name, node_name):
     required=False,
     default='node',
     type=click.Choice(['node', 'nfsd']),
-    help='type of node to add')
+    help='Type of node to add')
 @click.option(
     '--disable-rollback',
     'disable_rollback',
@@ -619,7 +597,7 @@ def node_info(ctx, cluster_name, node_name):
 def create_node(ctx, name, node_count, cpu, memory, network_name,
                 storage_profile, ssh_key_file, template, node_type,
                 disable_rollback):
-    """Add a node to a Kubernetes cluster."""
+    """Add node(s) to a cluster that uses native Kubernetes provider."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
@@ -644,11 +622,13 @@ def create_node(ctx, name, node_count, cpu, memory, network_name,
         stderr(e, ctx)
 
 
-@node_group.command('list', short_help='list nodes')
+@node_group.command('list',
+                    short_help='Display nodes of a cluster that was created '
+                               'with native Kubernetes provider')
 @click.pass_context
 @click.argument('name', required=True)
 def list_nodes(ctx, name):
-    """Display nodes in a Kubernetes cluster."""
+    """Display nodes of a cluster that uses native Kubernetes provider."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
@@ -660,20 +640,21 @@ def list_nodes(ctx, name):
         stderr(e, ctx)
 
 
-@node_group.command('delete', short_help='delete node(s)')
+@node_group.command('delete',
+                    short_help='Delete node(s) in a cluster that was created '
+                               'with native Kubernetes provider')
 @click.pass_context
 @click.argument('name', required=True)
 @click.argument('node-names', nargs=-1)
+@click.confirmation_option(prompt='Are you sure you want to delete the '
+                                  'node(s)?')
 @click.option(
-    '-y',
-    '--yes',
+    '-f',
+    '--force',
     is_flag=True,
-    callback=abort_if_false,
-    expose_value=False,
-    prompt='Are you sure you want to delete the node(s)')
-@click.option('-f', '--force', is_flag=True, help='Force delete node VM(s)')
+    help='Force delete node VM(s)')
 def delete_nodes(ctx, name, node_names, force):
-    """Delete node(s) in a Kubernetes cluster."""
+    """Delete node(s) in a cluster that uses native Kubernetes provider."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
@@ -707,29 +688,29 @@ def save_config(ctx):
         stderr(e, ctx)
 
 
-@cse.group('system', short_help='work with CSE service')
+@cse.group('system', short_help='Manage CSE service (system daemon)')
 @click.pass_context
 def system_group(ctx):
-    """Work with CSE service (system daemon).
+    """Manage CSE service (system daemon).
 
 \b
-    Examples
-        vcd cse system info
-            Displays detailed information about CSE
+Examples
+    vcd cse system info
+        Display detailed information about CSE.
 \b
-        vcd cse system enable --yes
-            Attempts to enable CSE system daemon without prompting
+    vcd cse system enable --yes
+        Enable CSE system daemon without prompting.
 \b
-        vcd cse system stop --yes
-            Attempts to stop CSE system daemon without prompting
+    vcd cse system stop --yes
+        Stop CSE system daemon without prompting.
 \b
-        vcd cse system disable --yes
-            Attempts to disable CSE system daemon without prompting
+    vcd cse system disable --yes
+        Disable CSE system daemon without prompting.
     """
     pass
 
 
-@system_group.command('info', short_help='CSE system info')
+@system_group.command('info', short_help='Display info about CSE')
 @click.pass_context
 def info(ctx):
     """Display info about CSE."""
@@ -743,15 +724,9 @@ def info(ctx):
         stderr(e, ctx)
 
 
-@system_group.command('stop', short_help='gracefully stop CSE service')
+@system_group.command('stop', short_help='Gracefully stop CSE service')
 @click.pass_context
-@click.option(
-    '-y',
-    '--yes',
-    is_flag=True,
-    callback=abort_if_false,
-    expose_value=False,
-    prompt='Are you sure you want to stop the service?')
+@click.confirmation_option(prompt='Are you sure you want to stop the service?')
 def stop_service(ctx):
     """Stop CSE system daemon."""
     try:
@@ -764,7 +739,7 @@ def stop_service(ctx):
         stderr(e, ctx)
 
 
-@system_group.command('enable', short_help='enable CSE service')
+@system_group.command('enable', short_help='Enable CSE service')
 @click.pass_context
 def enable_service(ctx):
     """Enable CSE system daemon."""
@@ -778,7 +753,7 @@ def enable_service(ctx):
         stderr(e, ctx)
 
 
-@system_group.command('disable', short_help='disable CSE service')
+@system_group.command('disable', short_help='Disable CSE service')
 @click.pass_context
 def disable_service(ctx):
     """Disable CSE system daemon."""
@@ -792,21 +767,22 @@ def disable_service(ctx):
         stderr(e, ctx)
 
 
-@cse.group('ovdc', short_help='enable/disable ovdc for kubernetes on container'
-                              ' providers like PKS or vCD',
-           options_metavar='[options]')
+@cse.group('ovdc', short_help='Manage Kubernetes provider for org VDCs')
 @click.pass_context
 def ovdc_group(ctx):
-    """Enable/disable ovdc for kubernetes deployment on container-provider.
+    """Manage Kubernetes provider for org VDCs.
+
+All commands execute in the context of user's currently logged-in
+organization. Use a different organization by using the '--org' option.
+
+Currently supported Kubernetes-providers:
+
+- native (vCD)
+
+- enterprise-pks
 
 \b
-    Note
-       All sub-commands execute in the context of organization specified
-       via --org option; it defaults to current organization-in-use
-       if --org option is not specified.
-
-\b
-    Examples
+Examples
         vcd cse ovdc enablek8s 'myOrgVdc' --container-provider pks
         --pks-plan 'plan1' --pks-cluster-domain 'org.com'
             Enable 'myOrgVdc' for k8s deployment on container-provider
@@ -819,32 +795,33 @@ def ovdc_group(ctx):
             Enable 'myOrgVdc' that backs organization 'myOrg', for k8s
             deployment on PKS with plan 'plan1' with cluster domain 'org.com'.
 \b
-        vcd cse ovdc enablek8s 'myOrgVdc' --container-provider vcd
-        --org 'myOrg'
-            Enable 'myOrgVdc' that backs 'myOrg' for k8s deployment on vCD.
+    vcd cse ovdc enable-k8s ovdc1 --k8s-provider native
+        Set 'ovdc1' Kubernetes provider to be native (vCD)
 \b
-        vcd cse ovdc disablek8s 'myOrgVdc' --org 'myOrg'
-            Disable 'myOrgVdc' that backs 'myOrg' for k8s deployment.
+    vcd cse ovdc enable-k8s ovdc2 --k8s-provider enterprise-pks \\
+    --pks-plans 'plan1,plan2' ?
+        Set 'ovdc2' Kubernetes provider to be enterprise-pks.
+        Use pks plans 'plan1' and 'plan2' for 'ovdc2'.
 \b
-        vcd cse ovdc disablek8s 'myOrgVdc'
-            Disable 'myOrgVdc' that backs organization of the logged-in user
-            for k8s deployment.
+    vcd cse ovdc disable-k8s ovdc3
+        Set 'ovdc3' Kubernetes provider to be none,
+        which disables Kubernetes cluster deployment on 'ovdc3'.
 \b
-        vcd cse ovdc infok8s 'myOrgVdc' --org 'myOrg'
-            Displays metadata information about 'myOrgVdc' that backs
-            organization 'myOrg' of the logged-in user for k8s deployment.
+    vcd cse ovdc info-k8s ovdc1
+        Display detailed information about ovdc 'ovdc1'.
 \b
-        vcd cse ovdc list
-            Displays list of ovdcs in a given org. If executed by
-            System-administrator, it will display all ovdcs from all orgs.
+    vcd cse ovdc list
+        Display ovdcs in vCD that are visible to your user status.
     """
     pass
 
 
-@ovdc_group.command('list', short_help='list ovdcs')
+@ovdc_group.command('list',
+                    short_help='Display org VDCs in vCD that are visible '
+                               'to your user status')
 @click.pass_context
-def list(ctx):
-    """List ovdcs in a given Org or System."""
+def list_ovdcs(ctx):
+    """Display org VDCs in vCD that are visible to your user status."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
@@ -855,25 +832,24 @@ def list(ctx):
         stderr(e, ctx)
 
 
-@ovdc_group.command('enablek8s', short_help='enable ovdc for kubernetes')
+@ovdc_group.command('enable-k8s',
+                    short_help='Set Kubernetes provider for an org VDC')
 @click.pass_context
-@click.argument('ovdc_name', required=True, metavar='<ovdc_name>')
+@click.argument('ovdc_name', required=True, metavar='OVDCNAME')
 @click.option(
-    '-c',
-    '--container-provider',
-    'container_provider',
+    '-k',
+    '--k8s-provider',
+    'k8s_provider',
     required=True,
-    type=click.Choice(['vcd', 'pks']),
-    help="name of the container provider. If set to 'pks', --pks-plans "
-         "argument is required")
+    type=click.Choice(['native', 'enterprise-pks']),
+    help="Name of the Kubernetes provider")
 @click.option(
     '-p',
     '--pks-plan',
     'pks_plan',
     required=False,
-    help="PKS plan to be used for all cluster deployments in the given ovdc."
-         "This is a required argument, if --container-provider"
-         " is set to 'pks'")
+    metavar='plan1,plan2',
+    help="PKS plans to use. (Required if --k8s-provider=enterprise-pks)")
 @click.option(
     '-d',
     '--pks-cluster-domain',
@@ -888,49 +864,51 @@ def list(ctx):
     'org_name',
     default=None,
     required=False,
-    metavar='[org-name]',
-    help="org name")
-def enablek8s(ctx, ovdc_name, container_provider,
-              pks_plan, pks_cluster_domain, org_name):
-    """Enable ovdc for k8s deployment on PKS or vCD."""
-    if 'pks' == container_provider and \
-            (pks_plan is None or pks_cluster_domain is None):
+    metavar='ORGNAME',
+    help="Org to use. Defaults to currently logged-in org")
+def enablek8s(ctx, ovdc_name, k8s_provider, pks_plans, pks_cluster_domain, org_name):
+    """Set Kubernetes provider for an org VDC."""
+    if 'enterprise-pks' == k8s_provider and \
+            (pks_plans is None or pks_cluster_domain is None):
         click.secho("One or both of the required params (--pks-plan,"
                     " --pks-cluster-domain) are missing", fg='yellow')
-    else:
-        try:
-            restore_session(ctx)
-            client = ctx.obj['client']
-            ovdc = Ovdc(client)
-            if client.is_sysadmin():
-                if org_name is None:
-                    org_name = ctx.obj['profiles'].get('org_in_use')
-                result = ovdc.enable_ovdc_for_k8s(
-                    ovdc_name,
-                    container_provider=container_provider,
-                    pks_plan=pks_plan,
-                    pks_cluster_domain=pks_cluster_domain,
-                    org_name=org_name)
-            else:
-                stderr("Unauthorized operation", ctx)
-            stdout(result, ctx)
-        except Exception as e:
-            stderr(e, ctx)
+        return
+
+    try:
+        restore_session(ctx)
+        client = ctx.obj['client']
+        ovdc = Ovdc(client)
+        if client.is_sysadmin():
+            if org_name is None:
+                org_name = ctx.obj['profiles'].get('org_in_use')
+            result = ovdc.enable_ovdc_for_k8s(
+                ovdc_name,
+                k8s_provider=k8s_provider,
+                pks_plans=pks_plans,
+                pks_cluster_domain=pks_cluster_domain,
+                org_name=org_name)
+        else:
+            stderr("Unauthorized operation", ctx)
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
 
 
-@ovdc_group.command('disablek8s', short_help='disable ovdc for kubernetes')
+@ovdc_group.command('disable-k8s',
+                    short_help='Disable Kubernetes cluster deployment for '
+                               'an org VDC')
 @click.pass_context
-@click.argument('ovdc_name', required=True, metavar='<ovdc_name>')
+@click.argument('ovdc_name', required=True, metavar='OVDCNAME')
 @click.option(
     '-o',
     '--org',
     'org_name',
     default=None,
     required=False,
-    metavar='[org-name]',
-    help="org name")
+    metavar='ORGNAME',
+    help="Org to use. Defaults to currently logged-in org")
 def disablek8s(ctx, ovdc_name, org_name):
-    """Disable ovdc for k8s deployment."""
+    """Disable Kubernetes cluster deployment for an org VDC."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
@@ -946,19 +924,21 @@ def disablek8s(ctx, ovdc_name, org_name):
         stderr(e, ctx)
 
 
-@ovdc_group.command('infok8s', short_help='info on ovdc for kubernetes')
+@ovdc_group.command('info-k8s',
+                    short_help='Display information about Kubernetes provider '
+                               'for an org VDC')
 @click.pass_context
-@click.argument('ovdc_name', required=True, metavar='<ovdc_name>')
+@click.argument('ovdc_name', required=True, metavar='OVDCNAME')
 @click.option(
     '-o',
     '--org',
     'org_name',
     default=None,
     required=False,
-    metavar='[org-name]',
-    help="org name")
+    metavar='ORGNAME',
+    help="Org to use. Defaults to currently logged-in org")
 def infok8s(ctx, ovdc_name, org_name):
-    """Get information on ovdc for k8s deployment."""
+    """Display information about Kubernetes provider for an org VDC."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -16,6 +16,7 @@ import yaml
 from container_service_extension.client.cluster import Cluster
 from container_service_extension.client.ovdc import Ovdc
 from container_service_extension.client.system import System
+from container_service_extension.server_constants import K8sProviders
 from container_service_extension.service import Service
 
 
@@ -777,7 +778,7 @@ Currently supported Kubernetes-providers:
 
 - native (vCD)
 
-- enterprise-pks
+- ent-pks (Enterprise PKS)
 
 \b
 Examples
@@ -793,19 +794,19 @@ Examples
             Enable 'myOrgVdc' that backs organization 'myOrg', for k8s
             deployment on PKS with plan 'plan1' with cluster domain 'org.com'.
 \b
-    vcd cse ovdc enable-k8s ovdc1 --k8s-provider native
+    vcd cse ovdc enable ovdc1 --k8s-provider native
         Set 'ovdc1' Kubernetes provider to be native (vCD)
 \b
-    vcd cse ovdc enable-k8s ovdc2 --k8s-provider enterprise-pks \\
+    vcd cse ovdc enable ovdc2 --k8s-provider ent-pks \\
     --pks-plans 'plan1,plan2' ?
-        Set 'ovdc2' Kubernetes provider to be enterprise-pks.
+        Set 'ovdc2' Kubernetes provider to be ent-pks.
         Use pks plans 'plan1' and 'plan2' for 'ovdc2'.
 \b
-    vcd cse ovdc disable-k8s ovdc3
+    vcd cse ovdc disable ovdc3
         Set 'ovdc3' Kubernetes provider to be none,
         which disables Kubernetes cluster deployment on 'ovdc3'.
 \b
-    vcd cse ovdc info-k8s ovdc1
+    vcd cse ovdc info ovdc1
         Display detailed information about ovdc 'ovdc1'.
 \b
     vcd cse ovdc list
@@ -825,12 +826,12 @@ def list_ovdcs(ctx):
         client = ctx.obj['client']
         ovdc = Ovdc(client)
         result = ovdc.list()
-        stdout(result, ctx)
+        stdout(result, ctx, sort_headers=False)
     except Exception as e:
         stderr(e, ctx)
 
 
-@ovdc_group.command('enable-k8s',
+@ovdc_group.command('enable',
                     short_help='Set Kubernetes provider for an org VDC')
 @click.pass_context
 @click.argument('ovdc_name', required=True, metavar='OVDCNAME')
@@ -839,7 +840,7 @@ def list_ovdcs(ctx):
     '--k8s-provider',
     'k8s_provider',
     required=True,
-    type=click.Choice(['native', 'enterprise-pks']),
+    type=click.Choice([K8sProviders.NATIVE, K8sProviders.PKS]),
     help="Name of the Kubernetes provider")
 @click.option(
     '-p',
@@ -847,7 +848,7 @@ def list_ovdcs(ctx):
     'pks_plan',
     required=False,
     metavar='plan1,plan2',
-    help="PKS plans to use. (Required if --k8s-provider=enterprise-pks)")
+    help=f"PKS plans to use. (Required if --k8s-provider={K8sProviders.PKS})")
 @click.option(
     '-d',
     '--pks-cluster-domain',
@@ -864,9 +865,9 @@ def list_ovdcs(ctx):
     required=False,
     metavar='ORGNAME',
     help="Org to use. Defaults to currently logged-in org")
-def enablek8s(ctx, ovdc_name, k8s_provider, pks_plans, pks_cluster_domain, org_name):
+def ovdc_enable(ctx, ovdc_name, k8s_provider, pks_plans, pks_cluster_domain, org_name):
     """Set Kubernetes provider for an org VDC."""
-    if 'enterprise-pks' == k8s_provider and \
+    if k8s_provider == K8sProviders.PKS and \
             (pks_plans is None or pks_cluster_domain is None):
         click.secho("One or both of the required params (--pks-plan,"
                     " --pks-cluster-domain) are missing", fg='yellow')
@@ -892,7 +893,7 @@ def enablek8s(ctx, ovdc_name, k8s_provider, pks_plans, pks_cluster_domain, org_n
         stderr(e, ctx)
 
 
-@ovdc_group.command('disable-k8s',
+@ovdc_group.command('disable',
                     short_help='Disable Kubernetes cluster deployment for '
                                'an org VDC')
 @click.pass_context
@@ -905,7 +906,7 @@ def enablek8s(ctx, ovdc_name, k8s_provider, pks_plans, pks_cluster_domain, org_n
     required=False,
     metavar='ORGNAME',
     help="Org to use. Defaults to currently logged-in org")
-def disablek8s(ctx, ovdc_name, org_name):
+def ovdc_disable(ctx, ovdc_name, org_name):
     """Disable Kubernetes cluster deployment for an org VDC."""
     try:
         restore_session(ctx)
@@ -922,7 +923,7 @@ def disablek8s(ctx, ovdc_name, org_name):
         stderr(e, ctx)
 
 
-@ovdc_group.command('info-k8s',
+@ovdc_group.command('info',
                     short_help='Display information about Kubernetes provider '
                                'for an org VDC')
 @click.pass_context
@@ -935,7 +936,7 @@ def disablek8s(ctx, ovdc_name, org_name):
     required=False,
     metavar='ORGNAME',
     help="Org to use. Defaults to currently logged-in org")
-def infok8s(ctx, ovdc_name, org_name):
+def ovdc_info(ctx, ovdc_name, org_name):
     """Display information about Kubernetes provider for an org VDC."""
     try:
         restore_session(ctx)

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -27,15 +27,15 @@ class Ovdc(object):
 
     def enable_ovdc_for_k8s(self,
                             ovdc_name,
-                            container_provider=None,
-                            pks_plan=None,
+                            k8s_provider=None,
+                            pks_plans=None,
                             pks_cluster_domain=None,
                             org_name=None):
         """Enable ovdc for k8s for the given container provider.
 
         :param str ovdc_name: Name of the ovdc to be enabled
-        :param str container_provider: Name of the container provider
-        :param str pks_plan: pks plan
+        :param str k8s_provider: Name of the container provider
+        :param str pks_plans: pks plans separated by comma
         :param str pks_cluster_domain: Suffix of the domain name, which will be
          used to construct FQDN of the clusters.
         :param str org_name: Name of organization that belongs to ovdc_name
@@ -49,11 +49,21 @@ class Ovdc(object):
                        is_admin_operation=True)
         ovdc_id = utils.extract_id(ovdc.resource.get('id'))
         uri = f'{self._uri}/ovdc/{ovdc_id}/info'
+
+        # TODO() this is a temporary fix to hack in the name change
+        # Naming changes (vcd -> native) (pks -> enterprise-pks)
+        # More work needs to be done to fix how k8s_provider names are handled
+        # Suggestion: we should have an enum for k8s_provider
+        if k8s_provider == 'native':
+            k8s_provider = 'vcd'
+        if k8s_provider == 'enterprise-pks':
+            k8s_provider = 'pks'
+
         data = {
             'ovdc_id': ovdc_id,
             'ovdc_name': ovdc_name,
-            'container_provider': container_provider,
-            'pks_plans': pks_plan,
+            'container_provider': k8s_provider,
+            'pks_plans': pks_plans,
             'pks_cluster_domain': pks_cluster_domain,
             'org_name': org_name,
             'enable': True

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -4,6 +4,7 @@
 
 from pyvcloud.vcd import utils
 
+from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.utils import get_vdc
 from container_service_extension.utils import process_response
 
@@ -51,18 +52,18 @@ class Ovdc(object):
         uri = f'{self._uri}/ovdc/{ovdc_id}/info'
 
         # TODO() this is a temporary fix to hack in the name change
-        # Naming changes (vcd -> native) (pks -> enterprise-pks)
+        # Naming changes (vcd -> native) (pks -> ent-pks)
         # More work needs to be done to fix how k8s_provider names are handled
         # Suggestion: we should have an enum for k8s_provider
-        if k8s_provider == 'native':
-            k8s_provider = 'vcd'
-        if k8s_provider == 'enterprise-pks':
-            k8s_provider = 'pks'
+        # if k8s_provider == K8sProviders.NATIVE:
+        #     k8s_provider = 'vcd'
+        # if k8s_provider == K8sProviders.PKS:
+        #     k8s_provider = 'pks'
 
         data = {
             'ovdc_id': ovdc_id,
             'ovdc_name': ovdc_name,
-            'container_provider': k8s_provider,
+            K8S_PROVIDER_KEY: k8s_provider,
             'pks_plans': pks_plans,
             'pks_cluster_domain': pks_cluster_domain,
             'org_name': org_name,
@@ -96,7 +97,7 @@ class Ovdc(object):
         data = {
             'ovdc_id': ovdc_id,
             'ovdc_name': ovdc_name,
-            'container_provider': None,
+            K8S_PROVIDER_KEY: None,
             'pks_plans': None,
             'org_name': org_name,
             'disable': True

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -5,6 +5,7 @@
 from pyvcloud.vcd import utils
 
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
+from container_service_extension.server_constants import K8sProviders
 from container_service_extension.utils import get_vdc
 from container_service_extension.utils import process_response
 
@@ -88,7 +89,7 @@ class Ovdc(object):
         data = {
             'ovdc_id': ovdc_id,
             'ovdc_name': ovdc_name,
-            K8S_PROVIDER_KEY: None,
+            K8S_PROVIDER_KEY: K8sProviders.NONE,
             'pks_plans': None,
             'org_name': org_name,
             'disable': True

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -29,14 +29,14 @@ class Ovdc(object):
     def enable_ovdc_for_k8s(self,
                             ovdc_name,
                             k8s_provider=None,
-                            pks_plans=None,
+                            pks_plan=None,
                             pks_cluster_domain=None,
                             org_name=None):
         """Enable ovdc for k8s for the given container provider.
 
         :param str ovdc_name: Name of the ovdc to be enabled
         :param str k8s_provider: Name of the container provider
-        :param str pks_plans: pks plans separated by comma
+        :param str pks_plan: PKS plan
         :param str pks_cluster_domain: Suffix of the domain name, which will be
          used to construct FQDN of the clusters.
         :param str org_name: Name of organization that belongs to ovdc_name
@@ -51,20 +51,11 @@ class Ovdc(object):
         ovdc_id = utils.extract_id(ovdc.resource.get('id'))
         uri = f'{self._uri}/ovdc/{ovdc_id}/info'
 
-        # TODO() this is a temporary fix to hack in the name change
-        # Naming changes (vcd -> native) (pks -> ent-pks)
-        # More work needs to be done to fix how k8s_provider names are handled
-        # Suggestion: we should have an enum for k8s_provider
-        # if k8s_provider == K8sProviders.NATIVE:
-        #     k8s_provider = 'vcd'
-        # if k8s_provider == K8sProviders.PKS:
-        #     k8s_provider = 'pks'
-
         data = {
             'ovdc_id': ovdc_id,
             'ovdc_name': ovdc_name,
             K8S_PROVIDER_KEY: k8s_provider,
-            'pks_plans': pks_plans,
+            'pks_plans': pks_plan,
             'pks_cluster_domain': pks_cluster_domain,
             'org_name': org_name,
             'enable': True

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -66,7 +66,7 @@ class Ovdc(object):
             uri,
             self.client._session,
             contents=data,
-            media_type=None,
+            media_type='application/json',
             accept_type='application/*+json')
         return process_response(response)
 
@@ -99,7 +99,7 @@ class Ovdc(object):
             uri,
             self.client._session,
             contents=data,
-            media_type=None,
+            media_type='application/json',
             accept_type='application/*+json')
         return process_response(response)
 

--- a/container_service_extension/client/system.py
+++ b/container_service_extension/client/system.py
@@ -31,7 +31,7 @@ class System(object):
             uri,
             self.client._session,
             contents={'stopped': True},
-            media_type=None,
+            media_type='application/json',
             accept_type='application/*+json',
             auth=None)
         return process_response(response)
@@ -44,7 +44,7 @@ class System(object):
             uri,
             self.client._session,
             contents={'enabled': enabled},
-            media_type=None,
+            media_type='application/json',
             accept_type='application/*+json',
             auth=None)
         return process_response(response)

--- a/container_service_extension/cse.py
+++ b/container_service_extension/cse.py
@@ -286,11 +286,8 @@ def run(ctx, config, skip_check):
     try:
         service = Service(config, should_check_config=not skip_check)
         service.run()
-    except (KeyError, TypeError):
-        click.secho(f"Config file '{config}' is invalid. Please "
-                    f"check the logs.", fg='red')
-    except (NotAcceptableException,
-            ValueError) as err:
+    except (NotAcceptableException, VcdException, ValueError, KeyError,
+            TypeError) as err:
         click.secho(str(err), fg='red')
     except AmqpConnectionError as err:
         click.secho(str(err), fg='red')
@@ -298,9 +295,6 @@ def run(ctx, config, skip_check):
     except requests.exceptions.ConnectionError:
         click.secho("Cannot connect to vCD host (check config file vCD host).",
                     fg='red')
-    except VcdException:
-        click.secho("vCD login failed (check config file vCD "
-                    "username/password).", fg='red')
     except vim.fault.InvalidLogin:
         click.secho("vCenter login failed (check config file vCenter "
                     "username/password).", fg='red')

--- a/container_service_extension/cse.py
+++ b/container_service_extension/cse.py
@@ -118,7 +118,7 @@ def version(ctx):
     'output',
     required=False,
     default=None,
-    metavar='<output-file-name>',
+    metavar='OUTPUT_FILE_NAME',
     help="Name of the config file to dump the CSE configs to.")
 @click.option(
     '-p',
@@ -126,7 +126,7 @@ def version(ctx):
     'pks_output',
     required=False,
     default=None,
-    metavar='<pks-output-file-name>',
+    metavar='OUTPUT_FILE_NAME',
     help="Name of the PKS config file to dump the PKS configs to.")
 def sample(ctx, output, pks_output):
     """Generate sample CSE configuration."""
@@ -142,7 +142,7 @@ def sample(ctx, output, pks_output):
     '--config',
     'config',
     type=click.Path(exists=True),
-    metavar='<config-file>',
+    metavar='CONFIG_FILE_NAME',
     envvar='CSE_CONFIG',
     default='config.yaml',
     help='Config file to use.')
@@ -160,7 +160,7 @@ def sample(ctx, output, pks_output):
     'template',
     required=False,
     default='*',
-    metavar='<template>',
+    metavar='TEMPLATE_NAME',
     help="If '--check-install' flag is set, validate specified template. "
          "Default value of '*' means that all templates in config file"
          " will be validated.")
@@ -198,7 +198,7 @@ def check(ctx, config, check_install, template):
     '--config',
     'config',
     type=click.Path(exists=True),
-    metavar='<config-file>',
+    metavar='CONFIG_FILE_NAME',
     envvar='CSE_CONFIG',
     default='config.yaml',
     help='Config file to use.')
@@ -208,7 +208,7 @@ def check(ctx, config, check_install, template):
     'template',
     required=False,
     default='*',
-    metavar='<template>',
+    metavar='TEMPLATE_NAME',
     help="Install only the specified template. Default value of '*' means that"
          " all templates in config file will be installed.")
 @click.option(
@@ -270,7 +270,7 @@ def install(ctx, config, template, update, no_capture, ssh_key_file):
     '--config',
     'config',
     type=click.Path(exists=True),
-    metavar='<config-file>',
+    metavar='CONFIG_FILE_NAME',
     envvar='CSE_CONFIG',
     default='config.yaml',
     help='Config file to use.')

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+from enum import Enum
+from enum import unique
 
 # CSE SERVICE
 # used for registering CSE to vCD as an api extension service.
@@ -20,3 +22,21 @@ CSE_PKS_DEPLOY_RIGHT_DESCRIPTION = 'Right necessary to deploy kubernetes ' \
     'cluster via vSphere apis in PKS'
 CSE_PKS_DEPLOY_RIGHT_CATEGORY = 'pksRight'
 CSE_PKS_DEPLOY_RIGHT_BUNDLE_KEY = 'pksBundleKey'
+
+
+# KUBERNETES PROVIDERS
+@unique
+class K8sProviders(str, Enum):
+    """Types of Kubernetes providers.
+
+    Having a str mixin allows us to do things like:
+    'native' == K8sProviders.NATIVE
+    f"Kubernetes provider is '{K8sProviders.NATIVE}'
+    """
+
+    NATIVE = 'native'
+    PKS = 'ent-pks'
+    NONE = 'none'
+
+
+K8S_PROVIDER_KEY = 'k8s_provider'

--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -33,19 +33,20 @@ NOTE:
     'base_config.yaml'.
 - This test module typically takes ~20 minutes to finish per template.
 
-TODO()
-- tests/fixtures to test command accessibility for various
-    users/roles (vcd_org_admin() fixture should be replaced with
-    a minimum rights user fixture)
-- test accessing cluster via kubectl
-- test nfs functionality
-- test pks functionality
+TODO() by priority
+- test `vcd cse ovdc...` commands
+- test system administrator should be able to deploy cluster
+- test pks broker
 - test that node rollback works correctly (node rollback is not implemented
     yet due to a vcd-side bug, where a partially powered-on VM cannot be force
     deleted)
-- test `vcd cse system` commands
+- tests/fixtures to test command accessibility for various
+    users/roles (vcd_org_admin() fixture should be replaced with
+    a minimum rights user fixture)
 - test `vcd cse cluster config testcluster --save` option (currently does
     not work)
+- test nfs functionality
+- test accessing cluster via kubectl (may be unnecessary)
 """
 
 import re
@@ -224,7 +225,8 @@ def test_0030_vcd_cse_cluster_create_rollback(config, vcd_org_admin,
           f"{config['broker']['network']} -N 1 -c 1000"
     result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
     assert result.exit_code == 0
-    time.sleep(env.WAIT_INTERVAL)  # wait for vApp to be deleted
+    # TODO() make cluster rollback delete call blocking
+    time.sleep(env.WAIT_INTERVAL * 6)  # wait for vApp to be deleted
     assert not env.vapp_exists(env.TEST_CLUSTER_NAME), \
         "Cluster exists when it should not."
 

--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -56,6 +56,7 @@ import pytest
 from vcd_cli.vcd import vcd
 
 from container_service_extension.cse import cli
+import container_service_extension.server_constants as constants
 import container_service_extension.system_test_framework.environment as env
 import container_service_extension.system_test_framework.utils as testutils
 import container_service_extension.utils as utils
@@ -106,10 +107,15 @@ def cse_server():
     cmd = f"org use {config['broker']['org']}"
     result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
     assert result.exit_code == 0
-    cmd = f"cse ovdc enablek8s {config['broker']['vdc']} -c vcd"
+    cmd = f"vdc use {config['broker']['vdc']}"
+    result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0
+    cmd = f"cse ovdc enable {config['broker']['vdc']} -k " \
+          f"{constants.K8sProviders.NATIVE}"
     result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
     assert result.exit_code == 0
     result = env.CLI_RUNNER.invoke(vcd, 'logout', catch_exceptions=False)
+    assert result.exit_code == 0
 
     yield
 


### PR DESCRIPTION
- Required and optional parameters for different Kubernetes
providers has been more clearly highlighted
- Renamed 'container_provider' to 'k8s_provider'
- Renamed 'vcd' to 'native'
- Renamed 'pks' to 'enterprise-pks'
- Renamed enablek8s, disablek8s, infok8s to
	enable-k8s, disable-k8s, info-k8s
- Revamped documentation for consistency, clarity, and usability

All system tests passed

Waiting on incoming changes for a few commands (create cluster, enablek8s)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/296)
<!-- Reviewable:end -->
