### PR TITLE
[VCDA-1175] Replace existing VMs compute policy with 'System Default' during forced ovdc compute policy removal

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -1164,7 +1164,8 @@ def compute_policy_add(ctx, org_name, ovdc_name, compute_policy_name):
         result = ovdc.update_ovdc_compute_policies(ovdc_name,
                                                    org_name,
                                                    compute_policy_name,
-                                                   ComputePolicyAction.ADD)
+                                                   ComputePolicyAction.ADD,
+                                                   False)
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)
@@ -1175,7 +1176,16 @@ def compute_policy_add(ctx, org_name, ovdc_name, compute_policy_name):
 @click.argument('org_name', metavar='ORG_NAME')
 @click.argument('ovdc_name', metavar='OVDC_NAME')
 @click.argument('compute_policy_name', metavar='COMPUTE_POLICY_NAME')
-def compute_policy_remove(ctx, org_name, ovdc_name, compute_policy_name):
+@click.option(
+    '-f',
+    '--force',
+    'remove_compute_policy_from_vms',
+    is_flag=True,
+    help="Remove the specified compute policy from deployed VMs as well. "
+         "Affected VMs will have 'System Default' compute policy. "
+         "Does not remove the compute policy from vApp templates in catalog.")
+def compute_policy_remove(ctx, org_name, ovdc_name, compute_policy_name,
+                          remove_compute_policy_from_vms):
     try:
         restore_session(ctx)
         client = ctx.obj['client']
@@ -1186,7 +1196,8 @@ def compute_policy_remove(ctx, org_name, ovdc_name, compute_policy_name):
         result = ovdc.update_ovdc_compute_policies(ovdc_name,
                                                    org_name,
                                                    compute_policy_name,
-                                                   ComputePolicyAction.REMOVE)
+                                                   ComputePolicyAction.REMOVE,
+                                                   remove_compute_policy_from_vms) # noqa: E501
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -100,7 +100,8 @@ class Ovdc:
         return process_response(response)
 
     def update_ovdc_compute_policies(self, ovdc_name, org_name,
-                                     compute_policy_name, action):
+                                     compute_policy_name, action,
+                                     remove_compute_policy_from_vms):
         """Update an ovdc's compute policies.
 
         :param str ovdc_name: Name of org VDC to update
@@ -119,7 +120,8 @@ class Ovdc:
         data = {
             RequestKey.OVDC_ID: ovdc_id, # also exists in url
             RequestKey.COMPUTE_POLICY_NAME: compute_policy_name,
-            RequestKey.COMPUTE_POLICY_ACTION: action
+            RequestKey.COMPUTE_POLICY_ACTION: action,
+            RequestKey.REMOVE_COMPUTE_POLICY_FROM_VMS: remove_compute_policy_from_vms # noqa: E501
         }
 
         response = self.client._do_request_prim(

--- a/container_service_extension/cloudapi/cloudapi_client.py
+++ b/container_service_extension/cloudapi/cloudapi_client.py
@@ -52,6 +52,8 @@ class CloudApiClient(object):
 
         :raises HTTPError: if the underlying REST call fails.
         """
+        # TODO this only sends a request to the first page found.
+        # TODO this should instead be able to deal with pagination
         url = f"{self._versioned_url}{resource_url_relative_path}"
 
         response = requests.request(

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -7,11 +7,11 @@ from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import MissingLinkException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 from pyvcloud.vcd.vm import VM
+from pyvcloud.vcd.utils import retrieve_compute_policy_id_from_href
 
 from container_service_extension.cloudapi.cloudapi_client import CloudApiClient
 from container_service_extension.cloudapi.constants import CloudApiResource
-from container_service_extension.cloudapi.constants import \
-    COMPUTE_POLICY_NAME_PREFIX
+from container_service_extension.cloudapi.constants import COMPUTE_POLICY_NAME_PREFIX # noqa: E501
 from container_service_extension.cloudapi.constants import EntityType
 from container_service_extension.cloudapi.constants import RelationType
 import container_service_extension.pyvcloud_utils as pyvcd_utils
@@ -231,7 +231,7 @@ class ComputePolicyManager:
                     f"Error: {_SYSTEM_DEFAULT_COMPUTE_POLICY} "
                     f"compute policy not found.")
 
-            compute_policy_id = compute_policy_href.split('/')[-1]
+            compute_policy_id = retrieve_compute_policy_id_from_href(compute_policy_href) # noqa: E501
             vapps = pyvcd_utils.get_all_vapps_in_ovdc(self._vcd_client, vdc_id)
             for vapp in vapps:
                 vm_resources = vapp.get_all_vms()

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -17,6 +17,8 @@ from container_service_extension.cloudapi.constants import RelationType
 import container_service_extension.pyvcloud_utils as pyvcd_utils
 from container_service_extension.shared_constants import RequestMethod
 
+_SYSTEM_DEFAULT_COMPUTE_POLICY = 'System Default'
+
 
 class ComputePolicyManager:
     """Manages creating, deleting, updating cloudapi compute policies.
@@ -221,18 +223,20 @@ class ComputePolicyManager:
             system_default_href = None
             system_default_id = None
             for cp_dict in cp_list:
-                if cp_dict['name'] == 'System Default':
+                if cp_dict['name'] == _SYSTEM_DEFAULT_COMPUTE_POLICY:
                     system_default_href = cp_dict['href']
                     system_default_id = cp_dict['id']
             if system_default_href is None:
-                raise EntityNotFoundException("Error: 'System Default' "
-                                              "policy not found.")
+                raise EntityNotFoundException(
+                    f"Error: {_SYSTEM_DEFAULT_COMPUTE_POLICY} "
+                    f"compute policy not found.")
 
+            compute_policy_id = compute_policy_href.split('/')[-1]
             vapps = pyvcd_utils.get_all_vapps_in_ovdc(self._vcd_client, vdc_id)
             for vapp in vapps:
                 vm_resources = vapp.get_all_vms()
                 for vm_resource in vm_resources:
-                    if vm_resource.VdcComputePolicy.get('href') == compute_policy_href: # noqa: E501
+                    if vm_resource.VdcComputePolicy.get('id') == compute_policy_id: # noqa: E501
                         vm = VM(self._vcd_client, resource=vm_resource)
                         task = vm.update_compute_policy(system_default_href,
                                                         system_default_id)

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -6,8 +6,8 @@ from pyvcloud.vcd.client import find_link
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import MissingLinkException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
-from pyvcloud.vcd.vm import VM
 from pyvcloud.vcd.utils import retrieve_compute_policy_id_from_href
+from pyvcloud.vcd.vm import VM
 
 from container_service_extension.cloudapi.cloudapi_client import CloudApiClient
 from container_service_extension.cloudapi.constants import CloudApiResource
@@ -96,6 +96,7 @@ class ComputePolicyManager:
         :return: policy details if found, else None
         :rtype: dict
         """
+        # TODO there can be multiple policies with the same name
         for policy_dict in self.list_policies():
             if policy_dict.get('display_name') == policy_name:
                 policy_dict['href'] = self._get_policy_href(policy_dict['id'])

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -81,7 +81,7 @@ class ComputePolicyManager:
         for policy in policies['values']:
             if policy['name'].startswith(COMPUTE_POLICY_NAME_PREFIX):
                 policy['display_name'] = \
-                    self._get_original_policy_name(policy['name'])
+                    self._get_policy_display_name(policy['name'])
             else:
                 policy['display_name'] = policy['name']
             cse_policies.append(policy)
@@ -118,7 +118,7 @@ class ComputePolicyManager:
             RequestMethod.POST,
             resource_url_relative_path=CloudApiResource.VDC_COMPUTE_POLICIES,
             payload=policy_info)
-        created_policy['display_name'] = self._get_original_policy_name(
+        created_policy['display_name'] = self._get_policy_display_name(
             created_policy['name'])
         created_policy['href'] = self._get_policy_href(created_policy['id'])
         return created_policy
@@ -160,7 +160,7 @@ class ComputePolicyManager:
                 resource_url_relative_path=resource_url_relative_path,
                 payload=payload)
             updated_policy['display_name'] = \
-                self._get_original_policy_name(updated_policy['name'])
+                self._get_policy_display_name(updated_policy['name'])
             updated_policy['href'] = policy_info['href']
             return updated_policy
 
@@ -197,7 +197,7 @@ class ComputePolicyManager:
         cp_list = vdc.list_compute_policies()
         for cp in cp_list:
             result.append({
-                'name': self._get_original_policy_name(cp.get('name')),
+                'name': self._get_policy_display_name(cp.get('name')),
                 'href': cp.get('href'),
                 'id': cp.get('id')
             })
@@ -324,7 +324,7 @@ class ComputePolicyManager:
         """
         return f"{COMPUTE_POLICY_NAME_PREFIX}{policy_name}"
 
-    def _get_original_policy_name(self, policy_name):
+    def _get_policy_display_name(self, policy_name):
         """Remove cse specific prefix from the given policy name.
 
         :param str policy_name: name of the policy

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -140,7 +140,7 @@ def ovdc_compute_policy_update(request_data, tenant_auth_token):
             cp_href = _cp['href']
             cp_id = _cp['id']
     if cp_href is None:
-        raise ValueError(f"Compute policy '{cp_name}' ({cp_id}) not found.")
+        raise ValueError(f"Compute policy '{cp_name}' not found.")
 
     if action == ComputePolicyAction.ADD:
         cpm.add_compute_policy_to_vdc(ovdc_id, cp_href)
@@ -155,8 +155,7 @@ def ovdc_compute_policy_update(request_data, tenant_auth_token):
                 remove_compute_policy_from_vms=remove_compute_policy_from_vms)
         except EntityNotFoundException:
             raise EntityNotFoundException(
-                f"Compute policy '{cp_name}' ({cp_id}) not "
-                f"found in ovdc ({ovdc_id})")
+                f"Compute policy '{cp_name}' not found in ovdc ({ovdc_id})")
         except Exception:
             # This ensures that BadRequestException message is printed
             # to console. (error when ovdc currently has VMs/vApp

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -77,6 +77,7 @@ class RequestKey(str, Enum):
     LIST_PKS_PLANS = 'list_pks_plans'
     COMPUTE_POLICY_ACTION = 'action'
     COMPUTE_POLICY_NAME = 'compute_policy_name'
+    REMOVE_COMPUTE_POLICY_FROM_VMS = 'remove_compute_policy_from_vms'
 
     # keys related to system requests
     SERVER_ACTION = 'server_action'

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -658,7 +658,7 @@ class VcdBroker(AbstractBroker):
             catalog_name = server_config['broker']['catalog']
             try:
                 add_nodes(client=self.tenant_client,
-                          num_nodes=num_workers,
+                          num_nodes=1,
                           node_type=NodeType.MASTER,
                           org=org,
                           vdc=vdc,

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -137,6 +137,7 @@ class VcdBroker(AbstractBroker):
                 cluster.get('nodes').append(node_info)
             elif vm.get('name').startswith(NodeType.NFS):
                 cluster.get('nfs_nodes').append(node_info)
+
         return cluster
 
     def list_clusters(self, data):
@@ -276,6 +277,11 @@ class VcdBroker(AbstractBroker):
             RequestKey.ROLLBACK: True,
         }
         validated_data = {**defaults, **data}
+
+        # TODO HACK default dictionary combining needs to be fixed
+        validated_data[RequestKey.TEMPLATE_NAME] = validated_data[RequestKey.TEMPLATE_NAME] or template[LocalTemplateKey.NAME] # noqa: E501
+        validated_data[RequestKey.TEMPLATE_REVISION] = validated_data[RequestKey.TEMPLATE_REVISION] or template[LocalTemplateKey.REVISION] # noqa: E501
+
         template_name = validated_data[RequestKey.TEMPLATE_NAME]
         template_revision = validated_data[RequestKey.TEMPLATE_REVISION]
 

--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -103,7 +103,7 @@ def cse_server():
         p = subprocess.Popen(cmd.split(),
                              stdout=subprocess.DEVNULL,
                              stderr=subprocess.STDOUT)
-    time.sleep(env.WAIT_INTERVAL)  # server takes a little while to set up
+    time.sleep(env.WAIT_INTERVAL * 3)  # server takes a little while to set up
 
     # enable kubernetes functionality on our ovdc
     # by default, an ovdc cannot deploy kubernetes clusters

--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -386,7 +386,7 @@ def test_0050_vcd_cse_system_toggle(config, test_runner_username,
     execute_commands(cmd_list)
 
     assert not env.vapp_exists(env.SYS_ADMIN_TEST_CLUSTER_NAME), \
-        "Cluster exist when it should not."
+        "Cluster exists when it should not."
 
 
 @pytest.mark.parametrize('test_runner_username', [env.SYS_ADMIN_NAME,


### PR DESCRIPTION
- Implemented get_all_vapps_in_ovdc()
- Bugfix: cluster create would create the same number of masters as workers. Fixed to only create 1 master node
- Bugfix: 'None' template name and revision during cluster create 
- Implemented replacing specified compute policy on VMs with 'System Default' compute policy
- Updated CSE client to expose force removal of compute policy from ovdc

**Important notes regarding this change:**
- 'System Default' compute policy must be assigned to the ovdc, but 'System Default' does not have to be the default compute policy.
- vCD extension timeout must be extended or else this operation will get a timeout error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/433)
<!-- Reviewable:end -->
