### PR TITLE
[VCDA-1334] Adding support for VmSizing Policy based compute policy association/d…

### DIFF
--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -406,11 +406,9 @@ class ComputePolicyManager:
             if remove_compute_policy_from_vms:
                 cp_list = self.list_compute_policies_on_vdc(ovdc_id)
                 system_default_href = None
-                system_default_id = None
                 for cp_dict in cp_list:
                     if cp_dict['name'] == _SYSTEM_DEFAULT_COMPUTE_POLICY:
                         system_default_href = cp_dict['href']
-                        system_default_id = cp_dict['id']
                 if system_default_href is None:
                     raise EntityNotFoundException(
                         f"Error: {_SYSTEM_DEFAULT_COMPUTE_POLICY} "
@@ -448,8 +446,7 @@ class ComputePolicyManager:
                 task_monitor = self._vcd_client.get_task_monitor()
                 for vm_resource in target_vms:
                     vm = VM(self._vcd_client, href=vm_resource.get('href'))
-                    _task = vm.update_compute_policy(system_default_href,
-                                                     system_default_id)
+                    _task = vm.update_compute_policy(system_default_href)
 
                     task.update(
                         status=TaskStatus.RUNNING.value,

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -14,7 +14,6 @@ import traceback
 
 import click
 import pkg_resources
-from pyvcloud.vcd.client import ApiVersion
 from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.exceptions import EntityNotFoundException
@@ -414,27 +413,15 @@ class Service(object, metaclass=Singleton):
 
         org_name = self.config['broker']['org']
         catalog_name = self.config['broker']['catalog']
-        api_version = self.config['vcd']['api_version']
         client = None
         try:
-            if float(api_version) >= float(ApiVersion.VERSION_32.value): # noqa: E501
-                # TODO this api version 32 client should be removed once
-                # vcd can handle cp removal/replacement on version 33
-                client = Client(self.config['vcd']['host'],
-                                api_version=ApiVersion.VERSION_32.value,
-                                verify_ssl_certs=self.config['vcd']['verify'],
-                                log_file=log_filename,
-                                log_requests=log_wire,
-                                log_headers=log_wire,
-                                log_bodies=log_wire)
-            else:
-                client = Client(self.config['vcd']['host'],
-                                api_version=api_version,
-                                verify_ssl_certs=self.config['vcd']['verify'],
-                                log_file=log_filename,
-                                log_requests=log_wire,
-                                log_headers=log_wire,
-                                log_bodies=log_wire)
+            client = Client(self.config['vcd']['host'],
+                            api_version=self.config['vcd']['api_version'],
+                            verify_ssl_certs=self.config['vcd']['verify'],
+                            log_file=log_filename,
+                            log_requests=log_wire,
+                            log_headers=log_wire,
+                            log_bodies=log_wire)
 
             credentials = BasicLoginCredentials(self.config['vcd']['username'],
                                                 SYSTEM_ORG_NAME,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cachetools >= 2.0.1
 humanfriendly >= 4.8
 pika >= 0.11.2, < 1.0.0
-pyvcloud >= 21.0.0
+pyvcloud >= 21.0.1.dev6
 vcd-cli >= 22.0.0
 vsphere-guest-run >= 0.0.7
 pyvmomi >= 6.7.0


### PR DESCRIPTION
Till api v32.0, Compute Policies were associated with VMs via the VdcComputePolicy tag.
In api v33.0, VdcComputePolicy tag was deprecated and replaced by ComputePolicy-VmSizingPolicy tags.
And in api v34.0, VdcComputePolicy will be completely removed.

The shift in XML tags for associating/disassociating compute policies with/from VMs has already been covered in pyvcloud via https://reviewable.io/reviews/vmware/pyvcloud/636#-. This PR concludes the change required on CSE side to get to full circle. This PR also removes the hack that we had in place to remove compute policy from vms using only api v32.0

Testing Done :
vCD 9.7
-------
Template - photon-v2_k8-1.14_weave-2.5.2

CSE startup with template rule - Success - Assigned policy correctly to template vms
Deploy cluster on ovdc without compute policy - Success (cluster deployment succeeded, this is a 9.7 bug which stops us from supporting compute policy based template protection on vCD 9.7)
Add policy to ovdc - Success
List compute policy on ovdc - Success
Deploy cluster on ovdc with compute policy - Success
Remove compute policy from ovdc - Success - Removed policy from vApp vms without using --force
CSE startup without template rule - Success - Removed policy from template vms


vCD 10.0.0
-------
Template - photon-v2_k8-1.14_weave-2.5.2

CSE startup with template rule - Success - Assigned policy correctly to template vms
Deploy cluster on ovdc without compute policy - Success (cluster deployment failed)
Add policy to ovdc - Success
List compute policy on ovdc - Success
Deploy cluster on ovdc with compute policy - Success (cluster deployment succeeded)
Remove compute policy from ovdc - Success - Removed policy correctly from vApp vms when used with --force option
CSE startup without template rule - Success - Removed policy from template vms


vCD 10.0.0.1
-------
Template - ubuntu-16.04_k8-1.15_weave-2.5.2

CSE startup with template rule - Success - Assigned policy correctly to template vms
Deploy cluster on ovdc without compute policy - Success (cluster deployment failed)
Adding policy to ovdc - Success
List compute policy on ovdc - Success
Deploy cluster on ovdc with compute policy - Success
Remove compute policy from ovdc - Success - Removed policy correctly from vApp vms when used with --force option
CSE startup without template rule - Success Removed policy correctly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/493)
<!-- Reviewable:end -->
