### PR TITLE
[VCDA-1049] Improve generation of cluster list visible to org-admin 

### DIFF
--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -209,18 +209,23 @@ class PKSBroker(AbstractBroker):
         :rtype: list
         """
         cluster_list = self._list_clusters()
+
+        # Required for all personae
+        for cluster in cluster_list:
+            self._restore_original_name(cluster)
+
+        # Complete list of clusters for sysadmin
         if self.tenant_client.is_sysadmin():
-            for cluster in cluster_list:
-                self._restore_original_name(cluster)
-        elif is_org_admin(self.client_session) or \
+            return cluster_list
+
+        # Filter the list for org admin and others.
+        if is_org_admin(self.client_session) or \
                 kwargs.get('is_org_admin_search'):
-            for cluster in cluster_list:
-                self._restore_original_name(cluster)
             # TODO() - Service accounts for exclusive org does not
             #  require the following filtering.
             cluster_list = [cluster_dict for cluster_dict in cluster_list
-                            if self._does_cluster_belong_to_org(
-                                cluster_dict, self.client_session.get('org'))]
+                            if self._is_cluster_visible_to_org_admin(
+                                cluster_dict)]
         else:
             cluster_list = [cluster_dict for cluster_dict in cluster_list
                             if self._is_user_cluster_owner(cluster_dict)]
@@ -782,6 +787,13 @@ class PKSBroker(AbstractBroker):
         original_name_info = cluster_info['name'].split(USER_ID_SEPARATOR)
         cluster_info['name'] = original_name_info[0]
 
+    def _is_cluster_visible_to_org_admin(self, cluster_info):
+        # Returns True if org-admin is the cluster owner, or
+        # the cluster belongs to same org as org-admin's.
+        return self._is_user_cluster_owner(cluster_info) or\
+            self._does_cluster_belong_to_org(cluster_info,
+                                             self.client_session.get('org'))
+
     def _is_user_cluster_owner(self, cluster_info):
         # Returns True if the logged-in user is the owner of the given cluster.
         # Also, restores the actual name of the cluster, if it is owned by
@@ -789,8 +801,7 @@ class PKSBroker(AbstractBroker):
 
         is_user_cluster_owner = False
         user_id = self._get_vcd_userid()
-        if user_id in cluster_info['name']:
-            self._restore_original_name(cluster_info)
+        if user_id in cluster_info['pks_cluster_name']:
             is_user_cluster_owner = True
 
         return is_user_cluster_owner


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- Improved cluster list filtering that are visible to org-admin

- When filtering the cluster list for org-admin, first lookup for clusters that are created/owned by org-admin ; if not, then check if the cluster belong to organization of org-admin using compute-profile. This optimizes the filtering. Also, correctly detects the resized-clusters that are created by org-admin.

Manual testing done for the following
- CRUD operations on clusters as org-admin. Specific tests to check if resized clusters that are created by org-admin show up in cluster list operation. 
- CRUD operation on clusters as other personas (sys admin, tenant user) works as expected.

System test completed

@sahithi @rocknes @sompa @harshneelmore @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/351)
<!-- Reviewable:end -->
