### PR TITLE
[VCDA-1006] Update org source to request spec in create_cluster_thread

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -319,15 +319,17 @@ def create(ctx, name, vdc, node_count, cpu, memory, network_name,
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
-        ssh_key = None
-        vdc_to_use = vdc if vdc is not None \
-            else ctx.obj['profiles'].get('vdc_in_use')
+
+        if vdc is None:
+            vdc = ctx.obj['profiles'].get('vdc_in_use')
         if org_name is None:
             org_name = ctx.obj['profiles'].get('org_in_use')
+        ssh_key = None
         if ssh_key_file is not None:
             ssh_key = ssh_key_file.read()
+
         result = cluster.create_cluster(
-            vdc_to_use,
+            vdc,
             network_name,
             name,
             node_count=node_count,

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -389,12 +389,14 @@ class VcdBroker(AbstractBroker, threading.Thread):
     def create_cluster_thread(self):
         network_name = self.req_spec['network']
         try:
-            clusters = load_from_metadata(
-                self.tenant_client, name=self.cluster_name)
+            clusters = load_from_metadata(self.tenant_client,
+                                          name=self.cluster_name)
             if len(clusters) != 0:
                 raise ClusterAlreadyExistsError(f"Cluster {self.cluster_name} "
                                                 "already exists.")
-            org_resource = self.tenant_client.get_org()
+
+            org_resource = \
+                self.tenant_client.get_org_by_name(self.req_spec['org'])
             org = Org(self.tenant_client, resource=org_resource)
             vdc_resource = org.get_vdc(self.req_spec['vdc'])
             vdc = VDC(self.tenant_client, resource=vdc_resource)

--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -149,6 +149,11 @@ def vcd_org_admin():
                                    catch_exceptions=False)
     assert result.exit_code == 0
 
+    # ovdc context may be nondeterministic when there's multiple ovdcs
+    cmd = f"vdc use {config['broker']['vdc']}"
+    result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0
+
     yield
 
     result = env.CLI_RUNNER.invoke(vcd, ['logout'])


### PR DESCRIPTION
This change makes create_cluster_thread recognize the `--org` option, by sourcing the org from the request spec instead of from the currently logged-in org

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/330)
<!-- Reviewable:end -->
