### PR TITLE
Avail plans to only sys admins and removing the org vdc in use to be passed as a param for vdc to resize clusters.

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -9,7 +9,7 @@ from http import HTTPStatus
 
 from pyvcloud.vcd.org import Org
 
-from container_service_extension.exceptions import ClusterNotFoundError
+from container_service_extension.exceptions import ClusterNotFoundError, UnauthorizaedActionError
 from container_service_extension.exceptions import CseServerError
 from container_service_extension.exceptions import PksServerError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
@@ -190,7 +190,7 @@ class BrokerManager(object):
             if self.vcd_client.is_sysadmin():
                 vc_to_pks_plans_map = self._construct_vc_to_pks_map()
             else:
-                raise Exception(
+                raise UnauthorizaedActionError(
                     'Operation Denied. Plans available only for System Administrator.')
         for org_resource in org_resource_list:
             org = Org(self.vcd_client, resource=org_resource)

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -187,7 +187,11 @@ class BrokerManager(object):
         ovdc_list = []
         vc_to_pks_plans_map = {}
         if list_pks_plans:
-            vc_to_pks_plans_map = self._construct_vc_to_pks_map()
+            if self.vcd_client.is_sysadmin():
+                vc_to_pks_plans_map = self._construct_vc_to_pks_map()
+            else:
+                raise Exception(
+                    'Operation Denied. Plans available only for System Administrator.')
         for org_resource in org_resource_list:
             org = Org(self.vcd_client, resource=org_resource)
             vdc_list = org.list_vdcs()

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -9,7 +9,8 @@ from http import HTTPStatus
 
 from pyvcloud.vcd.org import Org
 
-from container_service_extension.exceptions import ClusterNotFoundError, UnauthorizaedActionError
+from container_service_extension.exceptions import ClusterNotFoundError
+from container_service_extension.exceptions import UnauthorizaedActionError
 from container_service_extension.exceptions import CseServerError
 from container_service_extension.exceptions import PksServerError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
@@ -191,7 +192,8 @@ class BrokerManager(object):
                 vc_to_pks_plans_map = self._construct_vc_to_pks_map()
             else:
                 raise UnauthorizaedActionError(
-                    'Operation Denied. Plans available only for System Administrator.')
+                    'Operation Denied. Plans available only for '
+                    'System Administrator.')
         for org_resource in org_resource_list:
             org = Org(self.vcd_client, resource=org_resource)
             vdc_list = org.list_vdcs()

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -373,7 +373,7 @@ def create(ctx, name, vdc, node_count, cpu, memory, network_name,
     required=False,
     default=None,
     metavar='VDC_NAME',
-    help='Org VDC to use. Defaults to currently logged-in org VDC')
+    help='Org VDC to use.')
 @click.option(
     '--disable-rollback',
     'disable_rollback',
@@ -396,7 +396,7 @@ def resize(ctx, name, node_count, network_name, vdc, disable_rollback):
             network_name,
             name,
             node_count=node_count,
-            vdc=ctx.obj['profiles'].get('vdc_in_use') if vdc is None else vdc,
+            vdc=vdc,
             disable_rollback=disable_rollback)
         stdout(result, ctx)
     except Exception as e:

--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -75,6 +75,9 @@ class AmqpError(Exception):
 class AmqpConnectionError(AmqpError):
     """Raised when amqp connection is not open."""
 
+class UnauthorizaedActionError(CseServerError):
+    """Raised when an action is attempted by an unauthorized user."""
+
 
 class VcdResponseError(Exception):
     """Base class for all vcd response related Exceptions."""


### PR DESCRIPTION
Avail plans to only sys admins and removing the org vdc in use to be passed as a param to resize clusters.

Signed-off-by: Sompa Malakar <malakars@vmware.com>

To help us process your pull request efficiently, please include: 

- This PR fixes the pks plans command option added to `vcd cse ovdc list` to be only available to system administrators. Also removes the org vdc in use from profiles to be passed as a param for vdc, if user does not specify a vdc as an option explicitly. 

- Tested `vcd cse ovdc list -p` as sys admin, org admin and vappauthor. Plan information is available only to system administrators.
- @sahithi @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/332)
<!-- Reviewable:end -->
