### PR TITLE
[VCDA-1082, VCDA-1121] Support for list/create/delete/update vdc compute policy 

### DIFF
--- a/container_service_extension/cloudapi/cloudapi_client.py
+++ b/container_service_extension/cloudapi/cloudapi_client.py
@@ -1,0 +1,79 @@
+# container-service-extension
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import json
+
+import requests
+
+from container_service_extension.cloudapi.constants \
+    import CLOUDAPI_DEFAULT_VERSION
+
+
+class CloudApiClient(object):
+    """REST based client for cloudapi server."""
+
+    def __init__(self,
+                 base_url,
+                 auth_token,
+                 verify_ssl=True,
+                 api_version=CLOUDAPI_DEFAULT_VERSION,
+                 logger_instance=None,
+                 log_requests=False,
+                 log_headers=False,
+                 log_body=False):
+        self._base_url = base_url
+        self._versioned_url = f"{self._base_url}/{api_version}/"
+        self._headers = {"x-vcloud-authorization": auth_token}
+        self._verify_ssl = verify_ssl
+        self.LOGGER = logger_instance
+        self._log_requests = log_requests
+        self._log_headers = log_headers
+        self._log_body = log_body
+
+    def do_request(self, method, resource_url_relative_path=None,
+                   payload=None):
+        """Make a request to cloudpai server.
+
+        :param shared_constants.RequestMethodVerb method: One of the HTTP verb
+        defined in the enum.
+        :param str resource_url_relative_path: part of the url that identifies
+        just the resource (the host and the common /cloudapi/1.0.0 should be
+        omitted). E.g .vdcComputePolicies,
+        vdcComputePolicies/urn:vcloud:vdcComputePolicy:ac313b07-21df-45d2 etc.
+        :param dict payload: JSON payload for the REST call.
+
+        :return: body of the response text (JSON) in form of a dictionary.
+
+        :rtype: dict
+
+        :raises HTTPError: if the underlying REST call fails.
+        """
+        url = f"{self._versioned_url}{resource_url_relative_path}"
+
+        response = requests.request(
+            method.value,
+            url,
+            headers=self._headers,
+            json=payload,
+            verify=self._verify_ssl)
+
+        if self._log_requests:
+            self.LOGGER.debug(f"Request uri : {(method.value).upper()} {url}")
+            if self._log_headers:
+                self.LOGGER.debug("Request hedears : "
+                                  f"{response.request.headers}")
+            if self._log_body and payload:
+                self.LOGGER.debug(f"Request body : {response.request.body}")
+
+        if self._log_requests:
+            self.LOGGER.debug(f"Response status code: {response.status_code}")
+            if self._log_headers:
+                self.LOGGER.debug(f"Response hedears : {response.headers}")
+            if self._log_body:
+                self.LOGGER.debug(f"Response body : {response.text}")
+
+        response.raise_for_status()
+
+        if response.text:
+            return json.loads(response.text)

--- a/container_service_extension/cloudapi/compute_policy_manager.py
+++ b/container_service_extension/cloudapi/compute_policy_manager.py
@@ -1,0 +1,247 @@
+# container-service-extension
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from pyvcloud.vcd.client import Client
+from pyvcloud.vcd.client import find_link
+
+from container_service_extension.cloudapi.cloudapi_client import CloudApiClient
+from container_service_extension.cloudapi.constants import CloudApiResource
+from container_service_extension.cloudapi.constants import \
+    COMPUTE_POLICY_NAME_PREFIX
+from container_service_extension.cloudapi.constants import EntityType
+from container_service_extension.cloudapi.constants import RelationType
+from container_service_extension.pyvcloud_utils import get_org
+from container_service_extension.pyvcloud_utils import get_vdc
+from container_service_extension.shared_constants import RequestMethod
+
+
+class ComputePolicyManager:
+    """Manages creating, deleting, updating cloudapi compute policies.
+
+    All policy names are prepended with CSE specific literal and restored to
+    original names when returned back to the caller.
+    """
+
+    def __init__(self, vcd_uri, tenant_auth_token, verify_ssl,
+                 api_version):
+        """Initialize ComputePolicyManager Object.
+
+        :param str vcd_uri: base_url to create client
+        :param str tenant_auth_token: HTTP basic authentication token
+        :param str api_version:
+        :param bool verify_ssl: if True, verify SSL certificates of remote
+        host, else ignore verification.
+        """
+        self._vcd_client = Client(uri=vcd_uri,
+                                  api_version=api_version,
+                                  verify_ssl_certs=verify_ssl)
+        session = self._vcd_client.rehydrate_from_token(tenant_auth_token)
+        link = find_link(session, RelationType.OPEN_API,
+                         EntityType.APPLICATION_JSON)
+
+        self.cloud_api_client = CloudApiClient(
+            base_url=link.href,
+            auth_token=tenant_auth_token,
+            verify_ssl=verify_ssl)
+
+    def list_policies(self):
+        """Get all policies that are created by CSE.
+
+        :return: list of CSE created policies
+        :rtype: list of dict
+        """
+        policies = self.cloud_api_client.do_request(
+            RequestMethod.GET, CloudApiResource.VDC_COMPUTE_POLICIES)
+        cse_policies = []
+        for policy in policies['values']:
+            if policy['name'].startswith(COMPUTE_POLICY_NAME_PREFIX):
+                policy['display_name'] = \
+                    self._get_original_policy_name(policy['name'])
+            else:
+                policy['display_name'] = policy['name']
+            cse_policies.append(policy)
+
+        return cse_policies
+
+    def get_policy(self, policy_name):
+        """Get the compute policy information for the given policy name.
+
+        :param str policy_name: name of the compute policy
+
+        :return: policy details if found, else None
+        :rtype: dict
+        """
+        for policy_dict in self.list_policies():
+            if policy_dict.get('display_name') == policy_name:
+                policy_dict['href'] = self._get_policy_href(policy_dict['id'])
+                return policy_dict
+
+    def add_policy(self, policy_name, description=None):
+        """Add policy with the given name and description.
+
+        :param str policy_name: name of the compute policy
+        :param str description: description about the policy
+
+        :return: created policy information
+        :rtype: dict
+        """
+        policy_info = {}
+        policy_info['name'] = self._get_cse_policy_name(policy_name)
+        if description:
+            policy_info['description'] = description
+        created_policy = self.cloud_api_client.do_request(
+            RequestMethod.POST,
+            resource_url_relative_path=CloudApiResource.VDC_COMPUTE_POLICIES,
+            payload=policy_info)
+        created_policy['display_name'] = self._get_original_policy_name(
+            created_policy['name'])
+        created_policy['href'] = self._get_policy_href(created_policy['id'])
+        return created_policy
+
+    def remove_policy(self, policy_name):
+        """Remove the compute policy with the given name.
+
+        :param str policy_name: name of the compute policy
+        """
+        policy_info = self.get_policy(policy_name)
+        if policy_info:
+            resource_url_relative_path = \
+                f"{CloudApiResource.VDC_COMPUTE_POLICIES}/{policy_info['id']}"
+            return self.cloud_api_client.do_request(
+                RequestMethod.DELETE,
+                resource_url_relative_path=resource_url_relative_path)
+
+    def update_policy(self, policy_name, new_policy_info):
+        """Update the existing compute policy with new policy information.
+
+        :param str policy_name: existing policy name
+        :param dict new_policy_info: updated policy information with name and
+        optional description
+
+        :return: updated policy information; if no policy is found, return None
+        :rtype: dict
+        """
+        policy_info = self.get_policy(policy_name)
+        if policy_info and new_policy_info.get('name'):
+            payload = {}
+            payload['name'] = \
+                self._get_cse_policy_name(new_policy_info['name'])
+            if new_policy_info.get('description'):
+                payload['description'] = new_policy_info['description']
+            resource_url_relative_path = \
+                f"{CloudApiResource.VDC_COMPUTE_POLICIES}/{policy_info['id']}"
+            updated_policy = self.cloud_api_client.do_request(
+                RequestMethod.PUT,
+                resource_url_relative_path=resource_url_relative_path,
+                payload=payload)
+            updated_policy['display_name'] = \
+                self._get_original_policy_name(updated_policy['name'])
+            updated_policy['href'] = policy_info['href']
+            return updated_policy
+
+    def add_compute_policy_to_vdc(self, org_name, vdc_name, policy_href):
+        """Add compute policy to the given vdc that is found in given org.
+
+        :param str org_name: name of the organization to look for the vdc
+        :param str vdc_name: name of the vdc to assign the policy
+        :param policy_href: policy href that is created using cloudapi
+
+        :return: an object containing VdcComputePolicyReferences XML element
+        that refers to individual VdcComputePolicies.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        vdc = get_vdc(org_name=org_name, vdc_name=vdc_name,
+                      is_admin_operation=True)
+        return vdc.add_compute_policy(policy_href)
+
+    def remove_compute_policy_from_vdc(self, org_name, vdc_name, policy_href):
+        """Delete the compute policy from the vdc that belongs to given org.
+
+        :param str org_name: name of the organization to look for the vdc
+        :param str vdc_name: name of the vdc to assign the policy
+        :param policy_href: policy href that is created using cloudapi
+
+        :return: an object containing VdcComputePolicyReferences XML element
+        that refers to individual VdcComputePolicies.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        vdc = get_vdc(self._vcd_client, org_name=org_name, vdc_name=vdc_name,
+                      is_admin_operation=True)
+        return vdc.remove_compute_policy(policy_href)
+
+    def assign_compute_policy_to_vapp_template_vms(self,
+                                                   org_name,
+                                                   catalog_name,
+                                                   catalog_item_name,
+                                                   compute_policy_href):
+        """Assign the compute policy to vms of given vapp template.
+
+        :param str org_name: name of the organization that has the catalog
+        :param str catalog_name: name of the catalog
+        :param str catalog_item_name: name of the catalog item that has vms
+        :param str compute_policy_href: compute policy to be removed
+
+        :return: an object of type EntityType.TASK XML which represents
+        the asynchronous task that is updating virtual application template.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        org = get_org(self._vcd_client, org_name=org_name)
+        return org.assign_compute_policy_to_vapp_template_vms(
+            catalog_name, catalog_item_name, compute_policy_href)
+
+    def remove_compute_policy_from_vapp_template_vms(self,
+                                                     org_name,
+                                                     catalog_name,
+                                                     catalog_item_name,
+                                                     compute_policy_href):
+        """Remove the compute policy from vms of given vapp template.
+
+        :param str org_name: name of the organization that has the catalog
+        :param str catalog_name: name of the catalog
+        :param str catalog_item_name: name of the catalog item that has vms
+        :param str compute_policy_href: compute policy to be removed
+
+        :return: an object of type EntityType.TASK XML which represents
+        the asynchronous task that is updating virtual application template.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        org = get_org(self._vcd_client, org_name=org_name)
+        return org.remove_compute_policy_from_vapp_template_vms(
+            catalog_name, catalog_item_name, compute_policy_href)
+
+    def _get_cse_policy_name(self, policy_name):
+        """Add cse specific prefix to the policy name.
+
+        :param str policy_name: name of the compute policy
+
+        :return: policy name unique to cse
+        :rtype: str
+        """
+        return f"{COMPUTE_POLICY_NAME_PREFIX}{policy_name}"
+
+    def _get_original_policy_name(self, policy_name):
+        """Remove cse specific prefix from the given policy name.
+
+        :param str policy_name: name of the policy
+
+        :return: policy name after removing cse specific prefix
+        :rtype: str
+        """
+        if policy_name and policy_name.startswith(COMPUTE_POLICY_NAME_PREFIX):
+            return policy_name.replace(COMPUTE_POLICY_NAME_PREFIX, '', 1)
+        return policy_name
+
+    def _get_policy_href(self, policy_id):
+        """Construct policy href from given policy id.
+
+        :param str policy_id: policy id
+
+        :return: policy href
+        :rtype: str
+        """
+        return f"{self.cloud_api_client._versioned_url}{CloudApiResource.VDC_COMPUTE_POLICIES}/{policy_id}"  # noqa

--- a/container_service_extension/cloudapi/constants.py
+++ b/container_service_extension/cloudapi/constants.py
@@ -1,0 +1,28 @@
+# container-service-extension
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from enum import Enum
+
+CLOUDAPI_DEFAULT_VERSION = '1.0.0'
+COMPUTE_POLICY_NAME_PREFIX = 'cse----'
+
+
+class CloudApiResource(str, Enum):
+    """Keys that are used to get the cloudapi resource names."""
+
+    VDC_COMPUTE_POLICIES = 'vdcComputePolicies'
+
+
+class RelationType(Enum):
+    """Keys to use to find the link relation type."""
+
+    # TODO should be moved to pyvcloud
+    OPEN_API = 'openapi'
+
+
+class EntityType(str, Enum):
+    """Media type."""
+
+    # TODO should be moved to pyvcloud
+    APPLICATION_JSON = 'application/json'


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- Support added to do list/create/delete/update compute policy on cloudapi
- Assigning compute policy to vdc and vms need a valid compute policy id and href. This change provides methods to support CRUD on /cloudapi for vdcComputePolicy.
   In addition, support methods added to assign compute policy to vdc and vms of vapp template. (VCDA-1121)
- Testing done and verified using script and postman REST client for the following operations 
    - Add, update, delete, get, list compute policy from/to /cloudapi
    - Add, remove compute policies from/to vdc
    - Assign, remove compute policies from/to vms of vapp template


@rocknes @andrew-ni @harshneelmore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/397)
<!-- Reviewable:end -->
