### PR TITLE
[VCDA-1277] Client tests changes to handle plain-text configuration

### DIFF
--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -85,7 +85,8 @@ def cse_server():
     """
     config = testutils.yaml_to_dict(env.BASE_CONFIG_FILEPATH)
     install_cmd = ['install', '--config', env.ACTIVE_CONFIG_FILEPATH,
-                   '--ssh-key', env.SSH_KEY_FILEPATH]
+                   '--ssh-key', env.SSH_KEY_FILEPATH,
+                   '--skip-config-decryption']
     env.setup_active_config()
     result = env.CLI_RUNNER.invoke(cli, install_cmd,
                                    input='y',
@@ -95,7 +96,7 @@ def cse_server():
                                       result.output)
 
     # start cse server as subprocess
-    cmd = f"cse run -c {env.ACTIVE_CONFIG_FILEPATH}"
+    cmd = f"cse run -c {env.ACTIVE_CONFIG_FILEPATH} --skip-config-decryption"
     p = None
     if os.name == 'nt':
         p = subprocess.Popen(cmd, shell=True)


### PR DESCRIPTION

-  Fix to handle plain-text configuration file for client system tests
-  Tested and verified that the current tests pass thru the install and run with the base_config.yaml as before.

@andrew-ni @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/479)
<!-- Reviewable:end -->
