### PR TITLE
[VCDA-1269] Decouple PKS config from CSE config

### DIFF
--- a/container_service_extension/config_validator.py
+++ b/container_service_extension/config_validator.py
@@ -41,6 +41,7 @@ from container_service_extension.utils import get_duplicate_items_in_list
 
 
 def get_validated_config(config_file_name,
+                         pks_config_file=None,
                          skip_config_decryption=False,
                          decryption_password=None,
                          msg_update_callback=None):
@@ -52,6 +53,7 @@ def get_validated_config(config_file_name,
     config file.
 
     :param str config_file_name: path to config file.
+    :param str pks_config_file: path to PKS config file.
     :param bool skip_config_decryption: do not decrypt the config file.
     :param str decryption_password: password to decrypt the config file.
     :param utils.ConsoleMessagePrinter msg_update_callback: Callback object
@@ -88,7 +90,6 @@ def get_validated_config(config_file_name,
             get_decrypted_file_contents(config_file_name,
                                         decryption_password)) or {}
 
-    pks_config_location = config.get('pks_config')
     if msg_update_callback:
         msg_update_callback.info(
             f"Validating config file '{config_file_name}'")
@@ -112,27 +113,27 @@ def get_validated_config(config_file_name,
     if msg_update_callback:
         msg_update_callback.general(
             f"Config file '{config_file_name}' is valid")
-    if isinstance(pks_config_location, str) and pks_config_location:
-        check_file_permissions(pks_config_location,
+    if pks_config_file:
+        check_file_permissions(pks_config_file,
                                msg_update_callback=msg_update_callback)
         if skip_config_decryption:
-            with open(pks_config_location) as f:
+            with open(pks_config_file) as f:
                 pks_config = yaml.safe_load(f) or {}
         else:
             if msg_update_callback:
                 msg_update_callback.info(
-                    f"Decrypting '{pks_config_location}'")
+                    f"Decrypting '{pks_config_file}'")
             pks_config = yaml.safe_load(
-                get_decrypted_file_contents(pks_config_location,
+                get_decrypted_file_contents(pks_config_file,
                                             decryption_password)) or {}
         if msg_update_callback:
             msg_update_callback.info(
-                f"Validating PKS config file '{pks_config_location}'")
+                f"Validating PKS config file '{pks_config_file}'")
         _validate_pks_config_structure(pks_config, msg_update_callback)
         _validate_pks_config_data_integrity(pks_config, msg_update_callback)
         if msg_update_callback:
             msg_update_callback.general(
-                f"PKS Config file '{pks_config_location}' is valid")
+                f"PKS Config file '{pks_config_file}' is valid")
         config['pks_config'] = pks_config
     else:
         config['pks_config'] = None

--- a/container_service_extension/config_validator.py
+++ b/container_service_extension/config_validator.py
@@ -41,7 +41,7 @@ from container_service_extension.utils import get_duplicate_items_in_list
 
 
 def get_validated_config(config_file_name,
-                         pks_config_file=None,
+                         pks_config_file_name=None,
                          skip_config_decryption=False,
                          decryption_password=None,
                          msg_update_callback=None):
@@ -53,7 +53,7 @@ def get_validated_config(config_file_name,
     config file.
 
     :param str config_file_name: path to config file.
-    :param str pks_config_file: path to PKS config file.
+    :param str pks_config_file_name: path to PKS config file.
     :param bool skip_config_decryption: do not decrypt the config file.
     :param str decryption_password: password to decrypt the config file.
     :param utils.ConsoleMessagePrinter msg_update_callback: Callback object
@@ -113,27 +113,27 @@ def get_validated_config(config_file_name,
     if msg_update_callback:
         msg_update_callback.general(
             f"Config file '{config_file_name}' is valid")
-    if pks_config_file:
-        check_file_permissions(pks_config_file,
+    if pks_config_file_name:
+        check_file_permissions(pks_config_file_name,
                                msg_update_callback=msg_update_callback)
         if skip_config_decryption:
-            with open(pks_config_file) as f:
+            with open(pks_config_file_name) as f:
                 pks_config = yaml.safe_load(f) or {}
         else:
             if msg_update_callback:
                 msg_update_callback.info(
-                    f"Decrypting '{pks_config_file}'")
+                    f"Decrypting '{pks_config_file_name}'")
             pks_config = yaml.safe_load(
-                get_decrypted_file_contents(pks_config_file,
+                get_decrypted_file_contents(pks_config_file_name,
                                             decryption_password)) or {}
         if msg_update_callback:
             msg_update_callback.info(
-                f"Validating PKS config file '{pks_config_file}'")
+                f"Validating PKS config file '{pks_config_file_name}'")
         _validate_pks_config_structure(pks_config, msg_update_callback)
         _validate_pks_config_data_integrity(pks_config, msg_update_callback)
         if msg_update_callback:
             msg_update_callback.general(
-                f"PKS Config file '{pks_config_file}' is valid")
+                f"PKS Config file '{pks_config_file_name}' is valid")
         config['pks_config'] = pks_config
     else:
         config['pks_config'] = None

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -170,7 +170,8 @@ def check_cse_installation(config, msg_update_callback=None):
 
 
 def install_cse(config_file_name, skip_template_creation, force_update,
-                ssh_key, retain_temp_vapp, skip_config_decryption=False,
+                ssh_key, retain_temp_vapp, pks_config_file=None,
+                skip_config_decryption=False,
                 decryption_password=None, msg_update_callback=None):
     """Handle logistics for CSE installation.
 
@@ -184,6 +185,7 @@ def install_cse(config_file_name, skip_template_creation, force_update,
     :param str ssh_key: public ssh key to place into template vApp(s).
     :param bool retain_temp_vapp: if True, temporary vApp will not destroyed,
         so the user can ssh into and debug the vm.
+    :param str pks_config_file: pks config file name.
     :param bool skip_config_decryption: do not decrypt the config file.
     :param str decryption_password: password to decrypt the config file.
     :param utils.ConsoleMessagePrinter msg_update_callback: Callback object
@@ -194,7 +196,8 @@ def install_cse(config_file_name, skip_template_creation, force_update,
     configure_install_logger()
 
     config = get_validated_config(
-        config_file_name, skip_config_decryption=skip_config_decryption,
+        config_file_name, pks_config_file=pks_config_file,
+        skip_config_decryption=skip_config_decryption,
         decryption_password=decryption_password,
         msg_update_callback=msg_update_callback)
 

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -170,7 +170,7 @@ def check_cse_installation(config, msg_update_callback=None):
 
 
 def install_cse(config_file_name, skip_template_creation, force_update,
-                ssh_key, retain_temp_vapp, pks_config_file=None,
+                ssh_key, retain_temp_vapp, pks_config_file_name=None,
                 skip_config_decryption=False,
                 decryption_password=None, msg_update_callback=None):
     """Handle logistics for CSE installation.
@@ -185,7 +185,7 @@ def install_cse(config_file_name, skip_template_creation, force_update,
     :param str ssh_key: public ssh key to place into template vApp(s).
     :param bool retain_temp_vapp: if True, temporary vApp will not destroyed,
         so the user can ssh into and debug the vm.
-    :param str pks_config_file: pks config file name.
+    :param str pks_config_file_name: pks config file name.
     :param bool skip_config_decryption: do not decrypt the config file.
     :param str decryption_password: password to decrypt the config file.
     :param utils.ConsoleMessagePrinter msg_update_callback: Callback object
@@ -196,7 +196,7 @@ def install_cse(config_file_name, skip_template_creation, force_update,
     configure_install_logger()
 
     config = get_validated_config(
-        config_file_name, pks_config_file=pks_config_file,
+        config_file_name, pks_config_file_name=pks_config_file_name,
         skip_config_decryption=skip_config_decryption,
         decryption_password=decryption_password,
         msg_update_callback=msg_update_callback)

--- a/container_service_extension/sample_generator.py
+++ b/container_service_extension/sample_generator.py
@@ -282,61 +282,48 @@ SAMPLE_PKS_NSXT_SERVERS_SECTION = {
 }
 
 
-def generate_sample_config(output=None, pks_output=None):
+def generate_sample_config(output=None, pks_config=None):
     """Generate sample configs for cse.
 
     If config file names are
     provided, configs are dumped into respective files.
 
     :param str output: name of the config file to dump the CSE configs.
-    :param str pks_output: name of the PKS config file to dump the PKS
-    configs.
+    :param bool pks_config: flag to indicate only sample PKS config file
+    is required.
 
-    :return: sample config/ sample config files
+    :return: sample config
 
     :rtype: dict
     """
-    sample_config = yaml.safe_dump(SAMPLE_AMQP_CONFIG,
-                                   default_flow_style=False) + '\n'
-    sample_config += yaml.safe_dump(SAMPLE_VCD_CONFIG,
-                                    default_flow_style=False) + '\n'
-    sample_config += yaml.safe_dump(SAMPLE_VCS_CONFIG,
-                                    default_flow_style=False) + '\n'
-    sample_config += yaml.safe_dump(SAMPLE_SERVICE_CONFIG,
-                                    default_flow_style=False) + '\n'
-    sample_config += yaml.safe_dump(SAMPLE_BROKER_CONFIG,
-                                    default_flow_style=False) + '\n'
-    sample_config += TEMPLATE_RULE_NOTE + '\n'
-    sample_config += NOTE_FOR_PKS_KEY_IN_CONFIG_FILE + '\n'
-
-    if pks_output:
-        pks_config_location_dict = {}
-        pks_config_location_dict[PKS_CONFIG_FILE_LOCATION_SECTION_KEY] = \
-            f"{pks_output}"
-        sample_config += yaml.safe_dump(pks_config_location_dict,
-                                        default_flow_style=False)
+    if not pks_config:
+        sample_config = yaml.safe_dump(SAMPLE_AMQP_CONFIG,
+                                       default_flow_style=False) + '\n'
+        sample_config += yaml.safe_dump(SAMPLE_VCD_CONFIG,
+                                        default_flow_style=False) + '\n'
+        sample_config += yaml.safe_dump(SAMPLE_VCS_CONFIG,
+                                        default_flow_style=False) + '\n'
+        sample_config += yaml.safe_dump(SAMPLE_SERVICE_CONFIG,
+                                        default_flow_style=False) + '\n'
+        sample_config += yaml.safe_dump(SAMPLE_BROKER_CONFIG,
+                                        default_flow_style=False) + '\n'
+        sample_config += TEMPLATE_RULE_NOTE + '\n'
     else:
-        sample_config += yaml.safe_dump(SAMPLE_PKS_CONFIG_FILE_LOCATION,
-                                        default_flow_style=False)
-
-    sample_pks_config = yaml.safe_dump(
-        SAMPLE_PKS_SERVERS_SECTION, default_flow_style=False) + '\n'
-    sample_pks_config += yaml.safe_dump(
-        SAMPLE_PKS_ACCOUNTS_SECTION, default_flow_style=False) + '\n'
-    # Org - PKS account mapping section will be supressed for CSE 2.0 alpha
-    # sample_pks_config += yaml.safe_dump(
-    #    SAMPLE_PKS_ORGS_SECTION, default_flow_style=False) + '\n'
-    sample_pks_config += yaml.safe_dump(
-        SAMPLE_PKS_PVDCS_SECTION, default_flow_style=False) + '\n'
-    sample_pks_config += yaml.safe_dump(
-        SAMPLE_PKS_NSXT_SERVERS_SECTION, default_flow_style=False)
+        sample_config = yaml.safe_dump(
+            SAMPLE_PKS_SERVERS_SECTION, default_flow_style=False) + '\n'
+        sample_config += yaml.safe_dump(
+            SAMPLE_PKS_ACCOUNTS_SECTION, default_flow_style=False) + '\n'
+        # Org - PKS account mapping section will be supressed for CSE 2.0 alpha
+        # sample_pks_config += yaml.safe_dump(
+        # SAMPLE_PKS_ORGS_SECTION, default_flow_style=False) + '\n'
+        sample_config += yaml.safe_dump(
+            SAMPLE_PKS_PVDCS_SECTION, default_flow_style=False) + '\n'
+        sample_config += yaml.safe_dump(
+            SAMPLE_PKS_NSXT_SERVERS_SECTION, default_flow_style=False)
+        sample_config = f"{INSTRUCTIONS_FOR_PKS_CONFIG_FILE}\n{sample_config}"
 
     if output:
         with open(output, 'w') as f:
             f.write(sample_config)
-    if pks_output:
-        with open(pks_output, 'w') as f:
-            f.write(f"{INSTRUCTIONS_FOR_PKS_CONFIG_FILE}\n{sample_pks_config}")
 
-    return sample_config.strip() + '\n\n' + PKS_CONFIG_NOTE + '\n\n' + \
-        sample_pks_config.strip()
+    return sample_config.strip()

--- a/container_service_extension/sample_generator.py
+++ b/container_service_extension/sample_generator.py
@@ -57,15 +57,6 @@ INSTRUCTIONS_FOR_PKS_CONFIG_FILE = "\
 # For more information, please refer to CSE documentation page:\n\
 # https://vmware.github.io/container-service-extension/INSTALLATION.html\n"
 
-NOTE_FOR_PKS_KEY_IN_CONFIG_FILE = "\
-# This key should only be used if using Enterprise PKS with CSE. \n\
-# Value should be a filepath to PKS config file.\n"
-
-PKS_CONFIG_NOTE = "\
-# [OPTIONAL] PKS CONFIGS\n\
-# These configs are used for Enterprise PKS functionality.\n\
-# If Enterprise PKS is not being used, do not use these configs.\n"
-
 SAMPLE_AMQP_CONFIG = {
     'amqp': {
         'host': 'amqp.vmware.com',
@@ -162,12 +153,8 @@ TEMPLATE_RULE_NOTE = """# [Optional] Template rule section
 #  action:
 #    cpu: 2
 #    mem: 1024
-""" # noqa: E501
+"""  # noqa: E501
 
-PKS_CONFIG_FILE_LOCATION_SECTION_KEY = 'pks_config'
-SAMPLE_PKS_CONFIG_FILE_LOCATION = {
-    PKS_CONFIG_FILE_LOCATION_SECTION_KEY: None
-}
 
 PKS_SERVERS_SECTION_KEY = 'pks_api_servers'
 SAMPLE_PKS_SERVERS_SECTION = {
@@ -179,7 +166,8 @@ SAMPLE_PKS_SERVERS_SECTION = {
             'uaac_port': '8443',
             # 'proxy': 'proxy1.pks.local:80',
             'datacenter': 'pks-s1-dc',
-            'clusters': ['pks-s1-az-1', 'pks-s1-az-2', 'pks-s1-az-3'],
+            'clusters': ['vsphere-cluster-1', 'vsphere-cluster-2',
+                         'vsphere-cluster-3'],
             'cpi': 'cpi1',
             'vc': 'vc1',
             'verify': True
@@ -190,7 +178,8 @@ SAMPLE_PKS_SERVERS_SECTION = {
             'uaac_port': '8443',
             # 'proxy': 'proxy2.pks.local:80',
             'datacenter': 'pks-s2-dc',
-            'clusters': ['pks-s2-az-1', 'pks-s2-az-2', 'pks-s2-az-3'],
+            'clusters': ['vSphereCluster-1', 'vSphereCluster-2',
+                         'vSphereCluster-3'],
             'cpi': 'cpi2',
             'vc': 'vc2',
             'verify': True
@@ -239,15 +228,15 @@ SAMPLE_PKS_PVDCS_SECTION = {
         {
             'name': 'pvdc1',
             'pks_api_server': 'pks-api-server-1',
-            'cluster': 'pks-s1-az-1',
+            'cluster': 'vsphere-cluster-1',
         }, {
             'name': 'pvdc2',
             'pks_api_server': 'pks-api-server-2',
-            'cluster': 'pks-s2-az-1'
+            'cluster': 'vsphere-cluster-4'
         }, {
             'name': 'pvdc3',
             'pks_api_server': 'pks-api-server-1',
-            'cluster': 'pks-s1-az-2'
+            'cluster': 'vsphere-cluster-2'
         }
     ]
 }
@@ -282,21 +271,21 @@ SAMPLE_PKS_NSXT_SERVERS_SECTION = {
 }
 
 
-def generate_sample_config(output=None, pks_config=None):
+def generate_sample_config(output=None, generate_pks_config=False):
     """Generate sample configs for cse.
 
     If config file names are
     provided, configs are dumped into respective files.
 
     :param str output: name of the config file to dump the CSE configs.
-    :param bool pks_config: flag to indicate only sample PKS config file
-    is required.
+    :param bool generate_pks_config: Flag to generate sample of PKS specific
+    configuration file instead of sample regular CSE configuration file.
 
     :return: sample config
 
     :rtype: dict
     """
-    if not pks_config:
+    if not generate_pks_config:
         sample_config = yaml.safe_dump(SAMPLE_AMQP_CONFIG,
                                        default_flow_style=False) + '\n'
         sample_config += yaml.safe_dump(SAMPLE_VCD_CONFIG,

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -54,7 +54,7 @@ DISPLAY_DIFF = "diff"
 DISPLAY_LOCAL = "local"
 DISPLAY_REMOTE = "remote"
 CONFIG_DECRYPTION_ERROR_MSG = \
-    "CSE config file decryption failed: invalid decryption password"
+    "Config file decryption failed: invalid decryption password"
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
@@ -74,66 +74,72 @@ def cli(ctx):
             Generate sample CSE config as dict
             and print it to the console.
 \b
+        cse sample --pks-config
+            Generate sample PKS config and print it to the console.
+\b
         cse sample --output config.yaml
             Generate sample CSE config in the provided file name
             'config.yaml'.
 \b
-        cse sample --pks-output pks.yaml
-            Generate sample PKS config in a file named 'pks.yaml'.
+        cse sample --pks-config --output pks-config.yaml
+            Generate sample PKS config in the provided file name
+            'pks-config.yaml'
 \b
-        cse sample --output config.yaml --pks-output pks.yaml
-            Generate sample CSE and PKS config in the respective file
-            named provided as param.
-\b
-        cse install
+        cse install config.yaml --skip-config-decryption
             Install CSE using data from 'config.yaml'.
 \b
-        cse install -c myconfig.yaml --template photon-v2
-            Install CSE using data from 'myconfig.yaml' but only create
+        cse install encrypted-config.yaml -p abcde
+            Install CSE using data from 'encrypted-config.yaml' after running
+            decryption on the config file using password 'abcde'
+
+\b
+        cse install config.yaml --template photon-v2 --skip-config-decryption
+            Install CSE using data from 'config.yaml' but only create
             template 'photon-v2'.
 \b
-        cse install --update
+        cse install --force-update --skip-config-decryption config.yaml
             Install CSE, and if the templates already exist in vCD, create
             them again.
 \b
-        cse install --no-capture --ssh-key ~/.ssh/id_rsa.pub
-            Install CSE, but don't capture temporary vApps to a template.
-            Instead, leave them running for debugging purposes. Copy specified
-            SSH key into all template VMs so users with the cooresponding
-            private key have access (--ssh-key is required when --no-capture
-            is used).
+        cse install --retain-temp-vapp --ssh-key ~/.ssh/id_rsa.pub config.yaml
+            Install CSE, retain the temporary vApp after the template has been
+            captured. Copy specified SSH key into all template VMs so users
+            with the corresponding private key have access (--ssh-key is
+            required when --retain-temp-vapp is used).
 \b
-        cse check
+        cse check config.yaml --skip-config-decryption
             Checks that 'config.yaml' is valid.
 \b
-        cse check -c myconfig.yaml --check-install
+        cse check config.yaml --pks-config pks-config.yaml
+            Checks that 'pks-config.yaml' is valid.
+\b
+        cse check myconfig.yaml --check-install --skip-config-decryption
             Checks that 'myconfig.yaml' is valid. Also checks that CSE is
             installed on vCD according to 'myconfig.yaml' (Checks that all
             templates specified in 'myconfig.yaml' exist.)
 \b
-        cse check --check-install --template photon-v2
+        cse check --check-install --skip-config-decryption config.yaml
             Checks that 'config.yaml' is valid. Also checks that CSE is
-            installed on vCD according to 'config.yaml' (Checks that
-            template 'photon-v2' exists.)
+            installed on vCD according to 'config.yaml'
 \b
-        cse run
+        cse run config.yaml
             Run CSE Server using data from encrypted 'config.yaml',
             but first validate that CSE was installed according to
             'config.yaml'. This will prompt for password for decrypting
             the 'config.yaml'.
 \b
-        cse run --password xxxx
+        cse run --password xxxx config.yaml
             Run CSE Server using data from encrypted 'config.yaml'. Decryption
             of the config happens using password 'xxxx'. First validate that
             CSE was installed according to 'config.yaml'.
 \b
-        cse run --config myconfig.yaml --skip-check --password xxxx
+        cse run config.yaml --skip-check --password xxxx
             Run CSE Server using data from encrypted 'myconfig.yaml'
             without first validating that CSE was installed according
             to 'myconfig.yaml'. Decryption of the config happens using
             password 'xxxx'
 \b
-        cse run --config myconfig.yaml --skip-check --skip-config-decryption
+        cse run myconfig.yaml --skip-check --skip-config-decryption
             Run CSE Server using data from plain text 'myconfig.yaml'
             without first validating that CSE was installed according
             to 'myconfig.yaml'. Skip decryption of the config file.
@@ -145,14 +151,7 @@ def cli(ctx):
         cse decrypt --password xyz --output [decrypted-file-path] cipher.txt
             Decrypt the config file cipher.txt and save it in the given
             output file. If no output file provided, defaults to stdout.
-\b
-    Environment Variables
-        CSE_CONFIG
-            If this environment variable is set, the commands will use the file
-            indicated in the variable as the config file. The file indicated
-            with the '--config' option will have preference over the
-            environment variable. If both are omitted, it defaults to file
-            'config.yaml' in the current directory.
+
     """
     if ctx.invoked_subcommand is None:
         click.secho(ctx.get_help())
@@ -166,44 +165,44 @@ def template(ctx):
 
 \b
 Examples
-    By default, following commands expect an encrypted CSE configuration file.
+    By default, following commands expect an encrypted CSE configuration file
     To accept a plain-text configuration file, use --skip-config-decryption.
-
-    cse template list -c config.yaml --password xyzss
+\b
+    cse template list config.yaml --password xyzss
         Display all templates, including that are currently in the local
         catalog, and the ones that are defined in remote template cookbook.
         config.yaml will be decrypted using the given password 'xyzss'. If no
         password provided in the option, user will be prompted for password.
 \b
-    cse template list -c config.yaml --skip-config-decryption
+    cse template list config.yaml --skip-config-decryption
         Display all templates, including that are currently in the local
         catalog, and the ones that are defined in remote template cookbook.
         If config.yaml is in plain-text, use --skil-config-decryption.
 \b
-    cse template list --display local -c config.yaml
+    cse template list --display local config.yaml --skip-config-decryption
         Display templates that are currently in the local catalog.
 \b
-    cse template list --display remote -c config.yaml
+    cse template list --display remote config.yaml --skip-config-decryption
         Display templates that are defined in the remote template cookbook.
 \b
-    cse template list --display diff -c config.yaml
+    cse template list --display diff config.yaml --skip-config-decryption
         Display only templates that are defined in remote template cookbook but
         not present in the local catalog.
 \b
-    cse template install -c config.yaml --skip-config-decryption
+    cse template install config.yaml --skip-config-decryption
         Install all templates defined in remote template cookbook that are
         missing from the local catalog. Skip decryption of config file
 \b
-    cse template install -c config.yaml --password abcde
+    cse template install config.yaml --password abcde
         Install all templates defined in remote template cookbook that are
         missing from the local catalog. Before that, Decrypt config.yaml using
         password 'abcde'
 \b
-    cse template install [template name] [template revision] -c config.yaml
+    cse template install [template name] [template revision] config.yaml
         Install a particular template at a given revision defined in remote
         template cookbook that is missing from the local catalog.
 \b
-    cse template install -c config.yaml --force
+    cse template install config.yaml --force --skip-config-decryption
         Install all templates defined in remote template cookbook. Tempaltes
         already in the local catalog that match one in the remote catalog will
         be recreated from scratch.
@@ -222,7 +221,7 @@ def version(ctx):
     stdout(ver_obj, ctx, ver_str)
 
 
-@cli.command('sample', short_help='Generate sample CSE config')
+@cli.command('sample', short_help='Generate sample CSE config by default')
 @click.pass_context
 @click.option(
     '-o',
@@ -231,16 +230,13 @@ def version(ctx):
     required=False,
     default=None,
     metavar='OUTPUT_FILE_NAME',
-    help="Filepath to write CSE config file to")
+    help="Filepath to write config file to")
 @click.option(
     '-p',
-    '--pks-output',
-    'pks_output',
-    required=False,
-    default=None,
-    metavar='OUTPUT_FILE_NAME',
-    help="Filepath to write PKS config file to")
-def sample(ctx, output, pks_output):
+    '--pks-config',
+    is_flag=True,
+    help='Generate only sample PKS config')
+def sample(ctx, output, pks_config):
     """Display sample CSE config file contents."""
     try:
         check_python_version()
@@ -249,21 +245,20 @@ def sample(ctx, output, pks_output):
         sys.exit(1)
 
     click.secho(generate_sample_config(output=output,
-                                       pks_output=pks_output))
+                                       pks_config=pks_config))
 
 
 @cli.command(short_help="Checks that CSE config file is valid (Can also check "
                         "that CSE is installed according to config file)")
 @click.pass_context
+@click.argument('config', metavar='CONFIG_FILE_NAME',
+                type=click.Path(exists=True))
 @click.option(
-    '-c',
-    '--config',
-    'config',
+    '--pks-config',
     type=click.Path(exists=True),
-    metavar='CONFIG_FILE_NAME',
-    envvar='CSE_CONFIG',
-    default='config.yaml',
-    help='Filepath of CSE config file')
+    metavar='PKS_CONFIG_FILE_NAME',
+    required=False,
+    help='Filepath of PKS config file')
 @click.option(
     '-s',
     '--skip-config-decryption',
@@ -282,7 +277,8 @@ def sample(ctx, output, pks_output):
     'check_install',
     is_flag=True,
     help='Checks that CSE is installed on vCD according to the config file')
-def check(ctx, config, skip_config_decryption, password, check_install):
+def check(ctx, config, pks_config, skip_config_decryption, password,
+          check_install):
     """Validate CSE config file."""
     if not skip_config_decryption and password is None:
         password = prompt_text('Password for config file decryption',
@@ -296,7 +292,8 @@ def check(ctx, config, skip_config_decryption, password, check_install):
     config_dict = None
     try:
         config_dict = get_validated_config(
-            config, skip_config_decryption=skip_config_decryption,
+            config, pks_config_file=pks_config,
+            skip_config_decryption=skip_config_decryption,
             decryption_password=password,
             msg_update_callback=ConsoleMessagePrinter())
     except (NotAcceptableException, VcdException, ValueError,
@@ -350,9 +347,11 @@ def decrypt(ctx, input_file, password, output_file):
         decrypt_file(input_file, password, output_file)
     except cryptography.fernet.InvalidToken:
         click.secho("Decryption failed: invalid password", fg='red')
+        sys.exit(1)
     except Exception as err:
         click.secho(str(err), fg='red')
         sys.exit(1)
+    click.secho("\nDecryption is successfully completed", fg='green')
 
 
 @cli.command(short_help='Encrypt the given input file')
@@ -383,22 +382,23 @@ def encrypt(ctx, input_file, password, output_file):
         encrypt_file(input_file, password, output_file)
     except cryptography.fernet.InvalidToken:
         click.secho("Encryption failed: invalid password", fg='red')
+        sys.exit(1)
     except Exception as err:
         click.secho(str(err), fg='red')
         sys.exit(1)
+    click.secho("\nEncryption is successfully completed", fg='green')
 
 
 @cli.command(short_help='Install CSE on vCD')
 @click.pass_context
+@click.argument('config', metavar='CONFIG_FILE_NAME',
+                type=click.Path(exists=True))
 @click.option(
-    '-c',
-    '--config',
-    'config',
+    '--pks-config',
     type=click.Path(exists=True),
-    metavar='CONFIG_FILE_NAME',
-    envvar='CSE_CONFIG',
-    default='config.yaml',
-    help='Filepath of CSE config file')
+    metavar='PKS_CONFIG_FILE_NAME',
+    required=False,
+    help='Filepath of PKS config file')
 @click.option(
     '-s',
     '--skip-config-decryption',
@@ -437,7 +437,7 @@ def encrypt(ctx, input_file, password, output_file):
     default=None,
     type=click.File('r'),
     help='Filepath of SSH public key to add to vApp template')
-def install(ctx, config, skip_config_decryption, password,
+def install(ctx, config, pks_config, skip_config_decryption, password,
             skip_template_creation, force_update,
             retain_temp_vapp, ssh_key_file):
     """Install CSE on vCloud Director."""
@@ -462,6 +462,7 @@ def install(ctx, config, skip_config_decryption, password,
 
     try:
         install_cse(config_file_name=config,
+                    pks_config_file=pks_config,
                     skip_template_creation=skip_template_creation,
                     force_update=force_update, ssh_key=ssh_key,
                     retain_temp_vapp=retain_temp_vapp,
@@ -485,15 +486,14 @@ def install(ctx, config, skip_config_decryption, password,
 
 @cli.command(short_help='Run CSE service')
 @click.pass_context
+@click.argument('config', metavar='CONFIG_FILE_NAME',
+                type=click.Path(exists=True))
 @click.option(
-    '-c',
-    '--config',
-    'config',
+    '--pks-config',
     type=click.Path(exists=True),
-    metavar='CONFIG_FILE_NAME',
-    envvar='CSE_CONFIG',
-    default='config.yaml',
-    help='Filepath of CSE config file')
+    metavar='PKS_CONFIG_FILE_NAME',
+    required=False,
+    help='Filepath of PKS config file')
 @click.option(
     '--skip-check',
     is_flag=True,
@@ -510,7 +510,7 @@ def install(ctx, config, skip_config_decryption, password,
     default=None,
     metavar='PASSWORD_FOR_DECRYPTION',
     help='password to use for decrypting config file')
-def run(ctx, config, skip_check, skip_config_decryption, password):
+def run(ctx, config, pks_config, skip_check, skip_config_decryption, password):
     """Run CSE service."""
     if not skip_config_decryption and password is None:
         password = prompt_text('Password for config file decryption',
@@ -522,7 +522,8 @@ def run(ctx, config, skip_check, skip_config_decryption, password):
         sys.exit(1)
 
     try:
-        service = Service(config, should_check_config=not skip_check,
+        service = Service(config, pks_config_file=pks_config,
+                          should_check_config=not skip_check,
                           skip_config_decryption=skip_config_decryption,
                           decryption_password=password)
         service.run(msg_update_callback=ConsoleMessagePrinter())
@@ -547,15 +548,8 @@ def run(ctx, config, skip_check, skip_config_decryption, password):
 @cli.command('convert-cluster', short_help='Converts pre CSE 2.5.0 clusters to CSE 2.5.0 cluster format') # noqa: E501
 @click.pass_context
 @click.argument('cluster_name', metavar='CLUSTER_NAME', default=None)
-@click.option(
-    '-c',
-    '--config',
-    'config_file_name',
-    type=click.Path(exists=True),
-    metavar='CONFIG_FILE_NAME',
-    envvar='CSE_CONFIG',
-    default='config.yaml',
-    help='Filepath of CSE config file')
+@click.argument('config_file_name', metavar='CONFIG_FILE_NAME',
+                type=click.Path(exists=True))
 @click.option(
     '--admin-password',
     default=None,
@@ -759,15 +753,8 @@ def convert_cluster(ctx, config_file_name, skip_config_decryption,
     'list',
     short_help='List Kubernetes templates')
 @click.pass_context
-@click.option(
-    '-c',
-    '--config',
-    'config_file_name',
-    type=click.Path(exists=True),
-    metavar='CONFIG_FILE_NAME',
-    envvar='CSE_CONFIG',
-    default='config.yaml',
-    help='Filepath of CSE config file')
+@click.argument('config_file_name', metavar='CONFIG_FILE_NAME',
+                type=click.Path(exists=True))
 @click.option(
     '-s',
     '--skip-config-decryption',
@@ -818,7 +805,7 @@ def list_template(ctx, config_file_name, skip_config_decryption, password,
         if display_option in (DISPLAY_ALL, DISPLAY_DIFF, DISPLAY_LOCAL):
             client = None
             try:
-                # To supress the warning message that pyvcloud prints if
+                # To suppress the warning message that pyvcloud prints if
                 # ssl_cert verification is skipped.
                 if not config_dict['vcd']['verify']:
                     requests.packages.urllib3.disable_warnings()
@@ -935,15 +922,8 @@ def list_template(ctx, config_file_name, skip_config_decryption, password,
 @click.pass_context
 @click.argument('template_name', metavar='TEMPLATE_NAME', default='*')
 @click.argument('template_revision', metavar='TEMPLATE_REVISION', default='*')
-@click.option(
-    '-c',
-    '--config',
-    'config_file_name',
-    type=click.Path(exists=True),
-    metavar='CONFIG_FILE_NAME',
-    envvar='CSE_CONFIG',
-    default='config.yaml',
-    help='Filepath of CSE config file')
+@click.argument('config_file_name', metavar='CONFIG_FILE_NAME',
+                type=click.Path(exists=True))
 @click.option(
     '-s',
     '--skip-config-decryption',

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -80,9 +80,11 @@ class ServerState(Enum):
 
 
 class Service(object, metaclass=Singleton):
-    def __init__(self, config_file, should_check_config=True,
+    def __init__(self, config_file, pks_config_file=None,
+                 should_check_config=True,
                  skip_config_decryption=False, decryption_password=None):
         self.config_file = config_file
+        self.pks_config_file = pks_config_file
         self.config = None
         self.should_check_config = should_check_config
         self.skip_config_decryption = skip_config_decryption
@@ -194,6 +196,7 @@ class Service(object, metaclass=Singleton):
 
         self.config = get_validated_config(
             self.config_file,
+            self.pks_config_file,
             skip_config_decryption=self.skip_config_decryption,
             decryption_password=self.decryption_password,
             msg_update_callback=msg_update_callback)

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -196,7 +196,7 @@ class Service(object, metaclass=Singleton):
 
         self.config = get_validated_config(
             self.config_file,
-            self.pks_config_file,
+            pks_config_file_name=self.pks_config_file,
             skip_config_decryption=self.skip_config_decryption,
             decryption_password=self.decryption_password,
             msg_update_callback=msg_update_callback)

--- a/cse.sh
+++ b/cse.sh
@@ -2,4 +2,5 @@
 
 USER_DIR=/home/vmware
 PYTHONPATH=$USER_DIR/.local/lib/python3.6/site-packages
-$USER_DIR/.local/bin/cse run --config $USER_DIR/config.yaml
+$USER_DIR/.local/bin/cse run $USER_DIR/config.yaml
+#$USER_DIR/.local/bin/cse run $USER_DIR/config.yaml --pks-config $USER_DIR/pks.yaml

--- a/docs/CSE_CONFIG.md
+++ b/docs/CSE_CONFIG.md
@@ -95,10 +95,6 @@ broker:
 #    cpu: 2
 #    mem: 1024
 
-# This key should only be used if using Enterprise PKS with CSE.
-# Value should be a filepath to PKS config file.
-
-pks_config: null
 ```
 
 The config file has 5 mandatory sections (`amqp`, `vcd`, `vcs`, `service`,
@@ -195,26 +191,18 @@ Each rule comprises of the following attributes
 Please refer to [Restricting Kubernetes templates](/container-service-extension/TEMPLATE_MANAGEMENT.html#restrict_templates)
 for further details on compute policies.
 
-<a name="pksconfig"></a>
-### `pks_config` property
-
-Filling out this key for regular CSE set up is optional and should be left
-as is. Only for CSE set up enabled for [Enterprise PKS](/container-service-extension/ENT_PKS.html)
-container provider, this value needs to point to absolute path of valid Enterprise PKS config file.
-Please refer to [Enterprise PKS enablement](/container-service-extension/ENT_PKS.html) for more details.
-
 Enabling Enterprise PKS as a K8s provider changes the default behavior of CSE as described below.
-Presence of valid value for `pks_config` property gives an indication to CSE that
+Presence of option `--pks-config <pks-config-file> ` while executing `cse run` gives an indication to CSE that
 Enterprise PKS is enabled (in addition to Native vCD) as a K8s provider in the system.
 
 - CSE begins to mandate any given `ovdc` to be enabled for either Native or Enterprise PKS as a backing K8s provider.
 Cloud Administrators can do so via `vcd cse ovdc enable` command. This step is mandatory for ovdc(s) with
-preexisting native K8s clusters as well i.e., if CSE is upgraded from 1.2.x to 2.0 and `pks_config`
-is set, then it becomes mandatory to enable those ovdc(s) with pre-existing native K8s clusters.
-- In other words, If `pks_config`  value is present and if an ovdc is not enabled for either of the supported
+preexisting native K8s clusters as well i.e., if CSE is upgraded from 1.2.x to 2.0 and CSE is started with `--pks-config`
+option, then it becomes mandatory to enable those ovdc(s) with pre-existing native K8s clusters.
+- In other words, if CSE runs with `--pks-config <pks-config-file>` and if an ovdc is not enabled for either of the supported
 K8s providers, users will not be able to do any further K8s deployments in that ovdc.
 
-In the absence of value for `pks_config` key, there will not be any change in CSE's default behavior i.e.,
+If CSE runs with no `--pks-config` option, there will not be any change in CSE's default behavior i.e.,
 any ovdc is open for native K8s cluster deployments.
 
 #### Enterprise PKS Config file
@@ -272,9 +260,9 @@ any ovdc is open for native K8s cluster deployments.
 
 pks_api_servers:
 - clusters:
-  - pks-s1-az-1
-  - pks-s1-az-2
-  - pks-s1-az-3
+  - vsphere-cluster-1
+  - vsphere-cluster-2
+  - vsphere-cluster-3
   cpi: cpi1
   datacenter: pks-s1-dc
   host: pks-api-server-1.pks.local
@@ -284,9 +272,9 @@ pks_api_servers:
   vc: vc1
   verify: true
 - clusters:
-  - pks-s2-az-1
-  - pks-s2-az-2
-  - pks-s2-az-3
+  - vSphereCluster-1
+  - vSphereCluster-2
+  - vSphereCluster-3
   cpi: cpi2
   datacenter: pks-s2-dc
   host: pks-api-server-2.pks.local
@@ -311,13 +299,13 @@ pks_accounts:
   username: org2Admin
 
 pvdcs:
-- cluster: pks-s1-az-1
+- cluster: vsphere-cluster-1
   name: pvdc1
   pks_api_server: pks-api-server-1
-- cluster: pks-s2-az-1
+- cluster: vsphere-cluster-1
   name: pvdc2
   pks_api_server: pks-api-server-2
-- cluster: pks-s1-az-2
+- cluster: vsphere-cluster-4
   name: pvdc3
   pks_api_server: pks-api-server-1
 

--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -84,7 +84,7 @@ def cse_server():
     - Stop CSE server
     """
     config = testutils.yaml_to_dict(env.BASE_CONFIG_FILEPATH)
-    install_cmd = ['install', '--config', env.ACTIVE_CONFIG_FILEPATH,
+    install_cmd = ['install', env.ACTIVE_CONFIG_FILEPATH,
                    '--ssh-key', env.SSH_KEY_FILEPATH,
                    '--skip-config-decryption']
     env.setup_active_config()
@@ -96,7 +96,7 @@ def cse_server():
                                       result.output)
 
     # start cse server as subprocess
-    cmd = f"cse run -c {env.ACTIVE_CONFIG_FILEPATH} --skip-config-decryption"
+    cmd = f"cse run {env.ACTIVE_CONFIG_FILEPATH} --skip-config-decryption"
     p = None
     if os.name == 'nt':
         p = subprocess.Popen(cmd, shell=True)

--- a/system_tests/test_cse_server.py
+++ b/system_tests/test_cse_server.py
@@ -152,13 +152,13 @@ def test_0030_cse_check(config):
     Test that `cse check` command along with every option is an actual command.
     Does not test for validity of config files or CSE installations.
     """
-    cmd = f"check -c {env.ACTIVE_CONFIG_FILEPATH} --skip-config-decryption"
+    cmd = f"check {env.ACTIVE_CONFIG_FILEPATH} --skip-config-decryption"
     result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
     assert result.exit_code == 0,\
         testutils.format_command_info('cse', cmd, result.exit_code,
                                       result.output)
 
-    cmd = f"check -c {env.ACTIVE_CONFIG_FILEPATH} -i --skip-config-decryption"
+    cmd = f"check {env.ACTIVE_CONFIG_FILEPATH} -i --skip-config-decryption"
     result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
     assert result.exit_code == 0,\
         testutils.format_command_info('cse', cmd, result.exit_code,
@@ -249,19 +249,19 @@ def test_0080_install_skip_template_creation(config,
                                              unregister_cse_before_test):
     """Test install.
 
-    Installation options: '--config', '--ssh-key', '--skip-create-templates',
+    Installation options: '--ssh-key', '--skip-create-templates',
     '--skip-config-decryption'
 
     Tests that installation:
     - registers CSE, without installing the templates
 
-    command: cse install --config cse_test_config.yaml
-        --ssh-key ~/.ssh/id_rsa.pub --skip-create-templates
+    command: cse install cse_test_config.yaml
+        --ssh-key ~/.ssh/id_rsa.pub --skip-config-decryption --skip-create-templates # noqa: E501
     required files: ~/.ssh/id_rsa.pub, cse_test_config.yaml,
     expected: cse registered, catalog exists, source ovas do not exist,
         temp vapps do not exist, k8s templates do not exist.
     """
-    cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
+    cmd = f"install {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
           f"{env.SSH_KEY_FILEPATH} --skip-template-creation --skip-config-decryption"  # noqa: E501
     result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
     assert result.exit_code == 0,\
@@ -293,7 +293,7 @@ def test_0080_install_skip_template_creation(config,
 def test_0090_install_retain_temp_vapp(config, unregister_cse_before_test):
     """Test install.
 
-    Installation options: '--config', '--template', '--ssh-key',
+    Installation options: '--template', '--ssh-key',
         '--retain-temp-vapp', '--skip-config-decryption'.
 
     Tests that installation:
@@ -303,13 +303,13 @@ def test_0090_install_retain_temp_vapp(config, unregister_cse_before_test):
     - skips deleting the temp vapp
     - checks that proper packages are installed in the vm in temp vApp
 
-    command: cse install --config cse_test_config.yaml --retain-temp-vapp
+    command: cse install cse_test_config.yaml --retain-temp-vapp --skip-config-decryption  # noqa: E501
         --ssh-key ~/.ssh/id_rsa.pub
     required files: ~/.ssh/id_rsa.pub, cse_test_config.yaml
     expected: cse registered, catalog exists, source ovas exist,
         temp vapps exist, k8s templates exist.
     """
-    cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
+    cmd = f"install {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
           f"{env.SSH_KEY_FILEPATH} --retain-temp-vapp --skip-config-decryption"
     result = env.CLI_RUNNER.invoke(cli, cmd.split(),
                                    catch_exceptions=False)
@@ -351,14 +351,14 @@ def test_0100_install_force_update(config, unregister_cse_before_test):
     - creates all templates correctly,
     - customizes temp vapps correctly.
 
-    command: cse install --config cse_test_config.yaml
+    command: cse install cse_test_config.yaml
         --ssh-key ~/.ssh/id_rsa.pub --force-update --skip-config-decryption
     required files: cse_test_config.yaml, ~/.ssh/id_rsa.pub,
         ubuntu/photon init/cust scripts
     expected: cse registered, source ovas exist, k8s templates exist and
         temp vapps don't exist.
     """
-    cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
+    cmd = f"install {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
           f"{env.SSH_KEY_FILEPATH} --force-update --skip-config-decryption"
     result = env.CLI_RUNNER.invoke(
         cli, cmd.split(), catch_exceptions=False)
@@ -409,12 +409,12 @@ def test_0120_cse_run(config):
     process before then means that server run failed somehow.
 
     commands:
-    $ cse run --config cse_test_config
-    $ cse run --config cse_test_config --skip-check --skip-config-decryption
+    $ cse run cse_test_config
+    $ cse run cse_test_config --skip-check --skip-config-decryption
     """
     cmds = [
-        f"cse run -c {env.ACTIVE_CONFIG_FILEPATH} --skip-config-decryption",
-        f"cse run -c {env.ACTIVE_CONFIG_FILEPATH} --skip-check --skip-config-decryption"  # noqa: E501
+        f"cse run {env.ACTIVE_CONFIG_FILEPATH} --skip-config-decryption",
+        f"cse run {env.ACTIVE_CONFIG_FILEPATH} --skip-check --skip-config-decryption"  # noqa: E501
     ]
 
     for cmd in cmds:

--- a/system_tests/test_cse_server.py
+++ b/system_tests/test_cse_server.py
@@ -127,7 +127,7 @@ def test_0010_cse_sample():
         testutils.format_command_info('cse', cmd, result.exit_code,
                                       result.output)
 
-    cmd = f'sample --pks-output {output_filepath}'
+    cmd = f'sample --pks-config --output {output_filepath}'
     result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
     assert result.exit_code == 0,\
         testutils.format_command_info('cse', cmd, result.exit_code,


### PR DESCRIPTION
- Changes that decouple PKS config file from CSE config file

- All server side commands now accept pks config file an an option in addition to mandatory CSE configuration.
   - Config file has become mandatory argument
   - No more PKS specific information in CSE configuration
   - Support for optional PKS config file
   - Test case fixes 

- Test cases:
    - Executed updated system test cases to complete all tests successfully.
    - CSE sample, check, install, template list, install, run, convert cluster.
    - Client tests updated to run CSE server with --config removed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/480)
<!-- Reviewable:end -->
