### PR TITLE
[VCDA-1211] Modify VM compute policy update to be asynchronous

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -1203,7 +1203,8 @@ def compute_policy_add(ctx, org_name, ovdc_name, compute_policy_name):
     is_flag=True,
     help="Remove the specified compute policy from deployed VMs as well. "
          "Affected VMs will have 'System Default' compute policy. "
-         "Does not remove the compute policy from vApp templates in catalog.")
+         "Does not remove the compute policy from vApp templates in catalog. "
+         "This VM compute policy update is irreversible.")
 def compute_policy_remove(ctx, org_name, ovdc_name, compute_policy_name,
                           remove_compute_policy_from_vms):
     try:

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -365,7 +365,7 @@ class ComputePolicyManager:
             task=task,
             task_href=task_href,
             user_href=user_href,
-            org_href=org.name,
+            org_href=org.href,
             vdc_href=vdc.href,
             vdc_name=vdc.href,
             ovdc_id=ovdc_id,
@@ -415,7 +415,7 @@ class ComputePolicyManager:
                 vm_names = [vm.get('name') for vm in target_vms]
 
                 task.update(
-                    status=TaskStatus.RUNNING,
+                    status=TaskStatus.RUNNING.value,
                     namespace='vcloud.cse',
                     operation=f"Setting compute policy to "
                               f"'{_SYSTEM_DEFAULT_COMPUTE_POLICY}' on "
@@ -439,7 +439,7 @@ class ComputePolicyManager:
                                                      system_default_id)
 
                     task.update(
-                        status=TaskStatus.RUNNING,
+                        status=TaskStatus.RUNNING.value,
                         namespace='vcloud.cse',
                         operation=f"Setting compute policy to "
                                   f"'{_SYSTEM_DEFAULT_COMPUTE_POLICY}' on VM "
@@ -462,7 +462,7 @@ class ComputePolicyManager:
                                       is_admin_operation=True)
 
             task.update(
-                status=TaskStatus.RUNNING,
+                status=TaskStatus.RUNNING.value,
                 namespace='vcloud.cse',
                 operation=f"Removing compute policy (href:"
                           f"{compute_policy_href}) from org VDC '{vdc_name}'",
@@ -481,7 +481,7 @@ class ComputePolicyManager:
             vdc.remove_compute_policy(compute_policy_href)
 
             task.update(
-                status=TaskStatus.SUCCESS,
+                status=TaskStatus.SUCCESS.value,
                 namespace='vcloud.cse',
                 operation=f"Removed compute policy (href: "
                           f"{compute_policy_href}) from org VDC '{vdc_name}'",
@@ -499,7 +499,7 @@ class ComputePolicyManager:
         except Exception as err:
             LOGGER.error(err, exc_info=True)
             task.update(
-                status=TaskStatus.ERROR,
+                status=TaskStatus.ERROR.value,
                 namespace='vcloud.cse',
                 operation='',
                 operation_name='Updating VDC',

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -366,8 +366,6 @@ class ComputePolicyManager:
             task_href=task_href,
             user_href=user_href,
             org_href=org.href,
-            vdc_href=vdc.href,
-            vdc_name=vdc.href,
             ovdc_id=ovdc_id,
             compute_policy_href=compute_policy_href,
             remove_compute_policy_from_vms=remove_compute_policy_from_vms)
@@ -382,12 +380,13 @@ class ComputePolicyManager:
                                               task_href,
                                               user_href,
                                               org_href,
-                                              vdc_href,
-                                              vdc_name,
                                               ovdc_id,
                                               compute_policy_href,
                                               remove_compute_policy_from_vms):
         user_name = self._session.get('user')
+        vdc = pyvcd_utils.get_vdc(self._vcd_client,
+                                  vdc_id=ovdc_id,
+                                  is_admin_operation=True)
 
         try:
             if remove_compute_policy_from_vms:
@@ -420,11 +419,11 @@ class ComputePolicyManager:
                     operation=f"Setting compute policy to "
                               f"'{_SYSTEM_DEFAULT_COMPUTE_POLICY}' on "
                               f"{len(vm_names)} affected VMs: {vm_names}",
-                    operation_name='Updating VDC',
+                    operation_name='Remove org VDC compute policy',
                     details='',
                     progress=None,
-                    owner_href=vdc_href,
-                    owner_name=vdc_name,
+                    owner_href=vdc.href,
+                    owner_name=vdc.name,
                     owner_type=EntityType.VDC.value,
                     user_href=user_href,
                     user_name=user_name,
@@ -444,11 +443,11 @@ class ComputePolicyManager:
                         operation=f"Setting compute policy to "
                                   f"'{_SYSTEM_DEFAULT_COMPUTE_POLICY}' on VM "
                                   f"'{vm_resource.get('name')}'",
-                        operation_name='Updating VDC',
+                        operation_name='Remove org VDC compute policy',
                         details='',
                         progress=None,
-                        owner_href=vdc_href,
-                        owner_name=vdc_name,
+                        owner_href=vdc.href,
+                        owner_name=vdc.name,
                         owner_type=EntityType.VDC.value,
                         user_href=user_href,
                         user_name=user_name,
@@ -465,12 +464,12 @@ class ComputePolicyManager:
                 status=TaskStatus.RUNNING.value,
                 namespace='vcloud.cse',
                 operation=f"Removing compute policy (href:"
-                          f"{compute_policy_href}) from org VDC '{vdc_name}'",
-                operation_name='Updating VDC',
+                          f"{compute_policy_href}) from org VDC '{vdc.name}'",
+                operation_name='Remove org VDC compute policy',
                 details='',
                 progress=None,
-                owner_href=vdc_href,
-                owner_name=vdc_name,
+                owner_href=vdc.href,
+                owner_name=vdc.name,
                 owner_type=EntityType.VDC.value,
                 user_href=user_href,
                 user_name=user_name,
@@ -484,12 +483,12 @@ class ComputePolicyManager:
                 status=TaskStatus.SUCCESS.value,
                 namespace='vcloud.cse',
                 operation=f"Removed compute policy (href: "
-                          f"{compute_policy_href}) from org VDC '{vdc_name}'",
+                          f"{compute_policy_href}) from org VDC '{vdc.name}'",
                 operation_name='Updating VDC',
                 details='',
                 progress=None,
-                owner_href=vdc_href,
-                owner_name=vdc_name,
+                owner_href=vdc.href,
+                owner_name=vdc.name,
                 owner_type=EntityType.VDC.value,
                 user_href=user_href,
                 user_name=user_name,
@@ -502,11 +501,11 @@ class ComputePolicyManager:
                 status=TaskStatus.ERROR.value,
                 namespace='vcloud.cse',
                 operation='',
-                operation_name='Updating VDC',
+                operation_name='Remove org VDC compute policy',
                 details='',
                 progress=None,
-                owner_href=vdc_href,
-                owner_name=vdc_name,
+                owner_href=vdc.href,
+                owner_name=vdc.name,
                 owner_type=EntityType.VDC.value,
                 user_href=user_href,
                 user_name=user_name,

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -2,11 +2,14 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+from pyvcloud.vcd.client import EntityType as PyvcdEntityType
 from pyvcloud.vcd.client import find_link
+from pyvcloud.vcd.client import TaskStatus
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import MissingLinkException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 from pyvcloud.vcd.utils import retrieve_compute_policy_id_from_href
+from pyvcloud.vcd.task import Task
 from pyvcloud.vcd.vm import VM
 
 from container_service_extension.cloudapi.cloudapi_client import CloudApiClient
@@ -14,8 +17,10 @@ from container_service_extension.cloudapi.constants import CloudApiResource
 from container_service_extension.cloudapi.constants import CSE_COMPUTE_POLICY_PREFIX # noqa: E501
 from container_service_extension.cloudapi.constants import EntityType
 from container_service_extension.cloudapi.constants import RelationType
+from container_service_extension.logger import SERVER_LOGGER as LOGGER
 import container_service_extension.pyvcloud_utils as pyvcd_utils
 from container_service_extension.shared_constants import RequestMethod
+import container_service_extension.utils as utils
 
 _SYSTEM_DEFAULT_COMPUTE_POLICY = 'System Default'
 
@@ -53,12 +58,12 @@ class ComputePolicyManager:
             self._vcd_client._session.headers['x-vcloud-authorization']
         # pyvcloud doesn't store the vCD session response in client. So we need
         # to get it from vCD.
-        session = self._vcd_client.rehydrate_from_token(auth_token)
+        self._session = self._vcd_client.rehydrate_from_token(auth_token)
         # Ideally this information should be fetched from
         # client._session_endpoints. However pyvcloud client doesn't store
         # the cloudapi link, so we have to find it manually.
         try:
-            link = find_link(session, RelationType.OPEN_API,
+            link = find_link(self._session, RelationType.OPEN_API,
                              EntityType.APPLICATION_JSON)
         except MissingLinkException:
             raise OperationNotSupportedException(
@@ -220,49 +225,6 @@ class ComputePolicyManager:
 
         return result
 
-    def remove_compute_policy_from_vdc(self, vdc_id, compute_policy_href,
-                                       remove_compute_policy_from_vms=False):
-        """Delete the compute policy from the specified vdc.
-
-        :param str vdc_id: id of the vdc to assign the policy
-        :param compute_policy_href: policy href that is created using cloudapi
-        :param bool remove_compute_policy_from_vms: If True, will set affected
-            VMs' compute policy to 'System Default'
-
-        :return: an object containing VdcComputePolicyReferences XML element
-        that refers to individual VdcComputePolicies.
-
-        :rtype: lxml.objectify.ObjectifiedElement
-        """
-        if remove_compute_policy_from_vms:
-            cp_list = self.list_compute_policies_on_vdc(vdc_id)
-            system_default_href = None
-            system_default_id = None
-            for cp_dict in cp_list:
-                if cp_dict['name'] == _SYSTEM_DEFAULT_COMPUTE_POLICY:
-                    system_default_href = cp_dict['href']
-                    system_default_id = cp_dict['id']
-            if system_default_href is None:
-                raise EntityNotFoundException(
-                    f"Error: {_SYSTEM_DEFAULT_COMPUTE_POLICY} "
-                    f"compute policy not found.")
-
-            compute_policy_id = retrieve_compute_policy_id_from_href(compute_policy_href) # noqa: E501
-            vapps = pyvcd_utils.get_all_vapps_in_ovdc(self._vcd_client, vdc_id)
-            for vapp in vapps:
-                vm_resources = vapp.get_all_vms()
-                for vm_resource in vm_resources:
-                    if vm_resource.VdcComputePolicy.get('id') == compute_policy_id: # noqa: E501
-                        vm = VM(self._vcd_client, resource=vm_resource)
-                        task = vm.update_compute_policy(system_default_href,
-                                                        system_default_id)
-                        self._vcd_client.get_task_monitor().wait_for_status(task) # noqa: E501
-
-        vdc = pyvcd_utils.get_vdc(self._vcd_client,
-                                  vdc_id=vdc_id,
-                                  is_admin_operation=True)
-        return vdc.remove_compute_policy(compute_policy_href)
-
     def assign_compute_policy_to_vapp_template_vms(self,
                                                    compute_policy_href,
                                                    org_name,
@@ -360,4 +322,183 @@ class ComputePolicyManager:
         :return: policy href
         :rtype: str
         """
-        return f"{self._cloudapi_client.get_versioned_url()}{CloudApiResource.VDC_COMPUTE_POLICIES}/{policy_id}"  # noqa
+        return f"{self._cloudapi_client.get_versioned_url()}" \
+               f"{CloudApiResource.VDC_COMPUTE_POLICIES}/{policy_id}"
+
+    def remove_compute_policy_from_vdc(self, ovdc_id, compute_policy_href,
+                                       remove_compute_policy_from_vms=False):
+        """Delete the compute policy from the specified vdc.
+
+        :param str ovdc_id: id of the vdc to assign the policy
+        :param compute_policy_href: policy href to remove
+        :param bool remove_compute_policy_from_vms: If True, will set affected
+            VMs' compute policy to 'System Default'
+
+        :return: dictionary containing 'task_href'.
+        """
+        vdc = pyvcd_utils.get_vdc(self._vcd_client, vdc_id=ovdc_id)
+
+        # TODO is there no better way to get the client href?
+        org = pyvcd_utils.get_org(self._vcd_client)
+        org.reload()
+        user_name = self._session.get('user')
+        user_href = org.get_user(user_name).get('href')
+
+        task = Task(self._vcd_client)
+        task_resource = task.update(
+            status=TaskStatus.RUNNING.value,
+            namespace='vcloud.cse',
+            operation=f"Removing compute policy (href: {compute_policy_href})"
+                      f" from org VDC (vdc id: {ovdc_id})",
+            operation_name='Remove org VDC compute policy',
+            details='',
+            progress=None,
+            owner_href=vdc.href,
+            owner_name=vdc.name,
+            owner_type=PyvcdEntityType.VDC.value,
+            user_href=user_href,
+            user_name=user_name,
+            org_href=org.href)
+
+        task_href = task_resource.get('href')
+        self._remove_compute_policy_from_vdc_async(
+            task=task,
+            task_href=task_href,
+            ovdc_id=ovdc_id,
+            compute_policy_href=compute_policy_href,
+            remove_compute_policy_from_vms=remove_compute_policy_from_vms)
+
+        return {
+            'task_href': task_href
+        }
+
+    @utils.run_async
+    def _remove_compute_policy_from_vdc_async(self, *args,
+                                              task,
+                                              task_href,
+                                              ovdc_id,
+                                              compute_policy_href,
+                                              remove_compute_policy_from_vms):
+        vdc = pyvcd_utils.get_vdc(self._vcd_client, vdc_id=ovdc_id)
+
+        # TODO is there any better way to get the client href
+        org = pyvcd_utils.get_org(self._vcd_client)
+        org.reload()
+        user_name = self._session.get('user')
+        user_href = org.get_user(user_name).get('href')
+
+        try:
+            if remove_compute_policy_from_vms:
+                cp_list = self.list_compute_policies_on_vdc(ovdc_id)
+                system_default_href = None
+                system_default_id = None
+                for cp_dict in cp_list:
+                    if cp_dict['name'] == _SYSTEM_DEFAULT_COMPUTE_POLICY:
+                        system_default_href = cp_dict['href']
+                        system_default_id = cp_dict['id']
+                if system_default_href is None:
+                    raise EntityNotFoundException(
+                        f"Error: {_SYSTEM_DEFAULT_COMPUTE_POLICY} "
+                        f"compute policy not found")
+
+                compute_policy_id = retrieve_compute_policy_id_from_href(compute_policy_href) # noqa: E501
+                vapps = pyvcd_utils.get_all_vapps_in_ovdc(self._vcd_client,
+                                                          ovdc_id)
+                target_vms = []
+                for vapp in vapps:
+                    vm_resources = vapp.get_all_vms()
+                    for vm_resource in vm_resources:
+                        if vm_resource.VdcComputePolicy.get('id') == compute_policy_id: # noqa: E501
+                            target_vms.append(vm_resource)
+                vm_names = [vm.get('name') for vm in target_vms]
+                _update_vdc_task_resource(
+                    task,
+                    TaskStatus.RUNNING,
+                    vdc.href,
+                    vdc.name,
+                    user_href,
+                    user_name,
+                    task_href,
+                    org.href,
+                    message=f"Setting compute policy to "
+                            f"'{_SYSTEM_DEFAULT_COMPUTE_POLICY}' on "
+                            f"{len(vm_names)} affected VMs: {vm_names}")
+
+                task_monitor = self._vcd_client.get_task_monitor()
+                for vm_resource in target_vms:
+                    vm = VM(self._vcd_client, resource=vm_resource)
+                    _task = vm.update_compute_policy(system_default_href,
+                                                     system_default_id)
+                    _update_vdc_task_resource(
+                        task,
+                        TaskStatus.RUNNING,
+                        vdc.href,
+                        vdc.name,
+                        user_href,
+                        user_name,
+                        task_href,
+                        org.href,
+                        message=f"Setting compute policy to "
+                                f"'{_SYSTEM_DEFAULT_COMPUTE_POLICY}' on VM "
+                                f"'{vm_resource.get('name')}'")
+                    task_monitor.wait_for_success(_task)
+
+            vdc = pyvcd_utils.get_vdc(self._vcd_client,
+                                      vdc_id=ovdc_id,
+                                      is_admin_operation=True)
+            _update_vdc_task_resource(
+                task,
+                TaskStatus.RUNNING,
+                vdc.href,
+                vdc.name,
+                user_href,
+                user_name,
+                task_href,
+                org.href,
+                message=f"Removing compute policy (href:{compute_policy_href})"
+                        f" from org VDC '{vdc.name}'")
+            vdc.remove_compute_policy(compute_policy_href)
+            _update_vdc_task_resource(
+                task,
+                TaskStatus.SUCCESS,
+                vdc.href,
+                vdc.name,
+                user_href,
+                user_name,
+                task_href,
+                org.href,
+                message=f"Removed compute policy (href: {compute_policy_href})"
+                        f" from org VDC '{vdc.name}'")
+        except Exception as err:
+            LOGGER.error(err, exc_info=True)
+            _update_vdc_task_resource(
+                task,
+                TaskStatus.ERROR,
+                vdc.href,
+                vdc.name,
+                user_href,
+                user_name,
+                task_href,
+                org.href,
+                error_message=f"{err}")
+
+
+def _update_vdc_task_resource(task, status, vdc_href, vdc_name, user_href,
+                              user_name, task_href, org_href, message='',
+                              error_message=None):
+    return task.update(
+        status=status.value,
+        namespace='vcloud.cse',
+        operation=message,
+        operation_name='Updating VDC',
+        details='',
+        progress=None,
+        owner_href=vdc_href,
+        owner_name=vdc_name,
+        owner_type=PyvcdEntityType.VDC.value,
+        user_href=user_href,
+        user_name=user_name,
+        task_href=task_href,
+        org_href=org_href,
+        error_message=error_message,
+    )

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -456,10 +456,6 @@ class ComputePolicyManager:
                     )
                     task_monitor.wait_for_success(_task)
 
-            vdc = pyvcd_utils.get_vdc(self._vcd_client,
-                                      vdc_id=ovdc_id,
-                                      is_admin_operation=True)
-
             task.update(
                 status=TaskStatus.RUNNING.value,
                 namespace='vcloud.cse',

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -122,6 +122,9 @@ class ComputePolicyManager:
                 policy_dict['href'] = self._get_policy_href(policy_dict['id'])
                 return policy_dict
 
+        raise EntityNotFoundException(f"Compute policy '{policy_name}'"
+                                      f" does not exist.")
+
     def add_policy(self, policy_name, description=None):
         """Add policy with the given name and description.
 

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -14,7 +14,7 @@ from pyvcloud.vcd.vm import VM
 
 from container_service_extension.cloudapi.cloudapi_client import CloudApiClient
 from container_service_extension.cloudapi.constants import CloudApiResource
-from container_service_extension.cloudapi.constants import COMPUTE_POLICY_NAME_PREFIX # noqa: E501
+from container_service_extension.cloudapi.constants import CSE_COMPUTE_POLICY_PREFIX # noqa: E501
 # TODO move cloudapi.constants.EntityType to pyvcloud
 from container_service_extension.cloudapi.constants import EntityType as CloudAPIEntityType # noqa: E501
 from container_service_extension.cloudapi.constants import RelationType
@@ -300,7 +300,7 @@ class ComputePolicyManager:
         :return: policy name unique to cse
         :rtype: str
         """
-        return f"{COMPUTE_POLICY_NAME_PREFIX}{policy_name}"
+        return f"{CSE_COMPUTE_POLICY_PREFIX}{policy_name}"
 
     def _get_policy_display_name(self, policy_name):
         """Remove cse specific prefix from the given policy name.
@@ -310,8 +310,8 @@ class ComputePolicyManager:
         :return: policy name after removing cse specific prefix
         :rtype: str
         """
-        if policy_name and policy_name.startswith(COMPUTE_POLICY_NAME_PREFIX):
-            return policy_name.replace(COMPUTE_POLICY_NAME_PREFIX, '', 1)
+        if policy_name and policy_name.startswith(CSE_COMPUTE_POLICY_PREFIX):
+            return policy_name.replace(CSE_COMPUTE_POLICY_PREFIX, '', 1)
         return policy_name
 
     def _get_policy_href(self, policy_id):

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -300,7 +300,7 @@ class ComputePolicyManager:
         :return: policy name unique to cse
         :rtype: str
         """
-        return f"{CSE_COMPUTE_POLICY_PREFIX}{policy_name}"
+        return f"{COMPUTE_POLICY_NAME_PREFIX}{policy_name}"
 
     def _get_policy_display_name(self, policy_name):
         """Remove cse specific prefix from the given policy name.
@@ -310,8 +310,8 @@ class ComputePolicyManager:
         :return: policy name after removing cse specific prefix
         :rtype: str
         """
-        if policy_name and policy_name.startswith(CSE_COMPUTE_POLICY_PREFIX):
-            return policy_name.replace(CSE_COMPUTE_POLICY_PREFIX, '', 1)
+        if policy_name and policy_name.startswith(COMPUTE_POLICY_NAME_PREFIX):
+            return policy_name.replace(COMPUTE_POLICY_NAME_PREFIX, '', 1)
         return policy_name
 
     def _get_policy_href(self, policy_id):

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -2,13 +2,9 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-from pyvcloud.vcd.exceptions import EntityNotFoundException
-
 from container_service_extension.compute_policy_manager import ComputePolicyManager # noqa: E501
 from container_service_extension.exceptions import BadRequestError
 from container_service_extension.exceptions import CseServerError
-from container_service_extension.exceptions import InternalServerRequestError
-from container_service_extension.logger import SERVER_LOGGER as LOGGER
 import container_service_extension.ovdc_utils as ovdc_utils
 import container_service_extension.pyvcloud_utils as vcd_utils
 import container_service_extension.request_handlers.request_utils as req_utils
@@ -167,26 +163,9 @@ def ovdc_compute_policy_update(request_data, tenant_auth_token):
                f"({ovdc_id})"
 
     if action == ComputePolicyAction.REMOVE:
-        try:
-            cpm.remove_compute_policy_from_vdc(
-                ovdc_id,
-                cp_href,
-                remove_compute_policy_from_vms=remove_compute_policy_from_vms)
-        except EntityNotFoundException:
-            raise EntityNotFoundException(
-                f"Compute policy '{cp_name}' not found in ovdc ({ovdc_id})")
-        except Exception:
-            # This ensures that BadRequestException message is printed
-            # to console. (error when ovdc currently has VMs/vApp
-            # templates with the compute policy reference, so compute policy
-            # cannot be removed)
-            msg = f"Could not remove compute policy '{cp_name}' " \
-                  f"({cp_id}) from ovdc ({ovdc_id})."
-            LOGGER.error(msg, exc_info=True)
-            raise InternalServerRequestError(
-                f"{msg} (Please check that no vApp templates or VMs currently "
-                f"contain a reference to the compute policy)")
-        return f"Removed compute policy '{cp_name}' ({cp_id}) " \
-               f"from ovdc ({ovdc_id})"
+        return cpm.remove_compute_policy_from_vdc(
+            ovdc_id,
+            cp_href,
+            remove_compute_policy_from_vms=remove_compute_policy_from_vms)
 
     raise BadRequestError("Unsupported compute policy action")

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -1,6 +1,7 @@
 # container-service-extension
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
+from pyvcloud.vcd.exceptions import EntityNotFoundException
 
 from container_service_extension.compute_policy_manager import ComputePolicyManager # noqa: E501
 from container_service_extension.exceptions import BadRequestError
@@ -150,9 +151,12 @@ def ovdc_compute_policy_update(request_data, tenant_auth_token):
                 cp_href = _cp['href']
                 cp_id = _cp['id']
     else:
-        _cp = cpm.get_policy(cp_name)
-        cp_href = _cp['href']
-        cp_id = _cp['id']
+        try:
+            _cp = cpm.get_policy(cp_name)
+            cp_href = _cp['href']
+            cp_id = _cp['id']
+        except EntityNotFoundException:
+            pass
 
     if cp_href is None:
         raise BadRequestError(f"Compute policy '{cp_name}' not found.")

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -2,11 +2,13 @@
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+import functools
 import hashlib
 import os
 import pathlib
 import stat
 import sys
+import threading
 
 import click
 import requests
@@ -291,3 +293,14 @@ def read_data_file(filepath, logger=None, msg_update_callback=None):
     if logger:
         logger.info(msg)
     return path.read_text()
+
+
+def run_async(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        t = threading.Thread(target=func, args=args, kwargs=kwargs,
+                             daemon=True)
+        t.start()
+        return t
+
+    return wrapper

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -2,8 +2,6 @@
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-import functools
-import threading
 import uuid
 
 import pkg_resources
@@ -51,17 +49,6 @@ from container_service_extension.server_constants import NodeType
 from container_service_extension.shared_constants import RequestKey
 import container_service_extension.utils as utils
 import container_service_extension.vsphere_utils as vs_utils
-
-
-def run_async(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        t = threading.Thread(target=func, args=args, kwargs=kwargs,
-                             daemon=True)
-        t.start()
-        return t
-
-    return wrapper
 
 
 class VcdBroker(AbstractBroker):
@@ -612,7 +599,7 @@ class VcdBroker(AbstractBroker):
         }
 
     # all parameters following '*args' are required and keyword-only
-    @run_async
+    @utils.run_async
     def _create_cluster_async(self, *args,
                               org_name, ovdc_name, cluster_name, cluster_id,
                               template_name, template_revision, num_workers,
@@ -776,7 +763,7 @@ class VcdBroker(AbstractBroker):
         finally:
             self.logout_sys_admin_client()
 
-    @run_async
+    @utils.run_async
     def _create_nodes_async(self, *args,
                             cluster_name, cluster_vdc_href, cluster_vapp_href,
                             cluster_id, template_name, template_revision,
@@ -861,7 +848,7 @@ class VcdBroker(AbstractBroker):
             self.logout_sys_admin_client()
 
     # all parameters following '*args' are required and keyword-only
-    @run_async
+    @utils.run_async
     def _delete_nodes_async(self, *args,
                             cluster_name, cluster_vapp_href, node_names_list):
         try:
@@ -885,7 +872,7 @@ class VcdBroker(AbstractBroker):
             self.logout_sys_admin_client()
 
     # all parameters following '*args' are required and keyword-only
-    @run_async
+    @utils.run_async
     def _delete_cluster_async(self, *args, cluster_name, cluster_vdc_href):
         try:
             self._update_task(


### PR DESCRIPTION
Implement asynchronous processing for setting compute policies to 'System Default' for deployed VMs during 'force ovdc compute policy removal' operation.

This change creates a new thread to handle the VM compute policy updates that must be done during forced ovdc compute policy removal. For each affected VM, CSE server makes a call to vCD to update the compute policy to 'System Default', and then waits for task success before initiating the next call.

Notes:
- Due to a limitation on vCD, CSE server can not initiate several server-side calls to update multiple VMs and then wait for all of them at once. Doing this results in a `BusyEntity` error with vCD's networking.
- Investigated using **asyncio** library to make the process fully asynchronous (send all VM update requests and wait for them all at the same time), but don't think this is feasible given the described limitation.

Tested with vCD 10.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/443)
<!-- Reviewable:end -->
