### PR TITLE
VCDA-897: Implementation of PKS plans command in CSE

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -200,7 +200,7 @@ class BrokerManager(object):
                     pks_plans, pks_server = self.\
                         _get_pks_plans_and_server_for_vdc(vdc,
                                                           org_resource,
-                                                          ctr_prov_ctx,
+                                                          ctr_prov_ctx[K8S_PROVIDER_KEY],
                                                           pks_vc_plans_map)
                     vdc_dict = {
                         'org': org.get_name(),
@@ -559,15 +559,16 @@ class BrokerManager(object):
     def _get_pks_plans_and_server_for_vdc(self,
                                           vdc,
                                           org_resource,
-                                          ctr_prov_ctx,
+                                          k8provider,
                                           pks_vc_plans_map):
         pks_server = ''
         pks_plans = []
-        vc_backing_vdc = self.ovdc_cache.get_ovdc(
+        vc_backing_vdc =  ''
+        if k8provider != K8sProviders.PKS:
+            vc_backing_vdc = self.ovdc_cache.get_ovdc(
                                 ovdc_name=vdc['name'],
                                 org_name=org_resource.get('name')) \
-                                .resource.ComputeProviderScope \
-            if ctr_prov_ctx[K8S_PROVIDER_KEY] != K8sProviders.PKS else ''
+                                .resource.ComputeProviderScope
 
         pks_plan_and_server_info = pks_vc_plans_map.get(vc_backing_vdc, [])
         if len(pks_plan_and_server_info) > 0:
@@ -587,7 +588,7 @@ class BrokerManager(object):
             plans = pks_broker.list_plans()
             plan_names = [plan.to_dict().get('name') for plan in plans]
             pks_vc_plans_map[pks_ctx['vc']] = [plan_names, pks_ctx['host']]
-
+        return pks_vc_plans_map
 
 class PksComputeProfileParams(namedtuple("PksComputeProfileParams",
                                          'cp_name, az_name, description,'

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -164,11 +164,14 @@ class BrokerManager(object):
             result['body'] = self._create_cluster(**cluster_spec)
             result['status_code'] = ACCEPTED
         elif op == Operation.LIST_OVDCS:
-            result['body'] = self._list_ovdcs()
+            pks_plans_required = self.req_spec.get('pks_plans_required',
+                                                      False)
+            result['body'] = self._list_ovdcs(
+                pks_plans_required=pks_plans_required)
 
         return result
 
-    def _list_ovdcs(self):
+    def _list_ovdcs(self, pks_plans_required=False):
         """Get list of ovdcs.
 
         If client is sysadmin,
@@ -182,6 +185,9 @@ class BrokerManager(object):
             org_resource_list = list(self.vcd_client.get_org())
 
         ovdc_list = []
+        pks_vc_plans_map = {}
+        if pks_plans_required:
+            pks_vc_plans_map = self._construct_pks_vc_plans_map()
         for org_resource in org_resource_list:
             org = Org(self.vcd_client, resource=org_resource)
             vdc_list = org.list_vdcs()
@@ -190,11 +196,24 @@ class BrokerManager(object):
                     self.ovdc_cache.get_ovdc_container_provider_metadata(
                         ovdc_name=vdc['name'], org_name=org.get_name(),
                         credentials_required=False)
-                vdc_dict = {
-                    'name': vdc['name'],
-                    'org': org.get_name(),
-                    K8S_PROVIDER_KEY: ctr_prov_ctx[K8S_PROVIDER_KEY]
-                }
+                if pks_plans_required:
+                    pks_plans, pks_server = self.\
+                        _get_pks_plans_and_server_for_vdc(vdc,
+                                                          org_resource,
+                                                          ctr_prov_ctx,
+                                                          pks_vc_plans_map)
+                    vdc_dict = {
+                        'org': org.get_name(),
+                        'name': vdc['name'],
+                        'pks_api_server' : pks_server,
+                        'available pks plans': pks_plans
+                    }
+                else:
+                    vdc_dict = {
+                        'name': vdc['name'],
+                        'org': org.get_name(),
+                        K8S_PROVIDER_KEY: ctr_prov_ctx[K8S_PROVIDER_KEY]
+                    }
                 ovdc_list.append(vdc_dict)
         return ovdc_list
 
@@ -536,6 +555,38 @@ class BrokerManager(object):
                              f" already exists\n{str(ex)}")
             else:
                 raise ex
+
+    def _get_pks_plans_and_server_for_vdc(self,
+                                          vdc,
+                                          org_resource,
+                                          ctr_prov_ctx,
+                                          pks_vc_plans_map):
+        pks_server = ''
+        pks_plans = []
+        vc_backing_vdc = self.ovdc_cache.get_ovdc(
+                                ovdc_name=vdc['name'],
+                                org_name=org_resource.get('name')) \
+                                .resource.ComputeProviderScope \
+            if ctr_prov_ctx[K8S_PROVIDER_KEY] != K8sProviders.PKS else ''
+
+        pks_plan_and_server_info = pks_vc_plans_map.get(vc_backing_vdc, [])
+        if len(pks_plan_and_server_info) > 0:
+            pks_plans = pks_plan_and_server_info[0]
+            pks_server = pks_plan_and_server_info[1]
+        return pks_plans, pks_server
+
+    def _construct_pks_vc_plans_map(self):
+        pks_vc_plans_map = {}
+        pks_ctx_list = self._create_pks_context_for_all_accounts_in_org()
+
+        for pks_ctx in pks_ctx_list:
+            if pks_ctx['vc'] in pks_vc_plans_map:
+                continue
+            pks_broker = PKSBroker(self.req_headers, self.req_spec,
+                                   pks_ctx)
+            plans = pks_broker.list_plans()
+            plan_names = [plan.to_dict().get('name') for plan in plans]
+            pks_vc_plans_map[pks_ctx['vc']] = [plan_names, pks_ctx['host']]
 
 
 class PksComputeProfileParams(namedtuple("PksComputeProfileParams",

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -164,14 +164,14 @@ class BrokerManager(object):
             result['body'] = self._create_cluster(**cluster_spec)
             result['status_code'] = ACCEPTED
         elif op == Operation.LIST_OVDCS:
-            pks_plans_required = self.req_spec.get('pks_plans_required',
+            list_pks_plans = self.req_spec.get('list_pks_plans',
                                                       False)
             result['body'] = self._list_ovdcs(
-                pks_plans_required=pks_plans_required)
+                list_pks_plans=list_pks_plans)
 
         return result
 
-    def _list_ovdcs(self, pks_plans_required=False):
+    def _list_ovdcs(self, list_pks_plans=False):
         """Get list of ovdcs.
 
         If client is sysadmin,
@@ -185,9 +185,9 @@ class BrokerManager(object):
             org_resource_list = list(self.vcd_client.get_org())
 
         ovdc_list = []
-        pks_vc_plans_map = {}
-        if pks_plans_required:
-            pks_vc_plans_map = self._construct_pks_vc_plans_map()
+        vc_to_pks_plans_map = {}
+        if list_pks_plans:
+            vc_to_pks_plans_map = self._construct_vc_to_pks_map()
         for org_resource in org_resource_list:
             org = Org(self.vcd_client, resource=org_resource)
             vdc_list = org.list_vdcs()
@@ -196,12 +196,11 @@ class BrokerManager(object):
                     self.ovdc_cache.get_ovdc_container_provider_metadata(
                         ovdc_name=vdc['name'], org_name=org.get_name(),
                         credentials_required=False)
-                if pks_plans_required:
+                if list_pks_plans:
                     pks_plans, pks_server = self.\
                         _get_pks_plans_and_server_for_vdc(vdc,
                                                           org_resource,
-                                                          ctr_prov_ctx[K8S_PROVIDER_KEY],
-                                                          pks_vc_plans_map)
+                                                          vc_to_pks_plans_map)
                     vdc_dict = {
                         'org': org.get_name(),
                         'name': vdc['name'],
@@ -559,24 +558,21 @@ class BrokerManager(object):
     def _get_pks_plans_and_server_for_vdc(self,
                                           vdc,
                                           org_resource,
-                                          k8provider,
-                                          pks_vc_plans_map):
+                                          vc_to_pks_plans_map):
         pks_server = ''
         pks_plans = []
-        vc_backing_vdc =  ''
-        if k8provider != K8sProviders.PKS:
-            vc_backing_vdc = self.ovdc_cache.get_ovdc(
+        vc_backing_vdc = self.ovdc_cache.get_ovdc(
                                 ovdc_name=vdc['name'],
                                 org_name=org_resource.get('name')) \
                                 .resource.ComputeProviderScope
 
-        pks_plan_and_server_info = pks_vc_plans_map.get(vc_backing_vdc, [])
+        pks_plan_and_server_info = vc_to_pks_plans_map.get(vc_backing_vdc, [])
         if len(pks_plan_and_server_info) > 0:
             pks_plans = pks_plan_and_server_info[0]
             pks_server = pks_plan_and_server_info[1]
         return pks_plans, pks_server
 
-    def _construct_pks_vc_plans_map(self):
+    def _construct_vc_to_pks_map(self):
         pks_vc_plans_map = {}
         pks_ctx_list = self._create_pks_context_for_all_accounts_in_org()
 
@@ -586,7 +582,7 @@ class BrokerManager(object):
             pks_broker = PKSBroker(self.req_headers, self.req_spec,
                                    pks_ctx)
             plans = pks_broker.list_plans()
-            plan_names = [plan.to_dict().get('name') for plan in plans]
+            plan_names = [plan.get('name') for plan in plans]
             pks_vc_plans_map[pks_ctx['vc']] = [plan_names, pks_ctx['host']]
         return pks_vc_plans_map
 

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -811,8 +811,7 @@ Examples
         required=False,
         is_flag=True,
         default=False,
-        help="This option acts as a flag to get the list"
-             " of available PKS plans for the ovdcs.")
+        help="Display available PKS plans used by the Org VDC.")
 @click.pass_context
 def list_ovdcs(ctx, pks_plans):
     """Display org VDCs in vCD that are visible to the logged in user."""

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -807,19 +807,19 @@ Examples
 @click.option(
         '-p',
         '--pks-plans',
-        'pks_plans',
+        'list_pks_plans',
         required=False,
         is_flag=True,
         default=False,
         help="Display available PKS plans used by the Org VDC.")
 @click.pass_context
-def list_ovdcs(ctx, pks_plans):
+def list_ovdcs(ctx, list_pks_plans):
     """Display org VDCs in vCD that are visible to the logged in user."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
         ovdc = Ovdc(client)
-        result = ovdc.list(pks_plans_required=pks_plans)
+        result = ovdc.list(list_pks_plans=list_pks_plans)
         stdout(result, ctx, sort_headers=False)
     except Exception as e:
         stderr(e, ctx)

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -792,21 +792,35 @@ Examples
 \b
     vcd cse ovdc list
         Display ovdcs in vCD that are visible to the logged in user.
+        vcd cse ovdc list
+\b
+        vcd cse ovdc list --pks-plans
+            Displays list of ovdcs in a given org along with available PKS
+            plans if any. If executed by System-administrator, it will
+            display all ovdcs from all orgs.
     """
     pass
-
 
 @ovdc_group.command('list',
                     short_help='Display org VDCs in vCD that are visible '
                                'to the logged in user')
+@click.option(
+        '-p',
+        '--pks-plans',
+        'pks_plans',
+        required=False,
+        is_flag=True,
+        default=False,
+        help="This option acts as a flag to get the list"
+             " of available PKS plans for the ovdcs.")
 @click.pass_context
-def list_ovdcs(ctx):
+def list_ovdcs(ctx, pks_plans):
     """Display org VDCs in vCD that are visible to the logged in user."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
         ovdc = Ovdc(client)
-        result = ovdc.list()
+        result = ovdc.list(pks_plans_required=pks_plans)
         stdout(result, ctx, sort_headers=False)
     except Exception as e:
         stderr(e, ctx)

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -811,7 +811,8 @@ Examples
         required=False,
         is_flag=True,
         default=False,
-        help="Display available PKS plans used by the Org VDC.")
+        help="Display available PKS plans if Org vDC is backed by "
+             "Enterprise PKS infrastructure.")
 @click.pass_context
 def list_ovdcs(ctx, list_pks_plans):
     """Display org VDCs in vCD that are visible to the logged in user."""

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -15,17 +15,17 @@ class Ovdc(object):
         self.client = client
         self._uri = self.client.get_api_uri() + '/cse'
 
-    def list(self, pks_plans_required):
+    def list(self, list_pks_plans=False):
         method = 'GET'
         uri = f'{self._uri}/ovdc'
-        data = {
-            'pks_plans_required': pks_plans_required,
+        contents = {
+            'list_pks_plans': list_pks_plans,
         }
         response = self.client._do_request_prim(
             method,
             uri,
             self.client._session,
-            contents=data,
+            contents=contents,
             media_type=None,
             accept_type='application/json')
         return process_response(response)

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -15,14 +15,17 @@ class Ovdc(object):
         self.client = client
         self._uri = self.client.get_api_uri() + '/cse'
 
-    def list(self):
+    def list(self, pks_plans_required):
         method = 'GET'
         uri = f'{self._uri}/ovdc'
+        data = {
+            'pks_plans_required': pks_plans_required,
+        }
         response = self.client._do_request_prim(
             method,
             uri,
             self.client._session,
-            contents=None,
+            contents=data,
             media_type=None,
             accept_type='application/json')
         return process_response(response)

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -189,7 +189,10 @@ class PKSBroker(AbstractBroker):
         except v1Exception as err:
             LOGGER.debug(f"Listing PKS plans failed with error:\n {err}")
             raise PksServerError(err.status, err.body)
-        return plans
+        pks_plans_list = []
+        for plan in plans:
+            pks_plans_list.append(plan.to_dict())
+        return pks_plans_list
 
     def list_clusters(self, **kwargs):
         """Get list of clusters in PKS environment.


### PR DESCRIPTION
Signed-off-by: Sompa Malakar <malakars@vmware.com>

PR implements code for listing PKS Plan information available for the vdcs in the system.
This PR adds the following:
Added an option to vcd cse ovdc list command to include plan information. This does not show pks server information as the above command and that is intended to be that way.
vcd cse ovdc list -p

org name k8s_provider available pks plans
cse-org cseVdc1 native ['Plan 1', 'multi-master']
cse-org NoContainerVdc none ['Plan 1', 'multi-master']

Tested as both system and org admin.

- @sahithi @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/329)
<!-- Reviewable:end -->
