### PR TITLE
Change doc string to fix Photon OS Kubernetes version from 1.10.11 to 1.12.7

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -184,7 +184,7 @@ d89e1',
     'cpu': 2,
     'mem': 2048,
     'admin_password': 'guest_os_admin_password',
-    'description': 'PhotonOS v2\nDocker 17.06.0-9\nKubernetes 1.10.11\nweave \
+    'description': 'PhotonOS v2\nDocker 17.06.0-9\nKubernetes 1.12.7\nweave \
 2.3.0'
 }
 

--- a/docs/CSE_ADMIN.md
+++ b/docs/CSE_ADMIN.md
@@ -260,7 +260,7 @@ broker:
 
       Docker 17.06.0-9
 
-      Kubernetes 1.10.11
+      Kubernetes 1.12.7
 
       weave 2.3.0'
     mem: 2048

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -83,7 +83,7 @@ broker:
 
       Docker 17.06.0-9
 
-      Kubernetes 1.10.11
+      Kubernetes 1.12.7
 
       weave 2.3.0'
     mem: 2048


### PR DESCRIPTION
Update Kubernetes version for Photon OS

- @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/344)
<!-- Reviewable:end -->
