### PR TITLE
[VCDA-1121] Fix a bug in add_compute_policy_to_vdc method, missing vcd client argument

### DIFF
--- a/container_service_extension/cloudapi/compute_policy_manager.py
+++ b/container_service_extension/cloudapi/compute_policy_manager.py
@@ -152,7 +152,7 @@ class ComputePolicyManager:
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        vdc = get_vdc(org_name=org_name, vdc_name=vdc_name,
+        vdc = get_vdc(self._vcd_client, org_name=org_name, vdc_name=vdc_name,
                       is_admin_operation=True)
         return vdc.add_compute_policy(policy_href)
 


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- Fixed missing vcd client argument 

- get_vdc from given org-name and vdc-name requires vcd client. This PR fixed the missing client in get_vdc().

- Tested and verified

@rocknes @andrew-ni @harshneelmore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/403)
<!-- Reviewable:end -->
