### PR TITLE
[VCDA-1237] Set permission of downloaded script as 600

### DIFF
--- a/container_service_extension/remote_template_manager.py
+++ b/container_service_extension/remote_template_manager.py
@@ -4,6 +4,7 @@
 
 import os
 from pathlib import Path
+import stat
 
 import requests
 import yaml
@@ -151,6 +152,10 @@ class RemoteTemplateManager():
                           force_overwrite=force_overwrite,
                           logger=self.logger,
                           msg_update_callback=self.msg_update_callback)
+
+            # Set Read,Write permission only for the owner
+            if os.name != 'nt':
+                os.chmod(local_script_filepath, stat.S_IRUSR | stat.S_IWUSR)
 
     def download_all_template_scripts(self, force_overwrite=False):
         """Download all scripts for all templates mentioned in cookbook.


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>
- Set permissions on template script files that is downloaded to the local folder
- As part of the security requirement the template scripts that gets downloaded to the 
   local folder needs to have read/write permissions only for the owner. This fix sets those 
   permissions as soon the completion of the script download.

- Tests done:
     - cse install
     - cse template 
     - vcd cse cluster create

@rocknes @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/448)
<!-- Reviewable:end -->
