### PR TITLE
[VCDA-1042] Fix for filtering options vdc, org for vcd cse cluster list

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -77,6 +77,9 @@ class BrokerManager(object):
             vcd_uri=config['vcd']['host'],
             headers=self.req_headers,
             verify_ssl_certs=config['vcd']['verify'])
+        self.req_spec.update((param, val)
+                             for param, val in request_query_params.items()
+                             if val is not None)
 
     @exception_handler
     def invoke(self, op):
@@ -102,8 +105,7 @@ class BrokerManager(object):
         result['body'] = []
         result['status_code'] = OK
 
-        self.is_ovdc_present_in_request = self.req_spec.get('vdc') or \
-            self.req_qparams.get('vdc')
+        self.is_ovdc_present_in_request = self.req_spec.get('vdc')
         if op == Operation.INFO_OVDC:
             ovdc_id = self.req_spec.get('ovdc_id')
             # TODO() Constructing response should be moved out of this layer
@@ -435,11 +437,9 @@ class BrokerManager(object):
     def _get_ctr_prov_ctx_from_ovdc_metadata(self, ovdc_name=None,
                                              org_name=None):
         ovdc_name = \
-            ovdc_name or self.req_spec.get('vdc') or \
-            self.req_qparams.get('vdc')
+            ovdc_name or self.req_spec.get('vdc')
         org_name = \
-            org_name or self.req_spec.get('org') or \
-            self.req_qparams.get('org') or self.session.get('org')
+            org_name or self.req_spec.get('org') or self.session.get('org')
 
         if ovdc_name and org_name:
             ctr_prov_ctx = \
@@ -475,13 +475,8 @@ class BrokerManager(object):
 
         :rtype: container_service_extension.abstract_broker.AbstractBroker
         """
-        ovdc_name = \
-            self.req_spec.get('vdc') or \
-            self.req_qparams.get('vdc')
-        org_name = \
-            self.req_spec.get('org') or \
-            self.req_qparams.get('org') or \
-            self.session.get('org')
+        ovdc_name = self.req_spec.get('vdc')
+        org_name = self.req_spec.get('org') or self.session.get('org')
 
         ctr_prov_ctx = self._get_ctr_prov_ctx_from_ovdc_metadata(
             ovdc_name=ovdc_name, org_name=org_name)

--- a/container_service_extension/cluster.py
+++ b/container_service_extension/cluster.py
@@ -8,6 +8,7 @@ import string
 import time
 
 from pyvcloud.vcd.client import QueryResultFormat
+from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.vapp import VApp
 from pyvcloud.vcd.vm import VM
 
@@ -20,6 +21,7 @@ from container_service_extension.exceptions import ScriptExecutionError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.utils import get_data_file
 from container_service_extension.utils import get_vsphere
+from container_service_extension.utils import SYSTEM_ORG_NAME
 
 TYPE_MASTER = 'mstr'
 TYPE_NODE = 'node'
@@ -40,16 +42,29 @@ def wait_until_tools_ready(vm):
             time.sleep(1)
 
 
-def load_from_metadata(client, name=None, cluster_id=None):
+def load_from_metadata(client, name=None, cluster_id=None,
+                       org_name=None, vdc_name=None):
+
     if cluster_id is None:
         query_filter = 'metadata:cse.cluster.id==STRING:*'
     else:
         query_filter = f'metadata:cse.cluster.id==STRING:{cluster_id}'
     if name is not None:
         query_filter += f';name=={name}'
+
+    if vdc_name is not None:
+        query_filter += f";vdcName=={vdc_name}"
+
     resource_type = 'vApp'
     if client.is_sysadmin():
         resource_type = 'adminVApp'
+        if org_name is not None and \
+                org_name.lower() != SYSTEM_ORG_NAME.lower():
+            org_resource = \
+                client.get_org_by_name(org_name)
+            org = Org(client, resource=org_resource)
+            query_filter += f";org=={org.resource.get('id')}"
+
     q = client.get_typed_query(
         resource_type,
         query_result_format=QueryResultFormat.ID_RECORDS,

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -54,8 +54,11 @@ from container_service_extension.uaaclient.uaaclient import UaaClient
 from container_service_extension.utils import exception_handler
 from container_service_extension.utils \
     import extract_vdc_id_from_pks_compute_profile_name
+from container_service_extension.utils \
+    import extract_vdc_name_from_pks_compute_profile_name
 from container_service_extension.utils import get_pks_cache
 from container_service_extension.utils import OK
+from container_service_extension.utils import SYSTEM_ORG_NAME
 
 
 # Delimiter to append with user id context
@@ -214,29 +217,7 @@ class PKSBroker(AbstractBroker):
         for cluster in cluster_list:
             self._restore_original_name(cluster)
 
-        # Complete list of clusters for sysadmin
-        if self.tenant_client.is_sysadmin():
-            return cluster_list
-
-        # Filter the list for org admin and others.
-        if is_org_admin(self.client_session) or \
-                kwargs.get('is_org_admin_search'):
-            # TODO() - Service accounts for exclusive org does not
-            #  require the following filtering.
-            cluster_list = [cluster_dict for cluster_dict in cluster_list
-                            if self._is_cluster_visible_to_org_admin(
-                                cluster_dict)]
-        else:
-            cluster_list = [cluster_dict for cluster_dict in cluster_list
-                            if self._is_user_cluster_owner(cluster_dict)]
-
-            # 'is_admin_request' is a flag that is used to restrict access to
-            # user context and other secured information on pks cluster
-            # information.
-            if not kwargs.get('is_admin_request'):
-                for cluster in cluster_list:
-                    self._filter_pks_properties(cluster)
-        return cluster_list
+        return self._filter_clusters(cluster_list, **kwargs)
 
     def _list_clusters(self):
         """Get list of clusters in PKS environment.
@@ -774,6 +755,56 @@ class PKSBroker(AbstractBroker):
 
         return result
 
+    def _filter_clusters(self, cluster_list, **kwargs):
+        """Filter the cluster list based on vdc, org by personae.
+
+        Apply the filters in the following order of priority and return the
+        result once the specific-persona-only filter is applied.
+
+        1. Filter clusters based on vdc for all personae.
+        2. Filter clusters based on org only for sysadmin.
+        3. Filter clusters for org admin based on visibility.
+        4. Filter clusters for tenant users based on ownership only.
+
+        :param list cluster_list: list of clusters
+        :return: filtered list of clusters
+
+        :rtype: list
+        TODO() These filters should be moved to either broker layer or
+        delegated to dedicated filter class say: PksClusterFilter.
+        """
+        # Apply vdc filter, if provided to all personae.
+        if self.req_spec.get('vdc'):
+            cluster_list = self._apply_vdc_filter(cluster_list,
+                                                  self.req_spec.get('vdc'))
+
+        # Apply org filter, if provided, for sys admin.
+        if self.tenant_client.is_sysadmin():
+            org_name = self.req_spec.get('org')
+            if org_name and org_name.lower() != SYSTEM_ORG_NAME.lower():
+                cluster_list = self._apply_org_filter(cluster_list, org_name)
+            return cluster_list
+
+        # Filter the cluster list for org admin and others.
+        if is_org_admin(self.client_session) or \
+                kwargs.get('is_org_admin_search'):
+            # TODO() - Service accounts for exclusive org does not
+            #  require the following filtering.
+            cluster_list = [cluster_dict for cluster_dict in cluster_list
+                            if self._is_cluster_visible_to_org_admin(
+                                cluster_dict)]
+        else:
+            cluster_list = [cluster_dict for cluster_dict in cluster_list
+                            if self._is_user_cluster_owner(cluster_dict)]
+
+            # 'is_admin_request' is a flag that is used to restrict access to
+            # user context and other secured information on pks cluster
+            # information.
+            if not kwargs.get('is_admin_request'):
+                for cluster in cluster_list:
+                    self._filter_pks_properties(cluster)
+        return cluster_list
+
     def _append_user_id(self, name):
         user_id = self._get_vcd_userid()
         return f"{name}{USER_ID_SEPARATOR}{user_id}"
@@ -821,6 +852,30 @@ class PKSBroker(AbstractBroker):
         vdc_id = extract_vdc_id_from_pks_compute_profile_name(
             compute_profile_name)
         return org_name == get_org_name_of_ovdc(vdc_id)
+
+    def _apply_vdc_filter(self, cluster_list, vdc_name):
+        cluster_list = [cluster_dict for cluster_dict in cluster_list
+                        if self._does_cluster_belong_to_vdc
+                        (cluster_dict, vdc_name)]
+        return cluster_list
+
+    def _apply_org_filter(self, cluster_list, org_name):
+        cluster_list = [cluster_dict for cluster_dict in cluster_list
+                        if self._does_cluster_belong_to_org
+                        (cluster_dict, org_name)]
+        return cluster_list
+
+    def _does_cluster_belong_to_vdc(self, cluster_info, vdc_name):
+        # Returns True if the cluster backed by given vdc
+        # Else False (this also includes missing compute profile name)
+        compute_profile_name = cluster_info.get('compute_profile_name')
+        if compute_profile_name is None:
+            LOGGER.debug(f"compute-profile-name of {cluster_info.get('name')}"
+                         f" is not found")
+            return False
+        vdc_of_cluster = extract_vdc_name_from_pks_compute_profile_name(
+            compute_profile_name)
+        return vdc_of_cluster == vdc_name
 
     # TODO() Should be moved to filtering layer
     def _filter_list_by_cluster_name(self, cluster_list, cluster_name):

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -554,7 +554,8 @@ def get_vdc(client, vdc_name, org=None, org_name=None,
     # TODO() org.get_vdc() should throw exception if vdc not found in the org.
     # This should be handled in pyvcloud. For now, it is handled here.
     if resource is None:
-        raise EntityNotFoundException(f"VDC '{vdc_name}' not found")
+        raise EntityNotFoundException(f"VDC '{vdc_name}' not found"
+                                      f" in ORG '{org.resource.get('name')}'")
     vdc = VDC(client, resource=resource)
     return vdc
 
@@ -601,6 +602,18 @@ def get_pvdc_id_by_name(name, vc_name_in_vcd):
         pvdc_id = href.split("/")[-1]
         return pvdc_id
     return None
+
+
+def extract_vdc_name_from_pks_compute_profile_name(compute_profile_name):
+    """Extract the vdc name from pks compute profile name.
+
+    :param str compute_profile_name: name of the pks compute profile
+
+    :return: name of the vdc in vcd.
+
+    :rtype: str
+    """
+    return compute_profile_name.split('--')[2]
 
 
 def extract_vdc_id_from_pks_compute_profile_name(compute_profile_name):

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -223,7 +223,9 @@ class VcdBroker(AbstractBroker, threading.Thread):
     def list_clusters(self):
         self._connect_tenant()
         clusters = []
-        for c in load_from_metadata(self.tenant_client):
+        for c in load_from_metadata(self.tenant_client,
+                                    org_name=self.req_spec.get('org'),
+                                    vdc_name=self.req_spec.get('vdc')):
             clusters.append({
                 'name': c['name'],
                 'IP master': c['leader_endpoint'],


### PR DESCRIPTION


Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- Fixed filtering options --vdc, --org for vcd cse cluster list sysadmin, org admin and tenant users
- Enhancements done to support --vdc option for sysadmin, org-admin, tenant users, --org option for sysadmin  
- System test completed
- Manually tested and verified vcd cse cluster list for sysadmin, orgadmin and others
    --org with --vdc that is container provider for vDC only for sysadmin
    --org with --vdc that is container provider for PKS only for sysadmin
    --org with --vdc that has container provider(s) for both vDC and PKS for sysadmin
    --vdc for org-admin for multiple vdc(s) within the organization
    --vdc for tenant users who owns clusters backed by different vdc(s) 

@sahithi @rocknes @sompa @harshneelmore @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/354)
<!-- Reviewable:end -->
