### PR TITLE
Change how admin passwords are generated and read for K8 cluster vms

### DIFF
--- a/container_service_extension/cluster.py
+++ b/container_service_extension/cluster.py
@@ -162,6 +162,7 @@ def add_nodes(qty, template, node_type, config, client, org, vdc, vapp, body):
                 'vapp': source_vapp.resource,
                 'target_vm_name': name,
                 'hostname': name,
+                'password_auto': True,
                 'network': body['network'],
                 'ip_allocation_mode': 'pool'
             }
@@ -193,12 +194,12 @@ def add_nodes(qty, template, node_type, config, client, org, vdc, vapp, body):
                 vm = VM(client, resource=vm_resource)
                 task = vm.power_on()
                 client.get_task_monitor().wait_for_status(task)
-        password = source_vapp.get_admin_password(source_vm)
         vapp.reload()
+        password = vapp.get_admin_password(spec['target_vm_name'])
         for spec in specs:
             vm_resource = vapp.get_vm(spec['target_vm_name'])
-            command = '/bin/echo "root:{password}" | chpasswd'.format(
-                password=template['admin_password'])
+            command = \
+                f"/bin/echo \"root:{template['admin_password']}\" | chpasswd"
             nodes = [vm_resource]
             execute_script_in_nodes(
                 config,


### PR DESCRIPTION
While adding a node to a native K8 cluster, 
1. CSE assumes that the node vms admin password is always set.
2. CSE assumes the password is same as the one in the source template.

Both these assumptions can be wrong. The correct behavior in this case should be to auto generate a password while deploying the vm from template, read the password from the deployed VM instead of the template and update it to the user provided password.

Testing done:
* Used catalog external publish/subscribe model to create a copy of the CSE template in org1
* Manually checked that the subscribed catalog templates didn't have the vm password section.
* Deployed two K8 clusters (1 based on ubuntu template and 1 based on photon template) along with nfs servers, both deployments were successful.
* Also ran server and client system tests, both of them ran successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/367)
<!-- Reviewable:end -->
