### PR TITLE
[VCDA-966] Remove vcd user id from console output and exceptions

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -278,8 +278,7 @@ class BrokerManager(object):
                                        pks_ctx)
                 # Get all cluster information to get vdc name from
                 # compute-profile-name
-                for cluster in pks_broker.list_clusters(
-                        is_pks_context_data_required=True):
+                for cluster in pks_broker.list_clusters(is_admin_request=True):
                     pks_cluster = self._get_truncated_cluster_info(
                         cluster, pks_broker, common_cluster_properties)
                     pks_cluster[K8S_PROVIDER_KEY] = K8sProviders.PKS

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -276,7 +276,10 @@ class BrokerManager(object):
             for pks_ctx in pks_ctx_list:
                 pks_broker = PKSBroker(self.req_headers, self.req_spec,
                                        pks_ctx)
-                for cluster in pks_broker.list_clusters():
+                # Get all cluster information to get vdc name from
+                # compute-profile-name
+                for cluster in pks_broker.list_clusters(
+                        is_pks_context_data_required=True):
                     pks_cluster = self._get_truncated_cluster_info(
                         cluster, pks_broker, common_cluster_properties)
                     pks_cluster[K8S_PROVIDER_KEY] = K8sProviders.PKS

--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -95,6 +95,8 @@ class PksServerError(CseServerError):
         self.body = body
 
     def __str__(self):
+        # TODO() Removing user context should be moved to PksServer response
+        #  processing aka filtering layer
         from container_service_extension.pksbroker import PKSBroker
         return f"PKS error\n status: {self.status}\n body: " \
             f" {PKSBroker.remove_traces_of_user_context(self.body)}\n"

--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -99,7 +99,7 @@ class PksServerError(CseServerError):
         #  processing aka filtering layer
         from container_service_extension.pksbroker import PKSBroker
         return f"PKS error\n status: {self.status}\n body: " \
-            f" {PKSBroker.remove_traces_of_user_context(self.body)}\n"
+            f" {PKSBroker.filter_traces_of_user_context(self.body)}\n"
 
 
 class PksConnectionError(PksServerError):

--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -95,7 +95,9 @@ class PksServerError(CseServerError):
         self.body = body
 
     def __str__(self):
-        return f"PKS error\n status: {self.status}\n body: {self.body}\n"
+        from container_service_extension.pksbroker import PKSBroker
+        return f"PKS error\n status: {self.status}\n body: " \
+            f" {PKSBroker.remove_traces_of_user_context(self.body)}\n"
 
 
 class PksConnectionError(PksServerError):

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -56,8 +56,12 @@ from container_service_extension.utils import OK
 USER_ID_SEPARATOR = "---"
 # Properties that need to be excluded from cluster info before sending
 # to the client for reasons: security, too big that runs thru lines
-EXCLUDE_KEYS = ['authorization_mode', 'compute_profile', 'uuid', 'plan_name',
+EXCLUDE_KEYS = ['authorization_mode', 'compute_profile', 'pks_cluster_name',
+                'uuid', 'plan_name', 'compute_profile_name',
                 'network_profile_name', 'nsxt_network_profile']
+
+# TODO() Filtering of cluster results should be processed in
+#  different layer.
 
 
 class PKSBroker(AbstractBroker):
@@ -183,11 +187,17 @@ class PKSBroker(AbstractBroker):
             for cluster in cluster_list:
                 self._restore_original_name(cluster)
         else:
-            user_cluster_list = [cluster_dict for cluster_dict in cluster_list
-                                 if self._is_user_cluster_owner(cluster_dict)]
-            for cluster in user_cluster_list:
-                self._exclude_pks_properties(cluster)
-            return user_cluster_list
+            cluster_list = [cluster_dict for cluster_dict in cluster_list
+                            if self._is_user_cluster_owner(cluster_dict)]
+
+            """ 'is_pks_context_data_required' is a flag that is used to restrict
+            access to user context and other secured information on pks cluster
+            information.
+            """
+            if not kwargs.get('is_pks_context_data_required'):
+                for cluster in cluster_list:
+                    self._filter_pks_properties(cluster)
+        return cluster_list
 
     def _list_clusters(self):
         """Get list of clusters in PKS environment.
@@ -249,8 +259,7 @@ class PKSBroker(AbstractBroker):
             self._append_user_id(cluster_spec['cluster_name'])
         cluster_info = self._create_cluster(**cluster_spec)
         self._restore_original_name(cluster_info)
-        if not self.tenant_client.is_sysadmin():
-            self._exclude_pks_properties(cluster_info)
+        self._filter_pks_properties(cluster_info)
         return cluster_info
 
     def _create_cluster(self, cluster_name, node_count, pks_plan, pks_ext_host,
@@ -356,8 +365,9 @@ class PKSBroker(AbstractBroker):
             cluster_info = \
                 self._get_cluster_info(self._append_user_id(cluster_name))
             self._restore_original_name(cluster_info)
-            self._exclude_pks_properties(cluster_info)
-            return cluster_info
+            if not kwargs.get('is_pks_context_data_required'):
+                self._filter_pks_properties(cluster_info)
+        return cluster_info
 
     def _get_cluster_info(self, cluster_name):
         """Get the details of a cluster with a given name in PKS environment.
@@ -406,7 +416,7 @@ class PKSBroker(AbstractBroker):
             pks_cluster_name = self._append_user_id(cluster_name)
             config_info = self._get_cluster_config(pks_cluster_name)
 
-        return self.remove_traces_of_user_context(config_info)
+        return self.filter_traces_of_user_context(config_info)
 
     def _get_cluster_config(self, cluster_name):
         """Get the configuration of the cluster with the given name in PKS.
@@ -448,7 +458,7 @@ class PKSBroker(AbstractBroker):
             pks_cluster_name = self._append_user_id(cluster_name)
             result = self._delete_cluster(pks_cluster_name)
         self._restore_original_name(result)
-        self._exclude_pks_properties(result)
+        self._filter_pks_properties(result)
         return result
 
     def _delete_cluster(self, cluster_name):
@@ -518,7 +528,7 @@ class PKSBroker(AbstractBroker):
             cluster_spec['cluster_name'] = pks_cluster_name
             result = self._resize_cluster(**cluster_spec)
         self._restore_original_name(result)
-        self._exclude_pks_properties(result)
+        self._filter_pks_properties(result)
         return result
 
     def _resize_cluster(self, cluster_name, node_count, **kwargs):
@@ -726,19 +736,22 @@ class PKSBroker(AbstractBroker):
     def _get_vcd_userid(self):
         return extract_id(self.client_session.get('userId'))
 
+    # TODO() Should be moved to filtering layer
     def _filter_list_by_cluster_name(self, cluster_list, cluster_name):
         # Return those clusters which have the given cluster name
         return [cluster for cluster in cluster_list
                 if cluster['name'] == cluster_name]
 
-    def _exclude_pks_properties(self, cluster_info):
+    # TODO() Should be moved to filtering layer
+    def _filter_pks_properties(self, cluster_info):
         # Remove selective properties from the given cluster
         # information.
         for entry in EXCLUDE_KEYS:
             cluster_info.pop(entry, None)
 
+    # TODO() Should be moved to filtering layer
     @staticmethod
-    def remove_traces_of_user_context(cluster_info):
+    def filter_traces_of_user_context(cluster_info):
         """Remove traces of user-id pattern from the given string.
 
         :param str cluster_info: text information that may have user context


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- PKS cluster name and exceptions should not expose vcd user id

- Currently, PKS cluster name and exceptions as console output exposes vcd user-id. This is fixed in this commit. Tested manually and also completed system tests.

@sahithi @rocknes @sompa @harshneelmore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/304)
<!-- Reviewable:end -->
