### PR TITLE
[VCDA-12326] Change default template name and revision values to sample values.

### DIFF
--- a/container_service_extension/sample_generator.py
+++ b/container_service_extension/sample_generator.py
@@ -123,8 +123,8 @@ SAMPLE_BROKER_CONFIG = {
         'network': 'mynetwork',
         'ip_allocation_mode': 'pool',
         'storage_profile': '*',
-        'default_template_name': 'ubuntu-16.04_k8-1.15_weave-2.5.2',
-        'default_template_revision': 1,
+        'default_template_name': 'my_template',
+        'default_template_revision': 0,
         'remote_template_cookbook_url': 'https://raw.githubusercontent.com/vmware/container-service-extension-templates/master/template.yaml', # noqa: E501
     }
 }


### PR DESCRIPTION
Changed sample values from ubuntu (k8s 1.15) to a non existent template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/449)
<!-- Reviewable:end -->
