### PR TITLE
PR - vcd cse cluster list has missing vdc for PKS clusters

### DIFF
--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -56,8 +56,7 @@ USER_ID_SEPARATOR = "---"
 # Properties that need to be excluded from cluster info before sending
 # to the client for reasons: security, too big that runs thru lines
 EXCLUDE_KEYS = ['authorization_mode', 'compute_profile', 'uuid', 'plan_name',
-                'compute_profile_name', 'network_profile_name',
-                'nsxt_network_profile']
+                'network_profile_name', 'nsxt_network_profile']
 
 
 class PKSBroker(AbstractBroker):


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- Fixes the missing vdc in the console output of vcd cse cluster list for PKS clusters

- vcd cse cluster list extracts vdc name from pks compute profile name. This was excluded in cluster information in the previous commit (VCDA-966). By bringing it back in cluster information, this works fine now.

- Verified thru manual testing

@sahithi @sompa @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/316)
<!-- Reviewable:end -->
