### PR TITLE
[VCDA-1321] Telemetry framework with support for server install and cluster list CSE operations 

### DIFF
--- a/container_service_extension/request_handlers/cluster_handler.py
+++ b/container_service_extension/request_handlers/cluster_handler.py
@@ -13,10 +13,14 @@ from container_service_extension.server_constants import K8sProvider
 from container_service_extension.server_constants import PKS_CLUSTER_DOMAIN_KEY
 from container_service_extension.server_constants import PKS_PLANS_KEY
 from container_service_extension.shared_constants import RequestKey
+from container_service_extension.telemetry.constants import CseOperation
+from container_service_extension.telemetry.telemetry_handler import \
+    record_user_action_telemetry
 import container_service_extension.utils as utils
 import container_service_extension.vcdbroker as vcdbroker
 
 
+@record_user_action_telemetry(cse_operation=CseOperation.CLUSTER_CREATE)
 def cluster_create(request_data, tenant_auth_token):
     """Request handler for cluster create operation.
 
@@ -151,6 +155,7 @@ def cluster_upgrade(request_data, tenant_auth_token):
     return broker.upgrade_cluster(request_data)
 
 
+@record_user_action_telemetry(cse_operation=CseOperation.CLUSTER_LIST)
 def cluster_list(request_data, tenant_auth_token):
     """Request handler for cluster list operation.
 

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -2,10 +2,90 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-# End point of Vmware Analytics staging server
+from enum import Enum
+from enum import unique
+
+# End point of Vmware telemetry staging server
 # TODO() : This URL should reflect production server during release
 VAC_URL = "https://vcsa.vmware.com/ph-stg/api/hyper/send/"
 
 # Value of collector id that is required as part of HTTP request
-# to post sample data to analytics server
+# to post sample data to telemetry server
 COLLECTOR_ID = "CSE.2_6"
+
+
+@unique
+class CseOperation(Enum):
+    """Each CSE operation has a member with following values.
+
+    1. target - CSE object associated with the operation ex: SERVER, CLUSTER
+    2. action - What action is done on the target object
+    3. telemetry_table - name of the table that will hold the supplemental
+    data
+    """
+
+    def __init__(self, description, target, action, telemetry_table):
+        self.description = description
+        self._target = target
+        self._action = action
+        self._telemetry_table = telemetry_table
+
+    @property
+    def target(self):
+        return self._target
+
+    @property
+    def action(self):
+        return self._action
+
+    @property
+    def telemetry_table(self):
+        return self._telemetry_table
+
+    INSTALL_SERVER = ('install server', 'SERVER', 'INSTALL', 'CSE_SERVICE_INSTALL')  # noqa: E501
+    CLUSTER_LIST = ('cluster list', 'CLUSTER', 'LIST', 'CSE_CLUSTER_LIST')
+    CLUSTER_CREATE = ('cluster create', 'CLUSTER', 'CREATE', 'CSE_CLUSTER_CREATE')  # noqa: E501
+
+
+@unique
+class OperationStatus(str, Enum):
+    SUCCESS = 'SUCCESS',
+    FAILED = 'FAILURE'
+
+
+@unique
+class PayloadKey(str, Enum):
+    TYPE = '@type',
+    TARGET = 'target',
+    ACTION = 'action',
+    STATUS = 'status'
+    MESSAGE = 'message'
+    WAS_OVDC_SPECIFIED = 'was_ovdc_specified'
+    WAS_ORG_SPECIFIED = 'was_org_specified'
+    WAS_DECRYPTION_SKIPPED = 'was_decryption_skipped'
+    WAS_PASSWORD_PROVIDED = 'was_password_provided'
+    WAS_PKS_CONFIG_FILE_PROVIDED = 'was_pks_config_file_provided'
+    WERE_TEMPLATES_SKIPPED = 'were_templates_skipped'
+    WERE_TEMPLATES_FORCE_UPDATED = 'were_templates_force_updated'
+    WAS_TEMP_VAPP_RETAINED = 'was_temp_vapp_retained'
+    WAS_SSH_KEY_SPECIFIED = 'was_ssh_key_specified'
+    CLUSTER_ID = 'cluster_id'
+    TEMPLATE_NAME = 'template_name'
+    TEMPLATE_REVISION = 'template_revision'
+    K8S_DISTRIBUTION = 'k8s_distribution'
+    K8S_VERSION = 'k8s_version'
+    OS = 'os'
+    CNI = 'cni'
+    CNI_VERSION = 'cni_version'
+    NUMBER_OF_MASTER_NODES = 'number_of_master_nodes'
+    NUMBER_OF_WORKER_NODES = 'number_of_worker_nodes'
+    CPU = 'cpu'
+    MEMORY = 'memory'
+    WAS_STORAGE_PROFILE_SPECIFIED = 'was_storage_profile_specified'
+    ADDED_NFS_NODE = 'added_nfs_node'
+    WAS_ROLLBACK_DISABLED = 'was_rollback_disabled'
+
+
+@unique
+class PayloadTable(str, Enum):
+    USER_ACTIONS = 'CSE_USER_ACTIONS'

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -1,0 +1,102 @@
+# container-service-extension
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from container_service_extension.server_constants import LocalTemplateKey
+from container_service_extension.shared_constants import RequestKey
+from container_service_extension.telemetry.constants import PayloadKey
+from container_service_extension.telemetry.constants import PayloadTable
+
+
+def get_payload_for_user_action(cse_operation, status, message=None):
+    """Get payload for the given CSE operation.
+
+    :param CseOperation cse_operation: which CSE operation initiated by the
+    user
+    :param str status: success or failure status that indicates the outcome
+    of cse_operation
+    :param str message: custom message about the CSE operation
+
+    :return: json data specific to cse operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: PayloadTable.USER_ACTIONS,
+        PayloadKey.TARGET: cse_operation.target,
+        PayloadKey.ACTION: cse_operation.action,
+        PayloadKey.STATUS: status,
+        PayloadKey.MESSAGE: message
+    }
+
+
+def get_payload_for_list_clusters(cse_operation, params):
+    """Construct payload of list cluster operation.
+
+    :param CseOperation cse_operation: CSE operation that is running
+    :param params: parameters that the CSE operation uses
+
+    :return: json telemetry data for the CSE operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: cse_operation.telemetry_table,
+        PayloadKey.WAS_OVDC_SPECIFIED: bool(params.get(RequestKey.OVDC_NAME)),
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+    }
+
+
+def get_payload_for_create_cluster(cse_operation, params):
+    """Construct payload of cluster creation.
+
+    :param CseOperation cse_operation: CSE operation that is running
+    :param params: parameters that the CSE operation uses
+
+    :return: json telemetry data for the CSE operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: cse_operation.telemetry_table,
+        PayloadKey.CLUSTER_ID: params.get(PayloadKey.CLUSTER_ID),
+        PayloadKey.TEMPLATE_NAME: params.get(RequestKey.TEMPLATE_NAME),
+        PayloadKey.TEMPLATE_REVISION: params.get(RequestKey.TEMPLATE_REVISION),
+        PayloadKey.K8S_DISTRIBUTION: params.get(LocalTemplateKey.KUBERNETES),
+        PayloadKey.K8S_VERSION: params.get(LocalTemplateKey.KUBERNETES_VERSION),  # noqa: E501
+        PayloadKey.CNI_VERSION: params.get(LocalTemplateKey.CNI_VERSION),
+        PayloadKey.CNI: params.get(LocalTemplateKey.CNI),
+        PayloadKey.OS: params.get(LocalTemplateKey.OS),
+        PayloadKey.NUMBER_OF_MASTER_NODES: 1,
+        PayloadKey.NUMBER_OF_WORKER_NODES: params.get(RequestKey.NUM_WORKERS),
+        PayloadKey.CPU: params.get(LocalTemplateKey.CPU),
+        PayloadKey.MEMORY: params.get(LocalTemplateKey.MEMORY),
+        PayloadKey.WAS_STORAGE_PROFILE_SPECIFIED: bool(params.get(RequestKey.STORAGE_PROFILE_NAME)),  # noqa: E501
+        PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(params.get(RequestKey.SSH_KEY)),
+        PayloadKey.ADDED_NFS_NODE: params.get(RequestKey.ENABLE_NFS),
+        PayloadKey.WAS_ROLLBACK_DISABLED: not params.get(RequestKey.ROLLBACK),
+        PayloadKey.WAS_OVDC_SPECIFIED: bool(params.get(RequestKey.OVDC_NAME)),
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+    }
+
+
+def get_payload_for_install_server(cse_operation, params):
+    """Construct payload of server install operation.
+
+    :param CseOperation cse_operation: CSE operation that is running
+    :param params: parameters that the CSE operation uses
+
+    :return: json telemetry data for the CSE operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: cse_operation.telemetry_table,
+        PayloadKey.WAS_DECRYPTION_SKIPPED: bool(params.get(PayloadKey.WAS_DECRYPTION_SKIPPED)),  # noqa: E501
+        PayloadKey.WAS_PASSWORD_PROVIDED: bool(params.get(PayloadKey.WAS_PASSWORD_PROVIDED)),  # noqa: E501
+        PayloadKey.WAS_PKS_CONFIG_FILE_PROVIDED: bool(params.get(PayloadKey.WAS_PKS_CONFIG_FILE_PROVIDED)),  # noqa: E501
+        PayloadKey.WERE_TEMPLATES_SKIPPED: bool(params.get(PayloadKey.WERE_TEMPLATES_SKIPPED)),  # noqa: E501
+        PayloadKey.WERE_TEMPLATES_FORCE_UPDATED: bool(params.get(PayloadKey.WERE_TEMPLATES_FORCE_UPDATED)),  # noqa: E501
+        PayloadKey.WAS_TEMP_VAPP_RETAINED: bool(params.get(PayloadKey.WAS_TEMP_VAPP_RETAINED)),  # noqa: E501
+        PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(params.get(PayloadKey.WAS_SSH_KEY_SPECIFIED))  # noqa: E501
+    }

--- a/container_service_extension/telemetry/telemetry_handler.py
+++ b/container_service_extension/telemetry/telemetry_handler.py
@@ -1,0 +1,114 @@
+# container-service-extension
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import functools
+
+from container_service_extension.logger import SERVER_LOGGER as LOGGER
+from container_service_extension.telemetry.constants import CseOperation
+from container_service_extension.telemetry.constants import OperationStatus
+import container_service_extension.telemetry.payload_generator as\
+    payload_generator
+from container_service_extension.telemetry.payload_generator \
+    import get_payload_for_user_action
+from container_service_extension.telemetry.vac_client import VacClient
+from container_service_extension.utils import get_server_runtime_config
+
+# Payload generator function mappings for CSE operations
+# Each command has its own payload generator
+OPERATION_TO_PAYLOAD_GENERATOR = {
+    CseOperation.CLUSTER_LIST: payload_generator.get_payload_for_list_clusters,
+    CseOperation.CLUSTER_CREATE: payload_generator.get_payload_for_create_cluster,  # noqa: E501
+    CseOperation.INSTALL_SERVER: payload_generator.get_payload_for_install_server   # noqa: E501
+}
+
+
+def record_user_action_telemetry(cse_operation):
+    """Decorate to make access to cse_operation to decorated function.
+
+    This decorator is applicable only for CSE user commands.
+    :param CseOperation cse_operation: CSE operation
+
+    :return: reference to the wrapper function that decorates the
+    actual CSE operation.
+    """
+    def decorator_logger(func):
+        """Decorate to log cse operation and status to telemetry server.
+
+        No exception raised by the decorated function is recorded/logged
+        with status: SUCCESS and FAILURE otherwise.
+
+        :param method func: decorated function
+
+        :return: reference to the function that executes the decorated
+        function.
+        """
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                ret_value = func(*args, **kwargs)
+                record_user_action(cse_operation)
+                return ret_value
+            except Exception as err:
+                record_user_action(cse_operation,
+                                   status=OperationStatus.FAILED,
+                                   message=str(err))
+                raise err
+        return wrapper
+    return decorator_logger
+
+
+def record_user_action(cse_operation, status=OperationStatus.SUCCESS,
+                       message=None, telemetry_settings=None):
+    """Record CSE user action information in telemetry server.
+
+    No exception should be leaked. Catch all exceptions and log them.
+
+    :param CseOperation cse_operation:
+    :param OperationStatus status: SUCCESS/FAILURE of the user action
+    :param str message: any information about failure or custom message
+    :param dict telemetry_settings: telemetry section CSE config->service
+    """
+    if not telemetry_settings:
+        telemetry_settings = get_server_runtime_config()['service']['telemetry']  # noqa: E501
+
+    if telemetry_settings['enable']:
+        try:
+            payload = get_payload_for_user_action(cse_operation, status, message)  # noqa: E501
+            _send_data_to_telemetry_server(payload, telemetry_settings)
+        except Exception as err:
+            LOGGER.warning(f"Error in recording user action information:{str(err)}")  # noqa: E501
+
+
+def record_user_action_details(cse_operation, cse_params,
+                               telemetry_settings=None):
+    """Record CSE user operation details in telemetry server.
+
+    No exception should be leaked. Catch all exceptions and log them.
+
+    :param CseOperation cse_operation: CSE operation information
+    :param dict cse_params: CSE operation parameters
+    :param dict telemetry_settings: telemetry section of config->service
+    """
+    if not telemetry_settings:
+        telemetry_settings = get_server_runtime_config()['service']['telemetry']  # noqa: E501
+
+    if telemetry_settings['enable']:
+        try:
+            payload = OPERATION_TO_PAYLOAD_GENERATOR[cse_operation](cse_operation, cse_params)  # noqa: E501
+            _send_data_to_telemetry_server(payload, telemetry_settings)
+        except Exception as err:
+            LOGGER.warning(f"Error in recording CSE operation details :{str(err)}")  # noqa: E501
+
+
+def _send_data_to_telemetry_server(payload, telemetry_settings):
+    """Send the given payload to telemetry server.
+
+    :param dict payload: json metadata about CSE operation
+    :param dict telemetry_settings: telemetry section of config->service
+    """
+    vac_client = VacClient(base_url=telemetry_settings['vac_url'],
+                           collector_id=telemetry_settings['collector_id'],
+                           instance_id=telemetry_settings['instance_id'],
+                           logger_instance=LOGGER)
+    vac_client.send_data(payload)

--- a/container_service_extension/telemetry/telemetry_utils.py
+++ b/container_service_extension/telemetry/telemetry_utils.py
@@ -23,7 +23,7 @@ def get_telemetry_instance_id(vcd, logger_instance=None,
     :param utils.ConsoleMessagePrinter msg_update_callback: Callback object
     that writes messages onto console.
 
-    :return instance id to use for sending data to Vmware analytics server
+    :return instance id to use for sending data to Vmware telemetry server
 
     :rtype str
 

--- a/container_service_extension/telemetry/vac_client.py
+++ b/container_service_extension/telemetry/vac_client.py
@@ -43,7 +43,7 @@ class VacClient(object):
         self._log_body = log_body
 
     def send_data(self, payload=None):
-        """Ingest the given payload into Vmware Analytics Server.
+        """Send the given payload into Vmware Analytics Server.
 
         Trap all exceptions and log them.
 

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+import copy
 import random
 import re
 import string
@@ -49,6 +50,10 @@ from container_service_extension.server_constants import NodeType
 from container_service_extension.server_constants import ScriptFile
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
 from container_service_extension.shared_constants import RequestKey
+from container_service_extension.telemetry.constants import CseOperation
+from container_service_extension.telemetry.constants import PayloadKey
+from container_service_extension.telemetry.telemetry_handler import \
+    record_user_action_details
 import container_service_extension.utils as utils
 import container_service_extension.vsphere_utils as vs_utils
 
@@ -140,6 +145,10 @@ class VcdBroker(AbstractBroker):
             RequestKey.OVDC_NAME: None
         }
         validated_data = {**defaults, **data}
+
+        # Record the data for telemetry
+        record_user_action_details(cse_operation=CseOperation.CLUSTER_LIST,
+                                   cse_params=copy.deepcopy(validated_data))
 
         raw_clusters = get_all_clusters(
             self.tenant_client,
@@ -312,6 +321,7 @@ class VcdBroker(AbstractBroker):
                                  f"(received {num_workers}).")
 
         cluster_id = str(uuid.uuid4())
+
         # must _update_task or else self.task_resource is None
         # do not logout of sys admin, or else in pyvcloud's session.request()
         # call, session becomes None
@@ -335,6 +345,19 @@ class VcdBroker(AbstractBroker):
             ssh_key=validated_data[RequestKey.SSH_KEY],
             enable_nfs=validated_data[RequestKey.ENABLE_NFS],
             rollback=validated_data[RequestKey.ROLLBACK])
+
+        # Record the data for telemetry
+        cse_params = copy.deepcopy(validated_data)
+        cse_params[PayloadKey.CLUSTER_ID] = cluster_id
+        cse_params[LocalTemplateKey.MEMORY] = template.get(LocalTemplateKey.MEMORY)  # noqa: E501
+        cse_params[LocalTemplateKey.CPU] = template.get(LocalTemplateKey.CPU)
+        cse_params[LocalTemplateKey.KUBERNETES] = template.get(LocalTemplateKey.KUBERNETES)  # noqa: E501
+        cse_params[LocalTemplateKey.KUBERNETES_VERSION] = template.get(LocalTemplateKey.KUBERNETES_VERSION)  # noqa: E501
+        cse_params[LocalTemplateKey.OS] = template.get(LocalTemplateKey.OS)
+        cse_params[LocalTemplateKey.CNI] = template.get(LocalTemplateKey.CNI)
+        cse_params[LocalTemplateKey.CNI_VERSION] = template.get(LocalTemplateKey.CNI_VERSION)  # noqa: E501
+        record_user_action_details(cse_operation=CseOperation.CLUSTER_CREATE,
+                                   cse_params=cse_params)
 
         return {
             'name': cluster_name,


### PR DESCRIPTION
- Telemetry support for CSE operations 
- Implemented the following
    - Framwork code with one decorator for all USER operations
    - Framework support  individual CSE commands
    - Payload generation and workflow hook for cse install 
    - Payload generation and workflow hook for cse cluster list
- Tested the following
     - End to End test for cse install ( Both user action table and supplement table)
     - End to End test for cse cluster list ( Both user action adn supplement table )

@andrew-ni @rocknes @sahithi 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/494)
<!-- Reviewable:end -->
