### PR TITLE
[VCDA-1055] Fix filtering options 'vdc' and 'org' for cse cluster info (for sysadmin users)

### DIFF
--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -49,7 +49,7 @@ class Cluster(object):
             params=params)
         return process_response(response)
 
-    def get_cluster_info(self, name, vdc=None):
+    def get_cluster_info(self, name, org=None, vdc=None):
         method = 'GET'
         uri = '%s/%s/info' % (self._uri, name)
         response = self.client._do_request_prim(
@@ -60,7 +60,7 @@ class Cluster(object):
             media_type=None,
             accept_type='application/*+json',
             auth=None,
-            params={'vdc': vdc} if vdc else None)
+            params={'org': org, 'vdc': vdc})
         try:
             result = process_response(response)
         except VcdResponseError as e:

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -455,13 +455,23 @@ def config(ctx, name, vdc, org):
     default=None,
     metavar='VDC_NAME',
     help='Restrict cluster search to specified org VDC')
-def cluster_info(ctx, name, vdc):
+@click.option(
+    '-o',
+    '--org',
+    'org',
+    default=None,
+    required=False,
+    metavar='ORG_NAME',
+    help='Restrict cluster search to specified org')
+def cluster_info(ctx, name, org, vdc):
     """Display info about a Kubernetes cluster."""
     try:
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
-        cluster_info = cluster.get_cluster_info(name, vdc=vdc)
+        if not client.is_sysadmin() and org is None:
+            org = ctx.obj['profiles'].get('org_in_use')
+        cluster_info = cluster.get_cluster_info(name, org=org, vdc=vdc)
         stdout(cluster_info, ctx, show_id=True)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION


Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

To help us process your pull request efficiently, please include: 

- Supports --org and --vcd option. Fixed the missing --org option

-  Enhancement completed for for system administrator to know the cluster info on given org and vdc. Right error message if open ended cluster info detects duplicate cluster names across organizations.

- Manual testing completed. 
    - System administrator to get the cluster info based on the org and vdc
    - Org admin to get the cluster info of the cluster in the organization
    - Tenant user to get the cluster info that is owned.
- System tests completed

Depends on VCDA-1043 as server side changes and duplicate detection got done in this task.

- @sahithi @rocknes @sompa @harshneelmore @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/364)
<!-- Reviewable:end -->
