### PR TITLE
[VCDA-1002] Exclude admin level details on cluster information for tenant users

### DIFF
--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -55,7 +55,9 @@ from container_service_extension.utils import OK
 USER_ID_SEPARATOR = "---"
 # Properties that need to be excluded from cluster info before sending
 # to the client for reasons: security, too big that runs thru lines
-EXCLUDE_KEYS = ['compute_profile']
+EXCLUDE_KEYS = ['authorization_mode', 'compute_profile', 'uuid', 'plan_name',
+                'compute_profile_name', 'network_profile_name',
+                'nsxt_network_profile']
 
 
 class PKSBroker(AbstractBroker):
@@ -184,6 +186,8 @@ class PKSBroker(AbstractBroker):
         else:
             user_cluster_list = [cluster_dict for cluster_dict in cluster_list
                                  if self._is_user_cluster_owner(cluster_dict)]
+            for cluster in user_cluster_list:
+                self._exclude_pks_properties(cluster)
             return user_cluster_list
 
     def _list_clusters(self):
@@ -246,7 +250,8 @@ class PKSBroker(AbstractBroker):
             self._append_user_id(cluster_spec['cluster_name'])
         cluster_info = self._create_cluster(**cluster_spec)
         self._restore_original_name(cluster_info)
-        self._exclude_pks_properties(cluster_info)
+        if not self.tenant_client.is_sysadmin():
+            self._exclude_pks_properties(cluster_info)
         return cluster_info
 
     def _create_cluster(self, cluster_name, node_count, pks_plan, pks_ext_host,
@@ -351,6 +356,7 @@ class PKSBroker(AbstractBroker):
             cluster_info = \
                 self._get_cluster_info(self._append_user_id(cluster_name))
             self._restore_original_name(cluster_info)
+            self._exclude_pks_properties(cluster_info)
             return cluster_info
 
     def _get_cluster_info(self, cluster_name):


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com

- Exclude administrator level details of cluster information output for tenant users 
- This fix excludes uuid, plan-name, compute-profile-name, compute-profile, nsxt-profile-name, network-profile from cluster information for tenant users 
- Completed manual testing


@rocknes @sompa @sahithi @harshneelmore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/312)
<!-- Reviewable:end -->
