### PR TITLE
Update assert failures to print useful debugging info

### DIFF
--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -90,7 +90,10 @@ def cse_server():
     result = env.CLI_RUNNER.invoke(cli, install_cmd,
                                    input='y',
                                    catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [cse {install_cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     # start cse server as subprocess
     cmd = f"cse run -c {env.ACTIVE_CONFIG_FILEPATH}"
@@ -104,19 +107,34 @@ def cse_server():
     cmd = f"login {config['vcd']['host']} {utils.SYSTEM_ORG_NAME} " \
           f"{config['vcd']['username']} -iwp {config['vcd']['password']}"
     result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
     cmd = f"org use {config['broker']['org']}"
     result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
     cmd = f"vdc use {config['broker']['vdc']}"
     result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
     cmd = f"cse ovdc enable {config['broker']['vdc']} -k " \
           f"{constants.K8sProviders.NATIVE}"
     result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
     result = env.CLI_RUNNER.invoke(vcd, 'logout', catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     yield
 
@@ -140,24 +158,29 @@ def vcd_org_admin():
     be logged in as both sys admin and org admin.
     """
     config = testutils.yaml_to_dict(env.BASE_CONFIG_FILEPATH)
-    result = env.CLI_RUNNER.invoke(vcd,
-                                   ['login',
-                                    config['vcd']['host'],
-                                    config['broker']['org'],
-                                    config['vcd']['username'],
-                                    '-iwp', config['vcd']['password']],
-                                   catch_exceptions=False)
-    assert result.exit_code == 0
+    cmd = f"login {config['vcd']['host']} {config['broker']['org']} " \
+          f"{config['vcd']['username']} -iwp {config['vcd']['password']}"
+    result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     # ovdc context may be nondeterministic when there's multiple ovdcs
     cmd = f"vdc use {config['broker']['vdc']}"
     result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     yield
 
     result = env.CLI_RUNNER.invoke(vcd, ['logout'])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
 
 @pytest.fixture
@@ -170,19 +193,21 @@ def vcd_sys_admin():
     be logged in as both sys admin and org admin.
     """
     config = testutils.yaml_to_dict(env.BASE_CONFIG_FILEPATH)
-    result = env.CLI_RUNNER.invoke(vcd,
-                                   ['login',
-                                    config['vcd']['host'],
-                                    utils.SYSTEM_ORG_NAME,
-                                    config['vcd']['username'],
-                                    '-iwp', config['vcd']['password']],
-                                   catch_exceptions=False)
-    assert result.exit_code == 0
+    cmd = f"login {config['vcd']['host']} {utils.SYSTEM_ORG_NAME} " \
+          f"{config['vcd']['username']} -iwp {config['vcd']['password']}"
+    result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     yield
 
     result = env.CLI_RUNNER.invoke(vcd, ['logout'])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
 
 @pytest.fixture
@@ -205,16 +230,22 @@ def delete_test_cluster():
 
 def test_0010_vcd_cse_version(vcd_org_admin):
     """Test vcd cse version command."""
-    result = env.CLI_RUNNER.invoke(vcd, ['cse', 'version'],
-                                   catch_exceptions=False)
-    assert result.exit_code == 0
+    cmd = "cse version"
+    result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
 
 def test_0020_vcd_cse_system_info(vcd_org_admin):
     """Test vcd cse system info command."""
-    result = env.CLI_RUNNER.invoke(vcd, ['cse', 'system', 'info'],
-                                   catch_exceptions=False)
-    assert result.exit_code == 0
+    cmd = "cse system info"
+    result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
 
 def test_0030_vcd_cse_cluster_create_rollback(config, vcd_org_admin,
@@ -229,7 +260,10 @@ def test_0030_vcd_cse_cluster_create_rollback(config, vcd_org_admin,
     cmd = f"cse cluster create {env.TEST_CLUSTER_NAME} -n " \
           f"{config['broker']['network']} -N 1 -c 1000"
     result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
     # TODO() make cluster rollback delete call blocking
     time.sleep(env.WAIT_INTERVAL * 6)  # wait for vApp to be deleted
     assert not env.vapp_exists(env.TEST_CLUSTER_NAME), \
@@ -237,7 +271,10 @@ def test_0030_vcd_cse_cluster_create_rollback(config, vcd_org_admin,
 
     cmd += " --disable-rollback"
     result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
     assert env.vapp_exists(env.TEST_CLUSTER_NAME), \
         "Cluster does not exist when it should."
 
@@ -283,16 +320,20 @@ def test_0040_vcd_cse_cluster_and_node_operations(config, vcd_org_admin,
     # vcd cse template list
     # retrieves template names to test cluster deployment against
     cmd = 'cse template list'
-    print(f"Running command [vcd {cmd}]...", end='')
+    print(f"\nRunning command [vcd {cmd}]...", end='')
     result = env.CLI_RUNNER.invoke(vcd, ['cse', 'template', 'list'],
                                    catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
     print('SUCCESS')
-    template_pattern = r'(True|False)\s*(\S*)'
-    matches = re.findall(template_pattern, result.output)
-    template_names = [match[1] for match in matches]
-    if not env.TEST_ALL_TEMPLATES:
-        template_names = [template_names[0]]
+
+    template_names = [config['broker']['default_template']]
+    if env.TEST_ALL_TEMPLATES:
+        template_pattern = r'(True|False)\s*(\S*)'
+        matches = re.findall(template_pattern, result.output)
+        template_names = [match[1] for match in matches]
 
     # tests for cluster operations
     has_run = False  # some tests do not need to run for each template
@@ -305,7 +346,10 @@ def test_0040_vcd_cse_cluster_and_node_operations(config, vcd_org_admin,
         print(f"Running command [vcd {cmd}]...", end='')
         result = env.CLI_RUNNER.invoke(vcd, cmd.split(),
                                        catch_exceptions=False)
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                      f"\nExit Code: [{result.exit_code}]" \
+                                      f"\nOutput Start===" \
+                                      f"\n{result.output}===Output End"
         assert env.vapp_exists(env.TEST_CLUSTER_NAME), \
             "Cluster doesn't exist when it should."
         print(f"SUCCESS")
@@ -324,7 +368,10 @@ def test_0040_vcd_cse_cluster_and_node_operations(config, vcd_org_admin,
                 print(f"Running command [vcd {cmd}]...", end='')
                 result = env.CLI_RUNNER.invoke(vcd, cmd.split(),
                                                catch_exceptions=False)
-                assert result.exit_code == 0
+                assert result.exit_code == 0, \
+                    f"\nCommand: [vcd {cmd}]" \
+                    f"\nExit Code: [{result.exit_code}]" \
+                    f"\nOutput Start===\n{result.output}===Output End"
                 print('SUCCESS')
             has_run = True
 
@@ -334,7 +381,10 @@ def test_0040_vcd_cse_cluster_and_node_operations(config, vcd_org_admin,
         print(f"Running command [vcd {cmd}]...", end='')
         result = env.CLI_RUNNER.invoke(vcd, cmd.split(), input='y',
                                        catch_exceptions=False)
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                      f"\nExit Code: [{result.exit_code}]" \
+                                      f"\nOutput Start===" \
+                                      f"\n{result.output}===Output End"
         print('SUCCESS')
         check_node_list()
 
@@ -345,7 +395,10 @@ def test_0040_vcd_cse_cluster_and_node_operations(config, vcd_org_admin,
         print(f"Running command [vcd {cmd}]...", end='')
         result = env.CLI_RUNNER.invoke(vcd, cmd.split(),
                                        catch_exceptions=False)
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                      f"\nExit Code: [{result.exit_code}]" \
+                                      f"\nOutput Start===" \
+                                      f"\n{result.output}===Output End"
         print('SUCCESS')
         check_node_list()
 
@@ -354,7 +407,10 @@ def test_0040_vcd_cse_cluster_and_node_operations(config, vcd_org_admin,
         print(f"Running command [vcd {cmd}]...", end='')
         result = env.CLI_RUNNER.invoke(vcd, cmd.split(), input='y',
                                        catch_exceptions=False)
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                      f"\nExit Code: [{result.exit_code}]" \
+                                      f"\nOutput Start===" \
+                                      f"\n{result.output}===Output End"
         assert not env.vapp_exists(env.TEST_CLUSTER_NAME), \
             "Cluster exists when it should not"
         num_nodes = 0
@@ -378,7 +434,10 @@ class TestSystemToggle:
         cmd = 'cse system disable'
         result = env.CLI_RUNNER.invoke(vcd, cmd.split(),
                                        catch_exceptions=False)
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                      f"\nExit Code: [{result.exit_code}]" \
+                                      f"\nOutput Start===" \
+                                      f"\n{result.output}===Output End"
 
     def test_0020_cluster_create_disabled(self, config, vcd_org_admin,
                                           delete_test_cluster):
@@ -386,7 +445,10 @@ class TestSystemToggle:
               f"{config['broker']['network']} -N 1"
         result = env.CLI_RUNNER.invoke(vcd, cmd.split(),
                                        catch_exceptions=False)
-        assert result.exit_code == 2
+        assert result.exit_code == 2, f"\nCommand: [vcd {cmd}]" \
+                                      f"\nExit Code: [{result.exit_code}]" \
+                                      f"\nOutput Start===" \
+                                      f"\n{result.output}===Output End"
         assert not env.vapp_exists(env.TEST_CLUSTER_NAME), \
             "Cluster exists when it should not."
 
@@ -394,7 +456,10 @@ class TestSystemToggle:
         cmd = 'cse system enable'
         result = env.CLI_RUNNER.invoke(vcd, cmd.split(),
                                        catch_exceptions=False)
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                      f"\nExit Code: [{result.exit_code}]" \
+                                      f"\nOutput Start===" \
+                                      f"\n{result.output}===Output End"
 
     def test_0040_cluster_create_enabled(self, config, vcd_org_admin,
                                          delete_test_cluster):
@@ -402,7 +467,10 @@ class TestSystemToggle:
             f"{config['broker']['network']} -N 1 -c 1000 --disable-rollback"
         result = env.CLI_RUNNER.invoke(vcd, cmd.split(),
                                        catch_exceptions=False)
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                      f"\nExit Code: [{result.exit_code}]" \
+                                      f"\nOutput Start===" \
+                                      f"\n{result.output}===Output End"
         assert env.vapp_exists(env.TEST_CLUSTER_NAME), \
             "Cluster doesn't exist when it should."
 
@@ -415,9 +483,15 @@ def test_9999_vcd_cse_system_stop(vcd_sys_admin):
     # must disable CSE before attempting to stop
     cmd = 'cse system disable'
     result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     cmd = 'cse system stop'
     result = env.CLI_RUNNER.invoke(vcd, cmd.split(), input='y',
                                    catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [vcd {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"

--- a/system_tests/test_cse_server.py
+++ b/system_tests/test_cse_server.py
@@ -129,25 +129,39 @@ def test_0010_cse_sample():
     Test that `cse sample` command along with every option is an actual
     command. Does not test for validity of sample outputs.
     """
-    result = env.CLI_RUNNER.invoke(cli, ['sample'], catch_exceptions=False)
-    assert result.exit_code == 0
+    cmd = "sample"
+    result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0, f"\nCommand: [cse {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     output_filepath = 'dummy-output.yaml'
     cmd = f'sample --output {output_filepath}'
     result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [cse sample]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     cmd = f'sample --pks-output {output_filepath}'
     result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [cse sample]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     testutils.delete_file(output_filepath)
 
 
 def test_0020_cse_version():
     """Test that `cse version` is a valid command."""
-    result = env.CLI_RUNNER.invoke(cli, ['version'], catch_exceptions=False)
-    assert result.exit_code == 0
+    cmd = "version"
+    result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0, f"\nCommand: [cse {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
 
 def test_0030_cse_check(config):
@@ -158,15 +172,24 @@ def test_0030_cse_check(config):
     """
     cmd = f"check -c {env.ACTIVE_CONFIG_FILEPATH}"
     result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [cse {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     cmd = f"check -c {env.ACTIVE_CONFIG_FILEPATH} -i"
     result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [cse {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     cmd = f"check -c {env.ACTIVE_CONFIG_FILEPATH} -t dummy"
     result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"\nCommand: [cse {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
 
 def test_0040_config_missing_keys(config):
@@ -272,14 +295,14 @@ def test_0080_install_no_capture(config, blank_cust_scripts, unregister_cse):
     """
     template_config = testutils.get_default_template_config(config)
 
-    result = env.CLI_RUNNER.invoke(cli,
-                                   ['install',
-                                    '--config', env.ACTIVE_CONFIG_FILEPATH,
-                                    '--ssh-key', env.SSH_KEY_FILEPATH,
-                                    '--template', template_config['name'],
-                                    '--no-capture'],
-                                   catch_exceptions=False)
-    assert result.exit_code == 0
+    cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
+          f"{env.SSH_KEY_FILEPATH} --template {template_config['name']} " \
+          f"--no-capture"
+    result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0, f"\nCommand: [cse {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     # check that cse was registered correctly
     env.check_cse_registration(config['amqp']['routing_key'],
@@ -319,12 +342,13 @@ def test_0090_install_temp_vapp_already_exists(config, blank_cust_scripts,
 
     testutils.dict_to_yaml_file(config, env.ACTIVE_CONFIG_FILEPATH)
 
-    result = env.CLI_RUNNER.invoke(cli,
-                                   ['install',
-                                    '--config', env.ACTIVE_CONFIG_FILEPATH,
-                                    '--template', template_config['name']],
-                                   catch_exceptions=False)
-    assert result.exit_code == 0
+    cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
+          f"{env.SSH_KEY_FILEPATH} --template {template_config['name']}"
+    result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0, f"\nCommand: [cse {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     # check that cse was registered correctly
     env.check_cse_registration(config['amqp']['routing_key'],
@@ -353,14 +377,13 @@ def test_0100_install_update(config, unregister_cse):
     expected: cse registered, ubuntu/photon ovas exist, temp vapps exist,
         templates exist.
     """
-    result = env.CLI_RUNNER.invoke(cli,
-                                   ['install',
-                                    '--config', env.ACTIVE_CONFIG_FILEPATH,
-                                    '--ssh-key', env.SSH_KEY_FILEPATH,
-                                    '--update',
-                                    '--no-capture'],
-                                   catch_exceptions=False)
-    assert result.exit_code == 0
+    cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
+          f"{env.SSH_KEY_FILEPATH} --update --no-capture"
+    result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0, f"\nCommand: [cse {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     vdc = VDC(env.CLIENT, href=env.VDC_HREF)
 
@@ -422,11 +445,13 @@ def test_0110_install_cleanup_true(config, blank_cust_scripts, unregister_cse):
         template_config['cleanup'] = True
     testutils.dict_to_yaml_file(config, env.ACTIVE_CONFIG_FILEPATH)
 
-    result = env.CLI_RUNNER.invoke(cli,
-                                   ['install',
-                                    '--config', env.ACTIVE_CONFIG_FILEPATH],
-                                   catch_exceptions=False)
-    assert result.exit_code == 0
+    cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} " \
+          f"--ssh-key {env.SSH_KEY_FILEPATH}"
+    result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0, f"\nCommand: [cse {cmd}]" \
+                                  f"\nExit Code: [{result.exit_code}]" \
+                                  f"\nOutput Start===" \
+                                  f"\n{result.output}===Output End"
 
     # check that cse was registered correctly
     env.check_cse_registration(config['amqp']['routing_key'],


### PR DESCRIPTION
When debugging our CICD builds, we ran into many user/environment specific errors that we would have caught earlier had we captured all output from the failed commands.

This fix adds: command, command exit code, and command output to the AssertionError message

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/368)
<!-- Reviewable:end -->
