### PR TITLE
[VCDA-930] Fix broken ovdc-enable command when enabling k8s for unqualified ovdc

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -457,6 +457,10 @@ class BrokerManager(object):
             if not self.pks_cache:
                 raise CseServerError('PKS config file does not exist')
             pvdc_info = self.pks_cache.get_pvdc_info(pvdc_id)
+            if not pvdc_info:
+                raise CseServerError(f"'{ovdc.resource.get('name')}' is not "
+                                     f"eligible to provide resources for "
+                                     f"PKS clusters")
             pks_account_info = self.pks_cache.get_pks_account_info(
                 org_name, pvdc_info.vc)
             nsxt_info = self.pks_cache.get_nsxt_info(pvdc_info.vc)


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>
- Fixes broken ovdc-enable command when enabling unqualified ovdc for k8s deployment

- Unqualified ovdc that fails to find the supporting pvdc from pks config, command breaks. This fix raises proper exception and prints appropriate message to the console for the system administrator
- Manually tested and verified

@sahithi @sompa @rocknes @harshneelmore @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/299)
<!-- Reviewable:end -->
