### PR TITLE
Fix bug blocking new compute policy creation and server startup

### DIFF
--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -112,8 +112,9 @@ class ComputePolicyManager:
 
         :param str policy_name: name of the compute policy
 
-        :return: policy details if found, else None
+        :return: dictionary containing policy details
         :rtype: dict
+        :raises: EntityNotFoundException: if compute policy is not found
         """
         # NOTE If multiple policies with the same name exist, this function
         # returns the first found.
@@ -158,12 +159,11 @@ class ComputePolicyManager:
         :param str policy_name: name of the compute policy
         """
         policy_info = self.get_policy(policy_name)
-        if policy_info:
-            resource_url_relative_path = \
-                f"{CloudApiResource.VDC_COMPUTE_POLICIES}/{policy_info['id']}"
-            return self._cloudapi_client.do_request(
-                RequestMethod.DELETE,
-                resource_url_relative_path=resource_url_relative_path)
+        resource_url_relative_path = \
+            f"{CloudApiResource.VDC_COMPUTE_POLICIES}/{policy_info['id']}"
+        return self._cloudapi_client.do_request(
+            RequestMethod.DELETE,
+            resource_url_relative_path=resource_url_relative_path)
 
     def update_policy(self, policy_name, new_policy_info):
         """Update the existing compute policy with new policy information.
@@ -176,7 +176,7 @@ class ComputePolicyManager:
         :rtype: dict
         """
         policy_info = self.get_policy(policy_name)
-        if policy_info and new_policy_info.get('name'):
+        if new_policy_info.get('name'):
             payload = {}
             payload['name'] = \
                 self._get_cse_policy_name(new_policy_info['name'])

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -158,6 +158,9 @@ class ComputePolicyManager:
         """Delete the compute policy with the given name.
 
         :param str policy_name: name of the compute policy
+
+        :return: dictionary containing response text
+        :rtype: dict
         :raises: EntityNotFoundException: if compute policy is not found
         """
         policy_info = self.get_policy(policy_name)

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -139,6 +139,7 @@ class ComputePolicyManager:
 
         :return: created policy information
         :rtype: dict
+        :raises: EntityNotFoundException: if compute policy is not found
         """
         policy_info = {}
         policy_info['name'] = self._get_cse_policy_name(policy_name)
@@ -157,6 +158,7 @@ class ComputePolicyManager:
         """Delete the compute policy with the given name.
 
         :param str policy_name: name of the compute policy
+        :raises: EntityNotFoundException: if compute policy is not found
         """
         policy_info = self.get_policy(policy_name)
         resource_url_relative_path = \
@@ -172,7 +174,7 @@ class ComputePolicyManager:
         :param dict new_policy_info: updated policy information with name and
         optional description
 
-        :return: updated policy information; if no policy is found, return None
+        :return: updated policy information
         :rtype: dict
         """
         policy_info = self.get_policy(policy_name)

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -139,7 +139,6 @@ class ComputePolicyManager:
 
         :return: created policy information
         :rtype: dict
-        :raises: EntityNotFoundException: if compute policy is not found
         """
         policy_info = {}
         policy_info['name'] = self._get_cse_policy_name(policy_name)
@@ -179,6 +178,7 @@ class ComputePolicyManager:
 
         :return: updated policy information
         :rtype: dict
+        :raises: EntityNotFoundException: if compute policy is not found
         """
         policy_info = self.get_policy(policy_name)
         if new_policy_info.get('name'):

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -139,6 +139,7 @@ class ComputePolicyManager:
 
         :return: created policy information
         :rtype: dict
+        :raises: HTTPError 400 if policy already exists
         """
         policy_info = {}
         policy_info['name'] = self._get_cse_policy_name(policy_name)

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -17,6 +17,7 @@ import pkg_resources
 from pyvcloud.vcd.client import ApiVersion
 from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
+from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 
 from container_service_extension.compute_policy_manager import \
@@ -438,11 +439,12 @@ class Service(object, metaclass=Singleton):
                     catalog_item_name = template[LocalTemplateKey.CATALOG_ITEM_NAME] # noqa: E501
                     # if policy name is not empty, stamp it on the template
                     if policy_name:
-                        policy = cpm.get_policy(policy_name=policy_name)
-                        # create the policy if not present in system
-                        if not policy:
-                            msg = "Creating missing compute policy " \
-                                f"'{policy_name}'."
+                        try:
+                            policy = cpm.get_policy(policy_name=policy_name)
+                        except EntityNotFoundException:
+                            # create the policy if it does not exist
+                            msg = f"Creating missing compute policy " \
+                                  f"'{policy_name}'."
                             if msg_update_callback:
                                 msg_update_callback.info(msg)
                             LOGGER.debug(msg)

--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -418,8 +418,7 @@ def test_0070_vcd_cse_cluster_create(config, test_runner_username):
                    validate_output_func=None, test_user=test_runner_username),
         cmd_binder(cmd=f"cse cluster create "
                        f"{env.USERNAME_TO_CLUSTER_NAME[test_runner_username]}"
-                       f" -n {config['broker']['network']} -N 1 "
-                       f"--disable-rollback", exit_code=0,
+                       f" -n {config['broker']['network']} -N 1 ", exit_code=0,
                    validate_output_func=None, test_user=test_runner_username),
         cmd_binder(cmd=env.USER_LOGOUT_CMD, exit_code=0,
                    validate_output_func=None, test_user=test_runner_username)

--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -417,8 +417,9 @@ def test_0070_vcd_cse_cluster_create(config, test_runner_username):
         cmd_binder(cmd=f"vdc use {config['broker']['vdc']}", exit_code=0,
                    validate_output_func=None, test_user=test_runner_username),
         cmd_binder(cmd=f"cse cluster create "
-                       f"{env.USERNAME_TO_CLUSTER_NAME[test_runner_username]}"  # noqa
-                       f" -n {config['broker']['network']} -N 1", exit_code=0,
+                       f"{env.USERNAME_TO_CLUSTER_NAME[test_runner_username]}"
+                       f" -n {config['broker']['network']} -N 1 "
+                       f"--disable-rollback", exit_code=0,
                    validate_output_func=None, test_user=test_runner_username),
         cmd_binder(cmd=env.USER_LOGOUT_CMD, exit_code=0,
                    validate_output_func=None, test_user=test_runner_username)


### PR DESCRIPTION
An instance of get_policy() raising an exception was not
being handled. This prevents CSE from creating new
compute policies and starting up the server when a new
compute policy is specified in template rules

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/461)
<!-- Reviewable:end -->
