### PR TITLE
[VCDA-1223] CSE SERVER MANAGEMENT - Left Side Navigation Changes

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -23,13 +23,11 @@
   subtoc:
   - name: Overview
     sublink: overview
-  - name: CSE Server Versions
-    sublink: compatibility
   - name: vCD Prerequisites
     sublink: prerequisites
   - name: Server Config File
     sublink: configfile
-  - name: VM Templates
+  - name: Kubernetes Templates
     sublink: vmtemplates
   - name: Server Setup
     sublink: serversetup


### PR DESCRIPTION
Following changes are made on https://vmware.github.io/container-service-extension/CSE_ADMIN.htm

-  VM Templates replaced with Kubernetes Templates

- Removed CSE Server Versions Topic

@rocknes @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/441)
<!-- Reviewable:end -->
