### PR TITLE
[VCDA-1199] Add K8s_version field to output of /api/cse/clusters and /api/cse/cluster/{name}

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -179,7 +179,7 @@ def list_clusters(ctx, vdc, org_name):
         if not client.is_sysadmin() and org_name is None:
             org_name = ctx.obj['profiles'].get('org_in_use')
         result = cluster.get_clusters(vdc=vdc, org=org_name)
-        stdout(result, ctx, show_id=True)
+        stdout(result, ctx, show_id=True, sort_headers=False)
     except Exception as e:
         stderr(e, ctx)
 

--- a/container_service_extension/cluster.py
+++ b/container_service_extension/cluster.py
@@ -20,6 +20,8 @@ from container_service_extension.exceptions import CseServerError
 from container_service_extension.exceptions import DeleteNodeError
 from container_service_extension.exceptions import NodeCreationError
 from container_service_extension.exceptions import ScriptExecutionError
+from container_service_extension.local_template_manager import \
+    get_template_k8s_version
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 import container_service_extension.pyvcloud_utils as vcd_utils
 from container_service_extension.remote_template_manager import get_local_script_filepath # noqa: E501
@@ -114,6 +116,8 @@ def get_all_clusters(client, cluster_name=None, cluster_id=None,
                     cluster['template_name'] = str(entry.TypedValue.Value)
                 elif entry.Key == ClusterMetadataKey.TEMPLATE_REVISION:
                     cluster['template_revision'] = str(entry.TypedValue.Value)
+            cluster['k8s_version'] = \
+                get_template_k8s_version(cluster.get('template_name'))
 
         clusters.append(cluster)
 

--- a/container_service_extension/local_template_manager.py
+++ b/container_service_extension/local_template_manager.py
@@ -12,6 +12,16 @@ from container_service_extension.server_constants import \
     LocalTemplateKey
 
 
+def get_template_k8s_version(template_name):
+    if template_name:
+        properties = template_name.split("_")
+        if len(properties) == 3:
+            k8s_info = properties[1].split("-")
+            if len(k8s_info) == 2:
+                if k8s_info[0] in ("k8", "esspks"):
+                    return k8s_info[1]
+    return "Unknown"
+
 def _dict_to_k8s_local_template_definition(dikt):
     valid_keys = [e.value for e in LocalTemplateKey]
     missing_keys = []

--- a/container_service_extension/local_template_manager.py
+++ b/container_service_extension/local_template_manager.py
@@ -22,6 +22,7 @@ def get_template_k8s_version(template_name):
                     return k8s_info[1]
     return "Unknown"
 
+
 def _dict_to_k8s_local_template_definition(dikt):
     valid_keys = [e.value for e in LocalTemplateKey]
     missing_keys = []

--- a/container_service_extension/request_handlers/cluster_handler.py
+++ b/container_service_extension/request_handlers/cluster_handler.py
@@ -150,6 +150,7 @@ def cluster_list(request_data, tenant_auth_token):
         'vdc',
         'status',
         'org_name',
+        'k8s_version',
         K8S_PROVIDER_KEY
     ]
 

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -165,6 +165,7 @@ class VcdBroker(AbstractBroker):
                 'IP master': c['leader_endpoint'],
                 'template_name': c.get('template_name'),
                 'template_revision': c.get('template_revision'),
+                'k8s_version': c.get('k8s_version'),
                 'VMs': c['number_of_vms'],
                 'vdc': c['vdc_name'],
                 'status': c['status'],


### PR DESCRIPTION
When we query vCD for listing clusters, vCD sends back metadata on those vApps too as  part of the result. One of the metadata viz. template_name can be parsed to deduce the k8s version that's installed in the master node. This PR parses the name of the template of which the master node was created and appends it to the result of the call to list all clusters. If for any reason the name parsing fails, the value "Unknown" is returned.

This change only affects native clusters! To retrieve Enterprise PKS cluster's K8s version we need a separate REST call. Currently for Enterprise PKS clusters, the output of the REST call /api/clusters will have the k8s_version field set to None , while the field will be completely missing for /api/cluster/{name} calls

Testing done:
Created a native cluster. Ran vcd cse cluster list and vcd cse cluster info {cluster name}.
In both instances the k8s_version field was present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/434)
<!-- Reviewable:end -->
