### PR TITLE
[VCDA-960] org admin support for pks crud operations

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -11,8 +11,8 @@ from pyvcloud.vcd.org import Org
 
 from container_service_extension.exceptions import ClusterAlreadyExistsError
 from container_service_extension.exceptions import ClusterNotFoundError
-from container_service_extension.exceptions import UnauthorizaedActionError
 from container_service_extension.exceptions import CseServerError
+from container_service_extension.exceptions import UnauthorizaedActionError
 from container_service_extension.exceptions import PksServerError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.ovdc_cache import OvdcCache
@@ -321,7 +321,8 @@ class BrokerManager(object):
 
     def _create_cluster(self, **cluster_spec):
         cluster_name = cluster_spec['cluster_name']
-        cluster, _ = self._find_cluster_in_org(cluster_name)
+        cluster, _ = self._find_cluster_in_org(cluster_name,
+                                               is_admin_search=True)
 
         if not cluster:
             ctr_prov_ctx = self._get_ctr_prov_ctx_from_ovdc_metadata()
@@ -336,7 +337,7 @@ class BrokerManager(object):
             raise ClusterAlreadyExistsError(
                 f"Cluster {cluster_name} already exists.")
 
-    def _find_cluster_in_org(self, cluster_name):
+    def _find_cluster_in_org(self, cluster_name, **kwargs):
         """Invoke set of all (vCD/PKS)brokers in the org to find the cluster.
 
         If cluster found:
@@ -356,8 +357,8 @@ class BrokerManager(object):
         for pks_ctx in pks_ctx_list:
             pksbroker = PKSBroker(self.req_headers, self.req_spec, pks_ctx)
             try:
-                return pksbroker.get_cluster_info(cluster_name=cluster_name),\
-                    pksbroker
+                return pksbroker.get_cluster_info(cluster_name=cluster_name,
+                                                  **kwargs), pksbroker
             except PksServerError as err:
                 LOGGER.debug(f"Get cluster info on {cluster_name} failed "
                              f"on {pks_ctx['host']} with error: {err}")

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -12,8 +12,8 @@ from pyvcloud.vcd.org import Org
 from container_service_extension.exceptions import ClusterAlreadyExistsError
 from container_service_extension.exceptions import ClusterNotFoundError
 from container_service_extension.exceptions import CseServerError
-from container_service_extension.exceptions import UnauthorizaedActionError
 from container_service_extension.exceptions import PksServerError
+from container_service_extension.exceptions import UnauthorizedActionError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.ovdc_cache import OvdcCache
 from container_service_extension.pks_cache import PKS_CLUSTER_DOMAIN_KEY
@@ -23,6 +23,8 @@ from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProviders
 from container_service_extension.utils import ACCEPTED
 from container_service_extension.utils import connect_vcd_user_via_token
+from container_service_extension.utils \
+    import create_pks_compute_profile_name_from_vdc_id
 from container_service_extension.utils import exception_handler
 from container_service_extension.utils import get_pks_cache
 from container_service_extension.utils import get_server_runtime_config
@@ -191,7 +193,7 @@ class BrokerManager(object):
             if self.vcd_client.is_sysadmin():
                 vc_to_pks_plans_map = self._construct_vc_to_pks_map()
             else:
-                raise UnauthorizaedActionError(
+                raise UnauthorizedActionError(
                     'Operation Denied. Plans available only for '
                     'System Administrator.')
         for org_resource in org_resource_list:
@@ -321,9 +323,12 @@ class BrokerManager(object):
 
     def _create_cluster(self, **cluster_spec):
         cluster_name = cluster_spec['cluster_name']
+        # 'is_org_admin_search' is used here to prevent cluster creation with
+        # same cluster-name by users within org.
+        # If it is true, cluster list is filtered by the org name of the
+        # logged-in user to check for duplicates.
         cluster, _ = self._find_cluster_in_org(cluster_name,
-                                               is_admin_search=True)
-
+                                               is_org_admin_search=True)
         if not cluster:
             ctr_prov_ctx = self._get_ctr_prov_ctx_from_ovdc_metadata()
             if ctr_prov_ctx.get(
@@ -337,8 +342,12 @@ class BrokerManager(object):
             raise ClusterAlreadyExistsError(
                 f"Cluster {cluster_name} already exists.")
 
-    def _find_cluster_in_org(self, cluster_name, **kwargs):
+    def _find_cluster_in_org(self, cluster_name, is_org_admin_search=False):
         """Invoke set of all (vCD/PKS)brokers in the org to find the cluster.
+
+        'is_org_admin_search' is used here to prevent cluster creation with
+        same cluster-name by users within org. If it is true,
+        cluster list is filtered by the org name of the logged-in user.
 
         If cluster found:
             Return a tuple of (cluster and the broker instance used to find
@@ -357,8 +366,9 @@ class BrokerManager(object):
         for pks_ctx in pks_ctx_list:
             pksbroker = PKSBroker(self.req_headers, self.req_spec, pks_ctx)
             try:
-                return pksbroker.get_cluster_info(cluster_name=cluster_name,
-                                                  **kwargs), pksbroker
+                return pksbroker.get_cluster_info(
+                    cluster_name=cluster_name,
+                    is_org_admin_search=is_org_admin_search), pksbroker
             except PksServerError as err:
                 LOGGER.debug(f"Get cluster info on {cluster_name} failed "
                              f"on {pks_ctx['host']} with error: {err}")
@@ -503,8 +513,7 @@ class BrokerManager(object):
             nsxt_info = self.pks_cache.get_nsxt_info(pvdc_info.vc)
 
             pks_compute_profile_name = \
-                self.ovdc_cache.get_compute_profile_name(
-                    ovdc_id, ovdc.resource.get('name'))
+                create_pks_compute_profile_name_from_vdc_id(ovdc_id)
             pks_context = OvdcCache.construct_pks_context(
                 pks_account_info=pks_account_info,
                 pvdc_info=pvdc_info,
@@ -521,8 +530,8 @@ class BrokerManager(object):
         org_name = self.req_spec.get('org_name')
         ovdc_name = self.req_spec.get('ovdc_name')
         # Compute profile creation
-        pks_compute_profile_name = self.\
-            ovdc_cache.get_compute_profile_name(ovdc_id, ovdc_name)
+        pks_compute_profile_name = \
+            create_pks_compute_profile_name_from_vdc_id(ovdc_id)
         pks_compute_profile_description = f"{org_name}--{ovdc_name}" \
             f"--{ovdc_id}"
         pks_az_name = f"az-{ovdc_name}"

--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -79,7 +79,8 @@ class AmqpError(Exception):
 class AmqpConnectionError(AmqpError):
     """Raised when amqp connection is not open."""
 
-class UnauthorizaedActionError(CseServerError):
+
+class UnauthorizedActionError(CseServerError):
     """Raised when an action is attempted by an unauthorized user."""
 
 

--- a/container_service_extension/ovdc_cache.py
+++ b/container_service_extension/ovdc_cache.py
@@ -6,13 +6,13 @@ from pyvcloud.vcd import utils
 from pyvcloud.vcd.client import ApiVersion
 from pyvcloud.vcd.client import MetadataDomain
 from pyvcloud.vcd.client import MetadataVisibility
-from pyvcloud.vcd.vdc import VDC
 
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.pks_cache import PKS_CLUSTER_DOMAIN_KEY
 from container_service_extension.pks_cache import PKS_COMPUTE_PROFILE_KEY
 from container_service_extension.pks_cache import PKS_PLANS_KEY
 from container_service_extension.pks_cache import PksCache
+from container_service_extension.pyvcloud_utils import get_vdc_by_id
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProviders
 from container_service_extension.utils import get_org
@@ -164,14 +164,7 @@ class OvdcCache(object):
             return get_vdc(self.client, ovdc_name, org=org,
                            is_admin_operation=True)
         else:
-            return self.get_vdc_by_id(ovdc_id)
-
-    def get_vdc_by_id(self, vdc_id):
-        LOGGER.debug(f"Getting vdc by id:{vdc_id}")
-        admin_href = self.client.get_admin().get('href')
-        ovdc_href = f'{admin_href}vdc/{vdc_id}'
-        resource = self.client.get_resource(ovdc_href)
-        return VDC(self.client, resource=resource)
+            return get_vdc_by_id(self.client, ovdc_id)
 
     def get_pvdc_id(self, ovdc):
         pvdc_element = ovdc.resource.ProviderVdcReference
@@ -186,5 +179,3 @@ class OvdcCache(object):
             pvdc_id = pvdc_element.get('id')
             return utils.extract_id(pvdc_id)
 
-    def get_compute_profile_name(self, ovdc_id, ovdc_name):
-        return f"cp--{ovdc_id}--{ovdc_name}"

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -47,12 +47,14 @@ from container_service_extension.pksclient.models.v1beta.\
 from container_service_extension.pksclient.models.v1beta.\
     compute_profile_request import ComputeProfileRequest
 from container_service_extension.pyvcloud_utils import get_org_name_of_ovdc
+from container_service_extension.pyvcloud_utils import is_org_admin
 from container_service_extension.server_constants import \
     CSE_PKS_DEPLOY_RIGHT_NAME
 from container_service_extension.uaaclient.uaaclient import UaaClient
 from container_service_extension.utils import exception_handler
+from container_service_extension.utils \
+    import extract_vdc_id_from_pks_compute_profile_name
 from container_service_extension.utils import get_pks_cache
-from container_service_extension.utils import is_org_admin
 from container_service_extension.utils import OK
 
 
@@ -207,12 +209,15 @@ class PKSBroker(AbstractBroker):
         :rtype: list
         """
         cluster_list = self._list_clusters()
-        if self.tenant_client.is_sysadmin() or kwargs.get('is_admin_search'):
+        if self.tenant_client.is_sysadmin():
             for cluster in cluster_list:
                 self._restore_original_name(cluster)
-        elif is_org_admin(self.client_session):
+        elif is_org_admin(self.client_session) or \
+                kwargs.get('is_org_admin_search'):
             for cluster in cluster_list:
                 self._restore_original_name(cluster)
+            # TODO() - Service accounts for exclusive org does not
+            #  require the following filtering.
             cluster_list = [cluster_dict for cluster_dict in cluster_list
                             if self._does_cluster_belong_to_org(
                                 cluster_dict, self.client_session.get('org'))]
@@ -371,9 +376,9 @@ class PKSBroker(AbstractBroker):
         """
         if self.tenant_client.is_sysadmin() \
                 or is_org_admin(self.client_session) \
-                or kwargs.get('is_admin_search'):
+                or kwargs.get('is_org_admin_search'):
             cluster_list = self.list_clusters(
-                is_admin_search=kwargs.get('is_admin_search'))
+                is_org_admin_search=kwargs.get('is_org_admin_search'))
             filtered_cluster_list = \
                 self._filter_list_by_cluster_name(cluster_list, cluster_name)
             LOGGER.debug(f"filtered Cluster List:{filtered_cluster_list}")
@@ -795,18 +800,16 @@ class PKSBroker(AbstractBroker):
 
     def _does_cluster_belong_to_org(self, cluster_info, org_name):
         # Returns True if the cluster belongs to the given org
-        # False case include missing compute profile name of the cluster
+        # Else False (this also includes missing compute profile name)
 
         compute_profile_name = cluster_info.get('compute_profile_name')
         if compute_profile_name is None:
             LOGGER.debug(f"compute-profile-name of {cluster_info.get('name')}"
                          f" is not found")
             return False
-        vdc_id = compute_profile_name.split('--')[1]
-        LOGGER.debug(f"org-name of {vdc_id} is {get_org_name_of_ovdc(vdc_id)}")
-        if org_name == get_org_name_of_ovdc(vdc_id):
-            return True
-        return False
+        vdc_id = extract_vdc_id_from_pks_compute_profile_name(
+            compute_profile_name)
+        return org_name == get_org_name_of_ovdc(vdc_id)
 
     # TODO() Should be moved to filtering layer
     def _filter_list_by_cluster_name(self, cluster_list, cluster_name):

--- a/container_service_extension/pyvcloud_utils.py
+++ b/container_service_extension/pyvcloud_utils.py
@@ -2,22 +2,28 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+
 from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import find_link
 from pyvcloud.vcd.client import RelationType
 from pyvcloud.vcd.org import Org
+from pyvcloud.vcd.role import Role
 from pyvcloud.vcd.utils import get_admin_href
 from pyvcloud.vcd.vdc import VDC
 
+from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.utils import get_vcd_sys_admin_client
 
 # Cache to keep ovdc_id to org_name mapping for vcd cse cluster list
 OVDC_TO_ORG_MAP = {}
+ORG_ADMIN_RIGHTS = ['General: Administrator Control',
+                    'General: Administrator View']
 
 
 def get_org_name_of_ovdc(vdc_id):
-    """Get org_name from vdc_id; additionally update OVDC_TO_ORG_MAP
-        with key:vdc_id and value:org_name for new key-value pairs.
+    """Get org_name from vdc_id using OVDC_TO_ORG_MAP.
+
+    Update OVDC_TO_ORG_MAP for new {org_name:vdc_id} pair
 
     :param vdc_id: unique ovdc id
     :return: org_name
@@ -37,3 +43,62 @@ def get_org_name_of_ovdc(vdc_id):
         OVDC_TO_ORG_MAP[vdc_id] = org.get_name()
         org_name = org.get_name()
     return org_name
+
+
+def get_user_rights(sys_admin_client, user_session):
+    """Return rights associated with the role of an user.
+
+    :param pyvcloud.vcd.client.Client sys_admin_client: the sys admin cilent
+        that will be used to query vCD about the rights and roles of the
+        concerned user.
+    :param lxml.objectify.ObjectifiedElement user_session:
+
+    :return: the list of rights contained in the role of the user
+        (corresponding to the user_session).
+
+    :rtype: list of str
+    """
+    user_org_link = find_link(resource=user_session,
+                              rel=RelationType.DOWN,
+                              media_type=EntityType.ORG.value)
+    user_org_href = user_org_link.href
+    org = Org(sys_admin_client, href=user_org_href)
+    user_role_name = user_session.get('roles')
+    role = Role(sys_admin_client,
+                resource=org.get_role_resource(user_role_name))
+
+    user_rights = []
+    user_rights_as_list_of_dict = role.list_rights()
+    for right_dict in user_rights_as_list_of_dict:
+        user_rights.append(right_dict.get('name'))
+    return user_rights
+
+
+def is_org_admin(user_session):
+    """Return if the logged-in user is an org-admin.
+
+    :param lxml.objectify.ObjectifiedElement user_session:
+
+    :return True or False
+    :rtype: bool
+    """
+    user_rights = get_user_rights(get_vcd_sys_admin_client(), user_session)
+    return all(right in user_rights for right in ORG_ADMIN_RIGHTS)
+
+
+def get_vdc_by_id(sys_admin_client, vdc_id):
+    """Return VDC object for the given vdc_id.
+
+    :param pyvcloud.vcd.client.Client sys_admin_client: the sys admin cilent
+        that will be used to query vCD
+
+    :param str vdc_id: UUID of the vdc
+
+    :return VDC object
+    :rtype: pyvcloud.vcd.vdc.VDC
+    """
+    LOGGER.debug(f"Getting vdc by id:{vdc_id}")
+    admin_href = sys_admin_client.get_admin().get('href')
+    ovdc_href = f'{admin_href}vdc/{vdc_id}'
+    resource = sys_admin_client.get_resource(ovdc_href)
+    return VDC(sys_admin_client, resource=resource)

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -69,6 +69,9 @@ UNAUTHORIZED = 401
 INTERNAL_SERVER_ERROR = 500
 GATEWAY_TIMEOUT = 504
 
+org_admin_rights = ['General: Administrator Control',
+                    'General: Administrator View']
+
 
 def connect_vcd_user_via_token(vcd_uri, headers, verify_ssl_certs=True):
     if not verify_ssl_certs:
@@ -603,6 +606,13 @@ def get_pvdc_id_by_name(name, vc_name_in_vcd):
         pvdc_id = href.split("/")[-1]
         return pvdc_id
     return None
+
+
+def is_org_admin(user_session):
+    from container_service_extension import authorization
+    user_rights = authorization._get_user_rights(get_vcd_sys_admin_client(),
+                                                 user_session)
+    return all(right in user_rights for right in org_admin_rights)
 
 
 def get_data_file(filename, logger=None):

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -69,9 +69,6 @@ UNAUTHORIZED = 401
 INTERNAL_SERVER_ERROR = 500
 GATEWAY_TIMEOUT = 504
 
-org_admin_rights = ['General: Administrator Control',
-                    'General: Administrator View']
-
 
 def connect_vcd_user_via_token(vcd_uri, headers, verify_ssl_certs=True):
     if not verify_ssl_certs:
@@ -608,11 +605,31 @@ def get_pvdc_id_by_name(name, vc_name_in_vcd):
     return None
 
 
-def is_org_admin(user_session):
-    from container_service_extension import authorization
-    user_rights = authorization._get_user_rights(get_vcd_sys_admin_client(),
-                                                 user_session)
-    return all(right in user_rights for right in org_admin_rights)
+def extract_vdc_id_from_pks_compute_profile_name(compute_profile_name):
+    """Extract the vdc identifier from pks compute profile name.
+
+    :param str compute_profile_name: name of the pks compute profile
+
+    :return: UUID of the vdc in vcd.
+
+    :rtype: str
+    """
+    return compute_profile_name.split('--')[1]
+
+
+def create_pks_compute_profile_name_from_vdc_id(vdc_id):
+    """Construct pks compute profile name.
+
+    :param str vdc_id: UUID of the vdc in vcd
+
+    :return: pks compute profile name
+
+    :rtype: str
+    """
+    from container_service_extension.pyvcloud_utils import get_vdc_by_id
+    client = get_vcd_sys_admin_client()
+    vdc = get_vdc_by_id(client, vdc_id)
+    return f"cp--{vdc_id}--{vdc.name}"
 
 
 def get_data_file(filename, logger=None):


### PR DESCRIPTION
Support for org admin to do CRUD on PKS cluster

- New method for checking if the logged-in user is an Org admin ( General Administrator Control, Administrator View )
- Changes to check if the cluster belongs to the given organization
- Changes related to PKS CRUD handing of org admin
- PKS Clusters with duplicate-name by tenant-users get prevented at the point of creation 

Testing completed:

1. System tests passed
2. Org admin can do all CRUD on clusters created by himself and other users of the Org
3. Org admin cannot do CRUD clusters of other org
4. Org user can do CRUD on their clusters
5. Org users cannot see clusters of other users of the same organization
6. Org users cannot see clusters of other users of different organization
7. Cluster with duplicate name is prevented at the time of creation
8. System admin can do CRUD on every cluster including Org-admin
9. Manually tested all ovdc enable/disable/info after refactoring

NOTE: Cluster update wiping out pks-compute-profile-name would cause the updated cluster
escaping the org-admin search. This is a known issue at this time. Sys admin and tenant users
see their org-name and vdc missing on executing vdc cse cluster list on the updated cluster.

@sahithi @rocknes @sompa @harshneelmore @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/335)
<!-- Reviewable:end -->
