### PR TITLE
[VCDA-1213] Fixed GA Release Date For CSE 1.1.0

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -366,7 +366,7 @@ Supported vCD versions: 9.0, 9.1, 9.5
 
 ## CSE 1.1.0
 
-Release date: 2018-04-20
+Release date: 2018-06-15
 
 | vCD         | OS                 | Docker     | Kubernetes | Pod Network |
 |:------------|:-------------------|:-----------|:-----------|:------------|


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

Fixed GA release date of CSE 1.1.0 in RELEASE_NOTES.md. 
Verified to match the date in  https://pypi.org/project/container-service-extension/#history
@rocknes  @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/440)
<!-- Reviewable:end -->
