### PR TITLE
[PR] Fix error handling for cloudapi existence for vCD 9.1

### DIFF
--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -430,9 +430,9 @@ class Service(object, metaclass=Singleton):
                                                 SYSTEM_ORG_NAME,
                                                 self.config['vcd']['password'])
             client.set_credentials(credentials)
-            cpm = ComputePolicyManager(client)
 
             try:
+                cpm = ComputePolicyManager(client)
                 for template in self.config['broker']['templates']:
                     policy_name = template[LocalTemplateKey.COMPUTE_POLICY]
                     catalog_item_name = template[LocalTemplateKey.CATALOG_ITEM_NAME] # noqa: E501


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- Fix broken cloudapi vdcComputePolicy check
- During template processing, /cloudapi/vdcComputePolicies endpoint is used to get the policies. 
   This endpoint is not supported in vCD 9.1 and caused error. This fix check the existence of this 
   endpoint before accessing that.

- Tested and verified manually by adding and removing template rule

@rocknes @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/452)
<!-- Reviewable:end -->
