### PR TITLE
[VCDA-977] Redesign create-cluster, enablek8s, list-clusters; Fix broken exception handling from new pks bits.

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -303,7 +303,7 @@ class BrokerManager(object):
             if ctr_prov_ctx.get(
                 CONTAINER_PROVIDER_KEY) == CtrProvType.PKS.value:
                 cluster_spec['pks_plan'] = ctr_prov_ctx[PKS_PLANS_KEY][0]
-                cluster_spec['pks_ext_host'] = f"{cluster_spec['name']}." \
+                cluster_spec['pks_ext_host'] = f"{cluster_spec['cluster_name']}." \
                     f"{ctr_prov_ctx[PKS_CLUSTER_DOMAIN_KEY]}"
             broker = self.get_broker_based_on_vdc(vdc_metadata=ctr_prov_ctx)
             return broker.create_cluster(**cluster_spec)
@@ -404,12 +404,12 @@ class BrokerManager(object):
         # Extract vdc name from compute-profile-name
         # Example: vdc name in the below compute profile is: vdc-PKS1
         # compute-profile: cp--f3272127-9b7f-4f90-8849-0ee70a28be56--vdc-PKS1
-        compute_profile_name = cluster.get('compute-profile-name', '')
+        compute_profile_name = cluster.get('compute_profile_name', '')
         pks_cluster['vdc'] = compute_profile_name.split('--')[-1] \
             if compute_profile_name else ''
         pks_cluster['status'] = \
-            cluster.get('last-action', '').lower() + ' ' + \
-            pks_cluster.get('status', '').lower()
+            cluster.get('last_action', '').lower() + ' ' + \
+            cluster.get('last_action_state', '').lower()
         return pks_cluster
 
     def _get_ctr_ctx_from_ovdc_metadata(self, ovdc_name=None, org_name=None):

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -16,6 +16,8 @@ from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.ovdc_cache import CONTAINER_PROVIDER_KEY
 from container_service_extension.ovdc_cache import CtrProvType
 from container_service_extension.ovdc_cache import OvdcCache
+from container_service_extension.pks_cache import PKS_CLUSTER_DOMAIN_KEY
+from container_service_extension.pks_cache import PKS_PLANS_KEY
 from container_service_extension.pksbroker import PKSBroker
 from container_service_extension.utils import ACCEPTED
 from container_service_extension.utils import connect_vcd_user_via_token
@@ -158,8 +160,8 @@ class BrokerManager(object):
                 'storage_profile': self.req_spec.get('storage_profile', None),
                 'network_name': self.req_spec.get('network', None),
                 'template': self.req_spec.get('template', None),
-                'pks_plan': self.req_spec.get('pks_plan', None),
-                'pks_ext_host': self.req_spec.get('pks_ext_host', None)
+                # 'pks_plan': self.req_spec.get('pks_plan', None),
+                # 'pks_ext_host': self.req_spec.get('pks_ext_host', None)
             }
             result['body'] = self._create_cluster(**cluster_spec)
             result['status_code'] = ACCEPTED
@@ -297,7 +299,13 @@ class BrokerManager(object):
         cluster_name = cluster_spec['cluster_name']
         cluster = self._find_cluster_in_org(cluster_name)[0]
         if not cluster:
-            broker = self.get_broker_based_on_vdc()
+            ctr_prov_ctx = self._get_ctr_ctx_from_ovdc_metadata()
+            if ctr_prov_ctx.get(
+                CONTAINER_PROVIDER_KEY) == CtrProvType.PKS.value:
+                cluster_spec['pks_plan'] = ctr_prov_ctx[PKS_PLANS_KEY][0]
+                cluster_spec['pks_ext_host'] = f"{cluster_spec['name']}." \
+                    f"{ctr_prov_ctx[PKS_CLUSTER_DOMAIN_KEY]}"
+            broker = self.get_broker_based_on_vdc(vdc_metadata=ctr_prov_ctx)
             return broker.create_cluster(**cluster_spec)
         else:
             raise CseServerError(f'Cluster with name: {cluster_name} '
@@ -404,41 +412,37 @@ class BrokerManager(object):
             pks_cluster.get('status', '').lower()
         return pks_cluster
 
-    def get_broker_based_on_vdc(self):
+    def _get_ctr_ctx_from_ovdc_metadata(self, ovdc_name=None, org_name=None):
+
+        ovdc_name = self.req_spec.get('vdc') or \
+                    self.req_qparams.get('vdc') or ovdc_name
+        org_name = self.req_spec.get('org') or \
+                   self.req_qparams.get('org') or \
+                   self.session.get('org') or org_name
+
+        if ovdc_name and org_name:
+            ctr_prov_ctx = \
+                self.ovdc_cache.get_ovdc_container_provider_metadata(
+                    ovdc_name=ovdc_name, org_name=org_name,
+                    credentials_required=True, nsxt_info_required=True)
+            return ctr_prov_ctx
+        return None
+
+    def get_broker_based_on_vdc(self, vdc_metadata=None):
         """Get the broker based on ovdc.
 
         :return: broker
 
         :rtype: container_service_extension.abstract_broker.AbstractBroker
         """
-        ovdc_name = self.req_spec.get('vdc') or \
-            self.req_qparams.get('vdc')
-        org_name = self.req_spec.get('org') or \
-            self.req_qparams.get('org') or \
-            self.session.get('org')
+        ctr_prov_ctx = vdc_metadata
+        if not ctr_prov_ctx:
+            ctr_prov_ctx = self._get_ctr_ctx_from_ovdc_metadata()
 
-        LOGGER.debug(f"org_name={org_name};vdc_name=\'{ovdc_name}\'")
-
-        # Get the ovdc metadata using org and ovdc.
-        # Create the right broker based on value of 'container_provider'.
-        # Fall back to DefaultBroker for missing ovdc or org.
-        if ovdc_name and org_name:
-            ctr_prov_ctx = \
-                self.ovdc_cache.get_ovdc_container_provider_metadata(
-                    ovdc_name=ovdc_name, org_name=org_name,
-                    credentials_required=True, nsxt_info_required=True)
-            LOGGER.debug(
-                f"ovdc metadata for {ovdc_name}-{org_name}=>{ctr_prov_ctx}")
-            if ctr_prov_ctx.get(CONTAINER_PROVIDER_KEY) == \
-                    CtrProvType.PKS.value:
-                return PKSBroker(self.req_headers, self.req_spec,
+        if ctr_prov_ctx and ctr_prov_ctx.get(
+                CONTAINER_PROVIDER_KEY) == CtrProvType.PKS.value:
+            return PKSBroker(self.req_headers, self.req_spec,
                                  pks_ctx=ctr_prov_ctx)
-            elif ctr_prov_ctx.get(CONTAINER_PROVIDER_KEY) == \
-                    CtrProvType.VCD.value:
-                return VcdBroker(self.req_headers, self.req_spec)
-            else:
-                raise CseServerError(f"Vdc '{ovdc_name}' is not enabled for "
-                                     "Kubernetes cluster deployment")
         else:
             # TODO() - This call should be based on a boolean flag
             # Specify flag in config file whether to have default
@@ -449,6 +453,7 @@ class BrokerManager(object):
         ovdc_id = self.req_spec.get('ovdc_id')
         org_name = self.req_spec.get('org_name')
         pks_plans = self.req_spec['pks_plans']
+        pks_cluster_domain = self.req_spec['pks_cluster_domain']
         ovdc = self.ovdc_cache.get_ovdc(ovdc_id=ovdc_id)
         pvdc_id = self.ovdc_cache.get_pvdc_id(ovdc)
 
@@ -470,6 +475,7 @@ class BrokerManager(object):
                 nsxt_info=nsxt_info,
                 pks_compute_profile_name=pks_compute_profile_name,
                 pks_plans=pks_plans,
+                pks_cluster_domain=pks_cluster_domain,
                 credentials_required=True)
 
         return pks_context, ovdc

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -424,7 +424,6 @@ class BrokerManager(object):
                     ovdc_name=ovdc_name, org_name=org_name,
                     credentials_required=True, nsxt_info_required=True)
             return ctr_prov_ctx
-        return None
 
     def get_broker_based_on_vdc(self, vdc_metadata=None):
         """Get the broker based on ovdc.
@@ -433,9 +432,7 @@ class BrokerManager(object):
 
         :rtype: container_service_extension.abstract_broker.AbstractBroker
         """
-        ctr_prov_ctx = vdc_metadata
-        if not ctr_prov_ctx:
-            ctr_prov_ctx = self._get_ctr_ctx_from_ovdc_metadata()
+        ctr_prov_ctx = vdc_metadata or self._get_ctr_ctx_from_ovdc_metadata()
 
         if ctr_prov_ctx and ctr_prov_ctx.get(
                 CONTAINER_PROVIDER_KEY) == CtrProvType.PKS.value:

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -299,7 +299,7 @@ class BrokerManager(object):
         if not cluster:
             ctr_prov_ctx = self._get_ctr_prov_ctx_from_ovdc_metadata()
             if ctr_prov_ctx.get(
-                CONTAINER_PROVIDER_KEY) == CtrProvType.PKS.value:
+                    CONTAINER_PROVIDER_KEY) == CtrProvType.PKS.value:
                 cluster_spec['pks_plan'] = ctr_prov_ctx[PKS_PLANS_KEY][0]
                 cluster_spec['pks_ext_host'] = f"{cluster_name}." \
                     f"{ctr_prov_ctx[PKS_CLUSTER_DOMAIN_KEY]}"
@@ -410,13 +410,15 @@ class BrokerManager(object):
             cluster.get('last_action_state', '').lower()
         return pks_cluster
 
-    def _get_ctr_prov_ctx_from_ovdc_metadata(self, ovdc_name=None, org_name=None):
+    def _get_ctr_prov_ctx_from_ovdc_metadata(self, ovdc_name=None,
+                                             org_name=None):
 
-        ovdc_name = ovdc_name or self.req_spec.get('vdc') or \
-                    self.req_qparams.get('vdc')
-        org_name = org_name or self.req_spec.get('org') or \
-                   self.req_qparams.get('org') or \
-                   self.session.get('org')
+        ovdc_name = \
+            ovdc_name or self.req_spec.get('vdc') or \
+            self.req_qparams.get('vdc')
+        org_name = \
+            org_name or self.req_spec.get('org') or \
+            self.req_qparams.get('org') or self.session.get('org')
 
         if ovdc_name and org_name:
             ctr_prov_ctx = \
@@ -430,13 +432,12 @@ class BrokerManager(object):
         if ctr_prov_ctx and ctr_prov_ctx.get(
                 CONTAINER_PROVIDER_KEY) == CtrProvType.PKS.value:
             return PKSBroker(self.req_headers, self.req_spec,
-                                 pks_ctx=ctr_prov_ctx)
+                             pks_ctx=ctr_prov_ctx)
         else:
             # TODO() - This call should be based on a boolean flag
             # Specify flag in config file whether to have default
             # handling is required for missing ovdc or org.
             return VcdBroker(self.req_headers, self.req_spec)
-
 
     def get_broker_based_on_vdc(self):
         """Get the broker based on ovdc.
@@ -445,12 +446,13 @@ class BrokerManager(object):
 
         :rtype: container_service_extension.abstract_broker.AbstractBroker
         """
-
-        ovdc_name = self.req_spec.get('vdc') or \
-                    self.req_qparams.get('vdc')
-        org_name = self.req_spec.get('org') or \
-                   self.req_qparams.get('org') or \
-                   self.session.get('org')
+        ovdc_name = \
+            self.req_spec.get('vdc') or \
+            self.req_qparams.get('vdc')
+        org_name = \
+            self.req_spec.get('org') or \
+            self.req_qparams.get('org') or \
+            self.session.get('org')
 
         ctr_prov_ctx = self._get_ctr_prov_ctx_from_ovdc_metadata(
             ovdc_name=ovdc_name, org_name=org_name)

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -160,8 +160,6 @@ class BrokerManager(object):
                 'storage_profile': self.req_spec.get('storage_profile', None),
                 'network_name': self.req_spec.get('network', None),
                 'template': self.req_spec.get('template', None),
-                # 'pks_plan': self.req_spec.get('pks_plan', None),
-                # 'pks_ext_host': self.req_spec.get('pks_ext_host', None)
             }
             result['body'] = self._create_cluster(**cluster_spec)
             result['status_code'] = ACCEPTED
@@ -303,7 +301,7 @@ class BrokerManager(object):
             if ctr_prov_ctx.get(
                 CONTAINER_PROVIDER_KEY) == CtrProvType.PKS.value:
                 cluster_spec['pks_plan'] = ctr_prov_ctx[PKS_PLANS_KEY][0]
-                cluster_spec['pks_ext_host'] = f"{cluster_spec['cluster_name']}." \
+                cluster_spec['pks_ext_host'] = f"{cluster_name}." \
                     f"{ctr_prov_ctx[PKS_CLUSTER_DOMAIN_KEY]}"
             broker = self.get_broker_based_on_vdc(vdc_metadata=ctr_prov_ctx)
             return broker.create_cluster(**cluster_spec)

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -297,13 +297,13 @@ class BrokerManager(object):
         cluster_name = cluster_spec['cluster_name']
         cluster = self._find_cluster_in_org(cluster_name)[0]
         if not cluster:
-            ctr_prov_ctx = self._get_ctr_ctx_from_ovdc_metadata()
+            ctr_prov_ctx = self._get_ctr_prov_ctx_from_ovdc_metadata()
             if ctr_prov_ctx.get(
                 CONTAINER_PROVIDER_KEY) == CtrProvType.PKS.value:
                 cluster_spec['pks_plan'] = ctr_prov_ctx[PKS_PLANS_KEY][0]
                 cluster_spec['pks_ext_host'] = f"{cluster_name}." \
                     f"{ctr_prov_ctx[PKS_CLUSTER_DOMAIN_KEY]}"
-            broker = self.get_broker_based_on_vdc(vdc_metadata=ctr_prov_ctx)
+            broker = self._get_broker_based_on_ctr_prov_ctx(ctr_prov_ctx)
             return broker.create_cluster(**cluster_spec)
         else:
             raise CseServerError(f'Cluster with name: {cluster_name} '
@@ -410,13 +410,13 @@ class BrokerManager(object):
             cluster.get('last_action_state', '').lower()
         return pks_cluster
 
-    def _get_ctr_ctx_from_ovdc_metadata(self, ovdc_name=None, org_name=None):
+    def _get_ctr_prov_ctx_from_ovdc_metadata(self, ovdc_name=None, org_name=None):
 
-        ovdc_name = self.req_spec.get('vdc') or \
-                    self.req_qparams.get('vdc') or ovdc_name
-        org_name = self.req_spec.get('org') or \
+        ovdc_name = ovdc_name or self.req_spec.get('vdc') or \
+                    self.req_qparams.get('vdc')
+        org_name = org_name or self.req_spec.get('org') or \
                    self.req_qparams.get('org') or \
-                   self.session.get('org') or org_name
+                   self.session.get('org')
 
         if ovdc_name and org_name:
             ctr_prov_ctx = \
@@ -425,14 +425,7 @@ class BrokerManager(object):
                     credentials_required=True, nsxt_info_required=True)
             return ctr_prov_ctx
 
-    def get_broker_based_on_vdc(self, vdc_metadata=None):
-        """Get the broker based on ovdc.
-
-        :return: broker
-
-        :rtype: container_service_extension.abstract_broker.AbstractBroker
-        """
-        ctr_prov_ctx = vdc_metadata or self._get_ctr_ctx_from_ovdc_metadata()
+    def _get_broker_based_on_ctr_prov_ctx(self, ctr_prov_ctx):
 
         if ctr_prov_ctx and ctr_prov_ctx.get(
                 CONTAINER_PROVIDER_KEY) == CtrProvType.PKS.value:
@@ -443,6 +436,26 @@ class BrokerManager(object):
             # Specify flag in config file whether to have default
             # handling is required for missing ovdc or org.
             return VcdBroker(self.req_headers, self.req_spec)
+
+
+    def get_broker_based_on_vdc(self):
+        """Get the broker based on ovdc.
+
+        :return: broker
+
+        :rtype: container_service_extension.abstract_broker.AbstractBroker
+        """
+
+        ovdc_name = self.req_spec.get('vdc') or \
+                    self.req_qparams.get('vdc')
+        org_name = self.req_spec.get('org') or \
+                   self.req_qparams.get('org') or \
+                   self.session.get('org')
+
+        ctr_prov_ctx = self._get_ctr_prov_ctx_from_ovdc_metadata(
+            ovdc_name=ovdc_name, org_name=org_name)
+
+        return self._get_broker_based_on_ctr_prov_ctx(ctr_prov_ctx)
 
     def _get_ovdc_params(self):
         ovdc_id = self.req_spec.get('ovdc_id')

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -82,8 +82,6 @@ class Cluster(object):
                        template=None,
                        enable_nfs=False,
                        disable_rollback=True,
-                       # pks_ext_host=None,
-                       # pks_plan=None,
                        org=None):
         """Create a new Kubernetes cluster.
 
@@ -131,8 +129,6 @@ class Cluster(object):
             'template': template,
             'enable_nfs': enable_nfs,
             'disable_rollback': disable_rollback,
-            # 'pks_ext_host': pks_ext_host,
-            # 'pks_plan': pks_plan,
             'org': org
         }
         response = self.client._do_request_prim(

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -82,8 +82,8 @@ class Cluster(object):
                        template=None,
                        enable_nfs=False,
                        disable_rollback=True,
-                       pks_ext_host=None,
-                       pks_plan=None,
+                       # pks_ext_host=None,
+                       # pks_plan=None,
                        org=None):
         """Create a new Kubernetes cluster.
 
@@ -131,8 +131,8 @@ class Cluster(object):
             'template': template,
             'enable_nfs': enable_nfs,
             'disable_rollback': disable_rollback,
-            'pks_ext_host': pks_ext_host,
-            'pks_plan': pks_plan,
+            # 'pks_ext_host': pks_ext_host,
+            # 'pks_plan': pks_plan,
             'org': org
         }
         response = self.client._do_request_prim(

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -893,7 +893,8 @@ def list(ctx):
 def enablek8s(ctx, ovdc_name, container_provider,
               pks_plan, pks_cluster_domain, org_name):
     """Enable ovdc for k8s deployment on PKS or vCD."""
-    if 'pks' == container_provider and (pks_plan or pks_cluster_domain):
+    if 'pks' == container_provider and\
+            (pks_plan is None or pks_cluster_domain is None):
         click.secho("One or both of the required params (--pks-plan,"
                     " --pks-cluster-domain) are missing", fg='yellow')
     else:

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -115,27 +115,25 @@ def cluster_group(ctx):
              locating the cluster to 'myOvdc' only. (improves turnaround time
              of the command).
 \b
-        vcd cse cluster create mycluster --pks-external-hostname api.pks.local
-        --pks-plan 'myPlan'
-            Attempts to create a Kubernetes cluster named 'mycluster' with
-            external host name as 'api.pks.local' and available PKS-plan
-            'myPlan' using the VDC in context explicitly dedicated for PKS
-            cluster creation.
+        vcd cse cluster create mycluster
+            If ovdc in context is dedicated for PKS deployments, it attempts to
+             create a Kubernetes cluster 'mycluster' with external host name as
+              'mycluster.<pks_cluster_domain set on ovdc>', using PKS-plan
+              associated with that ovdc.
 
 \b
-        vcd cse cluster create mycluster --pks-external-hostname api.pks.local
-        --pks-plan 'myPlan' --vdc 'myVdc'
+        vcd cse cluster create mycluster --vdc 'myVdc'
             Attempts to create a Kubernetes cluster named 'mycluster' with
-            external host name as 'api.pks.local' and available PKS-plan
-            'myPlan' in the given VDC dedicated explicitly for PKS cluster
-            creation.
+            external host name as 'mycluster.<pks_cluster_domain set on ovdc>',
+             using PKS-plan associated with given VDC dedicated explicitly for
+             PKS cluster creation.
 
 \b
-        vcd cse cluster create mycluster --pks-external-hostname api.pks.local
-        --pks-plan 'myPlan' --vdc 'myVdc' --org 'myOrg'
+        vcd cse cluster create mycluster --vdc 'myVdc' --org 'myOrg'
             Attempts to create a Kubernetes cluster named 'mycluster' with
-            external host name as 'api.pks.local' and available PKS-plan
-            'myPlan' in the given VDC 'myVdc' found in the give org 'myOrg'.
+            external host name as 'mycluster.<pks_cluster_domain set on ovdc>',
+             using PKS-plan associated with given VDC 'myVdc'
+             of the given org 'myOrg'.
 
 \b
         vcd cse cluster config mycluster
@@ -347,20 +345,6 @@ def delete(ctx, name, vdc):
     default=True,
     help='Disable rollback for cluster')
 @click.option(
-    '--pks-external-hostname',
-    'pks_ext_host',
-    required=False,
-    default=None,
-    help='Address from which to access Kubernetes API for PKS. '
-         'Required for deploying PKS clusters. Optional otherwise.')
-@click.option(
-    '--pks-plan',
-    'pks_plan',
-    required=False,
-    default=None,
-    help='Preconfigured PKS plan to use for deploying the cluster. '
-         'Required for deploying PKS clusters. Optional otherwise.')
-@click.option(
     '-o',
     '--org',
     'org_name',
@@ -397,8 +381,6 @@ def create(ctx, name, vdc, node_count, cpu, memory, network_name,
             template=template,
             enable_nfs=enable_nfs,
             disable_rollback=disable_rollback,
-            # pks_ext_host=pks_ext_host,
-            # pks_plan=pks_plan,
             org=org_name)
         stdout(result, ctx)
     except Exception as e:
@@ -826,15 +808,16 @@ def ovdc_group(ctx):
 \b
     Examples
         vcd cse ovdc enablek8s 'myOrgVdc' --container-provider pks
-        --pks-plans 'plan1,plan2'
+        --pks-plan 'plan1' --pks-cluster-domain 'org.com'
             Enable 'myOrgVdc' for k8s deployment on container-provider
-            PKS with plans 'plan1' and 'plan2'. If no --org-name is provided,
-            organization of the logged-in user is used to find 'myOrgVdc'.
+            PKS with plan 'plan1' with cluster domain 'org.com'.
+            If no --org-name is provided, organization of the logged-in user
+            is used to find 'myOrgVdc'.
 \b
         vcd cse ovdc enablek8s 'myOrgVdc' --container-provider pks
-        --pks-plans 'plan1,plan2' --org 'myOrg'
+        --pks-plan 'plan1' --pks-cluster-domain 'org.com' --org 'myOrg'
             Enable 'myOrgVdc' that backs organization 'myOrg', for k8s
-            deployment on PKS with plans:'plan1' and 'plan2'.
+            deployment on PKS with plan 'plan1'with cluster domain 'org.com'.
 \b
         vcd cse ovdc enablek8s 'myOrgVdc' --container-provider vcd
         --org 'myOrg'
@@ -895,8 +878,9 @@ def list(ctx):
     '--pks-cluster-domain',
     'pks_cluster_domain',
     required=False,
-    help="This is a required argument, if --container-provider"
-         " is set to 'pks'")
+    help="Suffix of the domain name, which will be used to construct FQDN of "
+         "clusters that get deployed in this ovdc. This is a required "
+         "argument, if --container-provider is set to 'pks'")
 @click.option(
     '-o',
     '--org',

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -893,8 +893,8 @@ def list(ctx):
 def enablek8s(ctx, ovdc_name, container_provider,
               pks_plan, pks_cluster_domain, org_name):
     """Enable ovdc for k8s deployment on PKS or vCD."""
-    if 'pks' == container_provider and\
-            vcd (pks_plan is None or pks_cluster_domain is None):
+    if 'pks' == container_provider and \
+            (pks_plan is None or pks_cluster_domain is None):
         click.secho("One or both of the required params (--pks-plan,"
                     " --pks-cluster-domain) are missing", fg='yellow')
     else:

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -397,8 +397,8 @@ def create(ctx, name, vdc, node_count, cpu, memory, network_name,
             template=template,
             enable_nfs=enable_nfs,
             disable_rollback=disable_rollback,
-            pks_ext_host=pks_ext_host,
-            pks_plan=pks_plan,
+            # pks_ext_host=pks_ext_host,
+            # pks_plan=pks_plan,
             org=org_name)
         stdout(result, ctx)
     except Exception as e:
@@ -885,8 +885,15 @@ def list(ctx):
          "argument is required")
 @click.option(
     '-p',
-    '--pks-plans',
-    'pks_plans',
+    '--pks-plan',
+    'pks_plan',
+    required=False,
+    help="This is a required argument, if --container-provider"
+         " is set to 'pks'")
+@click.option(
+    '-d',
+    '--pks-cluster-domain',
+    'pks_cluster_domain',
     required=False,
     help="This is a required argument, if --container-provider"
          " is set to 'pks'")
@@ -898,10 +905,11 @@ def list(ctx):
     required=False,
     metavar='[org-name]',
     help="org name")
-def enablek8s(ctx, ovdc_name, container_provider, pks_plans, org_name):
+def enablek8s(ctx, ovdc_name, container_provider,
+              pks_plan, pks_cluster_domain, org_name):
     """Enable ovdc for k8s deployment on PKS or vCD."""
-    if 'pks' == container_provider and pks_plans is None:
-        click.echo("Must provide PKS plans using --pks-plans")
+    if 'pks' == container_provider and pks_plan is None:
+        click.echo("Must provide PKS plans using --pks-plan")
     else:
         try:
             restore_session(ctx)
@@ -913,7 +921,8 @@ def enablek8s(ctx, ovdc_name, container_provider, pks_plans, org_name):
                 result = ovdc.enable_ovdc_for_k8s(
                     ovdc_name,
                     container_provider=container_provider,
-                    pks_plans=pks_plans,
+                    pks_plan=pks_plan,
+                    pks_cluster_domain=pks_cluster_domain,
                     org_name=org_name)
             else:
                 stderr("Unauthorized operation", ctx)

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -817,7 +817,7 @@ def ovdc_group(ctx):
         vcd cse ovdc enablek8s 'myOrgVdc' --container-provider pks
         --pks-plan 'plan1' --pks-cluster-domain 'org.com' --org 'myOrg'
             Enable 'myOrgVdc' that backs organization 'myOrg', for k8s
-            deployment on PKS with plan 'plan1'with cluster domain 'org.com'.
+            deployment on PKS with plan 'plan1' with cluster domain 'org.com'.
 \b
         vcd cse ovdc enablek8s 'myOrgVdc' --container-provider vcd
         --org 'myOrg'
@@ -871,7 +871,8 @@ def list(ctx):
     '--pks-plan',
     'pks_plan',
     required=False,
-    help="This is a required argument, if --container-provider"
+    help="PKS plan to be used for all cluster deployments in the given ovdc."
+         "This is a required argument, if --container-provider"
          " is set to 'pks'")
 @click.option(
     '-d',
@@ -892,8 +893,9 @@ def list(ctx):
 def enablek8s(ctx, ovdc_name, container_provider,
               pks_plan, pks_cluster_domain, org_name):
     """Enable ovdc for k8s deployment on PKS or vCD."""
-    if 'pks' == container_provider and pks_plan is None:
-        click.echo("Must provide PKS plans using --pks-plan")
+    if 'pks' == container_provider and (pks_plan or pks_cluster_domain):
+        click.secho("One or both of the required params (--pks-plan,"
+                    " --pks-cluster-domain) are missing", fg='yellow')
     else:
         try:
             restore_session(ctx)

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -356,7 +356,7 @@ def delete(ctx, name, vdc):
          ' system administrators.')
 def create(ctx, name, vdc, node_count, cpu, memory, network_name,
            storage_profile, ssh_key_file, template, enable_nfs,
-           disable_rollback, pks_ext_host, pks_plan, org_name):
+           disable_rollback, org_name):
     """Create a Kubernetes cluster."""
     try:
         restore_session(ctx)
@@ -894,7 +894,7 @@ def enablek8s(ctx, ovdc_name, container_provider,
               pks_plan, pks_cluster_domain, org_name):
     """Enable ovdc for k8s deployment on PKS or vCD."""
     if 'pks' == container_provider and\
-            (pks_plan is None or pks_cluster_domain is None):
+            vcd (pks_plan is None or pks_cluster_domain is None):
         click.secho("One or both of the required params (--pks-plan,"
                     " --pks-cluster-domain) are missing", fg='yellow')
     else:

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -28,13 +28,14 @@ class Ovdc(object):
     def enable_ovdc_for_k8s(self,
                             ovdc_name,
                             container_provider=None,
-                            pks_plans=None,
+                            pks_plan=None,
+                            pks_cluster_domain=None,
                             org_name=None):
         """Enable ovdc for k8s for the given container provider.
 
         :param str ovdc_name: Name of the ovdc to be enabled
         :param str container_provider: Name of the container provider
-        :param str pks_plans: pks plans separated by comma
+        :param str pks_plan: pks plan
         :param str org_name: Name of organization that belongs to ovdc_name
 
         :return: response object
@@ -50,7 +51,8 @@ class Ovdc(object):
             'ovdc_id': ovdc_id,
             'ovdc_name': ovdc_name,
             'container_provider': container_provider,
-            'pks_plans': pks_plans,
+            'pks_plans': pks_plan,
+            'pks_cluster_domain':pks_cluster_domain,
             'org_name': org_name,
             'enable': True
         }

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -36,6 +36,8 @@ class Ovdc(object):
         :param str ovdc_name: Name of the ovdc to be enabled
         :param str container_provider: Name of the container provider
         :param str pks_plan: pks plan
+        :param str pks_cluster_domain: Suffix of the domain name, which will be
+         used to construct FQDN of the clusters.
         :param str org_name: Name of organization that belongs to ovdc_name
 
         :return: response object

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -54,7 +54,7 @@ class Ovdc(object):
             'ovdc_name': ovdc_name,
             'container_provider': container_provider,
             'pks_plans': pks_plan,
-            'pks_cluster_domain':pks_cluster_domain,
+            'pks_cluster_domain': pks_cluster_domain,
             'org_name': org_name,
             'enable': True
         }

--- a/container_service_extension/ovdc_cache.py
+++ b/container_service_extension/ovdc_cache.py
@@ -12,8 +12,9 @@ from pyvcloud.vcd.client import MetadataVisibility
 from pyvcloud.vcd.vdc import VDC
 
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
-from container_service_extension.pks_cache import PKS_COMPUTE_PROFILE
-from container_service_extension.pks_cache import PKS_PLANS
+from container_service_extension.pks_cache import PKS_COMPUTE_PROFILE_KEY
+from container_service_extension.pks_cache import PKS_CLUSTER_DOMAIN_KEY
+from container_service_extension.pks_cache import PKS_PLANS_KEY
 from container_service_extension.pks_cache import PksCache
 from container_service_extension.utils import get_org
 from container_service_extension.utils import get_pks_cache
@@ -45,6 +46,7 @@ class OvdcCache(object):
     @staticmethod
     def construct_pks_context(pks_account_info, pvdc_info=None, nsxt_info=None,
                               pks_compute_profile_name=None, pks_plans='',
+                              pks_cluster_domain='',
                               credentials_required=False):
         """Construct PKS context dictionary.
 
@@ -67,9 +69,11 @@ class OvdcCache(object):
             pks_ctx.update(credentials._asdict())
         if pvdc_info:
             pks_ctx.update(pvdc_info._asdict())
-        pks_ctx[PKS_COMPUTE_PROFILE] = '' if not pks_compute_profile_name \
+        pks_ctx[PKS_COMPUTE_PROFILE_KEY] = '' if not pks_compute_profile_name \
             else pks_compute_profile_name
-        pks_ctx[PKS_PLANS] = '' if not pks_plans else pks_plans
+        pks_ctx[PKS_PLANS_KEY] = '' if not pks_plans else pks_plans
+        pks_ctx[PKS_CLUSTER_DOMAIN_KEY] = '' if not pks_cluster_domain \
+            else pks_cluster_domain
         pks_ctx['nsxt'] = nsxt_info
         return pks_ctx
 
@@ -115,8 +119,8 @@ class OvdcCache(object):
             # Get the credentials from PksCache
             pvdc_id = self.get_pvdc_id(ovdc)
             pvdc_info = self.pks_cache.get_pvdc_info(pvdc_id)
-            ctr_prov_details[PKS_PLANS] = \
-                ctr_prov_details[PKS_PLANS].split(',')
+            ctr_prov_details[PKS_PLANS_KEY] = \
+                ctr_prov_details[PKS_PLANS_KEY].split(',')
             if credentials_required:
                 pks_info = self.pks_cache.get_pks_account_info(
                     org_name, pvdc_info.vc)

--- a/container_service_extension/ovdc_cache.py
+++ b/container_service_extension/ovdc_cache.py
@@ -12,8 +12,8 @@ from pyvcloud.vcd.client import MetadataVisibility
 from pyvcloud.vcd.vdc import VDC
 
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
-from container_service_extension.pks_cache import PKS_COMPUTE_PROFILE_KEY
 from container_service_extension.pks_cache import PKS_CLUSTER_DOMAIN_KEY
+from container_service_extension.pks_cache import PKS_COMPUTE_PROFILE_KEY
 from container_service_extension.pks_cache import PKS_PLANS_KEY
 from container_service_extension.pks_cache import PksCache
 from container_service_extension.utils import get_org

--- a/container_service_extension/pks_cache.py
+++ b/container_service_extension/pks_cache.py
@@ -9,8 +9,9 @@ from collections import namedtuple
 from container_service_extension.utils import get_pvdc_id_by_name
 
 # Refer  to TODO(Constants) in broker_manager.py
-PKS_PLANS = 'pks_plans'
-PKS_COMPUTE_PROFILE = 'pks_compute_profile_name'
+PKS_PLANS_KEY = 'pks_plans'
+PKS_CLUSTER_DOMAIN_KEY = 'pks_cluster_domain'
+PKS_COMPUTE_PROFILE_KEY = 'pks_compute_profile_name'
 
 
 class PksCache(object):
@@ -202,8 +203,9 @@ class PksCache(object):
         keys = set(PksAccountInfo._fields)
         keys.remove('credentials')
         [keys.add(field) for field in PvdcInfo._fields]
-        keys.add(PKS_PLANS)
-        keys.add(PKS_COMPUTE_PROFILE)
+        keys.add(PKS_PLANS_KEY)
+        keys.add(PKS_COMPUTE_PROFILE_KEY)
+        keys.add(PKS_CLUSTER_DOMAIN_KEY)
         return keys
 
     def _construct_pvdc_info_table(self, pvdcs):

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -121,7 +121,6 @@ class PKSBroker(AbstractBroker):
     def _get_pks_config(self, token, version):
         """Construct PKS configuration.
 
-
         (PKS configuration is required to construct pksclient)
 
         :return: PKS configuration

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -16,7 +16,6 @@ from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.nsxt.cluster_network_isolater import \
     ClusterNetworkIsolater
 from container_service_extension.nsxt.nsxt_client import NSXTClient
-from container_service_extension.pks_cache import PKS_CLUSTER_DOMAIN_KEY
 from container_service_extension.pks_cache import PKS_COMPUTE_PROFILE_KEY
 from container_service_extension.pksclient.api.v1.cluster_api \
     import ClusterApi as ClusterApiV1
@@ -26,8 +25,12 @@ from container_service_extension.pksclient.api.v1beta.profile_api \
     import ProfileApi
 from container_service_extension.pksclient.client.v1.api_client \
     import ApiClient as ApiClientV1
+from container_service_extension.pksclient.client.v1.rest\
+    import ApiException as v1Exception
 from container_service_extension.pksclient.client.v1beta.api_client \
     import ApiClient as ApiClientV1Beta
+from container_service_extension.pksclient.client.v1beta.rest\
+    import ApiException as v1BetaException
 from container_service_extension.pksclient.configuration import Configuration
 from container_service_extension.pksclient.models.v1.\
     update_cluster_parameters import UpdateClusterParameters
@@ -40,10 +43,6 @@ from container_service_extension.pksclient.models.v1beta.\
     compute_profile_parameters import ComputeProfileParameters
 from container_service_extension.pksclient.models.v1beta.\
     compute_profile_request import ComputeProfileRequest
-from container_service_extension.pksclient.client.v1.rest\
-    import ApiException as v1Exception
-from container_service_extension.pksclient.client.v1beta.rest\
-    import ApiException as v1BetaException
 from container_service_extension.server_constants import \
     CSE_PKS_DEPLOY_RIGHT_NAME
 from container_service_extension.uaaclient.uaaclient import UaaClient
@@ -206,7 +205,7 @@ class PKSBroker(AbstractBroker):
 
         list_of_cluster_dicts = []
         for cluster in clusters:
-            # TODO Below is a temporary fix to retrieve compute_profile_name.
+            # TODO() Below is a temporary fix to retrieve compute_profile_name.
             #  Expensive _get_cluster_info() call must be removed once PKS team
             #  moves list_clusters to v1beta endpoint.
             v1_beta_cluster = self._get_cluster_info(cluster_name=cluster.name)
@@ -218,9 +217,10 @@ class PKSBroker(AbstractBroker):
             #     'last_action': cluster.last_action,
             #     'k8_master_ips': cluster.kubernetes_master_ips,
             #     'compute_profile_name': cluster.compute_profile_name,
-            #     'worker_count': cluster.parameters.kubernetes_worker_instances
+            #     'worker_count':
+            #     cluster.parameters.kubernetes_worker_instances
             # }
-            #list_of_cluster_dicts.append(cluster_dict)
+            # list_of_cluster_dicts.append(cluster_dict)
             list_of_cluster_dicts.append(v1_beta_cluster)
 
         LOGGER.debug(f"Received response from PKS: {self.pks_host_uri} on the"

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -14,7 +14,8 @@ from container_service_extension.exceptions import CseServerError
 from container_service_extension.exceptions import PksConnectionError
 from container_service_extension.exceptions import PksServerError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
-from container_service_extension.pks_cache import PKS_COMPUTE_PROFILE
+from container_service_extension.pks_cache import PKS_CLUSTER_DOMAIN_KEY
+from container_service_extension.pks_cache import PKS_COMPUTE_PROFILE_KEY
 from container_service_extension.pksclient.api.v1.cluster_api \
     import ClusterApi as ClusterApiV1
 from container_service_extension.pksclient.api.v1beta.cluster_api \
@@ -87,7 +88,8 @@ class PKSBroker(AbstractBroker):
             f"https://{pks_ctx['host']}:{pks_ctx['uaac_port']}"
         self.proxy_uri = f"http://{pks_ctx['proxy']}:80" \
             if pks_ctx.get('proxy') else None
-        self.compute_profile = pks_ctx.get(PKS_COMPUTE_PROFILE, None)
+        self.compute_profile = pks_ctx.get(PKS_COMPUTE_PROFILE_KEY, None)
+        self.cluster_domain = pks_ctx.get(PKS_CLUSTER_DOMAIN_KEY, None)
         # TODO() Add support in pyvcloud to send metadata values with their
         # types intact.
         verify_ssl_value_in_ctx = pks_ctx.get('verify')

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -37,7 +37,10 @@ from container_service_extension.pksclient.models.v1beta.\
     compute_profile_parameters import ComputeProfileParameters
 from container_service_extension.pksclient.models.v1beta.\
     compute_profile_request import ComputeProfileRequest
-from container_service_extension.pksclient.rest import ApiException
+from container_service_extension.pksclient.client.v1.rest\
+    import ApiException as v1Exception
+from container_service_extension.pksclient.client.v1beta.rest\
+    import ApiException as v1BetaException
 from container_service_extension.server_constants import \
     CSE_PKS_DEPLOY_RIGHT_NAME
 from container_service_extension.uaaclient.uaaclient import UaaClient
@@ -180,7 +183,7 @@ class PKSBroker(AbstractBroker):
                      f"to list all clusters")
         try:
             clusters = cluster_api.list_clusters()
-        except ApiException as err:
+        except v1Exception as err:
             LOGGER.debug(f"Listing PKS clusters failed with error:\n {err}")
             raise PksServerError(err.status, err.body)
 
@@ -264,10 +267,14 @@ class PKSBroker(AbstractBroker):
                      f"cluster of name: {cluster_name}")
         try:
             cluster = cluster_api.add_cluster(cluster_request)
-        except ApiException as err:
+        except v1BetaException as err:
             LOGGER.debug(f"Creating cluster {cluster_name} in PKS failed with "
                          f"error:\n {err}")
             raise PksServerError(err.status, err.body)
+        except Exception as err:
+            LOGGER.debug(f"Creating cluster {cluster_name} in PKS failed with "
+                         f"error:\n {err}")
+            print(err)
         cluster_dict = cluster.to_dict()
         # Flattening the dictionary
         cluster_params_dict = cluster_dict.pop('parameters')
@@ -321,7 +328,7 @@ class PKSBroker(AbstractBroker):
                      f"details of cluster with name: {cluster_name}")
         try:
             cluster = cluster_api.get_cluster(cluster_name=cluster_name)
-        except ApiException as err:
+        except v1BetaException as err:
             LOGGER.debug(f"Getting cluster info on {cluster_name} failed with "
                          f"error:\n {err}")
             raise PksServerError(err.status, err.body)
@@ -405,7 +412,7 @@ class PKSBroker(AbstractBroker):
                      f"the cluster with name: {cluster_name}")
         try:
             cluster_api.delete_cluster(cluster_name=cluster_name)
-        except ApiException as err:
+        except v1Exception as err:
             LOGGER.debug(f"Deleting cluster {cluster_name} failed with "
                          f"error:\n {err}")
             raise PksServerError(err.status, err.body)
@@ -462,7 +469,7 @@ class PKSBroker(AbstractBroker):
             kubernetes_worker_instances=node_count)
         try:
             cluster_api.update_cluster(cluster_name, body=resize_params)
-        except ApiException as err:
+        except v1Exception as err:
             LOGGER.debug(f"Resizing cluster {cluster_name} failed with "
                          f"error:\n {err}")
             raise PksServerError(err.status, err.body)
@@ -523,7 +530,7 @@ class PKSBroker(AbstractBroker):
                      f"the compute profile: {cp_name} for ovdc {ovdc_rp_name}")
         try:
             profile_api.add_compute_profile(body=cp_request)
-        except ApiException as err:
+        except v1BetaException as err:
             LOGGER.debug(f"Creating compute-profile {cp_name} in PKS failed "
                          f"with error:\n {err}")
             raise PksServerError(err.status, err.body)
@@ -552,7 +559,7 @@ class PKSBroker(AbstractBroker):
         try:
             compute_profile = \
                 profile_api.get_compute_profile(profile_name=cp_name)
-        except ApiException as err:
+        except v1BetaException as err:
             LOGGER.debug(f"Creating compute-profile {cp_name} in PKS failed "
                          f"with error:\n {err}")
             raise PksServerError(err.status, err.body)
@@ -581,7 +588,7 @@ class PKSBroker(AbstractBroker):
                      f"list of compute profiles")
         try:
             cp_list = profile_api.list_compute_profiles()
-        except ApiException as err:
+        except v1BetaException as err:
             LOGGER.debug(f"Listing compute-profiles in PKS failed "
                          f"with error:\n {err}")
             raise PksServerError(err.status, err.body)
@@ -612,7 +619,7 @@ class PKSBroker(AbstractBroker):
 
         try:
             profile_api.delete_compute_profile(profile_name=cp_name)
-        except ApiException as err:
+        except v1BetaException as err:
             LOGGER.debug(f"Deleting compute-profile {cp_name} in PKS failed "
                          f"with error:\n {err}")
             raise PksServerError(err.status, err.body)

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -192,7 +192,7 @@ class PKSBroker(AbstractBroker):
         list_of_cluster_dicts = []
         for cluster in clusters:
             # TODO Below is a temporary fix to retrieve compute_profile_name.
-            #  Expensive _get_cluster_info() must be removed once PKS team
+            #  Expensive _get_cluster_info() call must be removed once PKS team
             #  moves list_clusters to v1beta endpoint.
             v1_beta_cluster = self._get_cluster_info(cluster_name=cluster.name)
             # cluster_dict = {
@@ -274,10 +274,7 @@ class PKSBroker(AbstractBroker):
             LOGGER.debug(f"Creating cluster {cluster_name} in PKS failed with "
                          f"error:\n {err}")
             raise PksServerError(err.status, err.body)
-        except Exception as err:
-            LOGGER.debug(f"Creating cluster {cluster_name} in PKS failed with "
-                         f"error:\n {err}")
-            print(err)
+
         cluster_dict = cluster.to_dict()
         # Flattening the dictionary
         cluster_params_dict = cluster_dict.pop('parameters')

--- a/container_service_extension/pksclient/client/v1/__init__.py
+++ b/container_service_extension/pksclient/client/v1/__init__.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import
 # import ApiClient
 from container_service_extension.pksclient.client.v1.api_client import ApiClient
 from container_service_extension.pksclient.client.v1.configuration import Configuration
+from container_service_extension.pksclient.client.v1.rest import ApiException
 # import models into sdk package
 # from container_service_extension.pksclient.models.v1.cluster import Cluster
 # from container_service_extension.pksclient.models.v1.cluster_parameters import ClusterParameters

--- a/container_service_extension/pksclient/client/v1beta/__init__.py
+++ b/container_service_extension/pksclient/client/v1beta/__init__.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import
 # import ApiClient
 from container_service_extension.pksclient.client.v1beta.api_client import ApiClient
 from container_service_extension.pksclient.client.v1beta.configuration import Configuration
+from container_service_extension.pksclient.client.v1beta.rest import ApiException
 # import models into sdk package
 # from container_service_extension.pksclient.models.v1beta.az import AZ
 # from container_service_extension.pksclient.models.v1beta.cluster import Cluster


### PR DESCRIPTION
1. For create-cluster operation on PKS, user no longer has to input pks-plan and pks-ext-host-name
2. For enablek8s, admins have to input new param called "pks-cluster-domain". For each subsequent cluster deployments in that ovdc, "pks-external-host-name" will be dynamically constructed by CSE using "pks-cluster-domain" set on the ovdc. For example, if name of the cluster is "mycluster" and pks-cluster-domain set on the ovdc is "pepsi.com", then external host name of the cluster would be "mycluster.pepsi.com"
3. List-clusters is broken with new pks bits (compute-profile-name is no longer part of the cluster object returned by PKS server). As a temporary fix from CSE side (until PKS provides the actual fix), we are making an extra get_cluster_info() call for each cluster to get what we need.
4. Fixed broken exception handling for PKS workflows (on upgrading to new PKS bits).

Testing:
Basic manual sanity testing done (cluster creation, list clusters, enablek8s). Rigorous testing will be done as part of upcoming testing task.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/301)
<!-- Reviewable:end -->
