### PR TITLE
[VCDA-1319] Add vac url, collector id in config at CSE server startup

### DIFF
--- a/container_service_extension/config_validator.py
+++ b/container_service_extension/config_validator.py
@@ -34,6 +34,10 @@ from container_service_extension.sample_generator import \
     SAMPLE_SERVICE_CONFIG, SAMPLE_VCD_CONFIG, SAMPLE_VCS_CONFIG # noqa: H301
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
 from container_service_extension.server_constants import VERSION_V1
+from container_service_extension.telemetry.constants import COLLECTOR_ID
+from container_service_extension.telemetry.constants import VAC_URL
+from container_service_extension.telemetry.telemetry_utils import \
+    get_telemetry_instance_id
 from container_service_extension.uaaclient.uaaclient import UaaClient
 from container_service_extension.utils import check_file_permissions
 from container_service_extension.utils import check_keys_and_value_types
@@ -142,6 +146,16 @@ def get_validated_config(config_file_name,
         config['pks_config'] = pks_config
     else:
         config['pks_config'] = None
+
+    # Store telemetry instance id, url and collector id in config
+    if config['service']['telemetry']['enable'] is True:
+        config['service']['telemetry']['instance_id'] =  \
+            get_telemetry_instance_id(config['vcd'])
+
+    if 'vac_url' not in config['service']['telemetry']:
+        config['service']['telemetry']['vac_url'] = VAC_URL
+
+    config['service']['telemetry']['collector_id'] = COLLECTOR_ID
 
     return config
 

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -1,0 +1,11 @@
+# container-service-extension
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+# End point of Vmware Analytics staging server
+# TODO() : This URL should reflect production server during release
+VAC_URL = "https://vcsa.vmware.com/ph-stg/api/hyper/send/"
+
+# Value of collector id that is required as part of HTTP request
+# to post sample data to analytics server
+COLLECTOR_ID = "CSE.2_6"

--- a/container_service_extension/telemetry/telemetry_utils.py
+++ b/container_service_extension/telemetry/telemetry_utils.py
@@ -1,0 +1,52 @@
+# container-service-extension
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+from pyvcloud.vcd.api_extension import APIExtension
+from pyvcloud.vcd.client import BasicLoginCredentials
+from pyvcloud.vcd.client import Client
+
+from container_service_extension.server_constants import CSE_SERVICE_NAME
+from container_service_extension.server_constants import CSE_SERVICE_NAMESPACE
+from container_service_extension.server_constants import SYSTEM_ORG_NAME
+
+
+def get_telemetry_instance_id(vcd, logger_instance=None,
+                              msg_update_callback=None):
+    """Get CSE extension id which is used as instance id.
+
+    Any exception is logged as error. No exception is leaked out
+    of this method and does not affect the server startup.
+
+    :param dict vcd: 'vcd' section of config file as a dict.
+    :param logging.logger logger_instance: logger instance to log any error
+    in retrieving CSE extension id.
+    :param utils.ConsoleMessagePrinter msg_update_callback: Callback object
+    that writes messages onto console.
+
+    :return instance id to use for sending data to Vmware analytics server
+
+    :rtype str
+
+    :raises Exception: if any exception happens while retrieving CSE
+    extension id
+    """
+    try:
+        client = Client(vcd['host'], api_version=vcd['api_version'],
+                        verify_ssl_certs=vcd['verify'])
+        client.set_credentials(BasicLoginCredentials(
+            vcd['username'], SYSTEM_ORG_NAME, vcd['password']))
+        ext = APIExtension(client)
+        cse_info = ext.get_extension_info(CSE_SERVICE_NAME,
+                                          namespace=CSE_SERVICE_NAMESPACE)
+        if logger_instance:
+            logger_instance.info("Retrieved telemetry instance id")
+        return cse_info.get('id')
+    except Exception as err:
+        msg = f"Cannot retrieve telemetry instance id:{err}"
+        if msg_update_callback:
+            msg_update_callback.general(msg)
+        if logger_instance:
+            logger_instance.error(msg)
+    finally:
+        if client is not None:
+            client.logout()


### PR DESCRIPTION
- Included Vmware analytics url, instance id and collector id as part of runtime config
- At CSE server startup, vmware analytics url, collector id and instance id are required to post
   analytics data. This PR stores url, instance id and collector id in runtime config under 
   service --> telemetry 
- Tested and verified manually these values are available in config dictionary.

@andrew-ni @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/490)
<!-- Reviewable:end -->
