### PR TITLE
Fix bugs preventing proper Kubernetes app deployment on clusters

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -265,7 +265,8 @@ def validate_broker_config(broker_dict):
         'templates, or if 'ip_allocation_mode' is not 'dhcp' or 'pool'
     """
     check_keys_and_value_types(broker_dict, SAMPLE_BROKER_CONFIG['broker'],
-                               location="config file 'broker' section")
+                               location="config file 'broker' section",
+                               excluded_keys=['remote_template_cookbook_url'])
 
     default_exists = False
     for template in broker_dict['templates']:

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -1029,18 +1029,10 @@ def _customize_vm(ctx, config, vapp, vm_name, cust_script, is_photon=False):
         # TODO() replace raw exception with specific exception
         raise Exception(msg)
 
-    # must reboot VM for some changes made during customization to take effect
-    # vs = get_vsphere(config, vapp, vm_name, logger=LOGGER)
-    # wait_until_tools_ready(vapp, vs, callback=callback)
-    # vapp.reload()
-    # task = vapp.shutdown()
-    # stdout(task, ctx=ctx)
-    # vapp.reload()
-    # task = vapp.power_on()
-    # stdout(task, ctx=ctx)
-    # vapp.reload()
-    # vs = get_vsphere(config, vapp, vm_name, logger=LOGGER)
-    # wait_until_tools_ready(vapp, vs, callback=callback)
+    # Do not reboot VM after customization. Reboot will generate a new
+    # machine-id, and once we capture the VM, all VMs deployed from the
+    # template will have the same machine-id, which can lead to unpredictable
+    # behavior
 
 
 def capture_vapp_to_template(ctx, vapp, catalog_name, catalog_item_name,

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -1004,19 +1004,6 @@ def _customize_vm(ctx, config, vapp, vm_name, cust_script, is_photon=False):
                      exc_info=True)
         raise
 
-    # must reboot VM for some changes made during customization to take effect
-    vs = get_vsphere(config, vapp, vm_name, logger=LOGGER)
-    wait_until_tools_ready(vapp, vs, callback=callback)
-    vapp.reload()
-    task = vapp.shutdown()
-    stdout(task, ctx=ctx)
-    vapp.reload()
-    task = vapp.power_on()
-    stdout(task, ctx=ctx)
-    vapp.reload()
-    vs = get_vsphere(config, vapp, vm_name, logger=LOGGER)
-    wait_until_tools_ready(vapp, vs, callback=callback)
-
     if len(result) > 0:
         msg = f'Result: {result}'
         click.echo(msg)
@@ -1041,6 +1028,19 @@ def _customize_vm(ctx, config, vapp, vm_name, cust_script, is_photon=False):
         LOGGER.error(msg, exc_info=True)
         # TODO() replace raw exception with specific exception
         raise Exception(msg)
+
+    # must reboot VM for some changes made during customization to take effect
+    # vs = get_vsphere(config, vapp, vm_name, logger=LOGGER)
+    # wait_until_tools_ready(vapp, vs, callback=callback)
+    # vapp.reload()
+    # task = vapp.shutdown()
+    # stdout(task, ctx=ctx)
+    # vapp.reload()
+    # task = vapp.power_on()
+    # stdout(task, ctx=ctx)
+    # vapp.reload()
+    # vs = get_vsphere(config, vapp, vm_name, logger=LOGGER)
+    # wait_until_tools_ready(vapp, vs, callback=callback)
 
 
 def capture_vapp_to_template(ctx, vapp, catalog_name, catalog_item_name,

--- a/container_service_extension/cse.py
+++ b/container_service_extension/cse.py
@@ -122,7 +122,7 @@ def version(ctx):
     required=False,
     default=None,
     metavar='OUTPUT_FILE_NAME',
-    help="Filepath to write CSE config file to.")
+    help="Filepath to write CSE config file to")
 @click.option(
     '-p',
     '--pks-output',
@@ -130,7 +130,7 @@ def version(ctx):
     required=False,
     default=None,
     metavar='OUTPUT_FILE_NAME',
-    help="Filepath to write PKS config file to.")
+    help="Filepath to write PKS config file to")
 def sample(ctx, output, pks_output):
     """Display sample CSE config file contents."""
     try:
@@ -154,7 +154,7 @@ def sample(ctx, output, pks_output):
     metavar='CONFIG_FILE_NAME',
     envvar='CSE_CONFIG',
     default='config.yaml',
-    help='Config file to use')
+    help='Filepath of CSE config file')
 @click.option(
     '-i',
     '--check-install',
@@ -215,7 +215,7 @@ def check(ctx, config, check_install, template):
     metavar='CONFIG_FILE_NAME',
     envvar='CSE_CONFIG',
     default='config.yaml',
-    help='Config file to use')
+    help='Filepath of CSE config file')
 @click.option(
     '-t',
     '--template',
@@ -224,7 +224,7 @@ def check(ctx, config, check_install, template):
     default='*',
     metavar='TEMPLATE_NAME',
     help="Create only the specified k8s template. Default value of '*' "
-         "means that all templates in config file will be created.")
+         "means that all templates in config file will be created")
 @click.option(
     '-u',
     '--update',
@@ -247,7 +247,7 @@ def check(ctx, config, check_install, template):
     required=False,
     default=None,
     type=click.File('r'),
-    help='SSH public key to connect to the guest OS on the VM.')
+    help='Filepath of SSH public key to add to vApp template')
 def install(ctx, config, template, update, no_capture, ssh_key_file):
     """Install CSE on vCloud Director."""
     try:
@@ -291,7 +291,7 @@ def install(ctx, config, template, update, no_capture, ssh_key_file):
     metavar='CONFIG_FILE_NAME',
     envvar='CSE_CONFIG',
     default='config.yaml',
-    help='Config file to use')
+    help='Filepath of CSE config file')
 @click.option(
     '-s',
     '--skip-check',

--- a/container_service_extension/processor.py
+++ b/container_service_extension/processor.py
@@ -44,7 +44,7 @@ class ServiceProcessor(object):
     PUT /cse/system
 
     GET /cse/template
-    """ ## noqa
+    """ # noqa
 
     def _parse_request_url(self, method, url):
         """Determine the operation that the REST request represent.

--- a/container_service_extension/sample_generator.py
+++ b/container_service_extension/sample_generator.py
@@ -119,34 +119,28 @@ SAMPLE_TEMPLATE_PHOTON_V2 = {
     'name': 'photon-v2',
     'catalog_item': 'photon-custom-hw11-2.0-304b817-k8s',
     'source_ova_name': 'photon-custom-hw11-2.0-304b817.ova',
-    'source_ova': 'http://dl.bintray.com/vmware/photon/2.0/GA/ova/photon-custo\
-m-hw11-2.0-304b817.ova',
-    'sha256_ova': 'cb51e4b6d899c3588f961e73282709a0d054bb421787e140a1d80c24d4f\
-d89e1',
+    'source_ova': 'http://dl.bintray.com/vmware/photon/2.0/GA/ova/photon-custom-hw11-2.0-304b817.ova', # noqa: E501
+    'sha256_ova': 'cb51e4b6d899c3588f961e73282709a0d054bb421787e140a1d80c24d4fd89e1', # noqa: E501
     'temp_vapp': 'photon2-temp',
     'cleanup': True,
     'cpu': 2,
     'mem': 2048,
     'admin_password': 'guest_os_admin_password',
-    'description': 'PhotonOS v2\nDocker 17.06.0-9\nKubernetes 1.12.7\nweave \
-2.3.0'
+    'description': 'PhotonOS v2\nDocker CE 18.06.2-3\nKubernetes 1.12.7\nweave2.3.0' # noqa: E501
 }
 
 SAMPLE_TEMPLATE_UBUNTU_16_04 = {
     'name': 'ubuntu-16.04',
     'catalog_item': 'ubuntu-16.04-server-cloudimg-amd64-k8s',
     'source_ova_name': 'ubuntu-16.04-server-cloudimg-amd64.ova',
-    'source_ova': 'https://cloud-images.ubuntu.com/releases/xenial/release-201\
-80418/ubuntu-16.04-server-cloudimg-amd64.ova',
-    'sha256_ova': '3c1bec8e2770af5b9b0462e20b7b24633666feedff43c099a6fb1330fcc\
-869a9',
+    'source_ova': 'https://cloud-images.ubuntu.com/releases/xenial/release-20180418/ubuntu-16.04-server-cloudimg-amd64.ova', # noqa: E501
+    'sha256_ova': '3c1bec8e2770af5b9b0462e20b7b24633666feedff43c099a6fb1330fcc869a9', # noqa: E501
     'temp_vapp': 'ubuntu1604-temp',
     'cleanup': True,
     'cpu': 2,
     'mem': 2048,
     'admin_password': 'guest_os_admin_password',
-    'description': 'Ubuntu 16.04\nDocker 18.06.3~ce\nKubernetes 1.13.5\nweave\
- 2.3.0'
+    'description': 'Ubuntu 16.04\nDocker CE 5:18.09.7~3-0~ubuntu-xenial\nKubernetes 1.13.5\nweave 2.3.0' # noqa: E501
 }
 
 SAMPLE_BROKER_CONFIG = {
@@ -158,7 +152,7 @@ SAMPLE_BROKER_CONFIG = {
         'network': 'mynetwork',
         'ip_allocation_mode': 'pool',
         'storage_profile': '*',
-        'remote_template_cookbook_url': 'https://raw.githubusercontent.com/rocknes/container-service-extension/remote_template/template.yaml',  # noqa
+        'remote_template_cookbook_url': 'https://raw.githubusercontent.com/rocknes/container-service-extension/remote_template/template.yaml', # noqa: E501
         'default_template': SAMPLE_TEMPLATE_PHOTON_V2['name'],
         'templates': [SAMPLE_TEMPLATE_PHOTON_V2, SAMPLE_TEMPLATE_UBUNTU_16_04],
         'cse_msg_dir': '/tmp/cse'

--- a/scripts/cust-photon-v2.sh
+++ b/scripts/cust-photon-v2.sh
@@ -40,7 +40,7 @@ while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'
 
 echo 'installing weave'
 export kubever=$(kubectl version --client | base64 | tr -d '\n')
-wget --no-verbose -O weave.yml "https://cloud.weave.works/k8s/net?k8s-version=$kubever"
+wget --no-verbose -O weave.yml "https://cloud.weave.works/k8s/net?k8s-version=$kubever&v=2.3.0"
 curl -L git.io/weave -o /usr/local/bin/weave
 chmod a+x /usr/local/bin/weave
 

--- a/scripts/cust-photon-v2.sh
+++ b/scripts/cust-photon-v2.sh
@@ -49,6 +49,7 @@ tdnf -y install nfs-utils
 systemctl stop nfs-server.service
 systemctl disable nfs-server.service
 
+# /etc/machine-id must be empty so that new machine-id gets assigned on boot (in our case boot is vApp deployment)
 echo -n > /etc/machine-id
 sync
 sync

--- a/scripts/cust-ubuntu-16.04.sh
+++ b/scripts/cust-ubuntu-16.04.sh
@@ -24,7 +24,7 @@ deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get -q update
-apt-get -q install -y docker-ce=18.06.3~ce~3-0~ubuntu
+apt-get -q install -y docker-ce=5:18.09.7~3-0~ubuntu-xenial
 apt-get -q install -y kubelet=1.13.5-00 kubeadm=1.13.5-00 kubectl=1.13.5-00 kubernetes-cni=0.7.5-00 --allow-unauthenticated
 systemctl restart docker
 while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,7 @@
 tox
 flake8
 flake8-import-order
-flake8_docstrings
-hacking
-yapf
+flake8-docstrings
 paramiko
 pytest
+pydocstyle < 4

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ ignore = H101,
          H306,
          D100, D101, D102, D103, D104, D105, D106, D107,
          D207,
-         D301
+         D301,
+         E261
 exclude = container_service_extension/pksclient/*.*, container_service_extension/uaaclient/*.*
 
 [pep8]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ application-import-names =
   container_service_extension.client
 
 # H101: Use TODO(NAME)
-# H238: old style class declaration, use new style (inherit from object)
+# H238: Old style class declaration, use new style (inherit from object)
 ignore = H101,
          H238,
          H306,
@@ -13,6 +13,10 @@ ignore = H101,
          D207,
          D301
 exclude = container_service_extension/pksclient/*.*, container_service_extension/uaaclient/*.*
+
+[pep8]
+# E261: At least two spaces before inline comment
+ignore = E261
 
 [tox]
 envlist=flake8


### PR DESCRIPTION
Removed vApp reboot step after template customization

Once we reboot the VM, the machine gets assigned a machine-id,
and once we capture this VM, all future VMs deployed from
this template will have the same machine-id. This breaks
Kubernetes functionality

Updated customization scripts to properly prepare **machine-id** files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/382)
<!-- Reviewable:end -->
