### PR TITLE
VCDA-897: Design and implement a command to list PKS plans

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -792,21 +792,35 @@ Examples
 \b
     vcd cse ovdc list
         Display ovdcs in vCD that are visible to the logged in user.
+        vcd cse ovdc list
+\b
+        vcd cse ovdc list --pks-plans
+            Displays list of ovdcs in a given org along with available PKS
+            plans if any. If executed by System-administrator, it will
+            display all ovdcs from all orgs.
     """
     pass
-
 
 @ovdc_group.command('list',
                     short_help='Display org VDCs in vCD that are visible '
                                'to the logged in user')
+@click.option(
+        '-p',
+        '--pks-plans',
+        'pks_plans',
+        required=False,
+        is_flag=True,
+        default=False,
+        help="This option acts as a flag to get the list"
+             " of available PKS plans for the ovdcs.")
 @click.pass_context
-def list_ovdcs(ctx):
+def list_ovdcs(ctx, pks_plans):
     """Display org VDCs in vCD that are visible to the logged in user."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
         ovdc = Ovdc(client)
-        result = ovdc.list()
+        result = ovdc.list(pks_plans_info_needed=pks_plans)
         stdout(result, ctx, sort_headers=False)
     except Exception as e:
         stderr(e, ctx)
@@ -932,5 +946,42 @@ def ovdc_info(ctx, ovdc_name, org_name):
             stdout(result, ctx)
         else:
             stderr("Unauthorized operation", ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@ovdc_group.group('pks-plans', short_help='Gets list of available PKS plans '
+                    'for the given ovdc or get details of a PKS plan.',
+           options_metavar='[options]')
+@click.pass_context
+def plans_group(ctx):
+    """Get available PKS Plan information for ovdcs in the system.
+
+\b
+    Note
+       This command is intended for use by the system administrator or org admin
+       to get relevant PKS plan information, before using the plans for enabling
+       an ovdc for container deployment on PKS.
+
+\b
+    Examples
+\b
+        vcd cse ovdc pks-plan list
+            Displays list of ovdcs and the available PKS Plans. If executed by
+            System-administrator, it will display all ovdcs from all orgs.
+    """
+    pass
+
+
+@plans_group.command(short_help='list pks plans')
+@click.pass_context
+def list(ctx):
+    """List of available PKS Plans for a system."""
+    try:
+        restore_session(ctx)
+        client = ctx.obj['client']
+        ovdc = Ovdc(client)
+        result = ovdc.list_pks_plans()
+        stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -15,14 +15,17 @@ class Ovdc(object):
         self.client = client
         self._uri = self.client.get_api_uri() + '/cse'
 
-    def list(self):
+    def list(self, pks_plans_info_needed):
         method = 'GET'
         uri = f'{self._uri}/ovdc'
+        data = {
+            'pks_plans_info_needed': pks_plans_info_needed,
+        }
         response = self.client._do_request_prim(
             method,
             uri,
             self.client._session,
-            contents=None,
+            contents=data,
             media_type=None,
             accept_type='application/json')
         return process_response(response)
@@ -127,4 +130,25 @@ class Ovdc(object):
             contents=None,
             media_type=None,
             accept_type='application/*+json')
+        return process_response(response)
+
+    def list_pks_plans(self):
+        """Get available PKS plans (if any) in the vCD system.
+
+        :return: response object
+
+        :rtype: list
+        """
+        method = 'GET'
+        uri = f'{self._uri}/ovdc/pks-plans'
+        params = {}
+        response = self.client._do_request_prim(
+            method,
+            uri,
+            self.client._session,
+            contents=None,
+            media_type=None,
+            accept_type='application/*+json',
+            auth=None,
+            params=params)
         return process_response(response)

--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -90,7 +90,7 @@ class VcdResponseError(Exception):
 class PksServerError(CseServerError):
     """Raised when error is received from PKS"""
 
-    def __init__(self, status, body):
+    def __init__(self, status, body=None):
         self.status = status
         self.body = body
 
@@ -98,6 +98,6 @@ class PksServerError(CseServerError):
         return f"PKS error\n status: {self.status}\n body: {self.body}\n"
 
 
-class PksConnectionError():
+class PksConnectionError(PksServerError):
     """Raised when connection establishment to PKS fails"""
 

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -17,6 +17,7 @@ from container_service_extension.nsxt.cluster_network_isolater import \
     ClusterNetworkIsolater
 from container_service_extension.nsxt.nsxt_client import NSXTClient
 from container_service_extension.pks_cache import PKS_COMPUTE_PROFILE_KEY
+from container_service_extension.pksclient.api.v1 import PlansApi
 from container_service_extension.pksclient.api.v1.cluster_api \
     import ClusterApi as ClusterApiV1
 from container_service_extension.pksclient.api.v1beta.cluster_api \
@@ -165,6 +166,17 @@ class PKSBroker(AbstractBroker):
         else:
             client = ApiClientV1Beta(configuration=pks_config)
         return client
+
+
+    def list_plans(self):
+        """Get list of available PKS plans in the system.
+
+        :return: a list of pks-plans if available.
+
+        :rtype: list
+        """
+        plan_api = PlansApi(api_client=self.client_v1)
+        return plan_api.list_plans()
 
     def list_clusters(self):
         """Get list of clusters in PKS environment.

--- a/container_service_extension/processor.py
+++ b/container_service_extension/processor.py
@@ -40,6 +40,7 @@ class ServiceProcessor(object):
         ovdc_request = False
         ovdc_id = None
         ovdc_info_request = False
+        pks_plan_request = False
 
         if len(tokens) > 3:
             if tokens[3] in ['swagger', 'swagger.json', 'swagger.yaml']:
@@ -63,7 +64,11 @@ class ServiceProcessor(object):
                 elif tokens[4] != '':
                     node_name = tokens[4]
             elif ovdc_request:
-                ovdc_id = tokens[4]
+                if tokens[4] == 'pks-plans':
+                    pks_plan_request = True
+                    ovdc_request = False
+                else:
+                    ovdc_id = tokens[4]
 
         if len(tokens) > 5:
             if node_name is not None:
@@ -108,6 +113,8 @@ class ServiceProcessor(object):
                 reply = broker_manager.invoke(Operation.INFO_OVDC)
             elif ovdc_request:
                 reply = broker_manager.invoke(op=Operation.LIST_OVDCS)
+            elif pks_plan_request:
+                reply = broker_manager.invoke(op=Operation.GET_PLANS)
             elif spec_request:
                 reply = self.get_spec(tokens[3])
             elif config_request:


### PR DESCRIPTION
- PR implements code for listing PKS Plan information available for the vdcs in the system.
- This PR adds the following:
 1. Adds a new command `vcd cse ovdc pks-plans list` to list pks plans and pks server information for 
      all vdcs available in the system. Example below.
    available pks plans         org       pks_server     vdc_name
--------------------------  --------  -------------  --------------
['Plan 1', 'multi-master']  cse-org   api.pks.local  cseVdc1
['Plan 1', 'multi-master']  cse-org   api.pks.local  NoContainerVdc
 ...
2. Also added an option to `vcd cse ovdc list` command to include plan information. This does not show pks server information as the above command and that is intended to be that way.
> vcd cse ovdc list -p
org       name            k8s_provider    available pks plans
--------  --------------  --------------  --------------------------
cse-org   cseVdc1         native          ['Plan 1', 'multi-master']
cse-org   NoContainerVdc  none            ['Plan 1', 'multi-master']

Tested as both system and org admin. 
- @sahithi @sakthisunda @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/308)
<!-- Reviewable:end -->
