### PR TITLE
[VCDA-1037] vcd cse node info command broken after enabling PKS

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -55,6 +55,7 @@ class Operation(Enum):
     ENABLE_OVDC = 'enable ovdc'
     INFO_OVDC = 'info ovdc'
     GET_CLUSTER_CONFIG = 'get cluster config'
+    GET_NODE_INFO = 'get node info'
 
 
 class BrokerManager(object):
@@ -173,6 +174,11 @@ class BrokerManager(object):
             list_pks_plans = self.req_spec.get('list_pks_plans', False)
             result['body'] = self._list_ovdcs(
                 list_pks_plans=list_pks_plans)
+        elif op == Operation.GET_NODE_INFO:
+            node_spec = \
+                {'cluster_name': self.req_spec.get('cluster_name', None),
+                 'node_name': self.req_spec.get('node_name', None)}
+            result['body'] = self._get_node_info(**node_spec)[0]
 
         return result
 
@@ -252,6 +258,38 @@ class BrokerManager(object):
                 return cluster, broker
 
         raise ClusterNotFoundError(f"Cluster {cluster_name} not found "
+                                   f"either in vCD or PKS")
+
+    def _get_node_info(self, **node_spec):
+        """Get node details directly from cloud provider.
+
+        Logic of the method is as follows.
+
+        If 'ovdc' is present in the cluster spec,
+            choose the right broker (by identifying the container_provider
+            (vcd|pks) defined for that ovdc) to do get_node operation.
+        else
+            Invoke set of all (vCD/PKS) brokers in the org to find the cluster
+            and then do get_node operation
+
+        :return: a tuple of node information as dictionary and the broker
+            instance used to find the cluster information.
+
+        :rtype: tuple
+        """
+        cluster_name = node_spec['cluster_name']
+        node_name = node_spec['node_name']
+        if self.is_ovdc_present_in_request:
+            broker = self.get_broker_based_on_vdc()
+            return broker.get_node_info(cluster_name, node_name), broker
+        else:
+            vcd_broker = VcdBroker(self.req_headers, self.req_spec)
+            cluster = vcd_broker.get_cluster_info(cluster_name)
+            if cluster:
+                return vcd_broker.get_node_info(cluster_name, node_name), vcd_broker
+
+        raise ClusterNotFoundError(f"Cluster {cluster_name} with "
+                                   f"Node {node_name} not found "
                                    f"either in vCD or PKS")
 
     def _get_cluster_config(self, **cluster_spec):

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -205,9 +205,10 @@ class Cluster(object):
             else:
                 raise e
 
-    def get_node_info(self, cluster_name, node_name):
+    def get_node_info(self, cluster_name, node_name, org=None, vdc=None):
         method = 'GET'
         uri = '%s/%s/%s/info' % (self._uri, cluster_name, node_name)
+        params = {'vdc': vdc, 'org': org}
         response = self.client._do_request_prim(
             method,
             uri,
@@ -215,7 +216,8 @@ class Cluster(object):
             contents=None,
             media_type=None,
             accept_type='application/*+json',
-            auth=None)
+            auth=None,
+            params=params)
         try:
             result = process_response(response)
         except VcdResponseError as e:

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -504,13 +504,34 @@ Examples
 @click.pass_context
 @click.argument('cluster_name', required=True)
 @click.argument('node_name', required=True)
-def node_info(ctx, cluster_name, node_name):
+@click.option(
+    '-o',
+    '--org',
+    'org_name',
+    default=None,
+    required=False,
+    metavar='ORG_NAME',
+    help='Org to use. Defaults to currently logged-in org only for '
+         'non sys-admin')
+@click.option(
+    '-v',
+    '--vdc',
+    'vdc',
+    required=False,
+    default=None,
+    metavar='VDC_NAME',
+    help='Org VDC to use.')
+def node_info(ctx, cluster_name, node_name, org_name, vdc):
     """Display info about a node in a native Kubernetes provider cluster."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
-        node_info = cluster.get_node_info(cluster_name, node_name)
+
+        if org_name is None and not client.is_sysadmin():
+            org_name = ctx.obj['profiles'].get('org_in_use')
+        node_info = cluster.get_node_info(cluster_name, node_name,
+                                          org_name, vdc)
         stdout(node_info, ctx, show_id=True)
     except Exception as e:
         stderr(e, ctx)

--- a/container_service_extension/processor.py
+++ b/container_service_extension/processor.py
@@ -135,8 +135,9 @@ class ServiceProcessor(object):
                 req_spec.update({'cluster_name': cluster_name})
                 reply = broker_manager.invoke(Operation.GET_CLUSTER)
             elif node_info_request:
-                broker = broker_manager.get_broker_based_on_vdc()
-                reply = broker.get_node_info(cluster_name, node_name)
+                req_spec.update({'cluster_name': cluster_name})
+                req_spec.update({'node_name': node_name})
+                reply = broker_manager.invoke(Operation.GET_NODE_INFO)
             elif system_request:
                 result = {}
                 result['body'] = service.info(req_headers)

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -285,7 +285,9 @@ class VcdBroker(AbstractBroker, threading.Thread):
         result['status_code'] = OK
         self._connect_tenant()
         clusters = load_from_metadata(self.tenant_client,
-                                      name=cluster_name)
+                                      name=cluster_name,
+                                      org_name=self.req_spec.get('org'),
+                                      vdc_name=self.req_spec.get('vdc'))
         if len(clusters) == 0:
             raise CseServerError(f"Cluster \'{cluster_name}\' not found.")
         vapp = VApp(self.tenant_client, href=clusters[0]['vapp_href'])


### PR DESCRIPTION
Added the param to include ORGVDC in use to the request parameters for node info.
- Tested the above change with native for Org Admin user.
- Tested the changes after enabling PKS for Org Admin user.

@sakthisunda @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/350)
<!-- Reviewable:end -->
