### PR TITLE
[VCDA-1043] Fix filtering options vdc,org for vcd cse cluster delete 

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -11,7 +11,9 @@ from pyvcloud.vcd.org import Org
 
 from container_service_extension.exceptions import ClusterAlreadyExistsError
 from container_service_extension.exceptions import ClusterNotFoundError
+from container_service_extension.exceptions import CseDuplicateClusterError
 from container_service_extension.exceptions import CseServerError
+from container_service_extension.exceptions import PksDuplicateClusterError
 from container_service_extension.exceptions import PksServerError
 from container_service_extension.exceptions import UnauthorizedActionError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
@@ -360,6 +362,10 @@ class BrokerManager(object):
         vcd_broker = VcdBroker(self.req_headers, self.req_spec)
         try:
             return vcd_broker.get_cluster_info(cluster_name), vcd_broker
+        except CseDuplicateClusterError as err:
+            LOGGER.debug(f"Get cluster info on {cluster_name}"
+                         f"on vCD failed with error: {err}")
+            raise err
         except Exception as err:
             LOGGER.debug(f"Get cluster info on {cluster_name} failed "
                          f"on vCD with error: {err}")
@@ -371,10 +377,13 @@ class BrokerManager(object):
                 return pksbroker.get_cluster_info(
                     cluster_name=cluster_name,
                     is_org_admin_search=is_org_admin_search), pksbroker
+            except PksDuplicateClusterError as err:
+                LOGGER.debug(f"Get cluster info on {cluster_name}"
+                             f"on PKS failed with error: {err}")
+                raise err
             except PksServerError as err:
                 LOGGER.debug(f"Get cluster info on {cluster_name} failed "
                              f"on {pks_ctx['host']} with error: {err}")
-
         return None, None
 
     def _create_pks_context_for_all_accounts_in_org(self):

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -165,7 +165,7 @@ class Cluster(object):
             accept_type='application/json')
         return process_response(response)
 
-    def delete_cluster(self, cluster_name, vdc=None):
+    def delete_cluster(self, cluster_name, org=None, vdc=None):
         method = 'DELETE'
         uri = '%s/%s' % (self._uri, cluster_name)
         response = self.client._do_request_prim(
@@ -173,7 +173,7 @@ class Cluster(object):
             uri,
             self.client._session,
             accept_type='application/*+json',
-            params={'vdc': vdc} if vdc else None)
+            params={'org': org, 'vdc': vdc})
         try:
             result = process_response(response)
         except VcdResponseError as e:

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -196,13 +196,23 @@ def list_clusters(ctx, vdc, org_name):
     default=None,
     metavar='VDC_NAME',
     help='Restrict cluster search to specified org VDC')
-def delete(ctx, name, vdc):
+@click.option(
+    '-o',
+    '--org',
+    'org',
+    default=None,
+    required=False,
+    metavar='ORG_NAME',
+    help='Restrict cluster search to specified org')
+def delete(ctx, name, vdc, org):
     """Delete a Kubernetes cluster."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
-        result = cluster.delete_cluster(name, vdc)
+        if not client.is_sysadmin() and org is None:
+            org = ctx.obj['profiles'].get('org_in_use')
+        result = cluster.delete_cluster(name, org, vdc)
         # result is empty for delete cluster operation on PKS-managed clusters.
         # In that specific case, below check helps to print out a meaningful
         # message to users.

--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -36,6 +36,10 @@ class ClusterNetworkIsolationError(ClusterOperationError):
     """Raised when any error happens while isolating cluster network."""
 
 
+class CseDuplicateClusterError(CseServerError):
+    """Raised when multiple vCD clusters of same name detected."""
+
+
 class NodeOperationError(ClusterOperationError):
     """Base class for all node operation related exceptions."""
 
@@ -112,3 +116,7 @@ class PksServerError(CseServerError):
 
 class PksConnectionError(PksServerError):
     """Raised when connection establishment to PKS fails."""
+
+
+class PksDuplicateClusterError(PksServerError):
+    """Raised when multiple PKS clusters of same name detected."""

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -35,6 +35,7 @@ from container_service_extension.exceptions import ClusterAlreadyExistsError
 from container_service_extension.exceptions import ClusterInitializationError
 from container_service_extension.exceptions import ClusterJoiningError
 from container_service_extension.exceptions import ClusterOperationError
+from container_service_extension.exceptions import CseDuplicateClusterError
 from container_service_extension.exceptions import CseServerError
 from container_service_extension.exceptions import MasterNodeCreationError
 from container_service_extension.exceptions import NFSNodeCreationError
@@ -246,7 +247,12 @@ class VcdBroker(AbstractBroker, threading.Thread):
         :return: (dict): Info of the cluster.
         """
         self._connect_tenant()
-        clusters = load_from_metadata(self.tenant_client, name=cluster_name)
+        clusters = load_from_metadata(self.tenant_client, name=cluster_name,
+                                      org_name=self.req_spec.get('org'),
+                                      vdc_name=self.req_spec.get('vdc'))
+        if len(clusters) > 1:
+            raise CseDuplicateClusterError(f"Multiple clusters of name"
+                                           f" '{cluster_name}' detected.")
         if len(clusters) == 0:
             raise CseServerError(f"Cluster '{cluster_name}' not found.")
         cluster = clusters[0]
@@ -524,7 +530,12 @@ class VcdBroker(AbstractBroker, threading.Thread):
         self._connect_sys_admin()
         self.op = OP_DELETE_CLUSTER
         clusters = load_from_metadata(
-            self.tenant_client, name=self.cluster_name)
+            self.tenant_client, name=self.cluster_name,
+            org_name=self.req_spec.get('org'),
+            vdc_name=self.req_spec.get('vdc'))
+        if len(clusters) > 1:
+            raise CseDuplicateClusterError(f"Multiple clusters of name"
+                                           f" '{self.cluster_name}' detected.")
         if len(clusters) != 1:
             raise CseServerError(f"Cluster {self.cluster_name} not found.")
         self.cluster = clusters[0]


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- Cluster delete support for vdc, org options

- With vdc and org option sys admin can pick and delete for a given org and vdc. This also work for other personas.

- Manual testing completed
       - Tested for --vdc, --org separately as well as together
       - Tested for duplicate cluster names with exception message
- System tests passed

NOTE: Dependency on VCDA-1042 commit. Sanity tests will be done again after merging VCDA-1042

@sahithi @rocknes @sompa @harshneelmore @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/357)
<!-- Reviewable:end -->
