### PR TITLE
Address CVE-2019-9636

### DIFF
--- a/container_service_extension/cse.py
+++ b/container_service_extension/cse.py
@@ -3,6 +3,7 @@
 # container-service-extension
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
+import sys
 
 import click
 from pyvcloud.vcd.exceptions import EntityNotFoundException
@@ -136,6 +137,8 @@ def sample(ctx, output, pks_output):
         check_python_version()
     except Exception as err:
         click.secho(str(err), fg='red')
+        sys.exit(0)
+
     click.secho(generate_sample_config(output=output,
                                        pks_output=pks_output))
 
@@ -176,6 +179,7 @@ def check(ctx, config, check_install, template):
         check_python_version()
     except Exception as err:
         click.secho(str(err), fg='red')
+        sys.exit(0)
 
     config_dict = None
     try:
@@ -252,6 +256,7 @@ def install(ctx, config, template, update, no_capture, ssh_key_file):
         check_python_version()
     except Exception as err:
         click.secho(str(err), fg='red')
+        sys.exit(0)
 
     if no_capture and ssh_key_file is None:
         click.echo('Must provide ssh-key file (using --ssh-key OR -k) if '
@@ -303,6 +308,7 @@ def run(ctx, config, skip_check):
         check_python_version()
     except Exception as err:
         click.secho(str(err), fg='red')
+        sys.exit(0)
 
     try:
         service = Service(config, should_check_config=not skip_check)

--- a/container_service_extension/cse.py
+++ b/container_service_extension/cse.py
@@ -18,6 +18,8 @@ from container_service_extension.configure_cse import get_validated_config
 from container_service_extension.configure_cse import install_cse
 from container_service_extension.exceptions import AmqpConnectionError
 from container_service_extension.service import Service
+from container_service_extension.utils import check_python_version
+
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
@@ -130,6 +132,10 @@ def version(ctx):
     help="Name of the PKS config file to dump the PKS configs to.")
 def sample(ctx, output, pks_output):
     """Generate sample CSE configuration."""
+    try:
+        check_python_version()
+    except Exception as err:
+        click.secho(str(err), fg='red')
     click.secho(generate_sample_config(output=output,
                                        pks_output=pks_output))
 
@@ -166,6 +172,11 @@ def sample(ctx, output, pks_output):
          " will be validated.")
 def check(ctx, config, check_install, template):
     """Validate CSE configuration."""
+    try:
+        check_python_version()
+    except Exception as err:
+        click.secho(str(err), fg='red')
+
     config_dict = None
     try:
         config_dict = get_validated_config(config)
@@ -237,6 +248,11 @@ def check(ctx, config, check_install, template):
 )
 def install(ctx, config, template, update, no_capture, ssh_key_file):
     """Install CSE on vCloud Director."""
+    try:
+        check_python_version()
+    except Exception as err:
+        click.secho(str(err), fg='red')
+
     if no_capture and ssh_key_file is None:
         click.echo('Must provide ssh-key file (using --ssh-key OR -k) if '
                    '--no-capture is True, or else temporary vm will '
@@ -283,6 +299,11 @@ def install(ctx, config, template, update, no_capture, ssh_key_file):
     help='Skip check')
 def run(ctx, config, skip_check):
     """Run CSE service."""
+    try:
+        check_python_version()
+    except Exception as err:
+        click.secho(str(err), fg='red')
+
     try:
         service = Service(config, should_check_config=not skip_check)
         service.run()

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -306,12 +306,10 @@ def check_python_version():
 
     :raises Exception: if user's Python version < 3.6.
     """
-    major = sys.version_info.major
-    minor = sys.version_info.minor
-    click.echo(f"Required Python version: >= 3.6\nInstalled Python version: "
-               f"{major}.{minor}.{sys.version_info.micro}")
-    if major < 3 or (major == 3 and minor < 6):
-        raise Exception("Python version should be 3.6 or greater")
+    click.echo("Required Python version: >= 3.7.3\n"
+               f"Installed Python version: {sys.version}")
+    if sys.version_info < (3, 7, 3):
+        raise Exception("Python version should be 3.7.3 or greater")
 
 
 def check_file_permissions(filename):


### PR DESCRIPTION
Vulnerability : https://nvd.nist.gov/vuln/detail/CVE-2019-9636
Score: 9.8

Impacted methods : urllib.parse.urlsplit or urllib.parse.urlparse when run on python versions prior to 3.7.3.

CSE server code uses the method urllib.parse.urlparse to parse vCenter url. Since the behavior is contained server side, we have decided to bump up the minimum version of python requiremed to run CSE server to 3.7.3.

With this PR, any attempt to run, install, generate sample off, check configuration file of, CSE server on a system running python versions prior to 3.7.3 will fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/339)
<!-- Reviewable:end -->
