### PR TITLE
[VCDA-1136] Implement ovdc compute policy operations

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -1072,43 +1072,20 @@ def ovdc_info(ctx, ovdc_name, org_name):
                   short_help='Manage compute policies for an org VDC')
 @click.pass_context
 def compute_policy_group(ctx):
-    """Manage Kubernetes provider for org VDCs.
+    """Manage compute policies for org VDCs.
 
-All commands execute in the context of user's currently logged-in
-organization. Use a different organization by using the '--org' option.
-
-Currently supported Kubernetes-providers:
-
-- native (vCD)
-
-- ent-pks (Enterprise PKS)
+System administrator operations.
 
 \b
 Examples
-    vcd cse ovdc enable ovdc1 --k8s-provider native
-        Set 'ovdc1' Kubernetes provider to be native (vCD).
+    vcd cse ovdc compute-policy list ORG_NAME OVDC_NAME
+        List all compute policies on an org VDC.
 \b
-    vcd cse ovdc enable ovdc2 --k8s-provider ent-pks \\
-    --pks-plan 'plan1' --pks-cluster-domain 'myorg.com'
-        Set 'ovdc2' Kubernetes provider to be ent-pks.
-        Use pks plan 'plan1' for 'ovdc2'.
-        Set cluster domain to be 'myorg.com'.
+    vcd cse ovdc compute-policy add ORG_NAME OVDC_NAME POLICY_NAME
+        Add a compute policy to an org VDC.
 \b
-    vcd cse ovdc disable ovdc3
-        Set 'ovdc3' Kubernetes provider to be none,
-        which disables Kubernetes cluster deployment on 'ovdc3'.
-\b
-    vcd cse ovdc info ovdc1
-        Display detailed information about ovdc 'ovdc1'.
-\b
-    vcd cse ovdc list
-        Display ovdcs in vCD that are visible to the logged in user.
-        vcd cse ovdc list
-\b
-        vcd cse ovdc list --pks-plans
-            Displays list of ovdcs in a given org along with available PKS
-            plans if any. If executed by System-administrator, it will
-            display all ovdcs from all orgs.
+    vcd cse ovdc compute-policy remove ORG_NAME OVDC_NAME POLICY_NAME
+        Remove a compute policy from an org VDC.
     """
     pass
 

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -105,8 +105,7 @@ class Ovdc:
 
         :param str ovdc_name: Name of org VDC to update
         :param str org_name: Name of org that @ovdc_name belongs to
-        :param str compute_policy_name: Name of compute policy to add
-            to org VDC
+        :param str compute_policy_name: Name of compute policy to add or remove
         :param ComputePolicyAction action:
 
         :rtype: dict

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -40,14 +40,12 @@ class Ovdc:
         :param bool enable: If set to True will enable the vdc for the
             paricular k8s_provider else if set to False, K8 support on
             the vdc will be disabled.
-        :param str ovdc_name: Name of the ovdc to be enabled
+        :param str ovdc_name: Name of org VDC to update
+        :param str org_name: Name of org that @ovdc_name belongs to
         :param str k8s_provider: Name of the container provider
         :param str pks_plan: PKS plan
         :param str pks_cluster_domain: Suffix of the domain name, which will be
          used to construct FQDN of the clusters.
-        :param str org_name: Name of organization that belongs to ovdc_name
-
-        :return: response object
 
         :rtype: dict
         """
@@ -83,10 +81,8 @@ class Ovdc:
     def info_ovdc_for_k8s(self, ovdc_name, org_name):
         """Disable ovdc for k8s for the given container provider.
 
-        :param str ovdc_name: Name of the ovdc to be enabled
-        :param str org_name: Name of organization that belongs to ovdc_name
-
-        :return: response object
+        :param str ovdc_name: Name of the org VDC to be enabled
+        :param str org_name: Name of org that @ovdc_name belongs to
 
         :rtype: dict
         """
@@ -95,6 +91,60 @@ class Ovdc:
                        is_admin_operation=True)
         ovdc_id = utils.extract_id(ovdc.get_resource().get('id'))
         uri = f'{self._uri}/ovdc/{ovdc_id}'
+
+        response = self.client._do_request_prim(
+            method,
+            uri,
+            self.client._session,
+            accept_type='application/json')
+        return process_response(response)
+
+    def update_ovdc_compute_policies(self, ovdc_name, org_name,
+                                     compute_policy_name, action):
+        """Update an ovdc's compute policies.
+
+        :param str ovdc_name: Name of org VDC to update
+        :param str org_name: Name of org that @ovdc_name belongs to
+        :param str compute_policy_name: Name of compute policy to add
+            to org VDC
+        :param ComputePolicyAction action:
+
+        :rtype: dict
+        """
+        method = RequestMethod.PUT
+        ovdc = get_vdc(self.client, vdc_name=ovdc_name, org_name=org_name,
+                       is_admin_operation=True)
+        ovdc_id = utils.extract_id(ovdc.get_resource().get('id'))
+        uri = f'{self._uri}/ovdc/{ovdc_id}/compute-policies'
+
+        data = {
+            RequestKey.OVDC_ID: ovdc_id, # also exists in url
+            RequestKey.COMPUTE_POLICY_NAME: compute_policy_name,
+            RequestKey.COMPUTE_POLICY_ACTION: action
+        }
+
+        response = self.client._do_request_prim(
+            method,
+            uri,
+            self.client._session,
+            contents=data,
+            media_type='application/json',
+            accept_type='application/json')
+        return process_response(response)
+
+    def list_ovdc_compute_policies(self, ovdc_name, org_name):
+        """List an ovdc's compute policies.
+
+        :param str ovdc_name: Name of org VDC to update
+        :param str org_name: Name of org that @ovdc_name belongs to
+
+        :rtype: dict
+        """
+        method = RequestMethod.GET
+        ovdc = get_vdc(self.client, vdc_name=ovdc_name, org_name=org_name,
+                       is_admin_operation=True)
+        ovdc_id = utils.extract_id(ovdc.get_resource().get('id'))
+        uri = f'{self._uri}/ovdc/{ovdc_id}/compute-policies'
 
         response = self.client._do_request_prim(
             method,

--- a/container_service_extension/client/response_processor.py
+++ b/container_service_extension/client/response_processor.py
@@ -31,12 +31,13 @@ def process_response(response):
     :raises VcdResponseError: if response http status code is not 2xx
     """
     if response.status_code in [
-        requests.codes.ok, requests.codes.created,
+        requests.codes.ok,
+        requests.codes.created,
         requests.codes.accepted
     ]:
         return deserialize_response_content(response)
-    else:
-        response_to_exception(response)
+
+    response_to_exception(response)
 
 
 def deserialize_response_content(response):

--- a/container_service_extension/cloudapi/cloudapi_client.py
+++ b/container_service_extension/cloudapi/cloudapi_client.py
@@ -38,7 +38,7 @@ class CloudApiClient(object):
                    payload=None):
         """Make a request to cloudpai server.
 
-        :param shared_constants.RequestMethodVerb method: One of the HTTP verb
+        :param shared_constants.RequestMethod method: One of the HTTP verb
         defined in the enum.
         :param str resource_url_relative_path: part of the url that identifies
         just the resource (the host and the common /cloudapi/1.0.0 should be

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -195,10 +195,8 @@ class ComputePolicyManager:
         :param str vdc_name: name of the vdc for which policies need to be
             retrieved.
 
-        :return: an object containing VdcComputePolicyReferences XML element
-            that refers to individual VdcComputePolicies.
-
-        :rtype: List[Dict]
+        :return: A list of dictionaries with the 'name' and 'href' key
+        :rtype: List
         """
         vdc = get_vdc(self._vcd_client, org_name=org_name, vdc_name=vdc_name,
                       vdc_id=vdc_id, is_admin_operation=True)

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -182,8 +182,8 @@ class ComputePolicyManager:
                       vdc_id=vdc_id, is_admin_operation=True)
         return vdc.add_compute_policy(policy_href)
 
-    def list_compute_policy_on_vdc(self, vdc_id=None, org_name=None,
-                                   vdc_name=None):
+    def list_compute_policies_on_vdc(self, vdc_id=None, org_name=None,
+                                     vdc_name=None):
         """List compute policy currently assigned to a given vdc.
 
         Atleast one of vdc_id or (org_name, vdc_name) should be provided, so

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -198,11 +198,20 @@ class ComputePolicyManager:
         :return: an object containing VdcComputePolicyReferences XML element
             that refers to individual VdcComputePolicies.
 
-        :rtype: lxml.objectify.ObjectifiedElement
+        :rtype: List[Dict]
         """
         vdc = get_vdc(self._vcd_client, org_name=org_name, vdc_name=vdc_name,
                       vdc_id=vdc_id, is_admin_operation=True)
-        return vdc.list_compute_policies()
+
+        result = []
+        cp_list = vdc.list_compute_policies()
+        for cp in cp_list:
+            result.append({
+                'name': self._get_original_policy_name(cp.get('name')),
+                'href': cp.get('href')
+            })
+
+        return result
 
     def remove_compute_policy_from_vdc(self, policy_href, vdc_id=None,
                                        org_name=None, vdc_name=None):

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -103,7 +103,7 @@ def ovdc_compute_policy_list(request_data, tenant_auth_token):
     client, _ = vcd_utils.connect_vcd_user_via_token(tenant_auth_token)
 
     cpm = ComputePolicyManager(client)
-    return cpm.list_compute_policy_on_vdc(vdc_id=request_data[RequestKey.OVDC_ID]) # noqa: E501
+    return cpm.list_compute_policies_on_vdc(vdc_id=request_data[RequestKey.OVDC_ID]) # noqa: E501
 
 
 def ovdc_compute_policy_update(request_data, tenant_auth_token):

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -10,9 +10,9 @@ import container_service_extension.utils as utils
 def ovdc_update(request_data, tenant_auth_token):
     """Request handler for ovdc enable, disable operations.
 
-    Required data: org_name, ovdc_name, k8s_provider.
-    Conditional data: if k8s_provider is 'ent-pks', pks_plan_name,
-        pks_cluster_domain are required.
+    Required data: org_name, ovdc_name, k8s_provider
+    Conditional data:
+        if k8s_provider is 'ent-pks': pks_plan_name, pks_cluster_domain
 
     :return: Dictionary with org VDC update task href.
     """
@@ -60,7 +60,7 @@ def ovdc_update(request_data, tenant_auth_token):
 def ovdc_info(request_data, tenant_auth_token):
     """Request handler for ovdc info operation.
 
-    Required data: org_name, ovdc_name.
+    Required data: org_name, ovdc_name
 
     :return: Dictionary with org VDC k8s provider metadata.
     """

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -1,8 +1,12 @@
+from pyvcloud.vcd.exceptions import EntityNotFoundException
+
+from container_service_extension.compute_policy_manager import ComputePolicyManager # noqa: E501
 from container_service_extension.exceptions import CseServerError
 import container_service_extension.ovdc_utils as ovdc_utils
 import container_service_extension.pyvcloud_utils as vcd_utils
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProvider
+from container_service_extension.shared_constants import ComputePolicyAction
 from container_service_extension.shared_constants import RequestKey
 import container_service_extension.utils as utils
 
@@ -83,3 +87,68 @@ def ovdc_list(request_data, tenant_auth_token):
 
     return ovdc_utils.get_ovdc_list(client, list_pks_plans=list_pks_plans,
                                     tenant_auth_token=tenant_auth_token)
+
+
+def ovdc_compute_policy_list(request_data, tenant_auth_token):
+    """Request handler for ovdc compute-policy list operation.
+
+    Required data: ovdc_id
+
+    :return: Dictionary with task href.
+    """
+    required = [
+        RequestKey.OVDC_ID
+    ]
+    utils.ensure_keys_in_dict(required, request_data, dict_name='data')
+    client, _ = vcd_utils.connect_vcd_user_via_token(tenant_auth_token)
+
+    cpm = ComputePolicyManager(client)
+    return cpm.list_compute_policy_on_vdc(vdc_id=request_data[RequestKey.OVDC_ID]) # noqa: E501
+
+
+def ovdc_compute_policy_update(request_data, tenant_auth_token):
+    """Request handler for ovdc compute-policy update operation.
+
+    Required data: ovdc_id, compute_policy_action, compute_policy_names
+
+    :return: Dictionary with task href.
+    """
+    required = [
+        RequestKey.OVDC_ID,
+        RequestKey.COMPUTE_POLICY_ACTION,
+        RequestKey.COMPUTE_POLICY_NAME
+    ]
+    utils.ensure_keys_in_dict(required, request_data, dict_name='data')
+    client, _ = vcd_utils.connect_vcd_user_via_token(tenant_auth_token)
+    action = request_data[RequestKey.COMPUTE_POLICY_ACTION]
+    cp_name = request_data[RequestKey.COMPUTE_POLICY_NAME]
+    ovdc_id = request_data[RequestKey.OVDC_ID]
+
+    cpm = ComputePolicyManager(client)
+    cp = cpm.get_policy(cp_name)
+    if cp is None:
+        raise ValueError(f"Compute policy '{cp_name}' does not exist")
+    cp_href = cp['href']
+
+    if action == ComputePolicyAction.ADD:
+        cpm.add_compute_policy_to_vdc(cp_href, vdc_id=ovdc_id)
+        return f"Added compute policy '{cp_name}' to ovdc '{ovdc_id}'"
+
+    if action == ComputePolicyAction.REMOVE:
+        try:
+            cpm.remove_compute_policy_from_vdc(cp_href, vdc_id=ovdc_id)
+        except EntityNotFoundException:
+            raise EntityNotFoundException(f"Compute policy '{cp_name}' not "
+                                          f"found in ovdc '{ovdc_id}'")
+        except Exception:
+            # This ensures that BadRequestException message is printed
+            # to console. (error when ovdc currently has VMs/vApp
+            # templates with the compute policy reference, so compute policy
+            # cannot be removed)
+            raise Exception(f"Could not remove compute policy '{cp_name}' "
+                            f"from ovdc '{ovdc_id}' (check that no vApp"
+                            f" templates or VMs currently contain a reference"
+                            f" to the compute policy).")
+        return f"Removed compute policy '{cp_name}' from ovdc '{ovdc_id}'"
+
+    raise ValueError("Unsupported compute policy action")

--- a/container_service_extension/request_handlers/system_handler.py
+++ b/container_service_extension/request_handlers/system_handler.py
@@ -1,11 +1,10 @@
-import container_service_extension.service as service
-
-
 def system_info(request_data, tenant_auth_token):
     """Request handler for system info operation.
 
     :return: Dictionary with system info data.
     """
+    # TODO: circular dependency with request_processor.py
+    import container_service_extension.service as service
     return service.Service().info(tenant_auth_token)
 
 
@@ -14,6 +13,8 @@ def system_update(request_data, tenant_auth_token):
 
     :return: Dictionary with system update status.
     """
+    # TODO: circular dependency with request_processor.py
+    import container_service_extension.service as service
     return {
         'message': service.Service().update_status(tenant_auth_token,
                                                    request_data)

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -39,8 +39,8 @@ GET /cse/node/{node name}?cluster_name={cluster name}&org={org name}&vdc={vdc na
 GET /cse/ovdcs
 GET /cse/ovdc/{ovdc id}
 PUT /cse/ovdc/{ovdc id}
-GET /ovdc/{ovdc_id}/compute-policies
-PUT /ovdc/{ovdc_id}/compute-policies
+GET /cse/ovdc/{ovdc_id}/compute-policies
+PUT /cse/ovdc/{ovdc_id}/compute-policies
 
 GET /cse/system
 PUT /cse/system

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -39,6 +39,8 @@ GET /cse/node/{node name}?cluster_name={cluster name}&org={org name}&vdc={vdc na
 GET /cse/ovdcs
 GET /cse/ovdc/{ovdc id}
 PUT /cse/ovdc/{ovdc id}
+GET /ovdc/{ovdc_id}/compute-policies
+PUT /ovdc/{ovdc_id}/compute-policies
 
 GET /cse/system
 PUT /cse/system
@@ -59,160 +61,27 @@ OPERATION_TO_HANDLER = {
     CseOperation.OVDC_UPDATE: ovdc_handler.ovdc_update,
     CseOperation.OVDC_INFO: ovdc_handler.ovdc_info,
     CseOperation.OVDC_LIST: ovdc_handler.ovdc_list,
+    CseOperation.OVDC_COMPUTE_POLICY_LIST: ovdc_handler.ovdc_compute_policy_list, # noqa: E501
+    CseOperation.OVDC_COMPUTE_POLICY_UPDATE: ovdc_handler.ovdc_compute_policy_update, # noqa: E501
     CseOperation.SYSTEM_INFO: system_handler.system_info,
     CseOperation.SYSTEM_UPDATE: system_handler.system_update,
     CseOperation.TEMPLATE_LIST: template_handler.template_list,
 }
 
-
-def _parse_request_url(method, url):
-    """Determine the operation that the REST request represent.
-
-    Additionally parse the url for data that might be needed while
-    processing the request.
-
-    :param str url: Incoming REST request url.
-    :param str method: HTTP method of the REST request.
-
-    :return: the type of operation the incoming REST request corresponds
-        to, plus associated parsed data from the url.
-
-    :rtype: dict
-    """
-    is_cluster_request = False
-    is_node_request = False
-    is_ovdc_request = False
-    is_system_request = False
-    is_template_request = False
-    result = {}
-
-    tokens = url.split('/')
-    if len(tokens) > 3:
-        if tokens[3] in ('cluster', 'clusters'):
-            is_cluster_request = True
-        elif tokens[3] in ('node', 'nodes'):
-            is_node_request = True
-        elif tokens[3] in ('ovdc', 'ovdcs'):
-            is_ovdc_request = True
-        elif tokens[3] == 'system':
-            is_system_request = True
-        elif tokens[3] == 'templates':
-            is_template_request = True
-
-    if is_cluster_request:
-        if len(tokens) == 4:
-            if method == RequestMethod.GET:
-                result['operation'] = CseOperation.CLUSTER_LIST
-            elif method == RequestMethod.POST:
-                result['operation'] = CseOperation.CLUSTER_CREATE
-            else:
-                raise CseRequestError(
-                    status=requests.codes.method_not_allowed,
-                    error_message="Method not allowed")
-        elif len(tokens) == 5:
-            if method == RequestMethod.GET:
-                result['operation'] = CseOperation.CLUSTER_INFO
-                result[RequestKey.CLUSTER_NAME] = tokens[4]
-            elif method == RequestMethod.PUT:
-                result['operation'] = CseOperation.CLUSTER_RESIZE
-                result[RequestKey.CLUSTER_NAME] = tokens[4]
-            elif method == RequestMethod.DELETE:
-                result['operation'] = CseOperation.CLUSTER_DELETE
-                result[RequestKey.CLUSTER_NAME] = tokens[4]
-            else:
-                raise CseRequestError(
-                    status=requests.codes.method_not_allowed,
-                    error_message="Method not allowed")
-        elif len(tokens) == 6:
-            if method == RequestMethod.GET:
-                if tokens[5] == 'config':
-                    result['operation'] = CseOperation.CLUSTER_CONFIG
-                    result[RequestKey.CLUSTER_NAME] = tokens[4]
-            else:
-                raise CseRequestError(
-                    status=requests.codes.method_not_allowed,
-                    error_message="Method not allowed")
-
-    if is_node_request:
-        if len(tokens) == 4:
-            if method == RequestMethod.POST:
-                result['operation'] = CseOperation.NODE_CREATE
-            elif method == RequestMethod.DELETE:
-                result['operation'] = CseOperation.NODE_DELETE
-            else:
-                raise CseRequestError(
-                    status=requests.codes.method_not_allowed,
-                    error_message="Method not allowed")
-        elif len(tokens) == 5:
-            if method == RequestMethod.GET:
-                result['operation'] = CseOperation.NODE_INFO
-                result[RequestKey.NODE_NAME] = tokens[4]
-            else:
-                raise CseRequestError(
-                    status=requests.codes.method_not_allowed,
-                    error_message="Method not allowed")
-
-    if is_ovdc_request:
-        if len(tokens) == 4:
-            if method == RequestMethod.GET:
-                result['operation'] = CseOperation.OVDC_LIST
-            else:
-                raise CseRequestError(
-                    status=requests.codes.method_not_allowed,
-                    error_message="Method not allowed")
-        elif len(tokens) == 5:
-            if method == RequestMethod.GET:
-                result['operation'] = CseOperation.OVDC_INFO
-                result[RequestKey.OVDC_ID] = tokens[4]
-            elif method == RequestMethod.PUT:
-                result['operation'] = CseOperation.OVDC_UPDATE
-                result[RequestKey.OVDC_ID] = tokens[4]
-            else:
-                raise CseRequestError(
-                    status=requests.codes.method_not_allowed,
-                    error_message="Method not allowed")
-
-    if is_system_request:
-        if len(tokens) == 4:
-            if method == RequestMethod.GET:
-                result['operation'] = CseOperation.SYSTEM_INFO
-            elif method == RequestMethod.PUT:
-                result['operation'] = CseOperation.SYSTEM_UPDATE
-            else:
-                raise CseRequestError(
-                    status=requests.codes.method_not_allowed,
-                    error_message="Method not allowed")
-
-    if is_template_request:
-        if len(tokens) == 4:
-            if method == RequestMethod.GET:
-                result['operation'] = CseOperation.TEMPLATE_LIST
-            else:
-                raise CseRequestError(
-                    status=requests.codes.method_not_allowed,
-                    error_message="Method not allowed")
-
-    if not result.get('operation'):
-        raise CseRequestError(
-            status=requests.codes.not_found,
-            error_message="Invalid Url. Not found.")
-    return result
+_OPERATION_KEY = 'operation'
 
 
 @handle_exception
 def process_request(body):
     from container_service_extension.service import Service
-
     LOGGER.debug(f"body: {json.dumps(body)}")
+    url = body['requestUri']
 
-    # parse url
-    url_data = _parse_request_url(method=body['method'], url=body['requestUri']) # noqa: E501
+    # url_data = _parse_request_url(method=body['method'], url=body['requestUri']) # noqa: E501
+    url_data = _get_url_data(body['method'], url)
+    operation = url_data[_OPERATION_KEY]
 
     # check if server is disabled
-    # TODO request id mapping in Service
-    tenant_auth_token = body['headers']['x-vcloud-authorization']
-    operation = url_data['operation']
-
     if operation not in (CseOperation.SYSTEM_INFO, CseOperation.SYSTEM_UPDATE)\
             and not Service().is_running():
         raise CseRequestError(status_code=requests.codes.bad_request,
@@ -231,26 +100,146 @@ def process_request(body):
         request_data.update(query_params)
         LOGGER.debug(f"query parameters: {query_params}")
     # update request spec with operation specific data in the url
-    if operation in (CseOperation.CLUSTER_CONFIG,
-                     CseOperation.CLUSTER_DELETE,
-                     CseOperation.CLUSTER_INFO,
-                     CseOperation.CLUSTER_RESIZE):
-        request_data.update({
-            RequestKey.CLUSTER_NAME: url_data[RequestKey.CLUSTER_NAME]
-        })
-    elif operation == CseOperation.NODE_INFO:
-        request_data.update({
-            RequestKey.NODE_NAME: url_data[RequestKey.NODE_NAME]
-        })
-    elif operation in (CseOperation.OVDC_UPDATE, CseOperation.OVDC_INFO):
-        request_data.update({
-            RequestKey.OVDC_ID: url_data[RequestKey.OVDC_ID]
-        })
+    request_data.update(url_data)
 
     # process the request
+    tenant_auth_token = body['headers']['x-vcloud-authorization']
     reply = {
         'status_code': operation.ideal_response_code,
         'body': OPERATION_TO_HANDLER[operation](request_data, tenant_auth_token) # noqa: E501
     }
     LOGGER.debug(f"reply: {str(reply)}")
     return reply
+
+
+def _get_url_data(method, url):
+    """Parse url and http method to get desired CSE operation and url data.
+
+    Url is processed like a tree to find the desired operation as fast as
+    possible. These explicit checks allow any invalid urls or http methods to
+    fall through and trigger the appropriate exception.
+
+    Returns a data dictionary with 'operation' key and also any relevant url
+    data.
+
+    :param RequestMethod method:
+    :param str url:
+
+    :rtype: dict
+    """
+    invalid_url_msg = "Invalid url - not found"
+    bad_method_msg = "Method not allowed"
+    tokens = url.split('/')
+    num_tokens = len(tokens)
+
+    if num_tokens < 4:
+        raise CseRequestError(requests.codes.not_found,
+                              error_message=invalid_url_msg)
+
+    operation_type = tokens[3].lower()
+    if operation_type.endswith('s'):
+        operation_type = operation_type[:-1]
+
+    if operation_type == 'cluster':
+        if num_tokens == 4:
+            if method == RequestMethod.GET:
+                return {_OPERATION_KEY: CseOperation.CLUSTER_LIST}
+            if method == RequestMethod.POST:
+                return {_OPERATION_KEY: CseOperation.CLUSTER_CREATE}
+            raise CseRequestError(requests.codes.method_not_allowed,
+                                  error_message=bad_method_msg)
+        if num_tokens == 5:
+            if method == RequestMethod.GET:
+                return {
+                    _OPERATION_KEY: CseOperation.CLUSTER_INFO,
+                    RequestKey.CLUSTER_NAME: tokens[4]
+                }
+            if method == RequestMethod.PUT:
+                return {
+                    _OPERATION_KEY: CseOperation.CLUSTER_RESIZE,
+                    RequestKey.CLUSTER_NAME: tokens[4]
+                }
+            if method == RequestMethod.DELETE:
+                return {
+                    _OPERATION_KEY: CseOperation.CLUSTER_DELETE,
+                    RequestKey.CLUSTER_NAME: tokens[4]
+                }
+            raise CseRequestError(requests.codes.method_not_allowed,
+                                  error_message=bad_method_msg)
+        if num_tokens == 6 and tokens[5] == 'config':
+            if method == RequestMethod.GET:
+                return {
+                    _OPERATION_KEY: CseOperation.CLUSTER_CONFIG,
+                    RequestKey.CLUSTER_NAME: tokens[4]
+                }
+            raise CseRequestError(requests.codes.method_not_allowed,
+                                  error_message=bad_method_msg)
+
+    elif operation_type == 'node':
+        if num_tokens == 4:
+            if method == RequestMethod.POST:
+                return {_OPERATION_KEY: CseOperation.NODE_CREATE}
+            if method == RequestMethod.DELETE:
+                return {_OPERATION_KEY: CseOperation.NODE_DELETE}
+            raise CseRequestError(requests.codes.method_not_allowed,
+                                  error_message=bad_method_msg)
+        if num_tokens == 5:
+            if method == RequestMethod.GET:
+                return {
+                    _OPERATION_KEY: CseOperation.NODE_INFO,
+                    RequestKey.NODE_NAME: tokens[4]
+                }
+            raise CseRequestError(requests.codes.method_not_allowed,
+                                  error_message=bad_method_msg)
+
+    elif operation_type == 'ovdc':
+        if num_tokens == 4:
+            if method == RequestMethod.GET:
+                return {_OPERATION_KEY: CseOperation.OVDC_LIST}
+            raise CseRequestError(requests.codes.method_not_allowed,
+                                  error_message=bad_method_msg)
+        if num_tokens == 5:
+            if method == RequestMethod.GET:
+                return {
+                    _OPERATION_KEY: CseOperation.OVDC_INFO,
+                    RequestKey.OVDC_ID: tokens[4]
+                }
+            if method == RequestMethod.PUT:
+                return {
+                    _OPERATION_KEY: CseOperation.OVDC_UPDATE,
+                    RequestKey.OVDC_ID: tokens[4]
+                }
+            raise CseRequestError(requests.codes.method_not_allowed,
+                                  error_message=bad_method_msg)
+        if num_tokens == 6 and tokens[5] == 'compute-policies':
+            if method == RequestMethod.GET:
+                return {
+                    _OPERATION_KEY: CseOperation.OVDC_COMPUTE_POLICY_LIST,
+                    RequestKey.OVDC_ID: tokens[4]
+                }
+            if method == RequestMethod.PUT:
+                return {
+                    _OPERATION_KEY: CseOperation.OVDC_COMPUTE_POLICY_UPDATE,
+                    RequestKey.OVDC_ID: tokens[4]
+                }
+            raise CseRequestError(requests.codes.method_not_allowed,
+                                  error_message=bad_method_msg)
+
+    elif operation_type == 'system':
+        if num_tokens == 4:
+            if method == RequestMethod.GET:
+                return {_OPERATION_KEY: CseOperation.SYSTEM_INFO}
+            if method == RequestMethod.PUT:
+                return {_OPERATION_KEY: CseOperation.SYSTEM_UPDATE}
+            raise CseRequestError(requests.codes.method_not_allowed,
+                                  error_message=bad_method_msg)
+
+    elif operation_type == 'template':
+        if num_tokens == 4:
+            if method == RequestMethod.GET:
+                return {_OPERATION_KEY: CseOperation.TEMPLATE_LIST}
+            raise CseRequestError(requests.codes.method_not_allowed,
+                                  error_message=bad_method_msg)
+
+    raise CseRequestError(requests.codes.not_found,
+                          error_message=invalid_url_msg)

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -130,8 +130,8 @@ class CseOperation(Enum):
     OVDC_UPDATE = ('enable or disable ovdc for k8s', requests.codes.accepted)
     OVDC_INFO = ('get info of ovdc')
     OVDC_LIST = ('list ovdcs')
-    OVDC_COMPUTE_POLICY_LIST = ('list ovdc compute policies', requests.codes.accepted) # noqa: E501
-    OVDC_COMPUTE_POLICY_UPDATE = ('update ovdc compute policies', requests.codes.accepted) # noqa: E501
+    OVDC_COMPUTE_POLICY_LIST = ('list ovdc compute policies')
+    OVDC_COMPUTE_POLICY_UPDATE = ('update ovdc compute policies')
     SYSTEM_INFO = ('get info of system')
     SYSTEM_UPDATE = ('update system status')
     TEMPLATE_LIST = ('list all templates')

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -130,6 +130,8 @@ class CseOperation(Enum):
     OVDC_UPDATE = ('enable or disable ovdc for k8s', requests.codes.accepted)
     OVDC_INFO = ('get info of ovdc')
     OVDC_LIST = ('list ovdcs')
+    OVDC_COMPUTE_POLICY_LIST = ('list ovdc compute policies', requests.codes.accepted) # noqa: E501
+    OVDC_COMPUTE_POLICY_UPDATE = ('update ovdc compute policies', requests.codes.accepted) # noqa: E501
     SYSTEM_INFO = ('get info of system')
     SYSTEM_UPDATE = ('update system status')
     TEMPLATE_LIST = ('list all templates')

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -438,8 +438,8 @@ class Service(object, metaclass=Singleton):
                             LOGGER.debug(msg)
                             policy = cpm.add_policy(policy_name=policy_name)
 
-                        msg = f"Assiging compute policy '{policy_name}' to " \
-                            f"template '{catalog_item_name}'."
+                        msg = f"Assigning compute policy '{policy_name}' to " \
+                              f"template '{catalog_item_name}'."
                         if msg_update_callback:
                             msg_update_callback.general(msg)
                         LOGGER.debug(msg)

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -28,6 +28,12 @@ class RequestMethod(str, Enum):
     PUT = 'PUT'
 
 
+@unique
+class ComputePolicyAction(str, Enum):
+    ADD = 'add'
+    REMOVE = 'remove'
+
+
 # TODO need mapping from request key to proper vcd construct error message
 @unique
 class RequestKey(str, Enum):
@@ -69,6 +75,8 @@ class RequestKey(str, Enum):
     PKS_CLUSTER_DOMAIN = 'pks_cluster_domain'
     PKS_PLAN_NAME = 'pks_plan_name'
     LIST_PKS_PLANS = 'list_pks_plans'
+    COMPUTE_POLICY_ACTION = 'action'
+    COMPUTE_POLICY_NAME = 'compute_policy_name'
 
     # keys related to system requests
     SERVER_ACTION = 'server_action'


### PR DESCRIPTION
Implemented:
- `ovdc compute-policy add org_name ovdc_name policy_name`
- `ovdc compute-policy remove org_name ovdc_name policy_name`
    - Known issue: cannot remove a compute policy from an org VDC if vApp templates or VMs contain the compute policy reference in their XML resource
- `ovdc compute-policy list org_name ovdc_name`

Cleaned up some code and updated docstrings

!!! Dependent on pyvcloud PR: https://github.com/vmware/pyvcloud/pull/607

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/414)
<!-- Reviewable:end -->
