### PR TITLE
[VCDA-1120] Making templates complaint with the compute policy

### DIFF
--- a/container_service_extension/cloudapi/cloudapi_client.py
+++ b/container_service_extension/cloudapi/cloudapi_client.py
@@ -31,6 +31,9 @@ class CloudApiClient(object):
         self._log_headers = log_headers
         self._log_body = log_body
 
+    def get_versioned_url(self):
+        return self._versioned_url
+
     def do_request(self, method, resource_url_relative_path=None,
                    payload=None):
         """Make a request to cloudpai server.

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -16,11 +16,10 @@ import click
 import pkg_resources
 from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
-from pyvcloud.vcd.exceptions import MissingLinkException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 import requests
 
-from container_service_extension.cloudapi.compute_policy_manager import \
+from container_service_extension.compute_policy_manager import \
     ComputePolicyManager
 from container_service_extension.config_validator import get_validated_config
 from container_service_extension.configure_cse import check_cse_installation
@@ -448,7 +447,7 @@ class Service(object, metaclass=Singleton):
                             compute_policy_href=policy['href'],
                             org_name=org_name,
                             catalog_name=catalog_name,
-                            catalog_item_name= catalog_item_name)
+                            catalog_item_name=catalog_item_name)
                     else:
                         # empty policy name means we should remove policy from
                         # template
@@ -464,7 +463,7 @@ class Service(object, metaclass=Singleton):
                         #    org_name=org_name,
                         #    catalog_name=catalog_name,
                         #    catalog_item_name=catalog_item_name)
-            except (OperationNotSupportedException, MissingLinkException):
+            except OperationNotSupportedException:
                 msg = "Compute policy not supported by vCD. Skipping " \
                     "assigning/removing it to/from templates."
                 if msg_update_callback:

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -206,7 +206,7 @@ class Service(object, metaclass=Singleton):
         # server run-time config
         self._process_template_rules(msg_update_callback=msg_update_callback)
 
-        # Make sure that all vms in tempaltes are compliant with the compute
+        # Make sure that all vms in templates are compliant with the compute
         # policy specified in template definition (can be affected by rules).
         self._process_template_compute_policy_compliance(
             msg_update_callback=msg_update_callback)

--- a/container_service_extension/template_rule.py
+++ b/container_service_extension/template_rule.py
@@ -151,19 +151,22 @@ class TemplateRule:
 
         target_template = template_table[self.target['name']][str(self.target['revision'])] # noqa: E501
 
-        new_admin_password = self.action.get(LocalTemplateKey.ADMIN_PASSWORD) # noqa: E501
-        if new_admin_password and new_admin_password != target_template[LocalTemplateKey.ADMIN_PASSWORD]: # noqa: E501
-            target_template[LocalTemplateKey.ADMIN_PASSWORD] = new_admin_password # noqa: E501
+        new_admin_password = \
+            self.action.get(LocalTemplateKey.ADMIN_PASSWORD)
+        if new_admin_password is not None:
+            target_template[LocalTemplateKey.ADMIN_PASSWORD] = \
+                new_admin_password
 
-        new_compute_profile = self.action.get(LocalTemplateKey.COMPUTE_POLICY) # noqa: E501
-        if new_compute_profile and new_compute_profile != target_template[LocalTemplateKey.COMPUTE_POLICY]: # noqa: E501
-            target_template[LocalTemplateKey.COMPUTE_POLICY] = new_compute_profile # noqa: E501
-            # TODO: Update the compute policy of the template right away!
+        new_compute_policy = \
+            self.action.get(LocalTemplateKey.COMPUTE_POLICY)
+        if new_compute_policy is not None:
+            target_template[LocalTemplateKey.COMPUTE_POLICY] = \
+                new_compute_policy
 
         new_cpu = self.action.get(LocalTemplateKey.CPU)
-        if new_cpu and new_cpu != target_template[LocalTemplateKey.CPU]: # noqa: E501
+        if new_cpu is not None:
             target_template[LocalTemplateKey.CPU] = new_cpu
 
         new_memory = self.action.get(LocalTemplateKey.MEMORY)
-        if new_memory and new_memory != target_template[LocalTemplateKey.MEMORY]: # noqa: E501
+        if new_memory is not None:
             target_template[LocalTemplateKey.MEMORY] = new_memory


### PR DESCRIPTION
Templates have metadata that is derived from remote cookbook recipe and represents the template's default state. However the state can be modified during CSE server startup via template rules. This PR makes sure that once the changes are made via rules, the template is made compliant to those changed values. This PR specifically makes sure that the compute policy that is specified in the template run-time definition is actually applied to the vms in the template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/410)
<!-- Reviewable:end -->
