### PR TITLE
[VCDA-1195] Force compute policy removal from template to be done only by API 32.0

### DIFF
--- a/container_service_extension/pyvcloud_utils.py
+++ b/container_service_extension/pyvcloud_utils.py
@@ -53,7 +53,7 @@ def connect_vcd_user_via_token(tenant_auth_token):
     return (client_tenant, session)
 
 
-def get_sys_admin_client():
+def get_sys_admin_client(api_version=None):
     server_config = get_server_runtime_config()
     if not server_config['vcd']['verify']:
         LOGGER.warning("InsecureRequestWarning: Unverified HTTPS "
@@ -62,11 +62,15 @@ def get_sys_admin_client():
         requests.packages.urllib3.disable_warnings()
     log_filename = None
     log_wire = str_to_bool(server_config['service'].get('log_wire'))
+
+    if api_version is None:
+        api_version = server_config['vcd']['api_version']
+
     if log_wire:
         log_filename = SERVER_DEBUG_WIRELOG_FILEPATH
     client = Client(
         uri=server_config['vcd']['host'],
-        api_version=server_config['vcd']['api_version'],
+        api_version=api_version,
         verify_ssl_certs=server_config['vcd']['verify'],
         log_file=log_filename,
         log_requests=log_wire,


### PR DESCRIPTION
vCD API v33.0 has a bug in it, due to which the call to remove compute policy from a template VM becomes a no-op. This fix will invoke the corresponding method in pyvcloud, to remove compute policy using a VCD API client version 32.0.
- Tested successfully on vCD 10.

- @rocknes @sakthisunda @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/429)
<!-- Reviewable:end -->
