### PR TITLE
[VCDA-1274] Change num_workers to be an optional parameter for PKS cluster creation

### DIFF
--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -301,7 +301,7 @@ class PksBroker(AbstractBroker):
         # this needs to be refactored
         cluster_info = self._create_cluster(
             cluster_name=data[RequestKey.CLUSTER_NAME],
-            num_workers=data[RequestKey.NUM_WORKERS],
+            num_workers=data.get(RequestKey.NUM_WORKERS),
             pks_plan_name=data[RequestKey.PKS_PLAN_NAME],
             pks_ext_host=data[RequestKey.PKS_EXT_HOST])
 

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -299,6 +299,7 @@ class PksBroker(AbstractBroker):
                 f"cluster : {cluster_name}. Aborting creation of cluster.")
 
         # this needs to be refactored
+        # when num_workers==None, PKS creates however many the plan specifies
         cluster_info = self._create_cluster(
             cluster_name=data[RequestKey.CLUSTER_NAME],
             num_workers=data.get(RequestKey.NUM_WORKERS),


### PR DESCRIPTION
Fixes the KeyError that shows up when creating PKS cluster without providing num_workers.

With this change, PKS cluster creation without specifying num_workers will deploy the plan's specified number of worker nodes instead of failing.

```
Error: <RequestKey.NUM_WORKERS: 'num_workers'>
```

Fixes #483

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/486)
<!-- Reviewable:end -->
