### PR TITLE
[VCDA-1155] Expose command to migrate clusters deployed by CSE 2.0.0 and below to current CSE.

### DIFF
--- a/container_service_extension/cluster.py
+++ b/container_service_extension/cluster.py
@@ -185,7 +185,7 @@ def add_nodes(client, num_nodes, node_type, org, vdc, vapp, catalog_name,
                 'vapp': source_vapp.resource,
                 'target_vm_name': name,
                 'hostname': name,
-                'password': template[LocalTemplateKey.ADMIN_PASSWORD],
+                'password_auto': True,
                 'network': network_name,
                 'ip_allocation_mode': 'pool'
             }

--- a/container_service_extension/sample_generator.py
+++ b/container_service_extension/sample_generator.py
@@ -137,7 +137,6 @@ TEMPLATE_RULE_NOTE = """# [Optional] Template rule section
 # the template. If only name is specified without the revision or vice versa,
 # the rule will not be processed. And once a match is found, as an action the
 # following attributes can be overriden.
-# * admin_password
 # * compute_policy
 # * cpu
 # * memory
@@ -150,8 +149,7 @@ TEMPLATE_RULE_NOTE = """# [Optional] Template rule section
 #    name: photon-v2_k8-1.12_weave-2.3.0
 #    revision: 1
 #  action:
-#    admin_password: 'mypassword'
-#    compute_policy: 'photon-policy'
+#    compute_policy: "sample policy"
 #    cpu: 4
 #    mem: 512
 #- name: Rule2
@@ -161,12 +159,6 @@ TEMPLATE_RULE_NOTE = """# [Optional] Template rule section
 #  action:
 #    cpu: 2
 #    mem: 1024
-#- name: Rule3
-#  target:
-#    name: ubuntu-16.04_k8-1.15_weave-2.5.2
-#    revision: 1
-#  action:
-#    admin_password: 'mypassword'
 """
 
 PKS_CONFIG_FILE_LOCATION_SECTION_KEY = 'pks_config'
@@ -264,7 +256,7 @@ SAMPLE_PKS_NSXT_SERVERS_SECTION = {
             'name': 'nsxt-server-1',
             'host': 'nsxt1.domain.local',
             'username': 'admin',
-            'password': 'secret',
+            'password': 'my_secret_password',
             'pks_api_server': 'pks-api-server-1',
             # 'proxy': 'proxy1.pks.local:80',
             'nodes_ip_block_ids': ['id1', 'id2'],
@@ -275,7 +267,7 @@ SAMPLE_PKS_NSXT_SERVERS_SECTION = {
             'name': 'nsxt-server-2',
             'host': 'nsxt2.domain.local',
             'username': 'admin',
-            'password': 'secret',
+            'password': 'my_secret_password',
             'pks_api_server': 'pks-api-server-2',
             # 'proxy': 'proxy2.pks.local:80',
             'nodes_ip_block_ids': ['id1', 'id2'],

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -503,7 +503,6 @@ def convert_cluster(ctx, config_file_name, cluster_name, password, org_name,
             console_message_printer.general(
                 "Finished processing metadata of cluster.")
 
-
             try:
                 console_message_printer.info(
                     f"Undeploying the vApp '{cluster['name']}'")

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -397,20 +397,20 @@ def run(ctx, config, skip_check):
     'org_name',
     default=None,
     metavar='ORG_NAME',
-    help="Match only clusters from a specific org")
+    help="Only convert clusters from a specific org")
 @click.option(
     '-v',
     '--vdc',
     'vdc_name',
     default=None,
     metavar='VDC_NAME',
-    help='Match only clusters from a specific org VDC')
+    help='Only convert clusters from a specific org VDC')
 @click.option(
     '-g',
     '--skip-wait-for-gc',
     'skip_wait_for_gc',
     is_flag=True,
-    help='Skip waiting for guest customizaiton to finish on vms')
+    help='Skip waiting for guest customization to finish on vms')
 def convert_cluster(ctx, config_file_name, cluster_name, password, org_name,
                     vdc_name, skip_wait_for_gc):
     try:

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -77,7 +77,6 @@ class ScriptFile(str, Enum):
 class LocalTemplateKey(str, Enum):
     """Enumerate the keys that define a template."""
 
-    ADMIN_PASSWORD = 'admin_password'  # nosec: Not a hardcoded password
     CATALOG_ITEM_NAME = 'catalog_item_name'
     COMPUTE_POLICY = 'compute_policy'
     CPU = 'cpu'
@@ -92,7 +91,6 @@ class LocalTemplateKey(str, Enum):
 class RemoteTemplateKey(str, Enum):
     """Enumerate the keys that define a template."""
 
-    ADMIN_PASSWORD = 'admin_password'  # nosec: Not a hardcoded password
     COMPUTE_POLICY = 'compute_policy'
     CPU = 'cpu'
     DEPRECATED = 'deprecated'

--- a/container_service_extension/template_rule.py
+++ b/container_service_extension/template_rule.py
@@ -14,7 +14,6 @@ class TemplateRule:
     If only name is specified without the revision or vice versa, the rule will
     not be processed. And once a match is found, as an 'action' the following
     attributes can be overriden.
-        * admin_password
         * compute_policy
         * cpu
         * memory
@@ -28,8 +27,7 @@ class TemplateRule:
         :param dict target: target template of the rule. The keys 'name' and
             'revision' should be present in the dictionary.
         :param dict action: attributes of the target template to update,
-            accepted keys are 'admin_password', 'compute_policy', 'cpu' and
-            'memory'.
+            accepted keys are 'compute_policy', 'cpu' and 'memory'.
         :param logging.Logger logger: optional logger to log with.
         :param utils.ConsoleMessagePrinter msg_update_callback: Callback
             object that writes messages onto console.
@@ -41,10 +39,7 @@ class TemplateRule:
         self.msg_update_callback = msg_update_callback
 
     def __str__(self):
-        redacted_action = dict(self.action)
-        if 'admin_password' in redacted_action:
-            redacted_action['admin_password'] = "[REDACTED]"  # nosec: redacted
-        return f"{self.name} : ({self.target.get('name')} at rev {self.target.get('revision')}) -> {redacted_action}" # noqa: E501
+        return f"{self.name} : ({self.target.get('name')} at rev {self.target.get('revision')}) -> {self.action}" # noqa: E501
 
     def _validate(self, template_table):
         """."""
@@ -104,7 +99,6 @@ class TemplateRule:
         all_actions = set(self.action.keys())
         invalid_actions = list(
             all_actions - set([
-                LocalTemplateKey.ADMIN_PASSWORD,
                 LocalTemplateKey.COMPUTE_POLICY,
                 LocalTemplateKey.CPU,
                 LocalTemplateKey.MEMORY
@@ -150,12 +144,6 @@ class TemplateRule:
             return
 
         target_template = template_table[self.target['name']][str(self.target['revision'])] # noqa: E501
-
-        new_admin_password = \
-            self.action.get(LocalTemplateKey.ADMIN_PASSWORD)
-        if new_admin_password is not None:
-            target_template[LocalTemplateKey.ADMIN_PASSWORD] = \
-                new_admin_password
 
         new_compute_policy = \
             self.action.get(LocalTemplateKey.COMPUTE_POLICY)

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -9,7 +9,6 @@ import uuid
 import pkg_resources
 from pyvcloud.vcd.client import TaskStatus
 from pyvcloud.vcd.client import VCLOUD_STATUS_MAP
-from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.task import Task
 from pyvcloud.vcd.vapp import VApp
 from pyvcloud.vcd.vdc import VDC
@@ -603,10 +602,10 @@ class VcdBroker(AbstractBroker):
                               network_name, num_cpu, mb_memory,
                               storage_profile_name, ssh_key_filepath,
                               enable_nfs, rollback):
-        org_resource = self.tenant_client.get_org_by_name(org_name)
-        org = Org(self.tenant_client, resource=org_resource)
-        vdc_resource = org.get_vdc(ovdc_name)
-        vdc = VDC(self.tenant_client, resource=vdc_resource)
+        org = vcd_utils.get_org(self.tenant_client, org_name=org_name)
+        vdc = vcd_utils.get_vdc(
+            self.tenant_client, vdc_name=ovdc_name, org=org)
+        print(vdc.href)
 
         LOGGER.debug(f"About to create cluster {cluster_name} on {ovdc_name}"
                      f" with {num_workers} worker nodes, "
@@ -623,7 +622,7 @@ class VcdBroker(AbstractBroker):
                                     fence_mode='bridged')
             except Exception as e:
                 msg = f"Error while creating vApp: {e}"
-                LOGGER.debug(msg)
+                LOGGER.debug(str(e))
                 raise ClusterOperationError(msg)
             self.tenant_client.get_task_monitor().wait_for_status(vapp_resource.Tasks.Task[0]) # noqa: E501
 
@@ -778,8 +777,7 @@ class VcdBroker(AbstractBroker):
                             num_workers, network_name, num_cpu, mb_memory,
                             storage_profile_name, ssh_key_filepath, enable_nfs,
                             rollback):
-        org_resource = self.tenant_client.get_org()
-        org = Org(self.tenant_client, resource=org_resource)
+        org = vcd_utils.get_org(self.tenant_client)
         vdc = VDC(self.tenant_client, href=cluster_vdc_href)
         vapp = VApp(self.tenant_client, href=cluster_vapp_href)
         template = get_template(name=template_name, revision=template_revision)
@@ -969,8 +967,7 @@ class VcdBroker(AbstractBroker):
         if self.task_resource is not None:
             task_href = self.task_resource.get('href')
 
-        org_sparse = self.tenant_client.get_org()
-        org = Org(self.tenant_client, resource=org_sparse)
+        org = vcd_utils.get_org(self.tenant_client)
         user_href = org.get_user(self.client_session.get('user')).get('href')
 
         self.task_resource = self.task.update(

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -605,7 +605,6 @@ class VcdBroker(AbstractBroker):
         org = vcd_utils.get_org(self.tenant_client, org_name=org_name)
         vdc = vcd_utils.get_vdc(
             self.tenant_client, vdc_name=ovdc_name, org=org)
-        print(vdc.href)
 
         LOGGER.debug(f"About to create cluster {cluster_name} on {ovdc_name}"
                      f" with {num_workers} worker nodes, "


### PR DESCRIPTION
Currently CSE doesn't lean on admin password defined in config file to interact with k8s clusters. Each cluster vm 's admin password is determined by the template that was used to create them. And the admin password is part of the vm XML representation. This change in password mechanism has rendered old clusters deployed by CSE 2.0.0 and below, unmanageable by current CSE. To fix this issue a new command viz. _cse convert-cluster_ has been exposed in cse server cli, that targets clusters and resets each vm's admin password to an auto generated password via guest customization. The command also formats the metadata on the cluster to suit the new CSE's cluster metadata structure.

Testing done:
Created a photon and ubuntu cluster using CSE 1.2.7
Upgraded CSE to the latest commit of this PR.
Tried interacting with the cluster - operation failed as expected.
Used the command to convert the cluster - operation was successful.
Could retrieve kubectl config from the cluster via CSE.
Could ssh into the cluster with the ssh private key.
Manually verified that all vms in the cluster had auto generated passwords and the cluster metadata was complaint with current CSE cluster metadata.

Known Issues:
1. photon based clusters often get stuck in GC_PENDING state after reboot, but GC finishes properly in background, and I am able to fetch kubectl config from the cluster via CSE.
2. After converting the cluster kube-api-server seems to be down, and kubectl isn't working correctly. - Found the reason behind this, after a restart kublet doesn't start automatically on the nodes. After I ssh-ed into the nodes and ran 'systemctl restart kubelet', everything started working fine. To increase resilliency of our k8s cluster, we should add this fix.



Additionally, this PR also removes all traces of template based admin password management. Each cluster vm will get their own auto generated password. This doesn't impact end users, since root login over ssh via passwords is prohibited for all cluster vms.

Testing Done:
Force installed a template while retaining the temp vApp - operation went through successfully
Was able to ssh into the temp vApp using ssh private key.
Deployed a cluster using this template. - operation was successful.
Could ssh into the cluster vms using the ssh private key.
Could retrieve the kubectl config from the cluster using CSE.
Verified manually via UI, that auto generated passwords were set for all the vms in the cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/421)
<!-- Reviewable:end -->
