### PR TITLE
[VCDA-1113] Expose template revision as cli command options

### DIFF
--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -58,7 +58,8 @@ class Cluster:
                        memory=None,
                        storage_profile=None,
                        ssh_key=None,
-                       template=None,
+                       template_name=None,
+                       template_revision=None,
                        enable_nfs=False,
                        rollback=True,
                        org=None):
@@ -78,7 +79,9 @@ class Cluster:
             will back the cluster
         :param ssh_key: (str): The ssh key that clients can use to log into the
             node vms without explicitly providing passwords
-        :param template: (str): The name of the template to use to
+        :param template_name: (str): The name of the template to use to
+            instantiate the nodes
+        :param template_revision: (str): The revision of the template to use to
             instantiate the nodes
         :param enable_nfs: (bool): bool value to indicate if NFS node is to be
             created
@@ -104,7 +107,8 @@ class Cluster:
             RequestKey.NETWORK_NAME: network_name,
             RequestKey.STORAGE_PROFILE_NAME: storage_profile,
             RequestKey.SSH_KEY_FILEPATH: ssh_key,
-            RequestKey.TEMPLATE_NAME: template,
+            RequestKey.TEMPLATE_NAME: template_name,
+            RequestKey.TEMPLATE_REVISION: template_revision,
             RequestKey.ENABLE_NFS: enable_nfs,
             RequestKey.ROLLBACK: rollback,
             RequestKey.ORG_NAME: org
@@ -195,7 +199,8 @@ class Cluster:
                  memory=None,
                  storage_profile=None,
                  ssh_key=None,
-                 template=None,
+                 template_name=None,
+                 template_revision=None,
                  enable_nfs=False,
                  rollback=True):
         """Add nodes to a Kubernetes cluster.
@@ -214,7 +219,9 @@ class Cluster:
             will back the new nodes
         :param ssh_key: (str): The ssh key that clients can use to log into the
             node vms without explicitly providing passwords
-        :param template: (str): The name of the catalog template to use to
+        :param template_name: (str): The name of the catalog template to use to
+            instantiate the nodes
+        :param template_revision: (str): The revision of the template to use to
             instantiate the nodes
         :param enable_nfs: (bool): Flag to enable NFS software on worker nodes
         :param rollback: (bool): Flag to control whether rollback
@@ -234,7 +241,8 @@ class Cluster:
             RequestKey.NETWORK_NAME: network_name,
             RequestKey.STORAGE_PROFILE_NAME: storage_profile,
             RequestKey.SSH_KEY_FILEPATH: ssh_key,
-            RequestKey.TEMPLATE_NAME: template,
+            RequestKey.TEMPLATE_NAME: template_name,
+            RequestKey.TEMPLATE_REVISION: template_revision,
             RequestKey.ENABLE_NFS: enable_nfs,
             RequestKey.ROLLBACK: rollback
         }

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -520,7 +520,7 @@ Examples
         The node will be connected to org VDC network 'mynetwork'.
         The VM will use the default template.
 \b
-    vcd cse node create mycluster --nodes 2 --type nfs --network mynetwork \\
+    vcd cse node create mycluster --nodes 2 --enable-nfs --network mynetwork \\
     --template-name photon-v2 --template-revision 1 --cpu 3 --memory 1024 \\
     --storage-profile mystorageprofile --ssh-key ~/.ssh/id_rsa.pub \\
         Add 2 nfs nodes to vApp named 'mycluster' on vCD.
@@ -649,7 +649,7 @@ def node_info(ctx, cluster_name, node_name, org_name, vdc):
     default=None,
     help='Name of the template to instantiate nodes from')
 @click.option(
-    '--nfs',
+    '--enable-nfs',
     'enable_nfs',
     is_flag=True,
     help='Enable NFS on all created nodes')

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -66,17 +66,8 @@ def list_templates(ctx):
         restore_session(ctx)
         client = ctx.obj['client']
         cluster = Cluster(client)
-        result = []
-        templates = cluster.get_templates()
-        for t in templates:
-            result.append({
-                'name': t['name'],
-                'description': t['description'],
-                'catalog': t['catalog'],
-                'catalog_item': t['catalog_item'],
-                'is_default': t['is_default'],
-            })
-        stdout(result, ctx, show_id=True)
+        result = cluster.get_templates()
+        stdout(result, ctx, sort_headers=False)
     except Exception as e:
         stderr(e, ctx)
 
@@ -108,9 +99,9 @@ Examples
         Kubernetes provider.
 \b
     vcd cse cluster create mycluster --nodes 1 --enable-nfs \\
-    --network mynetwork --template photon-v2 --cpu 3 --memory 1024 \\
-    --storage-profile mystorageprofile --ssh-key ~/.ssh/id_rsa.pub \\
-    --disable-rollback --vdc othervdc
+    --network mynetwork --template-name photon-v2 --template-revision 1 \\
+    --cpu 3 --memory 1024 --storage-profile mystorageprofile \\
+    --ssh-key ~/.ssh/id_rsa.pub --disable-rollback --vdc othervdc
         Create a Kubernetes cluster named 'mycluster' on org VDC 'othervdc'.
         The cluster will have 1 worker node and 1 NFS node.
         The cluster will be connected to org VDC network 'mynetwork'.
@@ -291,18 +282,26 @@ def cluster_delete(ctx, name, vdc, org):
     help='SSH public key filepath (Exclusive to native Kubernetes provider)')
 @click.option(
     '-t',
-    '--template',
-    'template',
+    '--template-name',
+    'template_name',
     required=False,
     default=None,
     help='Name of the template to instantiate nodes from '
-         '(Exclusive to native Kubernetes provider)')
+         '(Exclusive to native Kubernetes provider). Must be provided if '
+         '--template-revision flag is specified')
+@click.option(
+    '-r',
+    '--template-revision',
+    'template_revision',
+    required=False,
+    default=None,
+    help='Revision of the template to instantiate nodes from'
+         '((Exclusive to native Kubernetes provider). Must be provided if '
+         '--template-name flag is specified')
 @click.option(
     '--enable-nfs',
     'enable_nfs',
     is_flag=True,
-    required=False,
-    default=False,
     help='Create 1 additional NFS node (if --nodes=2, then CSE will create '
          '2 worker nodes and 1 NFS node) '
          '(Exclusive to native Kubernetes provider)')
@@ -310,9 +309,7 @@ def cluster_delete(ctx, name, vdc, org):
     '--disable-rollback',
     'disable_rollback',
     is_flag=True,
-    required=False,
-    default=False,
-    help='Disable rollback on failed cluster creation '
+    help='Disable rollback on cluster creation failure '
          '(Exclusive to native Kubernetes provider)')
 @click.option(
     '-o',
@@ -323,14 +320,16 @@ def cluster_delete(ctx, name, vdc, org):
     metavar='ORG_NAME',
     help='Org to use. Defaults to currently logged-in org')
 def cluster_create(ctx, name, vdc, node_count, cpu, memory, network_name,
-                   storage_profile, ssh_key_file, template, enable_nfs,
-                   disable_rollback, org_name):
+                   storage_profile, ssh_key_file, template_name,
+                   template_revision, enable_nfs, disable_rollback, org_name):
     """Create a Kubernetes cluster."""
     try:
-        restore_session(ctx)
-        client = ctx.obj['client']
-        cluster = Cluster(client)
+        if (template_name and not template_revision) or \
+                (not template_name and template_revision):
+            raise Exception("Both flags --template-name(-t) and "
+                            "--template-revision (-r) must be specified.")
 
+        restore_session(ctx)
         if vdc is None:
             vdc = ctx.obj['profiles'].get('vdc_in_use')
             if not vdc:
@@ -343,6 +342,8 @@ def cluster_create(ctx, name, vdc, node_count, cpu, memory, network_name,
         if ssh_key_file is not None:
             ssh_key = ssh_key_file.read()
 
+        client = ctx.obj['client']
+        cluster = Cluster(client)
         result = cluster.create_cluster(
             vdc,
             network_name,
@@ -352,7 +353,8 @@ def cluster_create(ctx, name, vdc, node_count, cpu, memory, network_name,
             memory=memory,
             storage_profile=storage_profile,
             ssh_key=ssh_key,
-            template=template,
+            template_name=template_name,
+            template_revision=template_revision,
             enable_nfs=enable_nfs,
             rollback=not disable_rollback,
             org=org_name)
@@ -401,9 +403,7 @@ def cluster_create(ctx, name, vdc, node_count, cpu, memory, network_name,
     '--disable-rollback',
     'disable_rollback',
     is_flag=True,
-    required=False,
-    default=False,
-    help='Disable rollback on failed node creation '
+    help='Disable rollback on node creation failure '
          '(Exclusive to native Kubernetes provider)')
 def cluster_resize(ctx, cluster_name, node_count, network_name, org_name,
                    vdc_name, disable_rollback):
@@ -521,7 +521,7 @@ Examples
         The VM will use the default template.
 \b
     vcd cse node create mycluster --nodes 2 --type nfs --network mynetwork \\
-    --template photon-v2 --cpu 3 --memory 1024 \\
+    --template-name photon-v2 --template-revision 1 --cpu 3 --memory 1024 \\
     --storage-profile mystorageprofile --ssh-key ~/.ssh/id_rsa.pub \\
         Add 2 nfs nodes to vApp named 'mycluster' on vCD.
         The nodes will be connected to org VDC network 'mynetwork'.
@@ -636,8 +636,15 @@ def node_info(ctx, cluster_name, node_name, org_name, vdc):
     help='SSH public key to connect to the guest OS on the VM')
 @click.option(
     '-t',
-    '--template',
-    'template',
+    '--template-name',
+    'template_name',
+    required=False,
+    default=None,
+    help='Name of the template to instantiate nodes from')
+@click.option(
+    '-r',
+    '--template-revision',
+    'template_revision',
     required=False,
     default=None,
     help='Name of the template to instantiate nodes from')
@@ -645,16 +652,12 @@ def node_info(ctx, cluster_name, node_name, org_name, vdc):
     '--nfs',
     'enable_nfs',
     is_flag=True,
-    required=False,
-    default=False,
     help='Enable NFS on all created nodes')
 @click.option(
     '--disable-rollback',
     'disable_rollback',
     is_flag=True,
-    required=False,
-    default=False,
-    help='Disable rollback for node')
+    help='Disable rollback on node deployment failure')
 @click.option(
     '-v',
     '--vdc',
@@ -672,10 +675,15 @@ def node_info(ctx, cluster_name, node_name, org_name, vdc):
     metavar='ORG_NAME',
     help='Restrict cluster search to specified org')
 def create_node(ctx, cluster_name, node_count, org, vdc, cpu, memory,
-                network_name, storage_profile, ssh_key_file, template,
-                enable_nfs, disable_rollback):
+                network_name, storage_profile, ssh_key_file, template_name,
+                template_revision, enable_nfs, disable_rollback):
     """Add node(s) to a cluster that uses native Kubernetes provider."""
     try:
+        if (template_name and not template_revision) or \
+                (not template_name and template_revision):
+            raise Exception("Both flags --template-name(-t) and "
+                            "--template-revision (-r) must be specified.")
+
         restore_session(ctx)
         client = ctx.obj['client']
         if org is None and not client.is_sysadmin():
@@ -694,7 +702,8 @@ def create_node(ctx, cluster_name, node_count, org, vdc, cpu, memory,
             memory=memory,
             storage_profile=storage_profile,
             ssh_key=ssh_key,
-            template=template,
+            template_name=template_name,
+            template_revision=template_revision,
             enable_nfs=enable_nfs,
             rollback=not disable_rollback)
         stdout(result, ctx)
@@ -916,9 +925,7 @@ Examples
     '-p',
     '--pks-plans',
     'list_pks_plans',
-    required=False,
     is_flag=True,
-    default=False,
     help="Display available PKS plans if org VDC is backed by "
          "Enterprise PKS infrastructure")
 @click.pass_context

--- a/container_service_extension/cluster.py
+++ b/container_service_extension/cluster.py
@@ -99,7 +99,10 @@ def load_from_metadata(client, name=None, cluster_id=None,
                 elif entry.Key == ClusterMetadataKey.MASTER_IP:
                     cluster['leader_endpoint'] = str(entry.TypedValue.Value)
                 elif entry.Key == ClusterMetadataKey.BACKWARD_COMPATIBILE_TEMPLATE_NAME: # noqa: E501
-                    cluster['template_name'] = str(entry.TypedValue.Value)
+                    # Don't overwrite the value if already populated from the
+                    # value corresponding to ClusterMetadataKey.TEMPLATE_NAME
+                    if not cluster['template_name']:
+                        cluster['template_name'] = str(entry.TypedValue.Value)
                 elif entry.Key == ClusterMetadataKey.TEMPLATE_NAME:
                     cluster['template_name'] = str(entry.TypedValue.Value)
                 elif entry.Key == ClusterMetadataKey.TEMPLATE_REVISION:

--- a/container_service_extension/cluster.py
+++ b/container_service_extension/cluster.py
@@ -24,26 +24,12 @@ from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.pyvcloud_utils import get_sys_admin_client
 from container_service_extension.remote_template_manager import \
     get_local_script_filepath
+from container_service_extension.server_constants import ClusterMetadataKey
 from container_service_extension.server_constants import NodeType
 from container_service_extension.server_constants import ScriptFile
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
-from container_service_extension.shared_constants import RequestKey
 from container_service_extension.utils import read_data_file
 from container_service_extension.vsphere_utils import get_vsphere
-
-
-def wait_until_tools_ready(vm):
-    while True:
-        try:
-            status = vm.guest.toolsRunningStatus
-            if 'guestToolsRunning' == status:
-                LOGGER.debug(f"vm tools {vm} are ready")
-                return
-            LOGGER.debug(f"waiting for vm tools {vm} to be ready ({status})")
-            time.sleep(1)
-        except Exception:
-            LOGGER.debug(f"waiting for vm tools {vm} to be ready ({status})* ")
-            time.sleep(1)
 
 
 def load_from_metadata(client, name=None, cluster_id=None,
@@ -73,8 +59,12 @@ def load_from_metadata(client, name=None, cluster_id=None,
         resource_type,
         query_result_format=QueryResultFormat.ID_RECORDS,
         qfilter=query_filter,
-        fields='metadata:cse.cluster.id,metadata:cse.master.ip,'
-               'metadata:cse.version,metadata:cse.template')
+        fields='metadata:' + ClusterMetadataKey.CLUSTER_ID + ',metadata:' + # noqa: W504,E501
+               ClusterMetadataKey.MASTER_IP + ',metadata:' + # noqa: W504
+               ClusterMetadataKey.CSE_VERSION + ',metadata:' + # noqa: W504
+               ClusterMetadataKey.TEMPLATE_NAME + ',metadata:' + # noqa: W504
+               ClusterMetadataKey.TEMPLATE_REVISION + ',metadata:' + # noqa: W504,E501
+               ClusterMetadataKey.BACKWARD_COMPATIBILE_TEMPLATE_NAME)
     records = list(q.execute())
 
     clusters = []
@@ -94,38 +84,53 @@ def load_from_metadata(client, name=None, cluster_id=None,
             'nodes': [],
             'nfs_nodes': [],
             'number_of_vms': record.get('numberOfVMs'),
-            'template': '',
+            'template_name': '',
+            'template_revision': '',
             'cse_version': '',
             'cluster_id': '',
             'status': record.get('status')
         }
         if hasattr(record, 'Metadata'):
             for entry in record.Metadata.MetadataEntry:
-                if entry.Key == 'cse.cluster.id':
+                if entry.Key == ClusterMetadataKey.CLUSTER_ID:
                     cluster['cluster_id'] = str(entry.TypedValue.Value)
-                elif entry.Key == 'cse.version':
+                elif entry.Key == ClusterMetadataKey.CSE_VERSION:
                     cluster['cse_version'] = str(entry.TypedValue.Value)
-                elif entry.Key == 'cse.master.ip':
+                elif entry.Key == ClusterMetadataKey.MASTER_IP:
                     cluster['leader_endpoint'] = str(entry.TypedValue.Value)
-                elif entry.Key == 'cse.template':
-                    cluster['template'] = str(entry.TypedValue.Value)
+                elif entry.Key == ClusterMetadataKey.BACKWARD_COMPATIBILE_TEMPLATE_NAME: # noqa: E501
+                    cluster['template_name'] = str(entry.TypedValue.Value)
+                elif entry.Key == ClusterMetadataKey.TEMPLATE_NAME:
+                    cluster['template_name'] = str(entry.TypedValue.Value)
+                elif entry.Key == ClusterMetadataKey.TEMPLATE_REVISION:
+                    cluster['template_revision'] = str(entry.TypedValue.Value)
 
         clusters.append(cluster)
 
     return clusters
 
 
-def add_nodes(qty, template, node_type, config, client, org, vdc, vapp,
-              req_spec):
+def add_nodes(client,
+              num_nodes,
+              node_type,
+              org,
+              vdc,
+              vapp,
+              catalog_name,
+              template,
+              network_name,
+              num_cpu=None,
+              memory_in_mb=None,
+              storage_profile=None,
+              ssh_key_filepath=None):
     try:
-        if qty < 1:
+        if num_nodes < 1:
             return None
         specs = []
-        catalog_item = org.get_catalog_item(config['broker']['catalog'],
+        catalog_item = org.get_catalog_item(catalog_name,
                                             template['catalog_item_name'])
         source_vapp = VApp(client, href=catalog_item.Entity.get('href'))
         source_vm = source_vapp.get_all_vms()[0].get('name')
-        storage_profile = req_spec.get(RequestKey.STORAGE_PROFILE_NAME)
         if storage_profile is not None:
             storage_profile = vdc.get_storage_profile(storage_profile)
 
@@ -143,7 +148,6 @@ then
 fi
 """  # noqa: E128
 
-        ssh_key_filepath = req_spec.get(RequestKey.SSH_KEY_FILEPATH)
         if ssh_key_filepath is not None:
             cust_script_common += \
 f"""
@@ -157,7 +161,8 @@ chmod -R go-rwx /root/.ssh
         else:
             cust_script = cust_script_init + cust_script_common + \
                 cust_script_end
-        for n in range(qty):
+
+        for n in range(num_nodes):
             name = None
             while True:
                 name = f"{node_type}-{''.join(random.choices(string.ascii_lowercase + string.digits, k=4))}" # noqa: E501
@@ -171,7 +176,7 @@ chmod -R go-rwx /root/.ssh
                 'target_vm_name': name,
                 'hostname': name,
                 'password_auto': True,
-                'network': req_spec.get(RequestKey.NETWORK_NAME),
+                'network': network_name,
                 'ip_allocation_mode': 'pool'
             }
             if cust_script is not None:
@@ -180,11 +185,10 @@ chmod -R go-rwx /root/.ssh
                 spec['storage_profile'] = storage_profile
             specs.append(spec)
 
-        num_cpu = req_spec.get(RequestKey.NUM_CPU)
-        mb_memory = req_spec.get(RequestKey.MB_MEMORY)
-        configure_hw = bool(num_cpu or mb_memory)
+        configure_hw = bool(num_cpu or memory_in_mb)
         task = vapp.add_vms(specs, power_on=not configure_hw)
-        # TODO(get details of the exception like not enough resources avail)
+        # TODO: get details of the exception like not enough resources
+        # available.
         client.get_task_monitor().wait_for_status(task)
         vapp.reload()
         if configure_hw:
@@ -194,9 +198,9 @@ chmod -R go-rwx /root/.ssh
                     vm = VM(client, resource=vm_resource)
                     task = vm.modify_cpu(num_cpu)
                     client.get_task_monitor().wait_for_status(task)
-                if mb_memory:
+                if memory_in_mb:
                     vm = VM(client, resource=vm_resource)
-                    task = vm.modify_memory(mb_memory)
+                    task = vm.modify_memory(memory_in_mb)
                     client.get_task_monitor().wait_for_status(task)
                 vm = VM(client, resource=vm_resource)
                 task = vm.power_on()
@@ -210,7 +214,6 @@ chmod -R go-rwx /root/.ssh
                 f"/bin/echo \"root:{template['admin_password']}\" | chpasswd"
             nodes = [vm_resource]
             execute_script_in_nodes(
-                config,
                 vapp,
                 password,
                 command,
@@ -224,10 +227,8 @@ chmod -R go-rwx /root/.ssh
                     template['name'], template['revision'], ScriptFile.NFSD)
                 script = read_data_file(script_filepath, logger=LOGGER)
                 exec_results = execute_script_in_nodes(
-                    config, vapp,
-                    template['admin_password'],
-                    script, nodes)
-                errors = get_script_execution_errors(exec_results)
+                    vapp, template['admin_password'], script, nodes)
+                errors = _get_script_execution_errors(exec_results)
                 if errors:
                     raise ScriptExecutionError(
                         f"Script execution failed on node "
@@ -238,7 +239,7 @@ chmod -R go-rwx /root/.ssh
     return {'task': task, 'specs': specs}
 
 
-def get_nodes(vapp, node_type):
+def _get_nodes(vapp, node_type):
     nodes = []
     for node in vapp.get_all_vms():
         if node.get('name').startswith(node_type):
@@ -246,39 +247,38 @@ def get_nodes(vapp, node_type):
     return nodes
 
 
-def wait_for_tools_ready_callback(message, exception=None):
+def _wait_for_tools_ready_callback(message, exception=None):
     LOGGER.debug(f"waiting for guest tools, status: {message}")
     if exception is not None:
         LOGGER.error(f"exception: {str(exception)}")
 
 
-def wait_for_guest_execution_callback(message, exception=None):
+def _wait_for_guest_execution_callback(message, exception=None):
     LOGGER.debug(message)
     if exception is not None:
         LOGGER.error(f"exception: {str(exception)}")
 
 
-def get_init_info(config, vapp, password):
+def _get_init_info(vapp, password):
     script = \
 """#!/usr/bin/env bash
 kubeadm token create
 ip route get 1 | awk '{print $NF;exit}'
 """ # NOQA
-    nodes = get_nodes(vapp, NodeType.MASTER)
+    nodes = _get_nodes(vapp, NodeType.MASTER)
     result = execute_script_in_nodes(
-        config, vapp, password, script, nodes, check_tools=False)
+        vapp, password, script, nodes, check_tools=False)
     return result[0][1].content.decode().split()
 
 
-def get_master_ip(config, vapp, template):
+def get_master_ip(vapp, template):
     LOGGER.debug(f"getting master IP for vapp: {vapp.resource.get('name')}")
     script = \
 """#!/usr/bin/env bash
 ip route get 1 | awk '{print $NF;exit}'
 """ # NOQA
-    nodes = get_nodes(vapp, NodeType.MASTER)
+    nodes = _get_nodes(vapp, NodeType.MASTER)
     result = execute_script_in_nodes(
-        config,
         vapp,
         template['admin_password'],
         script,
@@ -290,42 +290,42 @@ ip route get 1 | awk '{print $NF;exit}'
     return master_ip
 
 
-def get_cluster_config(config, vapp, password):
+def fetch_cluster_config(vapp, password):
     file_name = '/root/.kube/config'
-    nodes = get_nodes(vapp, NodeType.MASTER)
-    result = get_file_from_nodes(
-        config, vapp, password, file_name, nodes, check_tools=False)
+    nodes = _get_nodes(vapp, NodeType.MASTER)
+    result = _get_file_from_nodes(
+        vapp, password, file_name, nodes, check_tools=False)
     if len(result) == 0 or result[0].status_code != requests.codes.ok:
         raise ClusterOperationError('Couldn\'t get cluster configuration')
     return result[0].content.decode()
 
 
-def init_cluster(config, vapp, template):
+def init_cluster(vapp, template):
     script_filepath = get_local_script_filepath(
         template['name'], template['revision'], ScriptFile.MASTER)
     script = read_data_file(script_filepath, logger=LOGGER)
-    nodes = get_nodes(vapp, NodeType.MASTER)
-    result = execute_script_in_nodes(config, vapp, template['admin_password'],
+    nodes = _get_nodes(vapp, NodeType.MASTER)
+    result = execute_script_in_nodes(vapp, template['admin_password'],
                                      script, nodes)
     if result[0][0] != 0:
         raise ClusterInitializationError(
             f"Couldn\'t initialize cluster:\n{result[0][2].content.decode()}")
 
 
-def join_cluster(config, vapp, template, target_nodes=None):
-    init_info = get_init_info(config, vapp, template['admin_password'])
+def join_cluster(vapp, template, target_nodes=None):
+    init_info = _get_init_info(vapp, template['admin_password'])
     tmp_script_filepath = get_local_script_filepath(
         template['name'], template['revision'], ScriptFile.NODE)
     tmp_script = read_data_file(tmp_script_filepath, logger=LOGGER)
     script = tmp_script.format(token=init_info[0], ip=init_info[1])
     if target_nodes is None:
-        nodes = get_nodes(vapp, NodeType.WORKER)
+        nodes = _get_nodes(vapp, NodeType.WORKER)
     else:
         nodes = []
         for node in vapp.get_all_vms():
             if node.get('name') in target_nodes:
                 nodes.append(node)
-    results = execute_script_in_nodes(config, vapp, template['admin_password'],
+    results = execute_script_in_nodes(vapp, template['admin_password'],
                                       script, nodes)
     for result in results:
         if result[0] != 0:
@@ -333,7 +333,7 @@ def join_cluster(config, vapp, template, target_nodes=None):
                 'Couldn\'t join cluster:\n%s' % result[2].content.decode())
 
 
-def wait_until_ready_to_exec(vs, vm, password, tries=30):
+def _wait_until_ready_to_exec(vs, vm, password, tries=30):
     ready = False
     script = \
 """#!/usr/bin/env bash
@@ -351,7 +351,7 @@ uname -a
                 wait_time=5,
                 get_output=True,
                 delete_script=True,
-                callback=wait_for_guest_execution_callback)
+                callback=_wait_for_guest_execution_callback)
             if result[0] == 0:
                 ready = True
                 break
@@ -363,8 +363,7 @@ uname -a
         raise CseServerError('VM is not ready to execute scripts')
 
 
-def execute_script_in_nodes(config,
-                            vapp,
+def execute_script_in_nodes(vapp,
                             password,
                             script,
                             nodes,
@@ -391,8 +390,8 @@ def execute_script_in_nodes(config,
             if check_tools:
                 LOGGER.debug(f"waiting for tools on {node.get('name')}")
                 vs.wait_until_tools_ready(
-                    vm, sleep=5, callback=wait_for_tools_ready_callback)
-                wait_until_ready_to_exec(vs, vm, password)
+                    vm, sleep=5, callback=_wait_for_tools_ready_callback)
+                _wait_until_ready_to_exec(vs, vm, password)
             LOGGER.debug(f"about to execute script on {node.get('name')} "
                          f"(vm={vm}), wait={wait}")
             if wait:
@@ -406,7 +405,7 @@ def execute_script_in_nodes(config,
                     wait_time=10,
                     get_output=True,
                     delete_script=True,
-                    callback=wait_for_guest_execution_callback)
+                    callback=_wait_for_guest_execution_callback)
                 result_stdout = result[1].content.decode()
                 result_stderr = result[2].content.decode()
             else:
@@ -432,12 +431,7 @@ def execute_script_in_nodes(config,
     return all_results
 
 
-def get_file_from_nodes(config,
-                        vapp,
-                        password,
-                        file_name,
-                        nodes,
-                        check_tools=True):
+def _get_file_from_nodes(vapp, password, file_name, nodes, check_tools=True):
     all_results = []
     sys_admin_client = None
     try:
@@ -451,8 +445,8 @@ def get_file_from_nodes(config,
             vm = vs.get_vm_by_moid(moid)
             if check_tools:
                 vs.wait_until_tools_ready(
-                    vm, sleep=5, callback=wait_for_tools_ready_callback)
-                wait_until_ready_to_exec(vs, vm, password)
+                    vm, sleep=5, callback=_wait_for_tools_ready_callback)
+                _wait_until_ready_to_exec(vs, vm, password)
             result = vs.download_file_from_guest(vm, 'root', password,
                                                  file_name)
             all_results.append(result)
@@ -462,15 +456,15 @@ def get_file_from_nodes(config,
     return all_results
 
 
-def delete_nodes_from_cluster(config, vapp, template, nodes, force=False):
+def delete_nodes_from_cluster(vapp, template, nodes, force=False):
     script = '#!/usr/bin/env bash\nkubectl delete node '
     for node in nodes:
         script += ' %s' % node
     script += '\n'
     password = template['admin_password']
-    master_nodes = get_nodes(vapp, NodeType.MASTER)
+    master_nodes = _get_nodes(vapp, NodeType.MASTER)
     result = execute_script_in_nodes(
-        config, vapp, password, script, master_nodes, check_tools=False)
+        vapp, password, script, master_nodes, check_tools=False)
     if result[0][0] != 0:
         if not force:
             raise DeleteNodeError(
@@ -478,7 +472,7 @@ def delete_nodes_from_cluster(config, vapp, template, nodes, force=False):
                 f"{result[0][2].content.decode()}")
 
 
-def get_script_execution_errors(results):
+def _get_script_execution_errors(results):
     errors = []
     for result in results:
         if result[0] != 0:

--- a/container_service_extension/config_validator.py
+++ b/container_service_extension/config_validator.py
@@ -14,8 +14,6 @@ from vsphere_guest_run.vsphere import VSphere
 import yaml
 
 from container_service_extension.exceptions import AmqpConnectionError
-from container_service_extension.logger import SERVER_DEBUG_WIRELOG_FILEPATH
-from container_service_extension.logger import setup_log_file_directory
 from container_service_extension.nsxt.dfw_manager import DFWManager
 from container_service_extension.nsxt.ipset_manager import IPSetManager
 from container_service_extension.nsxt.nsxt_client import NSXTClient
@@ -189,18 +187,9 @@ def _validate_vcd_and_vcs_config(vcd_dict, vcs, msg_update_callback=None):
 
     client = None
     try:
-        # TODO() we get an error during client initialization if the specified
-        # logfile points to the directory which doesn't exist. This issue
-        # should be fixed in pyvcloud, where the logging setup creates
-        # directories used in the log filepath if they do not exist yet.
-        setup_log_file_directory()
         client = Client(vcd_dict['host'],
                         api_version=vcd_dict['api_version'],
-                        verify_ssl_certs=vcd_dict['verify'],
-                        log_file=SERVER_DEBUG_WIRELOG_FILEPATH,
-                        log_requests=True,
-                        log_headers=True,
-                        log_bodies=True)
+                        verify_ssl_certs=vcd_dict['verify'])
         client.set_credentials(BasicLoginCredentials(vcd_dict['username'],
                                                      SYSTEM_ORG_NAME,
                                                      vcd_dict['password']))

--- a/container_service_extension/config_validator.py
+++ b/container_service_extension/config_validator.py
@@ -91,6 +91,7 @@ def get_validated_config(config_file_name, msg_update_callback=None):
     check_keys_and_value_types(config['service'],
                                SAMPLE_SERVICE_CONFIG['service'],
                                location="config file 'service' section",
+                               excluded_keys=['log_wire'],
                                msg_update_callback=msg_update_callback)
     if msg_update_callback:
         msg_update_callback.general(
@@ -248,7 +249,6 @@ def _validate_broker_config(broker_dict, msg_update_callback=None):
     """
     check_keys_and_value_types(broker_dict, SAMPLE_BROKER_CONFIG['broker'],
                                location="config file 'broker' section",
-                               excluded_keys=['remote_template_cookbook_url'],
                                msg_update_callback=msg_update_callback)
 
     valid_ip_allocation_modes = [

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -37,6 +37,7 @@ from container_service_extension.server_constants import \
     RemoteTemplateKey, SYSTEM_ORG_NAME # noqa: H301
 from container_service_extension.template_builder import TemplateBuilder
 from container_service_extension.utils import ConsoleMessagePrinter
+from container_service_extension.utils import str_to_bool
 from container_service_extension.vsphere_utils import populate_vsphere_list
 
 
@@ -62,13 +63,18 @@ def check_cse_installation(config, msg_update_callback=None):
     err_msgs = []
     client = None
     try:
+        log_filename = None
+        log_wire = str_to_bool(config['service'].get('log_wire'))
+        if log_wire:
+            log_filename = SERVER_DEBUG_WIRELOG_FILEPATH
+
         client = Client(config['vcd']['host'],
                         api_version=config['vcd']['api_version'],
                         verify_ssl_certs=config['vcd']['verify'],
-                        log_file=SERVER_DEBUG_WIRELOG_FILEPATH,
-                        log_requests=True,
-                        log_headers=True,
-                        log_bodies=True)
+                        log_file=log_filename,
+                        log_requests=log_wire,
+                        log_headers=log_wire,
+                        log_bodies=log_wire)
         credentials = BasicLoginCredentials(config['vcd']['username'],
                                             SYSTEM_ORG_NAME,
                                             config['vcd']['password'])
@@ -199,13 +205,18 @@ def install_cse(ctx, config_file_name='config.yaml',
 
     client = None
     try:
+        log_filename = None
+        log_wire = str_to_bool(config['service'].get('log_wire'))
+        if log_wire:
+            log_filename = INSTALL_WIRELOG_FILEPATH
+
         client = Client(config['vcd']['host'],
                         api_version=config['vcd']['api_version'],
                         verify_ssl_certs=config['vcd']['verify'],
-                        log_file=INSTALL_WIRELOG_FILEPATH,
-                        log_requests=True,
-                        log_headers=True,
-                        log_bodies=True)
+                        log_file=log_filename,
+                        log_requests=log_wire,
+                        log_headers=log_wire,
+                        log_bodies=log_wire)
         credentials = BasicLoginCredentials(config['vcd']['username'],
                                             SYSTEM_ORG_NAME,
                                             config['vcd']['password'])

--- a/container_service_extension/pyvcloud_utils.py
+++ b/container_service_extension/pyvcloud_utils.py
@@ -24,6 +24,7 @@ from container_service_extension.logger import SERVER_DEBUG_WIRELOG_FILEPATH
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
 from container_service_extension.utils import get_server_runtime_config
+from container_service_extension.utils import str_to_bool
 
 # Cache to keep ovdc_id to org_name mapping for vcd cse cluster list
 OVDC_TO_ORG_MAP = {}
@@ -36,14 +37,18 @@ def connect_vcd_user_via_token(tenant_auth_token):
     vcd_uri = server_config['vcd']['host']
     version = server_config['vcd']['api_version']
     verify_ssl_certs = server_config['vcd']['verify']
+    log_filename = None
+    log_wire = str_to_bool(server_config['service'].get('log_wire'))
+    if log_wire:
+        log_filename = SERVER_DEBUG_WIRELOG_FILEPATH
     client_tenant = Client(
         uri=vcd_uri,
         api_version=version,
         verify_ssl_certs=verify_ssl_certs,
-        log_file=SERVER_DEBUG_WIRELOG_FILEPATH,
-        log_requests=True,
-        log_headers=True,
-        log_bodies=True)
+        log_file=log_filename,
+        log_requests=log_wire,
+        log_headers=log_wire,
+        log_bodies=log_wire)
     session = client_tenant.rehydrate_from_token(tenant_auth_token)
     return (client_tenant, session)
 
@@ -55,14 +60,18 @@ def get_sys_admin_client():
                        "request is being made. Adding certificate "
                        "verification is strongly advised.")
         requests.packages.urllib3.disable_warnings()
+    log_filename = None
+    log_wire = str_to_bool(server_config['service'].get('log_wire'))
+    if log_wire:
+        log_filename = SERVER_DEBUG_WIRELOG_FILEPATH
     client = Client(
         uri=server_config['vcd']['host'],
         api_version=server_config['vcd']['api_version'],
         verify_ssl_certs=server_config['vcd']['verify'],
-        log_file=SERVER_DEBUG_WIRELOG_FILEPATH,
-        log_requests=True,
-        log_headers=True,
-        log_bodies=True)
+        log_file=log_filename,
+        log_requests=log_wire,
+        log_headers=log_wire,
+        log_bodies=log_wire)
     credentials = BasicLoginCredentials(server_config['vcd']['username'],
                                         SYSTEM_ORG_NAME,
                                         server_config['vcd']['password'])

--- a/container_service_extension/request_handlers/cluster_handler.py
+++ b/container_service_extension/request_handlers/cluster_handler.py
@@ -9,8 +9,8 @@ def cluster_create(request_dict, tenant_auth_token):
 
     Required data: org_name, ovdc_name, cluster_name, num_nodes.
     Conditional data: if k8s_provider is 'native', num_cpu, mb_memory,
-        network_name, storage_profile_name, template_name, enable_nfs,
-        rollback are required (validation handled elsewhere).
+        network_name, storage_profile_name, template_name, template_revision,
+        enable_nfs, rollback are required (validation handled elsewhere).
 
     :return: Dict
     """
@@ -56,7 +56,6 @@ def cluster_delete(request_dict, tenant_auth_token):
     :return: Dict
     """
     required = [
-        RequestKey.ORG_NAME,
         RequestKey.CLUSTER_NAME,
     ]
     utils.ensure_keys_in_dict(required, request_dict, dict_name="request")
@@ -74,7 +73,6 @@ def cluster_info(request_dict, tenant_auth_token):
     :return: Dict
     """
     required = [
-        RequestKey.ORG_NAME,
         RequestKey.CLUSTER_NAME,
     ]
     utils.ensure_keys_in_dict(required, request_dict, dict_name="request")
@@ -92,7 +90,6 @@ def cluster_config(request_dict, tenant_auth_token):
     :return: Dict
     """
     required = [
-        RequestKey.ORG_NAME,
         RequestKey.CLUSTER_NAME,
     ]
     utils.ensure_keys_in_dict(required, request_dict, dict_name="request")
@@ -115,7 +112,7 @@ def node_create(request_dict, tenant_auth_token):
 
     Required data: org name, ovdc name, cluster name, num nodes, num cpu,
         mb memory, network name, storage profile name, template name,
-        rollback, enable nfs.
+        template_revision, rollback, enable nfs.
 
     :return: Dict
     """
@@ -128,6 +125,7 @@ def node_create(request_dict, tenant_auth_token):
         RequestKey.NETWORK_NAME,
         RequestKey.STORAGE_PROFILE_NAME,
         RequestKey.TEMPLATE_NAME,
+        RequestKey.TEMPLATE_REVISION,
         RequestKey.ROLLBACK,
         RequestKey.ENABLE_NFS,
     ]

--- a/container_service_extension/request_handlers/cluster_handler.py
+++ b/container_service_extension/request_handlers/cluster_handler.py
@@ -37,7 +37,6 @@ def cluster_resize(request_dict, tenant_auth_token):
     :return: Dict
     """
     required = [
-        RequestKey.ORG_NAME,
         RequestKey.CLUSTER_NAME,
         RequestKey.NUM_WORKERS
     ]
@@ -146,7 +145,6 @@ def node_delete(request_dict, tenant_auth_token):
     :return: Dict
     """
     required = [
-        RequestKey.ORG_NAME,
         RequestKey.CLUSTER_NAME,
         RequestKey.NODE_NAMES_LIST
     ]
@@ -167,7 +165,6 @@ def node_info(request_dict, tenant_auth_token):
     :return: Dict
     """
     required = [
-        RequestKey.ORG_NAME,
         RequestKey.CLUSTER_NAME,
         RequestKey.NODE_NAME
     ]

--- a/container_service_extension/request_handlers/template_handler.py
+++ b/container_service_extension/request_handlers/template_handler.py
@@ -12,9 +12,10 @@ def template_list(request_dict, tenant_auth_token):
     for t in config['broker']['templates']:
         templates.append({
             'name': t[LocalTemplateKey.NAME],
-            'is_default': t[LocalTemplateKey.NAME] == config['broker']['default_template_name'] and t[LocalTemplateKey.REVISION] == config['broker']['default_template_revision'], # noqa: E501
+            'revision': t[LocalTemplateKey.REVISION],
+            'is_default': t[LocalTemplateKey.NAME] == config['broker']['default_template_name'] and str(t[LocalTemplateKey.REVISION]) == str(config['broker']['default_template_revision']), # noqa: E501
             'catalog': config['broker']['catalog'],
             'catalog_item': t[LocalTemplateKey.CATALOG_ITEM_NAME],
-            'description': t[LocalTemplateKey.DESCRIPTION]
+            'description': t[LocalTemplateKey.DESCRIPTION].replace("\\n", ", ")
         })
     return templates

--- a/container_service_extension/sample_generator.py
+++ b/container_service_extension/sample_generator.py
@@ -111,7 +111,8 @@ SAMPLE_VCS_CONFIG = {
 SAMPLE_SERVICE_CONFIG = {
     'service': {
         'listeners': 5,
-        'enforce_authorization': False
+        'enforce_authorization': False,
+        'log_wire': False
     }
 }
 

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -133,3 +133,13 @@ class CseOperation(Enum):
     SYSTEM_INFO = ('get info of system')
     SYSTEM_UPDATE = ('update system status')
     TEMPLATE_LIST = ('list all templates')
+
+
+@unique
+class ClusterMetadataKey(str, Enum):
+    BACKWARD_COMPATIBILE_TEMPLATE_NAME = 'cse.template'
+    CLUSTER_ID = 'cse.cluster.id'
+    CSE_VERSION = 'cse.version'
+    MASTER_IP = 'cse.master.ip'
+    TEMPLATE_NAME = 'cse.template.name'
+    TEMPLATE_REVISION = 'cse.template.revision'

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -35,6 +35,7 @@ from container_service_extension.pyvcloud_utils import \
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
 from container_service_extension.shared_constants import RequestKey
 from container_service_extension.shared_constants import ServerAction
+from container_service_extension.utils import str_to_bool
 from container_service_extension.vsphere_utils import populate_vsphere_list
 
 
@@ -195,13 +196,18 @@ class Service(object, metaclass=Singleton):
         # to server config
         client = None
         try:
+            log_filename = None
+            log_wire = str_to_bool(self.config['service'].get('log_wire'))
+            if log_wire:
+                log_filename = SERVER_DEBUG_WIRELOG_FILEPATH
+
             client = Client(self.config['vcd']['host'],
                             api_version=self.config['vcd']['api_version'],
                             verify_ssl_certs=self.config['vcd']['verify'],
-                            log_file=SERVER_DEBUG_WIRELOG_FILEPATH,
-                            log_requests=True,
-                            log_headers=True,
-                            log_bodies=True)
+                            log_file=log_filename,
+                            log_requests=log_wire,
+                            log_headers=log_wire,
+                            log_bodies=log_wire)
             credentials = BasicLoginCredentials(self.config['vcd']['username'],
                                                 SYSTEM_ORG_NAME,
                                                 self.config['vcd']['password'])

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -55,6 +55,7 @@ class RequestKey(str, Enum):
     STORAGE_PROFILE_NAME = 'storage_profile_name'
     NUM_WORKERS = 'num_workers'
     TEMPLATE_NAME = 'template_name'
+    TEMPLATE_REVISION = 'template_revision'
     NODE_NAME = 'node_name'
     ENABLE_NFS = 'enable_nfs'
     NODE_NAMES_LIST = 'node_names'

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -426,30 +426,30 @@ class VcdBroker(AbstractBroker, threading.Thread):
             name=self.req_spec.get(RequestKey.TEMPLATE_NAME),
             revision=self.req_spec.get(RequestKey.TEMPLATE_REVISION))
 
-        cluster_name = self.req_spec[RequestKey.CLUSTER_NAME]
-        if not self._is_valid_name(cluster_name):
-            raise CseServerError(f"Invalid cluster name '{cluster_name}'")
+        self.cluster_name = self.req_spec[RequestKey.CLUSTER_NAME]
+        if not self._is_valid_name(self.cluster_name):
+            raise CseServerError("Invalid cluster name "
+                                 f"'{self.cluster_name}'")
 
+        self._connect_tenant()
         clusters = load_from_metadata(self.tenant_client,
                                       name=self.cluster_name)
         if len(clusters) != 0:
             raise ClusterAlreadyExistsError(f"Cluster {self.cluster_name} "
                                             "already exists.")
 
-        LOGGER.debug(f"About to create cluster {cluster_name} on "
+        LOGGER.debug(f"About to create cluster {self.cluster_name} on "
                      f"{self.req_spec[RequestKey.OVDC_NAME]} with "
                      f"{self.req_spec[RequestKey.NUM_WORKERS]} worker nodes, "
                      f"storage profile="
                      f"{self.req_spec[RequestKey.STORAGE_PROFILE_NAME]}")
 
-        self._connect_tenant()
         self._connect_sys_admin()
-        self.cluster_name = cluster_name
         self.cluster_id = str(uuid.uuid4())
         self.op = OP_CREATE_CLUSTER
         self._update_task(
             TaskStatus.RUNNING,
-            message=f"Creating cluster {cluster_name}({self.cluster_id})")
+            message=f"Creating cluster {self.cluster_name}({self.cluster_id})")
         self.daemon = True
         self.start()
         result = {}

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -22,7 +22,7 @@ from container_service_extension.authorization import secure
 from container_service_extension.cluster import add_nodes
 from container_service_extension.cluster import delete_nodes_from_cluster
 from container_service_extension.cluster import execute_script_in_nodes
-from container_service_extension.cluster import get_cluster_config
+from container_service_extension.cluster import fetch_cluster_config
 from container_service_extension.cluster import get_master_ip
 from container_service_extension.cluster import init_cluster
 from container_service_extension.cluster import join_cluster
@@ -42,6 +42,7 @@ from container_service_extension.exceptions import NodeNotFoundError
 from container_service_extension.exceptions import WorkerNodeCreationError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 import container_service_extension.pyvcloud_utils as vcd_utils
+from container_service_extension.server_constants import ClusterMetadataKey
 from container_service_extension.server_constants import \
     CSE_NATIVE_DEPLOY_RIGHT_NAME
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
@@ -174,16 +175,19 @@ class VcdBroker(AbstractBroker, threading.Thread):
         allowed = re.compile(r"(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
         return all(allowed.match(x) for x in name.split("."))
 
-    def _get_template(self, name=None):
+    def _get_template(self, name=None, revision=None):
         server_config = utils.get_server_runtime_config()
         name = name or \
             self.req_spec.get(RequestKey.TEMPLATE_NAME) or \
             server_config['broker']['default_template_name']
-        # TODO: Also consider template revision
+        revision = revision or \
+            self.req_spec.get(RequestKey.TEMPLATE_REVISION) or \
+            server_config['broker']['default_template_revision']
         for template in server_config['broker']['templates']:
-            if template['name'] == name:
+            if (template['name'] == name) and \
+                    (str(template['revision']) == str(revision)):
                 return template
-        raise Exception(f"Template {name} not found.")
+        raise Exception(f"Template '{name}' at revision {revision} not found.")
 
     def _get_nfs_exports(self, ip, vapp, node):
         """Get the exports from remote NFS server (helper method).
@@ -197,14 +201,16 @@ class VcdBroker(AbstractBroker, threading.Thread):
 
         :return: (List): List of exports
         """
-        # TODO(right template) find a right way to retrieve
-        # the template from which nfs node was created.
+        # TODO: Find the right way to retrieve the template from which nfs node
+        # was created.
         server_config = utils.get_server_runtime_config()
         template = server_config['broker']['templates'][0]
         script = f"#!/usr/bin/env bash\nshowmount -e {ip}"
-        result = execute_script_in_nodes(
-            server_config, vapp, template['admin_password'],
-            script, nodes=[node], check_tools=False)
+        result = execute_script_in_nodes(vapp,
+                                         template['admin_password'],
+                                         script,
+                                         nodes=[node],
+                                         check_tools=False)
         lines = result[0][1].content.decode().split('\n')
         exports = []
         for index in range(1, len(lines) - 1):
@@ -223,9 +229,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
         vapp = VApp(self.tenant_client, href=self.cluster['vapp_href'])
         template = self._get_template()
         try:
-            server_config = utils.get_server_runtime_config()
-            delete_nodes_from_cluster(server_config, vapp, template,
-                                      node_list, force=True)
+            delete_nodes_from_cluster(vapp, template, node_list, force=True)
         except Exception:
             LOGGER.warning("Couldn't delete node {node_list} from cluster:"
                            "{self.cluster_name}")
@@ -275,7 +279,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
             clusters.append({
                 'name': c['name'],
                 'IP master': c['leader_endpoint'],
-                'template': c['template'],
+                'template_name': c.get('template_name'),
+                'template_revision': c.get('template_revision'),
                 'VMs': c['number_of_vms'],
                 'vdc': c['vdc_name'],
                 'status': c['status'],
@@ -316,8 +321,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
                 'ipAddress': ''
             }
             try:
-                node_info['ipAddress'] = vapp.get_primary_ip(
-                    vm.get('name'))
+                node_info['ipAddress'] = vapp.get_primary_ip(vm.get('name'))
             except Exception:
                 LOGGER.debug(f"Unable to get ip address of node "
                              f"{vm.get('name')}")
@@ -404,11 +408,10 @@ class VcdBroker(AbstractBroker, threading.Thread):
             raise ClusterNotFoundError(f"Cluster '{cluster_name}' not found.")
 
         vapp = VApp(self.tenant_client, href=clusters[0]['vapp_href'])
-        template = self._get_template(name=clusters[0]['template'])
-        server_config = utils.get_server_runtime_config()
-        result = get_cluster_config(server_config, vapp,
-                                    template['admin_password'])
-        return result
+        template = self._get_template(
+            name=clusters[0]['template_name'],
+            revision=clusters[0]['template_revision'])
+        return fetch_cluster_config(vapp, template['admin_password'])
 
     @secure(required_rights=[CSE_NATIVE_DEPLOY_RIGHT_NAME])
     def create_cluster(self):
@@ -417,17 +420,27 @@ class VcdBroker(AbstractBroker, threading.Thread):
         ]
         utils.ensure_keys_in_dict(required, self.req_spec, dict_name='request')
 
-        # check that requested/default template is valid
-        self._get_template(name=self.req_spec.get(RequestKey.TEMPLATE_NAME))
+        # check that requested template is valid, else fall back to default
+        # template.
+        self._get_template(
+            name=self.req_spec.get(RequestKey.TEMPLATE_NAME),
+            revision=self.req_spec.get(RequestKey.TEMPLATE_REVISION))
 
         cluster_name = self.req_spec[RequestKey.CLUSTER_NAME]
+        if not self._is_valid_name(cluster_name):
+            raise CseServerError(f"Invalid cluster name '{cluster_name}'")
+
+        clusters = load_from_metadata(self.tenant_client,
+                                      name=self.cluster_name)
+        if len(clusters) != 0:
+            raise ClusterAlreadyExistsError(f"Cluster {self.cluster_name} "
+                                            "already exists.")
+
         LOGGER.debug(f"About to create cluster {cluster_name} on "
                      f"{self.req_spec[RequestKey.OVDC_NAME]} with "
                      f"{self.req_spec[RequestKey.NUM_WORKERS]} worker nodes, "
                      f"storage profile="
                      f"{self.req_spec[RequestKey.STORAGE_PROFILE_NAME]}")
-        if not self._is_valid_name(cluster_name):
-            raise CseServerError(f"Invalid cluster name '{cluster_name}'")
 
         self._connect_tenant()
         self._connect_sys_admin()
@@ -447,20 +460,13 @@ class VcdBroker(AbstractBroker, threading.Thread):
 
     @rollback_on_failure
     def create_cluster_thread(self):
-        network_name = self.req_spec.get(RequestKey.NETWORK_NAME)
         try:
-            clusters = load_from_metadata(self.tenant_client,
-                                          name=self.cluster_name)
-            if len(clusters) != 0:
-                raise ClusterAlreadyExistsError(f"Cluster {self.cluster_name} "
-                                                "already exists.")
-
             org_resource = self.tenant_client.get_org_by_name(
                 self.req_spec.get(RequestKey.ORG_NAME))
             org = Org(self.tenant_client, resource=org_resource)
             vdc_resource = org.get_vdc(self.req_spec.get(RequestKey.OVDC_NAME))
             vdc = VDC(self.tenant_client, resource=vdc_resource)
-            template = self._get_template()
+            network_name = self.req_spec.get(RequestKey.NETWORK_NAME)
             self._update_task(
                 TaskStatus.RUNNING,
                 message=f"Creating cluster vApp {self.cluster_name}"
@@ -477,15 +483,19 @@ class VcdBroker(AbstractBroker, threading.Thread):
 
             self.tenant_client.get_task_monitor().wait_for_status(
                 vapp_resource.Tasks.Task[0])
+
+            template = self._get_template()
+
             tags = {}
-            tags['cse.cluster.id'] = self.cluster_id
-            tags['cse.version'] = pkg_resources.require(
+            tags[ClusterMetadataKey.CLUSTER_ID] = self.cluster_id
+            tags[ClusterMetadataKey.CSE_VERSION] = pkg_resources.require(
                 'container-service-extension')[0].version
-            tags['cse.template'] = template['name']
+            tags[ClusterMetadataKey.TEMPLATE_NAME] = template['name']
+            tags[ClusterMetadataKey.TEMPLATE_REVISION] = template['revision']
             vapp = VApp(self.tenant_client, href=vapp_resource.get('href'))
-            for k, v in tags.items():
-                task = vapp.set_metadata('GENERAL', 'READWRITE', k, v)
-                self.tenant_client.get_task_monitor().wait_for_status(task)
+            task = vapp.set_multiple_metadata(tags)
+            self.tenant_client.get_task_monitor().wait_for_status(task)
+
             self._update_task(
                 TaskStatus.RUNNING,
                 message=f"Creating master node for {self.cluster_name}"
@@ -493,9 +503,22 @@ class VcdBroker(AbstractBroker, threading.Thread):
             vapp.reload()
 
             server_config = utils.get_server_runtime_config()
+            catalog_name = server_config['broker']['catalog']
             try:
-                add_nodes(1, template, NodeType.MASTER, server_config,
-                          self.tenant_client, org, vdc, vapp, self.req_spec)
+                add_nodes(
+                    client=self.tenant_client,
+                    num_nodes=1,
+                    node_type=NodeType.MASTER,
+                    org=org,
+                    vdc=vdc,
+                    vapp=vapp,
+                    catalog_name=catalog_name,
+                    template=template,
+                    network_name=self.req_spec.get(RequestKey.NETWORK_NAME),
+                    num_cpu=self.req_spec.get(RequestKey.NUM_CPU),
+                    memory_in_mb=self.req_spec.get(RequestKey.MB_MEMORY),
+                    storage_profile=self.req_spec.get(RequestKey.STORAGE_PROFILE_NAME), # noqa: E501
+                    ssh_key_filepath=self.req_spec.get(RequestKey.SSH_KEY_FILEPATH)) # noqa: E501
             except Exception as e:
                 raise MasterNodeCreationError(
                     "Error while adding master node:", str(e))
@@ -505,8 +528,8 @@ class VcdBroker(AbstractBroker, threading.Thread):
                 message=f"Initializing cluster {self.cluster_name}"
                         f"({self.cluster_id})")
             vapp.reload()
-            init_cluster(server_config, vapp, template)
-            master_ip = get_master_ip(server_config, vapp, template)
+            init_cluster(vapp, template)
+            master_ip = get_master_ip(vapp, template)
             task = vapp.set_metadata('GENERAL', 'READWRITE', 'cse.master.ip',
                                      master_ip)
             self.tenant_client.get_task_monitor().wait_for_status(task)
@@ -518,10 +541,20 @@ class VcdBroker(AbstractBroker, threading.Thread):
                             f"node(s) for "
                             f"{self.cluster_name}({self.cluster_id})")
                 try:
-                    add_nodes(self.req_spec.get(RequestKey.NUM_WORKERS),
-                              template, NodeType.WORKER, server_config,
-                              self.tenant_client, org, vdc, vapp,
-                              self.req_spec)
+                    add_nodes(
+                        client=self.tenant_client,
+                        num_nodes=self.req_spec.get(RequestKey.NUM_WORKERS),
+                        node_type=NodeType.WORKER,
+                        org=org,
+                        vdc=vdc,
+                        vapp=vapp,
+                        catalog_name=catalog_name,
+                        template=template,
+                        network_name=self.req_spec.get(RequestKey.NETWORK_NAME), # noqa: E501
+                        num_cpu=self.req_spec.get(RequestKey.NUM_CPU),
+                        memory_in_mb=self.req_spec.get(RequestKey.MB_MEMORY),
+                        storage_profile=self.req_spec.get(RequestKey.STORAGE_PROFILE_NAME), # noqa: E501
+                        ssh_key_filepath=self.req_spec.get(RequestKey.SSH_KEY_FILEPATH)) # noqa: E501
                 except Exception as e:
                     raise WorkerNodeCreationError(
                         "Error while creating worker node:", str(e))
@@ -533,16 +566,27 @@ class VcdBroker(AbstractBroker, threading.Thread):
                             f"node(s) to "
                             f"{self.cluster_name}({self.cluster_id})")
                 vapp.reload()
-                join_cluster(server_config, vapp, template)
+                join_cluster(vapp, template)
             if self.req_spec.get(RequestKey.ENABLE_NFS):
                 self._update_task(
                     TaskStatus.RUNNING,
                     message=f"Creating NFS node for {self.cluster_name}"
                             f"({self.cluster_id})")
                 try:
-                    add_nodes(1, template, NodeType.NFS,
-                              server_config, self.tenant_client, org, vdc,
-                              vapp, self.req_spec)
+                    add_nodes(
+                        client=self.tenant_client,
+                        num_nodes=1,
+                        node_type=NodeType.NFS,
+                        org=org,
+                        vdc=vdc,
+                        vapp=vapp,
+                        catalog_name=catalog_name,
+                        template=template,
+                        network_name=self.req_spec.get(RequestKey.NETWORK_NAME), # noqa: E501
+                        num_cpu=self.req_spec.get(RequestKey.NUM_CPU),
+                        memory_in_mb=self.req_spec.get(RequestKey.MB_MEMORY),
+                        storage_profile=self.req_spec.get(RequestKey.STORAGE_PROFILE_NAME), # noqa: E501
+                        ssh_key_filepath=self.req_spec.get(RequestKey.SSH_KEY_FILEPATH)) # noqa: E501
                 except Exception as e:
                     raise NFSNodeCreationError(
                         "Error while creating NFS node:", str(e))
@@ -670,7 +714,6 @@ class VcdBroker(AbstractBroker, threading.Thread):
         LOGGER.debug(f"About to add nodes to cluster with name: "
                      f"{self.cluster_name}")
         try:
-            server_config = utils.get_server_runtime_config()
             org_resource = self.tenant_client.get_org()
             org = Org(self.tenant_client, resource=org_resource)
             vdc = VDC(self.tenant_client, href=self.cluster['vdc_href'])
@@ -685,10 +728,25 @@ class VcdBroker(AbstractBroker, threading.Thread):
             if self.req_spec.get(RequestKey.ENABLE_NFS):
                 node_type = NodeType.NFS
 
-            new_nodes = add_nodes(self.req_spec.get(RequestKey.NUM_WORKERS),
-                                  template, node_type, server_config,
-                                  self.tenant_client, org, vdc, vapp,
-                                  self.req_spec)
+            server_config = utils.get_server_runtime_config()
+            catalog_name = server_config['broker']['catalog']
+
+            new_nodes = \
+                add_nodes(
+                    client=self.tenant_client,
+                    num_nodes=self.req_spec.get(RequestKey.NUM_WORKERS),
+                    node_type=node_type,
+                    org=org,
+                    vdc=vdc,
+                    vapp=vapp,
+                    catalog_name=catalog_name,
+                    template=template,
+                    network_name=self.req_spec.get(RequestKey.NETWORK_NAME),
+                    num_cpu=self.req_spec.get(RequestKey.NUM_CPU),
+                    memory_in_mb=self.req_spec.get(RequestKey.MB_MEMORY),
+                    storage_profile=self.req_spec.get(RequestKey.STORAGE_PROFILE_NAME), # noqa: E501
+                    ssh_key_filepath=self.req_spec.get(RequestKey.SSH_KEY_FILEPATH)) # noqa: E501
+
             if node_type == NodeType.NFS:
                 self._update_task(
                     TaskStatus.SUCCESS,
@@ -707,7 +765,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
                 for spec in new_nodes['specs']:
                     target_nodes.append(spec['target_vm_name'])
                 vapp.reload()
-                join_cluster(server_config, vapp, template, target_nodes)
+                join_cluster(vapp, template, target_nodes)
                 self._update_task(
                     TaskStatus.SUCCESS,
                     message=f"Added "
@@ -790,9 +848,7 @@ class VcdBroker(AbstractBroker, threading.Thread):
                         f" node(s) from "
                         f"{self.cluster_name}({self.cluster_id})")
             try:
-                server_config = utils.get_server_runtime_config()
                 delete_nodes_from_cluster(
-                    server_config,
                     vapp,
                     template,
                     self.req_spec.get(RequestKey.NODE_NAMES_LIST),

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -46,6 +46,7 @@ vcs:
 service:
   enforce_authorization: false
   listeners: 5
+  log_wire: false
 
 broker:
   catalog: cse                          # public shared catalog within org where the template will be published


### PR DESCRIPTION
* Updated vcd cse cluster create, vcd cse node create commands to expose template revision as a param.
* Propagated the concept of template revision through relevant backed methods in cluster.py
* Store/Retrieve template revision to/from cluster metadata.
* Relaxed requirement of Org name in most of cluster related operations. This change is required for sys admin cli commands to be less verbose.
* Cleaned up cluster.py to get rid of dependency on server run-time config.
* Made wire logging optional via a config flag service->log_wire, which is false by default.

Testing done:
* Both system tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/393)
<!-- Reviewable:end -->
