### PR TITLE
[VCDA-1005] Restrict access to clusters with failed network isolation

### DIFF
--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -32,6 +32,10 @@ class ClusterInitializationError(ClusterOperationError):
     """Raised when any error happens while cluster initialization."""
 
 
+class ClusterNetworkIsolationError(ClusterOperationError):
+    """Raised when any error happens while isolating cluster network."""
+
+
 class NodeOperationError(ClusterOperationError):
     """Base class for all node operation related exceptions."""
 

--- a/container_service_extension/nsxt/cluster_network_isolater.py
+++ b/container_service_extension/nsxt/cluster_network_isolater.py
@@ -63,7 +63,11 @@ class ClusterNetworkIsolater(object):
         rules = dfw_manager.get_all_rules_in_section(
             section_id=firewall_section['id'])
 
-        # check for presence of the isolation DFW rules
+        # Check for presence of the isolation DFW rules.
+        # The checks are overly rigid, because we don't want any tampering with
+        # the network isolation rules created by CSE on NSX-T. If the number of
+        # rules are changed in future, this piece of logic should be updated
+        # accordingly.
         if len(rules) != 2:
             return False
 

--- a/container_service_extension/nsxt/dfw_manager.py
+++ b/container_service_extension/nsxt/dfw_manager.py
@@ -163,6 +163,25 @@ class DFWManager(object):
 
         return True
 
+    def get_all_rules_in_section(self, section_id):
+        """."""
+        if not section_id:
+            return
+
+        resource_url_fragment = f"firewall/sections/{section_id}/rules"
+        try:
+            response = self._nsxt_client.do_request(
+                method=RequestMethodVerb.GET,
+                resource_url_fragment=resource_url_fragment)
+        except HTTPError as err:
+            if err.response.status_code != 404:
+                raise
+            else:
+                return
+
+        rules = response['results']
+        return rules
+
     def create_dfw_rule(self,
                         section_id,
                         rule_name,

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -10,6 +10,7 @@ import yaml
 
 from container_service_extension.abstract_broker import AbstractBroker
 from container_service_extension.authorization import secure
+from container_service_extension.exceptions import ClusterNetworkIsolationError
 from container_service_extension.exceptions import CseServerError
 from container_service_extension.exceptions import PksConnectionError
 from container_service_extension.exceptions import PksServerError
@@ -174,7 +175,6 @@ class PKSBroker(AbstractBroker):
             client = ApiClientV1Beta(configuration=pks_config)
         return client
 
-
     def list_plans(self):
         """Get list of available PKS plans in the system.
 
@@ -277,12 +277,23 @@ class PKSBroker(AbstractBroker):
 
         :rtype: dict
         """
-        cluster_spec['cluster_name'] = \
-            self._append_user_id(cluster_spec['cluster_name'])
+        cluster_name = cluster_spec['cluster_name']
+        qualified_cluster_name = self._append_user_id(cluster_name)
+        cluster_spec['cluster_name'] = qualified_cluster_name
+
+        if not self.nsxt_server:
+            raise CseServerError(
+                "NSX-T server details not found for PKS server selected for "
+                f"cluster : {cluster_name}. Aborting creation of cluster.")
+
         cluster_info = self._create_cluster(**cluster_spec)
+
+        self._isolate_cluster(qualified_cluster_name, cluster_info.get('uuid'))
+
         self._restore_original_name(cluster_info)
         if not self.tenant_client.is_sysadmin():
             self._filter_pks_properties(cluster_info)
+
         return cluster_info
 
     def _create_cluster(self, cluster_name, node_count, pks_plan, pks_ext_host,
@@ -309,11 +320,6 @@ class PKSBroker(AbstractBroker):
         #  Method 'Create_cluster' in VcdBroker and PksBroker should take
         #  ClusterSpec either as a param (or)
         #  read from instance variable (if needed only).
-        if not self.nsxt_server:
-            raise CseServerError(
-                "NSX-T server details not found for PKS server selected for "
-                f"cluster : {cluster_name}. Aborting creation of cluster.")
-
         compute_profile = compute_profile \
             if compute_profile else self.compute_profile
         cluster_api = ClusterApiV1Beta(api_client=self.client_v1beta)
@@ -340,24 +346,6 @@ class PKSBroker(AbstractBroker):
 
         LOGGER.debug(f"PKS: {self.pks_host_uri} accepted the request to create"
                      f" cluster: {cluster_name}")
-
-        # TODO() : Rollback cluster if any error is encountered in this section
-        # isolate cluster via NSX-T DFW
-        try:
-            cluster_id = cluster_dict.get('uuid')
-            if cluster_id:
-                LOGGER.debug(f"Isolating network of cluster {cluster_name}.")
-                cluster_network_isolater = ClusterNetworkIsolater(
-                    self.nsxt_client)
-                cluster_network_isolater.isolate_cluster(cluster_name,
-                                                         cluster_id)
-            else:
-                raise CseServerError("Failed to isolate network of cluster "
-                                     f"{cluster_name}. Cluster ID not found.")
-        except Exception as err:
-            raise CseServerError("Failed to isolate network of cluster "
-                                 f"{cluster_name} : Aborting creation of "
-                                 "cluster.") from err
 
         return cluster_dict
 
@@ -393,6 +381,7 @@ class PKSBroker(AbstractBroker):
             self._restore_original_name(cluster_info)
             if not kwargs.get('is_admin_request'):
                 self._filter_pks_properties(cluster_info)
+
         return cluster_info
 
     def _get_cluster_info(self, cluster_name):
@@ -434,13 +423,16 @@ class PKSBroker(AbstractBroker):
 
         :rtype: str
         """
+        self._check_cluster_isolation(cluster_name)
+
         if self.tenant_client.is_sysadmin():
-            cluster = self.get_cluster_info(cluster_name,
-                                            is_admin_request=True)
-            config_info = self._get_cluster_config(cluster['pks_cluster_name'])
+            cluster_info = self.get_cluster_info(cluster_name,
+                                                 is_admin_request=True)
+            config_info = self._get_cluster_config(
+                cluster_info['pks_cluster_name'])
         else:
-            pks_cluster_name = self._append_user_id(cluster_name)
-            config_info = self._get_cluster_config(pks_cluster_name)
+            config_info = self._get_cluster_config(
+                self._append_user_id(cluster_name))
 
         return self.filter_traces_of_user_context(config_info)
 
@@ -484,6 +476,19 @@ class PKSBroker(AbstractBroker):
             pks_cluster_name = self._append_user_id(cluster_name)
 
         result = self._delete_cluster(pks_cluster_name)
+
+        # remove cluster network isolation
+        try:
+            LOGGER.debug("Removing network isolation of cluster "
+                         f"{cluster_name}.")
+            cluster_network_isolater = ClusterNetworkIsolater(self.nsxt_client)
+            cluster_network_isolater.remove_cluster_isolation(pks_cluster_name)
+        except Exception:
+            # NSX-T oprations are idempotent so they should not cause erros
+            # if say NSGroup is missing. But for any other exception, simply
+            # catch them and ignore.
+            pass
+
         self._restore_original_name(result)
         self._filter_pks_properties(result)
         return result
@@ -512,18 +517,6 @@ class PKSBroker(AbstractBroker):
         LOGGER.debug(f"PKS: {self.pks_host_uri} accepted the request to delete"
                      f" the cluster: {cluster_name}")
 
-        # remove cluster network isolation
-        try:
-            LOGGER.debug("Removing network isolation of cluster "
-                         f"{cluster_name}.")
-            cluster_network_isolater = ClusterNetworkIsolater(self.nsxt_client)
-            cluster_network_isolater.remove_cluster_isolation(cluster_name)
-        except Exception:
-            # NSX-T oprations are idempotent so they should not cause erros
-            # if say NSGroup is missing. But for any other exception, simply
-            # them and ignore.
-            pass
-
         result['name'] = cluster_name
         result['task_status'] = 'in progress'
         return result
@@ -545,6 +538,7 @@ class PKSBroker(AbstractBroker):
 
         """
         cluster_name = cluster_spec['cluster_name']
+        self._check_cluster_isolation(cluster_name)
 
         if self.tenant_client.is_sysadmin():
             cluster = self.get_cluster_info(cluster_name,
@@ -587,6 +581,29 @@ class PKSBroker(AbstractBroker):
         result['task_status'] = 'in progress'
 
         return result
+
+    def _check_cluster_isolation(self, cluster_name):
+        qualified_cluster_name = self._append_user_id(cluster_name)
+        cluster_network_isolater = ClusterNetworkIsolater(
+            self.nsxt_client)
+        if not cluster_network_isolater.is_cluster_isolated(
+                cluster_name=qualified_cluster_name):
+            raise ClusterNetworkIsolationError(
+                f"Cluster '{cluster_name}' is in an unusable state. Please "
+                "delete it and redeploy.")
+
+    def _isolate_cluster(self, cluster_name, cluster_id):
+        try:
+            if not cluster_id:
+                raise ValueError(
+                    f"Invalid cluster_id for cluster : '{cluster_name}'")
+            LOGGER.debug(f"Isolating network of cluster {cluster_name}.")
+            cluster_network_isolater = ClusterNetworkIsolater(self.nsxt_client)
+            cluster_network_isolater.isolate_cluster(cluster_name, cluster_id)
+        except Exception as err:
+            raise ClusterNetworkIsolationError(
+                f"Cluster : '{cluster_name}' is in an unstable state. Failed "
+                "to isolate cluster network") from err
 
     def create_compute_profile(self, cp_name, az_name, description, cpi,
                                datacenter_name, cluster_name, ovdc_rp_name):
@@ -800,7 +817,8 @@ class PKSBroker(AbstractBroker):
         return unsupported_method
 
     @staticmethod
-    def generate_cluster_subset_with_given_keys(cluster, cluster_property_keys):
+    def generate_cluster_subset_with_given_keys(cluster,
+                                                cluster_property_keys):
         pks_cluster = {k: cluster.get(k) for k in
                        cluster_property_keys}
         # Extract vdc name from compute-profile-name


### PR DESCRIPTION
If cluster network isolation fails during creation of the cluster, we should ideally delete such clusters. However due to lack of post-creation hook from PKS, we are choosing to restrict access to the affected clusters, these clusters should be manually removed as soon as possible.

* Added new method to determine cluster network isolation is present or not.
* cluster config and cluster resize will now throw relevant exceptions if invoked on a cluster that isn't isolated at network layer.

Testing done:
1. Ran all CRUD operation on a healthy cluster to check for regressions. No regressions were found.
2. Failed network isolation of a cluster (via code) during creation. Checked all CRUD operation on it and validated that config and resize are the only operations that are failing with proper error messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/334)
<!-- Reviewable:end -->
