### PR TITLE
[VCDA-930] Fixed broken ovdc-enable command when enabling for unqualified ovdc

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -458,9 +458,12 @@ class BrokerManager(object):
                 raise CseServerError('PKS config file does not exist')
             pvdc_info = self.pks_cache.get_pvdc_info(pvdc_id)
             if not pvdc_info:
+                LOGGER.debug(f"pvdc '{pvdc_id}' is not backed "
+                             f"by PKS-managed-vSphere resources")
                 raise CseServerError(f"'{ovdc.resource.get('name')}' is not "
                                      f"eligible to provide resources for "
-                                     f"PKS clusters")
+                                     f"PKS clusters. Refer debug logs for more"
+                                     f" details.")
             pks_account_info = self.pks_cache.get_pks_account_info(
                 org_name, pvdc_info.vc)
             nsxt_info = self.pks_cache.get_nsxt_info(pvdc_info.vc)


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- Fixes broken ovdc-enable command when enabling unqualified ovdc for k8s deployment

- Unqualified ovdc that fails to find the supporting pvdc from pks config, command breaks. This fix raises proper exception and prints appropriate message to the console for the system administrator. Debug statements included.

 - Manually tested and verified

 
