### PR TITLE
[VCDA-1044] Fix filtering options 'vdc' and 'org' for cse cluster resize (for sysadmin users)

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -58,6 +58,8 @@ class Operation(Enum):
     INFO_OVDC = 'info ovdc'
     GET_CLUSTER_CONFIG = 'get cluster config'
     GET_NODE_INFO = 'get node info'
+    CREATE_NODE = 'create node'
+    DELETE_NODE = 'delete node'
 
 
 class BrokerManager(object):
@@ -181,7 +183,16 @@ class BrokerManager(object):
                 {'cluster_name': self.req_spec.get('cluster_name', None),
                  'node_name': self.req_spec.get('node_name', None)}
             result['body'] = self._get_node_info(**node_spec)[0]
-
+        elif op == Operation.CREATE_NODE:
+            # Currently node create is a vCD only operation.
+            broker = VcdBroker(self.req_headers, self.req_spec)
+            result['body'] = broker.create_nodes()
+            result['status_code'] = ACCEPTED
+        elif op == Operation.DELETE_NODE:
+            # Currently node delete is a vCD only operation.
+            broker = VcdBroker(self.req_headers, self.req_spec)
+            result['body'] = broker.delete_nodes()
+            result['status_code'] = ACCEPTED
         return result
 
     def _list_ovdcs(self, list_pks_plans=False):
@@ -288,7 +299,8 @@ class BrokerManager(object):
             vcd_broker = VcdBroker(self.req_headers, self.req_spec)
             cluster = vcd_broker.get_cluster_info(cluster_name)
             if cluster:
-                return vcd_broker.get_node_info(cluster_name, node_name), vcd_broker
+                return vcd_broker.get_node_info(
+                    cluster_name, node_name), vcd_broker
 
         raise ClusterNotFoundError(f"Cluster {cluster_name} with "
                                    f"Node {node_name} not found "

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -144,6 +144,7 @@ class Cluster(object):
                        network_name,
                        cluster_name,
                        node_count=1,
+                       org=None,
                        vdc=None,
                        disable_rollback=True):
         method = 'PUT'
@@ -152,6 +153,7 @@ class Cluster(object):
             'name': cluster_name,
             'node_count': node_count,
             'node_type': TYPE_NODE,
+            'org': org,
             'vdc': vdc,
             'network': network_name,
             'disable_rollback': disable_rollback
@@ -231,10 +233,11 @@ class Cluster(object):
         return result
 
     def add_node(self,
-                 vdc,
                  network_name,
                  name,
                  node_count=1,
+                 org=None,
+                 vdc=None,
                  cpu=None,
                  memory=None,
                  storage_profile=None,
@@ -244,6 +247,7 @@ class Cluster(object):
                  disable_rollback=True):
         """Add nodes to a Kubernetes cluster.
 
+        :param org: (str): The name of the org that contains the cluster
         :param vdc: (str): The name of the vdc that contains the cluster
         :param network_name: (str): The name of the network to which the
             node VMs will connect to
@@ -270,6 +274,7 @@ class Cluster(object):
         data = {
             'name': name,
             'node_count': node_count,
+            'org': org,
             'vdc': vdc,
             'cpu': cpu,
             'memory': memory,
@@ -289,9 +294,10 @@ class Cluster(object):
             accept_type='application/*+json')
         return process_response(response)
 
-    def delete_nodes(self, vdc, name, nodes, force=False):
+    def delete_nodes(self, name, nodes, org=None, vdc=None, force=False):
         """Delete nodes from a Kubernetes cluster.
 
+        :param org: (str): Name of the organization that contains the cluster
         :param vdc: (str): The name of the vdc that contains the cluster
         :param name: (str): The name of the cluster
         :param nodes: (list(str)): The list of nodes to delete
@@ -301,7 +307,8 @@ class Cluster(object):
         """
         method = 'DELETE'
         uri = '%s/%s/node' % (self._uri, name)
-        data = {'name': name, 'vdc': vdc, 'nodes': nodes, 'force': force}
+        data = {'name': name, 'org': org, 'vdc': vdc, 'nodes': nodes,
+                'force': force}
         response = self.client._do_request_prim(
             method,
             uri,

--- a/container_service_extension/processor.py
+++ b/container_service_extension/processor.py
@@ -150,8 +150,7 @@ class ServiceProcessor(object):
                 reply = broker_manager.invoke(Operation.CREATE_CLUSTER)
             else:
                 if node_request:
-                    broker = broker_manager.get_broker_based_on_vdc()
-                    reply = broker.create_nodes()
+                    reply = broker_manager.invoke(Operation.CREATE_NODE)
         elif body['method'] == 'PUT':
             if ovdc_info_request:
                 reply = broker_manager.invoke(Operation.ENABLE_OVDC)
@@ -162,8 +161,7 @@ class ServiceProcessor(object):
                 reply = broker_manager.invoke(Operation.RESIZE_CLUSTER)
         elif body['method'] == 'DELETE':
             if node_request:
-                broker = broker_manager.get_broker_based_on_vdc()
-                reply = broker.delete_nodes()
+                reply = broker_manager.invoke(Operation.DELETE_NODE)
             else:
                 req_spec.update({'cluster_name': cluster_name})
                 reply = broker_manager.invoke(Operation.DELETE_CLUSTER)


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- Fixed handling of org and vdc options of cluster resize, node create, node delete, node list. Also fixed full stack trace on console. 

-  This is an enhancement for cluster resize where system administrator can pick and choose to resize cluster by providing which organization and vdc. Proper error message on choosing cluster with same name across organizations. Full stack trace on console fixed by moving the exception handler and related logic to broker manager from processor. 

- All system tests passed. 
   Completed manual tests as system administrator and others.
   Duplicate cluster testing, no more stack trace on the console.  

@rocknes @sahithi @sompa @harshneelmore @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/365)
<!-- Reviewable:end -->
