### PR TITLE
VCDA-1033: Proper message for missing network name error in cluster creation command

### DIFF
--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -364,6 +364,10 @@ class VcdBroker(AbstractBroker, threading.Thread):
         #  ClusterParams either as a param (or)
         #  read from instance variable (if needed only).
 
+        if network_name is None:
+            raise CseServerError(f"Cluster cannot be created. Please provide"
+                             f"a valid org vDC network param.")
+
         LOGGER.debug(f"About to create cluster {cluster_name} on {vdc_name} "
                      f"with {node_count} nodes, sp={storage_profile}")
 

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -364,9 +364,9 @@ class VcdBroker(AbstractBroker, threading.Thread):
         #  ClusterParams either as a param (or)
         #  read from instance variable (if needed only).
 
-        if network_name is None:
+        if not network_name:
             raise CseServerError(f"Cluster cannot be created. Please provide"
-                             f"a valid org vDC network param.")
+                             f" a valid value for org vDC network param.")
 
         LOGGER.debug(f"About to create cluster {cluster_name} on {vdc_name} "
                      f"with {node_count} nodes, sp={storage_profile}")


### PR DESCRIPTION


Signed-off-by: Sompa Malakar <malakars@vmware.com>

- This PR provides a check for missing network name param for the cluster creation command and provides a proper error message that conveys about the missing network name. 

- @sahithi @rocknes @sakthisunda @harshneelmore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/343)
<!-- Reviewable:end -->
