### PR TITLE
Update init-ubuntu-16.04.sh

### DIFF
--- a/scripts/init-ubuntu-16.04.sh
+++ b/scripts/init-ubuntu-16.04.sh
@@ -4,7 +4,8 @@ set -e
 ### Uncomment if you want to enable root password access
 ### root password access is dangerous; ssh-key access is recommended
 # sed -i 's/prohibit-password/yes/' /etc/ssh/sshd_config
-
+#AuthorizedKeysFile is commented out in /etc/ssh/sshd_config add in fix
+sed -i '/AuthorizedKeysFile/s/#//g' /etc/ssh/sshd_config
 sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 apt remove -y cloud-init
 dpkg-reconfigure openssh-server


### PR DESCRIPTION
- (Required) update init script to remove # from sshd_config AuthorizedKeysFile

- (Required) Current template builds wont allow ssh login as the authorized keys file location is commented out


Signed-off-by: Tony Ironside <tony@ironside.ca>



