### PR TITLE
[VCDA-976] Refactor pks.yaml to get rid of optional orgs section from sample.

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -62,33 +62,48 @@ TEMP_VAPP_NETWORK_ADAPTER_TYPE = "vmxnet3"
 TEMP_VAPP_FENCE_MODE = FenceMode.BRIDGED.value
 
 INSTRUCTIONS_FOR_PKS_CONFIG_FILE = "\
-# Config file for PKS enabled CSE Server to be filled by the administrator.\n\
-# This config file has the following three sections:\n\
-#   1. pks_accounts:\n\
-#       a. Cloud Admins can specify PKS service account for every\n\
-#          (PKS managed) vCenter in vCD i.e. a common PKS account per\n\
-#          vCenter will be used for all the organizations.\n\
-#       b. Cloud Admin can choose to create separate PKS service\n\
-#          account per organization per vCenter, if this option is chosen,\n\
-#          admins need to ensure that PKS accounts are correctly mapped to\n\
-#          their respective organization in the 'orgs' section of this\n\
-#          config file.\n\
-#       P.S: Currently, we mandate each PKS service account in the system to\n\
-#       have a unique account name.\n\
-#   2. orgs: [OPTIONAL SECTION for admins who chose 1a above.]\n\
-#       a. If cloud admin chooses to define PKS service account per\n\
-#          organization per vCenter, include the organization and respective\n\
-#          pks_account names in this section, else should be left blank with\n\
-#          empty values.\n\
+# Config file for PKS enabled CSE Server to be filled by administrators.\n\
+# This config file has the following four sections:\n\
+#   1. pks_api_servers:\n\
+#       a. Each entry in the list represents a PKS api server that is part \n\
+#          of the deployment.\n\
+#       b. The field 'name' in each entry should be unique. The value of \n\
+#          the field has no bearing on the real world PKS api server, it's \n\
+#          used to tie in various segments of the config file together.\n\
+#       c. The field 'vc' represents the name with which the PKS vCenter \n\
+#          is registered in vCD.\n\
+#   2. pks_accounts:\n\
+#       a. Each entry in the list represents a PKS account that can be used \n\
+#          talk to a certain PKS api server.\n\
+#       b. The field 'name' in each entry should be unique. The value of \n\
+#          the field has no bearing on the real world PKS accounts, it's \n\
+#          used to tie in various segments of the config file together.\n\
+#       c. The field 'pks_api_server' is a reference to the PKS api server \n\
+#          which owns this account. It's value should be equal to value of \n\
+#          the field 'name' of the corresponding PKS api server.\n\
 #   3. pvdcs:\n\
-#       a. List of Provider vDCs dedicated for PKS enabled CSE set up only\n\
-# Each PKS service account needs to have the following information fields to\n\
-# be filled in: \n\
-#       1. PKS account name\n\
-#       2. vCenter name in vCD for this PKS account\n\
-#       3. PKS server host\n\
-#       4. PKS server port\n\
-#       5. PKS UAAC account information\n\
+#       a. Each entry in the list represents a Provider VDC in vCD that is \n\
+#          backed by a cluster of the PKS managed vCenter server.\n\
+#       b. The field 'name' in each entry should be the name of the \n\
+#          Provider VDC as it appears in vCD.\n\
+#       c. The field 'pks_api_server' is a reference to the PKS api server \n\
+#          which owns this account. It's value should be equal to value of \n\
+#          the field 'name' of the corresponding PKS api server.\n\
+#   4. nsxt_servers:\n\
+#       a. Each entry in the list represents a NSX-T server that has been \n\
+#          alongside a PKS server to manage its networking.\n\
+#       b. The field 'name' in each entry should be unique. The value of \n\
+#          the field has no bearing on the real world NSX-T server, it's \n\
+#          used to tie in various segments of the config file together.\n\
+#       c. The field 'pks_api_server' is a reference to the PKS api server \n\
+#          which owns this account. It's value should be equal to value of \n\
+#          the field 'name' of the corresponding PKS api server.\n\
+#       d. The field 'distributed_firewall_section_anchor_id' should be \n\
+#          populated with id of a Distributed Firewall Section, above which \n\
+#          CSE will create an empty Section to guide NCP to create dynamic \n\
+#          Distributed Firewall rules. Normally it can be the id of the \n\
+#          section called 'Default Layer3 Section' which PKS creates on \n\
+#          installation.\n\
 # For more information, please refer to CSE documentation page:\n\
 # https://vmware.github.io/container-service-extension/INSTALLATION.html\n"
 
@@ -100,8 +115,8 @@ NOTE_FOR_PKS_KEY_IN_CONFIG_FILE = "\
 PKS_CONFIG_NOTE = "\
 # [OPTIONAL] PKS CONFIGS\n\
 # These configs are required only for customers with PKS enabled CSE.\n\
-# Regular CSE users with no PKS container provider do not need these configs\n\
-# to be filled out in a separate yaml file."
+# Regular CSE users, with no PKS container provider in their system, do not \n\
+# need these configs to be filled out in a separate yaml file."
 
 SAMPLE_AMQP_CONFIG = {
     'amqp': {
@@ -208,12 +223,12 @@ SAMPLE_PKS_CONFIG_FILE_LOCATION = {
     PKS_CONFIG_FILE_LOCATION_SECTION_KEY: None
 }
 
-PKS_SERVERS_SECTION_KEY = 'pks_servers'
+PKS_SERVERS_SECTION_KEY = 'pks_api_servers'
 SAMPLE_PKS_SERVERS_SECTION = {
     PKS_SERVERS_SECTION_KEY: [
         {
-            'name': 'pks-server-1',
-            'host': 'pks-server-1.pks.local',
+            'name': 'pks-api-server-1',
+            'host': 'pks-api-server-1.pks.local',
             'port': '9021',
             'uaac_port': '8443',
             # 'proxy': 'proxy1.pks.local:80',
@@ -223,8 +238,8 @@ SAMPLE_PKS_SERVERS_SECTION = {
             'vc': 'vc1',
             'verify': True
         }, {
-            'name': 'pks-server-2',
-            'host': 'pks-server-2.pks.local',
+            'name': 'pks-api-server-2',
+            'host': 'pks-api-server-2.pks.local',
             'port': '9021',
             'uaac_port': '8443',
             # 'proxy': 'proxy2.pks.local:80',
@@ -242,17 +257,17 @@ SAMPLE_PKS_ACCOUNTS_SECTION = {
     PKS_ACCOUNTS_SECTION_KEY: [
         {
             'name': 'Org1ServiceAccount1',
-            'pks_server': 'pks-server-1',
+            'pks_api_server': 'pks-api-server-1',
             'secret': 'secret',
             'username': 'org1Admin'
         }, {
             'name': 'Org1ServiceAccount2',
-            'pks_server': 'pks-server-2',
+            'pks_api_server': 'pks-api-server-2',
             'secret': 'secret',
             'username': 'org1Admin'
         }, {
             'name': 'Org2ServiceAccount',
-            'pks_server': 'pks-server-2',
+            'pks_api_server': 'pks-api-server-2',
             'secret': 'secret',
             'username': 'org2Admin'
         }
@@ -277,15 +292,15 @@ SAMPLE_PKS_PVDCS_SECTION = {
     PKS_PVDCS_SECTION_KEY: [
         {
             'name': 'pvdc1',
-            'pks_server': 'pks-server-1',
+            'pks_api_server': 'pks-api-server-1',
             'cluster': 'pks-s1-az-1',
         }, {
             'name': 'pvdc2',
-            'pks_server': 'pks-server-2',
+            'pks_api_server': 'pks-api-server-2',
             'cluster': 'pks-s2-az-1'
         }, {
             'name': 'pvdc3',
-            'pks_server': 'pks-server-1',
+            'pks_api_server': 'pks-api-server-1',
             'cluster': 'pks-s1-az-2'
         }
     ]
@@ -299,7 +314,7 @@ SAMPLE_PKS_NSXT_SERVERS_SECTION = {
             'host': 'nsxt1.domain.local',
             'username': 'admin',
             'password': 'secret',
-            'pks_server': 'pks-server-1',
+            'pks_api_server': 'pks-api-server-1',
             # 'proxy': 'proxy1.pks.local:80',
             'nodes_ip_block_ids': ['id1', 'id2'],
             'pods_ip_block_ids': ['id1', 'id2'],
@@ -310,7 +325,7 @@ SAMPLE_PKS_NSXT_SERVERS_SECTION = {
             'host': 'nsxt2.domain.local',
             'username': 'admin',
             'password': 'secret',
-            'pks_server': 'pks-server-2',
+            'pks_api_server': 'pks-api-server-2',
             # 'proxy': 'proxy2.pks.local:80',
             'nodes_ip_block_ids': ['id1', 'id2'],
             'pods_ip_block_ids': ['id1', 'id2'],
@@ -361,8 +376,9 @@ def generate_sample_config(output=None, pks_output=None):
         SAMPLE_PKS_SERVERS_SECTION, default_flow_style=False) + '\n'
     sample_pks_config += yaml.safe_dump(
         SAMPLE_PKS_ACCOUNTS_SECTION, default_flow_style=False) + '\n'
-    sample_pks_config += yaml.safe_dump(
-        SAMPLE_PKS_ORGS_SECTION, default_flow_style=False) + '\n'
+    # Org - PKS account mapping section will be supressed for CSE 2.0 alpha
+    # sample_pks_config += yaml.safe_dump(
+    #    SAMPLE_PKS_ORGS_SECTION, default_flow_style=False) + '\n'
     sample_pks_config += yaml.safe_dump(
         SAMPLE_PKS_PVDCS_SECTION, default_flow_style=False) + '\n'
     sample_pks_config += yaml.safe_dump(
@@ -640,19 +656,48 @@ def validate_pks_config_structure(pks_config):
             excluded_keys=['proxy'])
 
 
+def _get_duplicate_in_list(data):
+    seen = set()
+    duplicates = set()
+    if data:
+        for x in data:
+            if x in seen:
+                duplicates.add(x)
+            else:
+                seen.add(x)
+    return list(duplicates)
+
+
 def validate_pks_config_data_integrity(pks_config):
     all_pks_servers = \
         [entry['name'] for entry in pks_config[PKS_SERVERS_SECTION_KEY]]
     all_pks_accounts = \
         [entry['name'] for entry in pks_config[PKS_ACCOUNTS_SECTION_KEY]]
 
-    for pks_account in pks_config[PKS_ACCOUNTS_SECTION_KEY]:
-        pks_server = pks_account.get('pks_server')
-        if pks_server not in all_pks_servers:
-            raise ValueError(f"Unknown PKS server : {pks_server} referenced"
-                             f" by PKS account : {pks_account.get('name')} in "
-                             f"Section : {PKS_ACCOUNTS_SECTION_KEY}")
+    # Check for duplicate pks api server names
+    duplicate_pks_server_names = _get_duplicate_in_list(all_pks_servers)
+    if len(duplicate_pks_server_names) != 0:
+        raise ValueError(
+            f"Duplicate PKS api server(s) : {duplicate_pks_server_names} found"
+            f" in Section : {PKS_SERVERS_SECTION_KEY}")
 
+    # Check for duplicate pks account names
+    duplicate_pks_account_names = _get_duplicate_in_list(all_pks_accounts)
+    if len(duplicate_pks_account_names) != 0:
+        raise ValueError(
+            f"Duplicate PKS account(s) : {duplicate_pks_account_names} found"
+            f" in Section : {PKS_ACCOUNTS_SECTION_KEY}")
+
+    # Check validity of all PKS api servers referenced in PKS accounts section
+    for pks_account in pks_config[PKS_ACCOUNTS_SECTION_KEY]:
+        pks_server_name = pks_account.get('pks_api_server')
+        if pks_server_name not in all_pks_servers:
+            raise ValueError(
+                f"Unknown PKS api server : {pks_server_name} referenced by "
+                f"PKS account : {pks_account.get('name')} in Section : "
+                f"{PKS_ACCOUNTS_SECTION_KEY}")
+
+    # Check validity of all PKS accounts referenced in Orgs section
     if PKS_ORGS_SECTION_KEY in pks_config.keys():
         for org in pks_config[PKS_ORGS_SECTION_KEY]:
             referenced_accounts = org.get('pks_accounts')
@@ -664,19 +709,22 @@ def validate_pks_config_data_integrity(pks_config):
                                      f"nced by Org : {org.get('name')} in "
                                      f"Section : {PKS_ORGS_SECTION_KEY}")
 
+    # Check validity of all PKS api servers referenced in PVDC section
     for pvdc in pks_config[PKS_PVDCS_SECTION_KEY]:
-        pks_server = pvdc.get('pks_server')
-        if pks_server not in all_pks_servers:
-            raise ValueError(f"Unknown PKS server : {pks_server} referenced"
-                             f" by PVDC : {pvdc.get('name')} in Section : "
-                             f"{PKS_PVDCS_SECTION_KEY}")
+        pks_server_name = pvdc.get('pks_api_server')
+        if pks_server_name not in all_pks_servers:
+            raise ValueError(f"Unknown PKS api server : {pks_server_name} "
+                             f"referenced by PVDC : {pvdc.get('name')} in "
+                             f"Section : {PKS_PVDCS_SECTION_KEY}")
 
+    # Check validity of all PKS api servers referenced in NSX-T section
     for nsxt_server in pks_config[PKS_NSXT_SERVERS_SECTION_KEY]:
-        pks_server = nsxt_server.get('pks_server')
-        if pks_server not in all_pks_servers:
-            raise ValueError(f"Unknown PKS server : {pks_server} reference"
-                             f"d by NSX-T server : {nsxt_server.get('name')} "
-                             f"in Section : {PKS_NSXT_SERVERS_SECTION_KEY}")
+        pks_server_name = nsxt_server.get('pks_api_server')
+        if pks_server_name not in all_pks_servers:
+            raise ValueError(
+                f"Unknown PKS api server : {pks_server_name} referenced by "
+                f"NSX-T server : {nsxt_server.get('name')} in Section : "
+                f"{PKS_NSXT_SERVERS_SECTION_KEY}")
 
         # Create a NSX-T client and verify connection
         nsxt_client = NSXTClient(
@@ -687,8 +735,9 @@ def validate_pks_config_data_integrity(pks_config):
             https_proxy=nsxt_server.get('proxy'),
             verify_ssl=nsxt_server.get('verify'))
         if not nsxt_client.test_connectivity():
-            raise ValueError(f"Unable to connect to NSX-T server : "
-                             f"{nsxt_server.get('name')}")
+            raise ValueError(
+                "Unable to connect to NSX-T server : "
+                f"{nsxt_server.get('name')} ({nsxt_server.get('host')})")
 
         click.secho(f"Connected to NSX-T server ({nsxt_server.get('host')})",
                     fg='green')

--- a/container_service_extension/cse.py
+++ b/container_service_extension/cse.py
@@ -113,6 +113,7 @@ def version(ctx):
 @cli.command('sample', short_help='generate sample configuration')
 @click.pass_context
 @click.option(
+    '-o',
     '--output',
     'output',
     required=False,
@@ -120,6 +121,7 @@ def version(ctx):
     metavar='<output-file-name>',
     help="Name of the config file to dump the CSE configs to.")
 @click.option(
+    '-p',
     '--pks-output',
     'pks_output',
     required=False,

--- a/container_service_extension/nsxt/nsxt_client.py
+++ b/container_service_extension/nsxt/nsxt_client.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+from http import HTTPStatus
 import json
 
 import requests
@@ -73,7 +74,8 @@ class NSXTClient(object):
         try:
             self.do_request(RequestMethodVerb.GET, "")
         except RequestException as err:
-            if err.response.status_code == 404:
+            if err.response is not None and \
+                    (err.response.status_code == HTTPStatus.NOT_FOUND):
                 return True
             else:
                 return False

--- a/container_service_extension/pks_cache.py
+++ b/container_service_extension/pks_cache.py
@@ -57,7 +57,7 @@ class PksCache(object):
         """
         orgs_to_pks_account_mapper = {}
         for org in orgs:
-            orgs_to_pks_account_mapper[org['name']] = org['pks_accounts']
+                orgs_to_pks_account_mapper[org['name']] = org['pks_accounts']
         super().__setattr__("orgs_to_pks_account_mapper",
                             orgs_to_pks_account_mapper)
 
@@ -68,7 +68,7 @@ class PksCache(object):
 
         vc_to_nsxt_server_mapper = {}
         for nsxt_server in nsxt_servers:
-            pks_server = pks_servers_table[nsxt_server['pks_server']]
+            pks_server = pks_servers_table[nsxt_server['pks_api_server']]
             vc_to_nsxt_server_mapper[pks_server['vc']] = nsxt_server
         super().__setattr__("vc_to_nsxt_server_mapper",
                             vc_to_nsxt_server_mapper)
@@ -222,7 +222,7 @@ class PksCache(object):
         for pvdc in pvdcs:
             pvdc_name = pvdc['name']
             cluster = pvdc['cluster']
-            pks_server_name = pvdc['pks_server']
+            pks_server_name = pvdc['pks_api_server']
 
             pks_server = self.pks_servers_table.get(pks_server_name)
             vc = pks_server['vc']
@@ -258,7 +258,7 @@ class PksCache(object):
             credentials = Credentials(pks_account['username'],
                                       pks_account['secret'])
 
-            pks_server_name = pks_account['pks_server']
+            pks_server_name = pks_account['pks_api_server']
             pks_server = self.pks_servers_table.get(pks_server_name)
 
             pks_proxy = '' \

--- a/container_service_extension/pks_cache.py
+++ b/container_service_extension/pks_cache.py
@@ -57,7 +57,7 @@ class PksCache(object):
         """
         orgs_to_pks_account_mapper = {}
         for org in orgs:
-                orgs_to_pks_account_mapper[org['name']] = org['pks_accounts']
+            orgs_to_pks_account_mapper[org['name']] = org['pks_accounts']
         super().__setattr__("orgs_to_pks_account_mapper",
                             orgs_to_pks_account_mapper)
 

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -200,12 +200,13 @@ class Service(object, metaclass=Singleton):
         LOGGER.info(message)
 
         if self.config.get('pks_config'):
+            pks_config = self.config.get('pks_config')
             self.pks_cache = PksCache(
-                pks_servers=self.config.get('pks_config').get('pks_servers'),
-                pks_accounts=self.config.get('pks_config').get('pks_accounts'),
-                pvdcs=self.config.get('pks_config').get('pvdcs'),
-                orgs=self.config.get('pks_config').get('orgs'),
-                nsxt_servers=self.config.get('pks_config').get('nsxt_servers'))
+                pks_servers=pks_config.get('pks_api_servers', []),
+                pks_accounts=pks_config.get('pks_accounts', []),
+                pvdcs=pks_config.get('pvdcs', []),
+                orgs=pks_config.get('orgs', []),
+                nsxt_servers=pks_config.get('nsxt_servers', []))
 
         amqp = self.config['amqp']
         num_consumers = self.config['service']['listeners']

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -220,6 +220,27 @@ def bool_to_msg(value):
     return 'fail'
 
 
+def get_duplicate_items_in_list(items):
+    """Find duplicate entries in a list.
+
+    :param list items: list of items with possible duplicates.
+
+    :return: the items that occur more than once in niput list. Each duplicated
+        item will be mentioned only once in the returned list.
+
+    :rtype: list
+    """
+    seen = set()
+    duplicates = set()
+    if items:
+        for item in items:
+            if item in seen:
+                duplicates.add(item)
+            else:
+                seen.add(item)
+    return list(duplicates)
+
+
 def get_sha256(filepath):
     """Get sha256 hash of file as a string.
 


### PR DESCRIPTION
* Removed the optional section 'orgs' from sample pks.yaml
* Renamed the key 'pks_server' in pks.yaml to 'pks_api_server'
* Added stricter data validation for pks.yaml
* Added documentation for pks.yaml
* Small bug fix in nsx-t client to avoid failures while testing connection to a nsxt server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/303)
<!-- Reviewable:end -->
