### PR TITLE
[VCDA-1210] Fix cluster deployment for non admin cross org users with api v33.0

### DIFF
--- a/container_service_extension/pyvcloud_utils.py
+++ b/container_service_extension/pyvcloud_utils.py
@@ -336,6 +336,11 @@ def upload_ova_to_catalog(client, catalog_name, filepath, update=False,
             pass
     else:
         try:
+            # DEV NOTE: With api v33.0 and onwards, get_catalog_item operation
+            # will fail for non admin users of an org which is not hosting the
+            # catalog, even if the catalog is explicitly shared with the org in
+            # question. Please use this method only for org admin and
+            # sys admins.
             org.get_catalog_item(catalog_name, catalog_item_name)
             msg = f"'{catalog_item_name}' already exists in catalog " \
                   f"'{catalog_name}'"
@@ -375,6 +380,10 @@ def catalog_exists(org, catalog_name):
 
     :rtype: bool
     """
+    # DEV NOTE: With api v33.0 and onwards, get_catalog operation will fail for
+    # non admin users of an org which is not hosting the catalog, even if the
+    # catalog is explicitly shared with the org in question. Please use this
+    # method only for org admin and sys admins.
     try:
         org.get_catalog(catalog_name)
         return True
@@ -393,6 +402,10 @@ def catalog_item_exists(org, catalog_name, catalog_item_name):
 
     :rtype: bool
     """
+    # DEV NOTE: With api v33.0 and onwards, get_catalog_item operation will
+    # fail for non admin users of an an org which is not hosting the catalog,
+    # even if the catalog is explicitly shared with the org in question. Please
+    # use this method only for org admin and sys admins.
     try:
         org.get_catalog_item(catalog_name, catalog_item_name)
         return True
@@ -444,6 +457,10 @@ def create_and_share_catalog(org, catalog_name, catalog_desc='', logger=None,
         org.reload()
     org.share_catalog(catalog_name)
     org.reload()
+    # DEV NOTE: With api v33.0 and onwards, get_catalog operation will fail for
+    # non admin users of an org which is not hosting the catalog, even if the
+    # catalog is explicitly shared with the org in question. Please use this
+    # method only for org admin and sys admins.
     return org.get_catalog(catalog_name)
 
 
@@ -463,6 +480,10 @@ def wait_for_catalog_item_to_resolve(client, catalog_name, catalog_item_name,
     """
     if org is None:
         org = get_org(client, org_name=org_name)
+    # DEV NOTE: With api v33.0 and onwards, get_catalog_item operation will
+    # fail for non admin users of an an org which is not hosting the catalog,
+    # even if the catalog is explicitly shared with the org in question. Please
+    # use this method only for org admin and sys admins.
     item = org.get_catalog_item(catalog_name, catalog_item_name)
     resource = client.get_resource(item.Entity.get('href'))
     client.get_task_monitor().wait_for_success(resource.Tasks.Task[0])

--- a/container_service_extension/system_test_framework/environment.py
+++ b/container_service_extension/system_test_framework/environment.py
@@ -259,6 +259,10 @@ def catalog_item_exists(catalog_item, catalog_name=None):
         catalog_name = CATALOG_NAME
     org = Org(CLIENT, href=ORG_HREF)
     try:
+        # DEV NOTE: With api v33.0 and onwards, get_catalog_item operation will
+        # fail for non admin users of an an org which is not hosting the
+        # catalog, even if the catalog is explicitly shared with the org in
+        # question. Please use this method only for org admin and sys admins.
         org.get_catalog_item(catalog_name, catalog_item)
         return True
     except EntityNotFoundException:

--- a/container_service_extension/template_builder.py
+++ b/container_service_extension/template_builder.py
@@ -384,6 +384,10 @@ class TemplateBuilder():
         if self.logger:
             self.logger.info(msg)
 
+        # DEV NOTE: With api v33.0 and onwards, get_catalog operation will fail
+        # for non admin users of an org which is not hosting the catalog, even
+        # if the catalog is explicitly shared with the org in question. Please
+        # use this method only for org admin and sys admins.
         catalog = self.org.get_catalog(self.catalog_name)
         try:
             msg = f"Shutting down vApp '{self.temp_vapp_name}'"


### PR DESCRIPTION
In vcd api v33.0, due to a change in the way how non admin users find href of a catalog that is shared from another org, they are unable to access such catalogs and deploy k8s clusters. To fix this issue, sys admin gets the href of the catalog for these affected users.

Additional fix:
Trap exceptions raised by pyvmomi and convert them to CSE exception to patch the workflow where cluster rollback on error was being skipped.

Testing done:
With the fix in, a vapp_author is able to deploy cluster from shared catalogs (server is running on api v33.0)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/442)
<!-- Reviewable:end -->
