### PR TITLE
Fix how server handles default data values

### DIFF
--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -36,12 +36,8 @@ def ovdc_update(request_data, tenant_auth_token):
         RequestKey.K8S_PROVIDER,
         RequestKey.OVDC_ID
     ]
-    req_utils.validate_payload(request_data, required)
-    defaults = {
-        RequestKey.PKS_PLAN_NAME: None,
-        RequestKey.PKS_CLUSTER_DOMAIN: None
-    }
-    validated_data = {**defaults, **request_data}
+    validated_data = request_data
+    req_utils.validate_payload(validated_data, required)
 
     k8s_provider = validated_data[RequestKey.K8S_PROVIDER]
     k8s_provider_info = {K8S_PROVIDER_KEY: k8s_provider}
@@ -137,12 +133,11 @@ def ovdc_compute_policy_update(request_data, tenant_auth_token):
         RequestKey.COMPUTE_POLICY_ACTION,
         RequestKey.COMPUTE_POLICY_NAME
     ]
-    req_utils.validate_payload(request_data, required)
-
     defaults = {
         RequestKey.REMOVE_COMPUTE_POLICY_FROM_VMS: False,
     }
     validated_data = {**defaults, **request_data}
+    req_utils.validate_payload(validated_data, required)
 
     action = validated_data[RequestKey.COMPUTE_POLICY_ACTION]
     cp_name = validated_data[RequestKey.COMPUTE_POLICY_NAME]

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -37,8 +37,12 @@ def ovdc_update(request_data, tenant_auth_token):
         RequestKey.OVDC_ID
     ]
     req_utils.validate_payload(request_data, required)
+    defaults = {
+        RequestKey.PKS_PLAN_NAME: None,
+        RequestKey.PKS_CLUSTER_DOMAIN: None
+    }
+    validated_data = {**defaults, **request_data}
 
-    validated_data = request_data
     k8s_provider = validated_data[RequestKey.K8S_PROVIDER]
     k8s_provider_info = {K8S_PROVIDER_KEY: k8s_provider}
 
@@ -90,8 +94,14 @@ def ovdc_list(request_data, tenant_auth_token):
 
     :return: List of dictionaries with org VDC k8s provider metadata.
     """
+    defaults = {
+        RequestKey.LIST_PKS_PLANS: False
+    }
+    validated_data = {**defaults, **request_data}
+
     client, _ = vcd_utils.connect_vcd_user_via_token(tenant_auth_token)
-    list_pks_plans = utils.str_to_bool(request_data[RequestKey.LIST_PKS_PLANS])
+    # TODO check if this is needed
+    list_pks_plans = utils.str_to_bool(validated_data[RequestKey.LIST_PKS_PLANS]) # noqa: E501
 
     return ovdc_utils.get_ovdc_list(client, list_pks_plans=list_pks_plans,
                                     tenant_auth_token=tenant_auth_token)
@@ -133,7 +143,6 @@ def ovdc_compute_policy_update(request_data, tenant_auth_token):
         RequestKey.REMOVE_COMPUTE_POLICY_FROM_VMS: False,
     }
     validated_data = {**defaults, **request_data}
-    req_utils.validate_payload(request_data, required)
 
     action = validated_data[RequestKey.COMPUTE_POLICY_ACTION]
     cp_name = validated_data[RequestKey.COMPUTE_POLICY_NAME]

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -101,11 +101,13 @@ def process_request(body):
         LOGGER.debug(f"query parameters: {query_params}")
     # update request spec with operation specific data in the url
     request_data.update(url_data)
+    # remove None values from request payload
+    data = {k: v for k, v in request_data.items() if v is not None}
 
     # process the request
     tenant_auth_token = body['headers']['x-vcloud-authorization']
     body_content = \
-        OPERATION_TO_HANDLER[operation](request_data, tenant_auth_token)
+        OPERATION_TO_HANDLER[operation](data, tenant_auth_token)
 
     if not (isinstance(body_content, (list, dict))):
         body_content = {RESPONSE_MESSAGE_KEY: str(body_content)}

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -321,15 +321,8 @@ class VcdBroker(AbstractBroker):
             RequestKey.NUM_WORKERS,
             RequestKey.NETWORK_NAME
         ]
-        # template-related defaults are taken care of in self.create_nodes()
-        defaults = {
-            RequestKey.ORG_NAME: None,
-            RequestKey.OVDC_NAME: None,
-            RequestKey.ROLLBACK: True,
-            RequestKey.TEMPLATE_NAME: None,
-            RequestKey.TEMPLATE_REVISION: None
-        }
-        validated_data = {**defaults, **data}
+        # default data values are taken care of in self.create_nodes()
+        validated_data = data
         req_utils.validate_payload(validated_data, required)
 
         cluster_name = validated_data[RequestKey.CLUSTER_NAME]

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -493,7 +493,7 @@ class VcdBroker(AbstractBroker):
         }
         validated_data = {**defaults, **data}
 
-        cluster_name = data[RequestKey.CLUSTER_NAME]
+        cluster_name = validated_data[RequestKey.CLUSTER_NAME]
         template_name = validated_data[RequestKey.TEMPLATE_NAME]
         template_revision = validated_data[RequestKey.TEMPLATE_REVISION]
         num_workers = validated_data[RequestKey.NUM_WORKERS]

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -91,12 +91,12 @@ class VcdBroker(AbstractBroker):
         required = [
             RequestKey.CLUSTER_NAME
         ]
-        req_utils.validate_payload(data, required)
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None
         }
         validated_data = {**defaults, **data}
+        req_utils.validate_payload(validated_data, required)
 
         cluster_name = validated_data[RequestKey.CLUSTER_NAME]
         cluster = get_cluster(self.tenant_client, cluster_name,
@@ -174,12 +174,12 @@ class VcdBroker(AbstractBroker):
         required = [
             RequestKey.CLUSTER_NAME
         ]
-        req_utils.validate_payload(data, required)
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None
         }
         validated_data = {**defaults, **data}
+        req_utils.validate_payload(validated_data, required)
 
         cluster_name = validated_data[RequestKey.CLUSTER_NAME]
         cluster = get_cluster(self.tenant_client, cluster_name,
@@ -232,8 +232,6 @@ class VcdBroker(AbstractBroker):
             RequestKey.OVDC_NAME,
             RequestKey.NETWORK_NAME
         ]
-        req_utils.validate_payload(data, required)
-
         cluster_name = data[RequestKey.CLUSTER_NAME]
         # check that cluster name is syntactically valid
         if not is_valid_cluster_name(cluster_name):
@@ -263,6 +261,7 @@ class VcdBroker(AbstractBroker):
             RequestKey.ROLLBACK: True,
         }
         validated_data = {**defaults, **data}
+        req_utils.validate_payload(validated_data, required)
         template_name = validated_data[RequestKey.TEMPLATE_NAME]
         template_revision = validated_data[RequestKey.TEMPLATE_REVISION]
         num_workers = validated_data[RequestKey.NUM_WORKERS]
@@ -322,7 +321,6 @@ class VcdBroker(AbstractBroker):
             RequestKey.NUM_WORKERS,
             RequestKey.NETWORK_NAME
         ]
-        req_utils.validate_payload(data, required)
         # template-related defaults are taken care of in self.create_nodes()
         defaults = {
             RequestKey.ORG_NAME: None,
@@ -332,6 +330,7 @@ class VcdBroker(AbstractBroker):
             RequestKey.TEMPLATE_REVISION: None
         }
         validated_data = {**defaults, **data}
+        req_utils.validate_payload(validated_data, required)
 
         cluster_name = validated_data[RequestKey.CLUSTER_NAME]
         num_workers_wanted = validated_data[RequestKey.NUM_WORKERS]
@@ -370,12 +369,12 @@ class VcdBroker(AbstractBroker):
         required = [
             RequestKey.CLUSTER_NAME
         ]
-        req_utils.validate_payload(data, required)
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None
         }
         validated_data = {**defaults, **data}
+        req_utils.validate_payload(validated_data, required)
 
         cluster_name = validated_data[RequestKey.CLUSTER_NAME]
 
@@ -407,12 +406,12 @@ class VcdBroker(AbstractBroker):
             RequestKey.CLUSTER_NAME,
             RequestKey.NODE_NAME
         ]
-        req_utils.validate_payload(data, required)
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None
         }
         validated_data = {**defaults, **data}
+        req_utils.validate_payload(validated_data, required)
 
         cluster_name = validated_data[RequestKey.CLUSTER_NAME]
         node_name = validated_data[RequestKey.NODE_NAME]
@@ -473,7 +472,6 @@ class VcdBroker(AbstractBroker):
             RequestKey.CLUSTER_NAME,
             RequestKey.NETWORK_NAME
         ]
-        req_utils.validate_payload(data, required)
         # check that requested/default template is valid
         template = get_template(
             name=data.get(RequestKey.TEMPLATE_NAME),
@@ -492,6 +490,7 @@ class VcdBroker(AbstractBroker):
             RequestKey.ROLLBACK: True,
         }
         validated_data = {**defaults, **data}
+        req_utils.validate_payload(validated_data, required)
 
         cluster_name = validated_data[RequestKey.CLUSTER_NAME]
         template_name = validated_data[RequestKey.TEMPLATE_NAME]
@@ -550,12 +549,12 @@ class VcdBroker(AbstractBroker):
             RequestKey.CLUSTER_NAME,
             RequestKey.NODE_NAMES_LIST
         ]
-        req_utils.validate_payload(data, required)
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None
         }
         validated_data = {**defaults, **data}
+        req_utils.validate_payload(validated_data, required)
 
         cluster_name = validated_data[RequestKey.CLUSTER_NAME]
         node_names_list = validated_data[RequestKey.NODE_NAMES_LIST]

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -92,12 +92,12 @@ class VcdBroker(AbstractBroker):
             RequestKey.CLUSTER_NAME
         ]
         req_utils.validate_payload(data, required)
-
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None
         }
         validated_data = {**defaults, **data}
+
         cluster_name = validated_data[RequestKey.CLUSTER_NAME]
         cluster = get_cluster(self.tenant_client, cluster_name,
                               org_name=validated_data[RequestKey.ORG_NAME],
@@ -175,7 +175,6 @@ class VcdBroker(AbstractBroker):
             RequestKey.CLUSTER_NAME
         ]
         req_utils.validate_payload(data, required)
-
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None
@@ -264,16 +263,11 @@ class VcdBroker(AbstractBroker):
             RequestKey.ROLLBACK: True,
         }
         validated_data = {**defaults, **data}
-
-        # TODO HACK default dictionary combining needs to be fixed
-        validated_data[RequestKey.TEMPLATE_NAME] = validated_data[RequestKey.TEMPLATE_NAME] or template[LocalTemplateKey.NAME] # noqa: E501
-        validated_data[RequestKey.TEMPLATE_REVISION] = validated_data[RequestKey.TEMPLATE_REVISION] or template[LocalTemplateKey.REVISION] # noqa: E501
-
         template_name = validated_data[RequestKey.TEMPLATE_NAME]
         template_revision = validated_data[RequestKey.TEMPLATE_REVISION]
+        num_workers = validated_data[RequestKey.NUM_WORKERS]
 
         # check that requested number of worker nodes is at least more than 1
-        num_workers = validated_data[RequestKey.NUM_WORKERS]
         if num_workers < 1:
             raise CseServerError(f"Worker node count must be > 0 "
                                  f"(received {num_workers}).")
@@ -329,7 +323,7 @@ class VcdBroker(AbstractBroker):
             RequestKey.NETWORK_NAME
         ]
         req_utils.validate_payload(data, required)
-
+        # template-related defaults are taken care of in self.create_nodes()
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None,
@@ -338,8 +332,10 @@ class VcdBroker(AbstractBroker):
             RequestKey.TEMPLATE_REVISION: None
         }
         validated_data = {**defaults, **data}
+
         cluster_name = validated_data[RequestKey.CLUSTER_NAME]
         num_workers_wanted = validated_data[RequestKey.NUM_WORKERS]
+
         if num_workers_wanted < 1:
             raise CseServerError(f"Worker node count must be > 0 "
                                  f"(received {num_workers_wanted}).")
@@ -375,12 +371,12 @@ class VcdBroker(AbstractBroker):
             RequestKey.CLUSTER_NAME
         ]
         req_utils.validate_payload(data, required)
-
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None
         }
         validated_data = {**defaults, **data}
+
         cluster_name = validated_data[RequestKey.CLUSTER_NAME]
 
         cluster = get_cluster(self.tenant_client, cluster_name,
@@ -412,12 +408,12 @@ class VcdBroker(AbstractBroker):
             RequestKey.NODE_NAME
         ]
         req_utils.validate_payload(data, required)
-
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None
         }
         validated_data = {**defaults, **data}
+
         cluster_name = validated_data[RequestKey.CLUSTER_NAME]
         node_name = validated_data[RequestKey.NODE_NAME]
 
@@ -478,8 +474,6 @@ class VcdBroker(AbstractBroker):
             RequestKey.NETWORK_NAME
         ]
         req_utils.validate_payload(data, required)
-
-        cluster_name = data[RequestKey.CLUSTER_NAME]
         # check that requested/default template is valid
         template = get_template(
             name=data.get(RequestKey.TEMPLATE_NAME),
@@ -499,14 +493,11 @@ class VcdBroker(AbstractBroker):
         }
         validated_data = {**defaults, **data}
 
-        # TODO HACK default dictionary combining needs to be fixed
-        validated_data[RequestKey.TEMPLATE_NAME] = validated_data[RequestKey.TEMPLATE_NAME] or template[LocalTemplateKey.NAME] # noqa: E501
-        validated_data[RequestKey.TEMPLATE_REVISION] = validated_data[RequestKey.TEMPLATE_REVISION] or template[LocalTemplateKey.REVISION] # noqa: E501
-
+        cluster_name = data[RequestKey.CLUSTER_NAME]
         template_name = validated_data[RequestKey.TEMPLATE_NAME]
         template_revision = validated_data[RequestKey.TEMPLATE_REVISION]
-
         num_workers = validated_data[RequestKey.NUM_WORKERS]
+
         if num_workers < 1:
             raise CseServerError(f"Worker node count must be > 0 "
                                  f"(received {num_workers}).")
@@ -560,14 +551,15 @@ class VcdBroker(AbstractBroker):
             RequestKey.NODE_NAMES_LIST
         ]
         req_utils.validate_payload(data, required)
-
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None
         }
         validated_data = {**defaults, **data}
+
         cluster_name = validated_data[RequestKey.CLUSTER_NAME]
         node_names_list = validated_data[RequestKey.NODE_NAMES_LIST]
+
         # check that there are nodes to delete
         if len(node_names_list) == 0:
             LOGGER.debug("No nodes specified to delete")


### PR DESCRIPTION
Server previously replaced all default values with the request data values,
even if the request data values were 'None'

Now, request processor strips out 'None' values from the request data, so
that non-None default values are properly preserved in the final validated
data

Testing in progress

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/459)
<!-- Reviewable:end -->
