### PR TITLE
[VCDA-993] Do not check for pks specific params if ovdc is not enabled for pks

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -460,13 +460,13 @@ class BrokerManager(object):
     def _get_ovdc_params(self):
         ovdc_id = self.req_spec.get('ovdc_id')
         org_name = self.req_spec.get('org_name')
-        pks_plans = self.req_spec['pks_plans']
-        pks_cluster_domain = self.req_spec['pks_cluster_domain']
         ovdc = self.ovdc_cache.get_ovdc(ovdc_id=ovdc_id)
         pvdc_id = self.ovdc_cache.get_pvdc_id(ovdc)
 
         pks_context = None
         if self.req_spec[K8S_PROVIDER_KEY] == K8sProviders.PKS:
+            pks_plans = self.req_spec['pks_plans']
+            pks_cluster_domain = self.req_spec['pks_cluster_domain']
             if not self.pks_cache:
                 raise CseServerError('PKS config file does not exist')
             pvdc_info = self.pks_cache.get_pvdc_info(pvdc_id)


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com

- Failing ovdc enable for native container provider
- Fixes checking pks specific parameters when ovdc not enabled for that. Tested manually. 
  This may be required depending on what got fixed in addition to : https://github.com/vmware/container-service-extension/pull/306

@sahithi @sompa @harshneelmore @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/307)
<!-- Reviewable:end -->
