### PR TITLE
Update init-ubuntu-16.04.sh fix for sshd_config AuthorizedKeysFile

### DIFF
--- a/scripts/init-ubuntu-16.04.sh
+++ b/scripts/init-ubuntu-16.04.sh
@@ -3,7 +3,11 @@ set -e
 
 ### Uncomment if you want to enable root password access
 ### root password access is dangerous; ssh-key access is recommended
+
 # sed -i 's/prohibit-password/yes/' /etc/ssh/sshd_config
+
+### AuthorizedKeysFile is commented out in /etc/ssh/sshd_config add in fix
+sed -i '/AuthorizedKeysFile/s/#//g' /etc/ssh/sshd_config
 
 sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 apt remove -y cloud-init


### PR DESCRIPTION
### AuthorizedKeysFile is commented out in /etc/ssh/sshd_config add in fix
sed -i '/AuthorizedKeysFile/s/#//g' /etc/ssh/sshd_config

To help us process your pull request efficiently, please include: 

- (Required) Correct commented out statement to allow ssh login

- (Required) 
### AuthorizedKeysFile is commented out in /etc/ssh/sshd_config add in fix
sed -i '/AuthorizedKeysFile/s/#//g' /etc/ssh/sshd_config


