### PR TITLE
VCDA-999: Unable to get the correct cluster config as sys admin

### DIFF
--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -183,9 +183,12 @@ class Cluster(object):
                 raise e
         return result
 
-    def get_config(self, cluster_name, vdc=None):
+    def get_config(self, cluster_name, vdc=None, org=None):
         method = 'GET'
         uri = '%s/%s/config' % (self._uri, cluster_name)
+        queryparams = dict()
+        queryparams['vdc'] = vdc if vdc else None
+        queryparams['org'] = org if org else None
         response = self.client._do_request_prim(
             method,
             uri,
@@ -194,7 +197,7 @@ class Cluster(object):
             media_type=None,
             accept_type='text/x-yaml',
             auth=None,
-            params={'vdc': vdc} if vdc else None)
+            params=queryparams)
         if response.status_code == requests.codes.ok:
             return response.content.decode('utf-8').replace('\\n', '\n')[1:-1]
         try:

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -432,6 +432,8 @@ def config(ctx, name, vdc, org):
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
+        if not client.is_sysadmin() and org is None:
+            org = ctx.obj['profiles'].get('org_in_use')
         cluster_config = cluster.get_config(name, vdc=vdc, org=org)
         if os.name == 'nt':
             cluster_config = str.replace(cluster_config, '\n', '\r\n')

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -408,6 +408,14 @@ def resize(ctx, name, node_count, network_name, vdc, disable_rollback):
 @click.pass_context
 @click.argument('name', required=True)
 @click.option(
+    '-o',
+    '--org',
+    'org',
+    required=False,
+    default=None,
+    metavar='ORG_NAME',
+    help='Restrict cluster search to specified org')
+@click.option(
     '-v',
     '--vdc',
     'vdc',
@@ -415,7 +423,7 @@ def resize(ctx, name, node_count, network_name, vdc, disable_rollback):
     default=None,
     metavar='VDC_NAME',
     help='Restrict cluster search to specified org VDC')
-def config(ctx, name, vdc):
+def config(ctx, name, vdc, org):
     """Display cluster configuration.
 
     To write to a file: `vcd cse cluster config mycluster > ~/.kube/my_config`
@@ -424,7 +432,7 @@ def config(ctx, name, vdc):
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
-        cluster_config = cluster.get_config(name, vdc=vdc)
+        cluster_config = cluster.get_config(name, vdc=vdc, org=org)
         if os.name == 'nt':
             cluster_config = str.replace(cluster_config, '\n', '\r\n')
 

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -367,8 +367,9 @@ class VcdBroker(AbstractBroker, threading.Thread):
         #  read from instance variable (if needed only).
 
         if not network_name:
-            raise CseServerError(f"Cluster cannot be created. Please provide"
-                             f" a valid value for org vDC network param.")
+            raise CseServerError(f"Cluster cannot be created. "
+                                 f"Please provide a valid value for org "
+                                 f"vDC network param.")
 
         LOGGER.debug(f"About to create cluster {cluster_name} on {vdc_name} "
                      f"with {node_count} nodes, sp={storage_profile}")
@@ -558,9 +559,10 @@ class VcdBroker(AbstractBroker, threading.Thread):
     def get_cluster_config(self, cluster_name):
         self._connect_tenant()
         clusters = load_from_metadata(
-            self.tenant_client, name=cluster_name,
-                    org_name=self.req_spec.get('org'),
-                    vdc_name=self.req_spec.get('vdc'))
+            self.tenant_client,
+            name=cluster_name,
+            org_name=self.req_spec.get('org'),
+            vdc_name=self.req_spec.get('vdc'))
         if len(clusters) != 1:
             raise CseServerError(f"Cluster '{cluster_name}' not found")
         vapp = VApp(self.tenant_client, href=clusters[0]['vapp_href'])

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -558,7 +558,9 @@ class VcdBroker(AbstractBroker, threading.Thread):
     def get_cluster_config(self, cluster_name):
         self._connect_tenant()
         clusters = load_from_metadata(
-            self.tenant_client, name=cluster_name)
+            self.tenant_client, name=cluster_name,
+                    org_name=self.req_spec.get('org'),
+                    vdc_name=self.req_spec.get('vdc'))
         if len(clusters) != 1:
             raise CseServerError(f"Cluster '{cluster_name}' not found")
         vapp = VApp(self.tenant_client, href=clusters[0]['vapp_href'])


### PR DESCRIPTION

- Fixes the filtering options for system administrator and org admins for getting the cluster config correctly using the --vdc and --org options in cluster config command.

- Tested both namesake clusters of type vcd and pks with the filtering options and verified that the correct config for the cluster gets retrieved. Please refer to the JIRA task for details on the bug : https://jira.eng.vmware.com/browse/VCDA-999

- @sahithi @sakthisunda @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/361)
<!-- Reviewable:end -->
