### PR TITLE
[VCDA-1032] System admin create cluster show appropriate error message

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -322,6 +322,10 @@ def create(ctx, name, vdc, node_count, cpu, memory, network_name,
 
         if vdc is None:
             vdc = ctx.obj['profiles'].get('vdc_in_use')
+            if not vdc:
+                raise Exception(f"Virtual datacenter context is not set. "
+                                "Use either command 'vcd vdc use' or option "
+                                "'--vdc' to set the vdc context.")
         if org_name is None:
             org_name = ctx.obj['profiles'].get('org_in_use')
         ssh_key = None
@@ -802,6 +806,7 @@ Examples
             display all ovdcs from all orgs.
     """
     pass
+
 
 @ovdc_group.command('list',
                     short_help='Display org VDCs in vCD that are visible '


### PR DESCRIPTION
System Admin trying to create cluster should display the correct error message. If org is specified and vdc is missing it will display the correct error message.

- Tested the creation manually.

- @rocknes @sahithi @sakthisunda @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/338)
<!-- Reviewable:end -->
