### PR TITLE
[VCDA - 1340, 1342] Adding support for JWT token for authorization in CSE

### DIFF
--- a/container_service_extension/abstract_broker.py
+++ b/container_service_extension/abstract_broker.py
@@ -11,7 +11,7 @@ import container_service_extension.pyvcloud_utils as vcd_utils
 
 class AbstractBroker(abc.ABC):
 
-    def __init__(self, tenant_auth_token):
+    def __init__(self, tenant_auth_token, is_jwt_token):
         self.tenant_client = None
         self.client_session = None
         self.tenant_user_name = None
@@ -19,8 +19,10 @@ class AbstractBroker(abc.ABC):
         self.tenant_org_name = None
         self.tenant_org_href = None
 
-        self.tenant_client, self.client_session = \
-            vcd_utils.connect_vcd_user_via_token(tenant_auth_token=tenant_auth_token) # noqa: E501
+        self.tenant_client = vcd_utils.connect_vcd_user_via_token(
+            tenant_auth_token=tenant_auth_token,
+            is_jwt_token=is_jwt_token)
+        self.client_session = self.tenant_client.get_vcloud_session()
         self.tenant_user_name = self.client_session.get('user')
         self.tenant_user_id = self.client_session.get('userId')
         self.tenant_org_name = self.client_session.get('org')

--- a/container_service_extension/cloudapi/cloudapi_client.py
+++ b/container_service_extension/cloudapi/cloudapi_client.py
@@ -15,7 +15,8 @@ class CloudApiClient(object):
 
     def __init__(self,
                  base_url,
-                 auth_token,
+                 token,
+                 is_jwt_token,
                  verify_ssl=True,
                  api_version=CLOUDAPI_DEFAULT_VERSION,
                  logger_instance=None,
@@ -24,7 +25,10 @@ class CloudApiClient(object):
                  log_body=False):
         self._base_url = base_url
         self._versioned_url = f"{self._base_url}/{api_version}/"
-        self._headers = {"x-vcloud-authorization": auth_token}
+        if is_jwt_token:
+            self._headers = {"Authorization": f"Bearer {token}"}
+        else:
+            self._headers = {"x-vcloud-authorization": token}
         self._verify_ssl = verify_ssl
         self.LOGGER = logger_instance
         self._log_requests = log_requests

--- a/container_service_extension/cloudapi/constants.py
+++ b/container_service_extension/cloudapi/constants.py
@@ -12,17 +12,3 @@ class CloudApiResource(str, Enum):
     """Keys that are used to get the cloudapi resource names."""
 
     VDC_COMPUTE_POLICIES = 'vdcComputePolicies'
-
-
-class RelationType(Enum):
-    """Keys to use to find the link relation type."""
-
-    # TODO should be moved to pyvcloud
-    OPEN_API = 'openapi'
-
-
-class EntityType(str, Enum):
-    """Media type."""
-
-    # TODO should be moved to pyvcloud
-    APPLICATION_JSON = 'application/json'

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -58,7 +58,7 @@ class ComputePolicyManager:
             token = self._vcd_client.get_xvcloud_authorization_token()
             is_jwt_token = False
 
-        self._session = self._vcd_client.get_vlcoud_session()
+        self._session = self._vcd_client.get_vcloud_session()
         cloudapi_href = self._vcd_client.get_cloudapi_uri()
 
         try:

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -81,7 +81,7 @@ class PksBroker(AbstractBroker):
     VERSION_V1 = 'v1'
     VERSION_V1BETA = 'v1beta1'
 
-    def __init__(self, pks_ctx, tenant_auth_token):
+    def __init__(self, pks_ctx, tenant_auth_token, is_jwt_token):
         """Initialize PKS broker.
 
         :param dict pks_ctx: A dictionary with which should atleast have the
@@ -97,7 +97,7 @@ class PksBroker(AbstractBroker):
         self.tenant_org_name = None
         self.tenant_org_href = None
         # populates above attributes
-        super().__init__(tenant_auth_token)
+        super().__init__(tenant_auth_token, is_jwt_token)
 
         if not pks_ctx:
             raise ValueError(

--- a/container_service_extension/pksbroker_manager.py
+++ b/container_service_extension/pksbroker_manager.py
@@ -12,13 +12,13 @@ from container_service_extension.server_constants import K8sProvider
 import container_service_extension.utils as utils
 
 
-def list_clusters(request_data, tenant_auth_token):
+def list_clusters(request_data, tenant_auth_token, is_jwt_token):
     request_data['is_admin_request'] = True
     pks_clusters = []
-    pks_ctx_list = \
-        create_pks_context_for_all_accounts_in_org(tenant_auth_token)
+    pks_ctx_list = create_pks_context_for_all_accounts_in_org(
+        tenant_auth_token, is_jwt_token)
     for pks_ctx in pks_ctx_list:
-        pks_broker = PksBroker(pks_ctx, tenant_auth_token)
+        pks_broker = PksBroker(pks_ctx, tenant_auth_token, is_jwt_token)
         # Get all cluster information to get vdc name from compute-profile-name
         for cluster in pks_broker.list_clusters(request_data):
             pks_cluster = \
@@ -27,7 +27,8 @@ def list_clusters(request_data, tenant_auth_token):
     return pks_clusters
 
 
-def create_pks_context_for_all_accounts_in_org(tenant_auth_token):
+def create_pks_context_for_all_accounts_in_org(tenant_auth_token,
+                                               is_jwt_token):
     """Create PKS context for accounts in a given Org.
 
     If user is Sysadmin
@@ -47,7 +48,8 @@ def create_pks_context_for_all_accounts_in_org(tenant_auth_token):
     pks_cache = utils.get_pks_cache()
     if pks_cache is None:
         return []
-    client, _ = connect_vcd_user_via_token(tenant_auth_token=tenant_auth_token)
+    client = connect_vcd_user_via_token(tenant_auth_token=tenant_auth_token,
+                                        is_jwt_token=is_jwt_token)
 
     if client.is_sysadmin():
         all_pks_account_info = pks_cache.get_all_pks_account_info_in_system()

--- a/container_service_extension/pyvcloud_utils.py
+++ b/container_service_extension/pyvcloud_utils.py
@@ -33,7 +33,7 @@ ORG_ADMIN_RIGHTS = ['General: Administrator Control',
                     'General: Administrator View']
 
 
-def connect_vcd_user_via_token(tenant_auth_token):
+def connect_vcd_user_via_token(tenant_auth_token, is_jwt_token):
     server_config = get_server_runtime_config()
     vcd_uri = server_config['vcd']['host']
     version = server_config['vcd']['api_version']
@@ -50,8 +50,8 @@ def connect_vcd_user_via_token(tenant_auth_token):
         log_requests=log_wire,
         log_headers=log_wire,
         log_bodies=log_wire)
-    session = client_tenant.rehydrate_from_token(tenant_auth_token)
-    return (client_tenant, session)
+    client_tenant.rehydrate_from_token(tenant_auth_token, is_jwt_token)
+    return client_tenant
 
 
 def get_sys_admin_client():

--- a/container_service_extension/pyvcloud_utils.py
+++ b/container_service_extension/pyvcloud_utils.py
@@ -167,7 +167,7 @@ def get_org_name_from_ovdc_id(vdc_id):
         client = None
         try:
             client = get_sys_admin_client()
-            vdc_href = f"{client._uri}/vdc/{vdc_id}"
+            vdc_href = f"{client.get_api_uri()}/vdc/{vdc_id}"
             vdc_resource = client.get_resource(get_admin_href(vdc_href))
             vdc_obj = VDC(client, resource=vdc_resource)
             link = find_link(vdc_obj.get_resource(), RelationType.UP,

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -19,7 +19,7 @@ import container_service_extension.utils as utils
 SYSTEM_DEFAULT_COMPUTE_POLICY_NAME = "System Default"
 
 
-def ovdc_update(request_data, tenant_auth_token):
+def ovdc_update(request_data, tenant_auth_token, is_jwt_token):
     """Request handler for ovdc enable, disable operations.
 
     Required data: org_name, ovdc_name, k8s_provider
@@ -59,6 +59,7 @@ def ovdc_update(request_data, tenant_auth_token):
             k8s_provider=k8s_provider)
         ovdc_utils.create_pks_compute_profile(k8s_provider_info,
                                               tenant_auth_token,
+                                              is_jwt_token,
                                               validated_data)
 
     task = ovdc_utils.update_ovdc_k8s_provider_metadata(
@@ -69,7 +70,7 @@ def ovdc_update(request_data, tenant_auth_token):
     return {'task_href': task.get('href')}
 
 
-def ovdc_info(request_data, tenant_auth_token):
+def ovdc_info(request_data, tenant_auth_token, is_jwt_token):
     """Request handler for ovdc info operation.
 
     Required data: org_name, ovdc_name
@@ -85,7 +86,7 @@ def ovdc_info(request_data, tenant_auth_token):
         ovdc_id=request_data[RequestKey.OVDC_ID])
 
 
-def ovdc_list(request_data, tenant_auth_token):
+def ovdc_list(request_data, tenant_auth_token, is_jwt_token):
     """Request handler for ovdc list operation.
 
     :return: List of dictionaries with org VDC k8s provider metadata.
@@ -95,15 +96,17 @@ def ovdc_list(request_data, tenant_auth_token):
     }
     validated_data = {**defaults, **request_data}
 
-    client, _ = vcd_utils.connect_vcd_user_via_token(tenant_auth_token)
+    client = vcd_utils.connect_vcd_user_via_token(
+        tenant_auth_token, is_jwt_token)
     # TODO check if this is needed
     list_pks_plans = utils.str_to_bool(validated_data[RequestKey.LIST_PKS_PLANS]) # noqa: E501
 
     return ovdc_utils.get_ovdc_list(client, list_pks_plans=list_pks_plans,
-                                    tenant_auth_token=tenant_auth_token)
+                                    tenant_auth_token=tenant_auth_token,
+                                    is_jwt_token=is_jwt_token)
 
 
-def ovdc_compute_policy_list(request_data, tenant_auth_token):
+def ovdc_compute_policy_list(request_data, tenant_auth_token, is_jwt_token):
     """Request handler for ovdc compute-policy list operation.
 
     Required data: ovdc_id
@@ -115,13 +118,14 @@ def ovdc_compute_policy_list(request_data, tenant_auth_token):
     ]
     req_utils.validate_payload(request_data, required)
 
-    client, _ = vcd_utils.connect_vcd_user_via_token(tenant_auth_token)
+    client = vcd_utils.connect_vcd_user_via_token(
+        tenant_auth_token, is_jwt_token)
 
     cpm = ComputePolicyManager(client)
     return cpm.list_compute_policies_on_vdc(request_data[RequestKey.OVDC_ID])
 
 
-def ovdc_compute_policy_update(request_data, tenant_auth_token):
+def ovdc_compute_policy_update(request_data, tenant_auth_token, is_jwt_token):
     """Request handler for ovdc compute-policy update operation.
 
     Required data: ovdc_id, compute_policy_action, compute_policy_names
@@ -144,7 +148,8 @@ def ovdc_compute_policy_update(request_data, tenant_auth_token):
     ovdc_id = validated_data[RequestKey.OVDC_ID]
     remove_compute_policy_from_vms = validated_data[RequestKey.REMOVE_COMPUTE_POLICY_FROM_VMS] # noqa: E501
 
-    client, _ = vcd_utils.connect_vcd_user_via_token(tenant_auth_token)
+    client = vcd_utils.connect_vcd_user_via_token(
+        tenant_auth_token, is_jwt_token)
 
     cpm = ComputePolicyManager(client)
     cp_href = None

--- a/container_service_extension/request_handlers/system_handler.py
+++ b/container_service_extension/request_handlers/system_handler.py
@@ -6,17 +6,17 @@ import container_service_extension.request_handlers.request_utils as req_utils
 from container_service_extension.shared_constants import RequestKey
 
 
-def system_info(request_data, tenant_auth_token):
+def system_info(request_data, tenant_auth_token, is_jwt_token):
     """Request handler for system info operation.
 
     :return: Dictionary with system info data.
     """
     # TODO: circular dependency with request_processor.py
     import container_service_extension.service as service
-    return service.Service().info(tenant_auth_token)
+    return service.Service().info(tenant_auth_token, is_jwt_token)
 
 
-def system_update(request_data, tenant_auth_token):
+def system_update(request_data, tenant_auth_token, is_jwt_token):
     """Request handler for system update operation.
 
     :return: Dictionary with system update status.
@@ -28,4 +28,5 @@ def system_update(request_data, tenant_auth_token):
 
     # TODO: circular dependency with request_processor.py
     import container_service_extension.service as service
-    return service.Service().update_status(tenant_auth_token, request_data)
+    return service.Service().update_status(
+        tenant_auth_token, is_jwt_token, request_data)

--- a/container_service_extension/request_handlers/template_handler.py
+++ b/container_service_extension/request_handlers/template_handler.py
@@ -6,7 +6,7 @@ from container_service_extension.server_constants import LocalTemplateKey
 import container_service_extension.utils as utils
 
 
-def template_list(request_data, tenant_auth_token):
+def template_list(request_data, tenant_auth_token, is_jwt_token):
     """Request handler for template list operation.
 
     :return: List of dictionaries with template info.

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -109,10 +109,20 @@ def process_request(body):
     # remove None values from request payload
     data = {k: v for k, v in request_data.items() if v is not None}
 
+    # extract out the authorization token
+    auth_header = body['headers'].get('Authorization')
+    if auth_header:
+        tokens = auth_header.split(" ")
+        if len(tokens) == 2 and tokens[0].lower() == 'bearer':
+            tenant_auth_token = tokens[1]
+            is_jwt_token = True
+    if not auth_header:
+        tenant_auth_token = body['headers'].get('x-vcloud-authorization')
+        is_jwt_token = False
+
     # process the request
-    tenant_auth_token = body['headers']['x-vcloud-authorization']
     body_content = \
-        OPERATION_TO_HANDLER[operation](data, tenant_auth_token)
+        OPERATION_TO_HANDLER[operation](data, tenant_auth_token, is_jwt_token)
 
     if not (isinstance(body_content, (list, dict))):
         body_content = {RESPONSE_MESSAGE_KEY: str(body_content)}

--- a/container_service_extension/security.py
+++ b/container_service_extension/security.py
@@ -12,7 +12,7 @@ class RedactingFilter(logging.Filter):
     This filter looks for certain sensitive keys and if a match is found, the
     value will be redacted. The value are expected to be strings. If they are
     dictionaries or iterables, resulting redaction will be partial. Normally
-    the value for a sesitive key will be a plain string.
+    the value for a sensitive key will be a plain string.
     """
 
     _SENSITIVE_KEYS = ['authorization',

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -116,9 +116,10 @@ class Service(object, metaclass=Singleton):
     def is_running(self):
         return self._state == ServerState.RUNNING
 
-    def info(self, tenant_auth_token):
-        tenant_client, _ = connect_vcd_user_via_token(
-            tenant_auth_token=tenant_auth_token)
+    def info(self, tenant_auth_token, is_jwt_token):
+        tenant_client = connect_vcd_user_via_token(
+            tenant_auth_token=tenant_auth_token,
+            is_jwt_token=is_jwt_token)
         result = Service.version()
         if tenant_client.is_sysadmin():
             result['consumer_threads'] = len(self.threads)
@@ -142,9 +143,10 @@ class Service(object, metaclass=Singleton):
         }
         return ver_obj
 
-    def update_status(self, tenant_auth_token, request_data):
-        tenant_client, _ = connect_vcd_user_via_token(
-            tenant_auth_token=tenant_auth_token)
+    def update_status(self, tenant_auth_token, is_jwt_token, request_data):
+        tenant_client = connect_vcd_user_via_token(
+            tenant_auth_token=tenant_auth_token,
+            is_jwt_token=is_jwt_token)
 
         if not tenant_client.is_sysadmin():
             raise UnauthorizedRequestError(

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -61,7 +61,7 @@ import container_service_extension.vsphere_utils as vs_utils
 class VcdBroker(AbstractBroker):
     """Handles cluster operations for 'native' k8s provider."""
 
-    def __init__(self, tenant_auth_token):
+    def __init__(self, tenant_auth_token, is_jwt_token):
         self.tenant_client = None
         self.client_session = None
         self.tenant_user_name = None
@@ -69,7 +69,7 @@ class VcdBroker(AbstractBroker):
         self.tenant_org_name = None
         self.tenant_org_href = None
         # populates above attributes
-        super().__init__(tenant_auth_token)
+        super().__init__(tenant_auth_token, is_jwt_token)
 
         self._sys_admin_client = None # private: use sys_admin_client property
         self.task = None

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -1411,7 +1411,7 @@ def get_all_clusters(client, cluster_name=None, cluster_id=None,
     for record in q.execute():
         vapp_id = record.get('id').split(':')[-1]
         vdc_id = record.get('vdc').split(':')[-1]
-        vapp_href = f'{client._uri}/vApp/vapp-{vapp_id}'
+        vapp_href = f'{client.get_api_uri()}/vApp/vapp-{vapp_id}'
 
         # TODO THIS CLUSTER DICTIONARY NEEDS TO BE MORE WELL-DEFINED
         clusters[vapp_id] = {
@@ -1419,7 +1419,7 @@ def get_all_clusters(client, cluster_name=None, cluster_id=None,
             'vapp_id': vapp_id,
             'vapp_href': vapp_href,
             'vdc_name': record.get('vdcName'),
-            'vdc_href': f'{client._uri}/vdc/{vdc_id}',
+            'vdc_href': f'{client.get_api_uri()}/vdc/{vdc_id}',
             'vdc_id': vdc_id,
             'leader_endpoint': '',
             'master_nodes': [],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 cachetools >= 2.0.1
 humanfriendly >= 4.8
 pika >= 0.11.2, < 1.0.0
-pyvcloud >= 21.0.1.dev6
-vcd-cli >= 22.0.0
+pyvcloud >= 21.0.1.dev7
+vcd-cli >= 22.0.1.dev3
 vsphere-guest-run >= 0.0.7
 pyvmomi >= 6.7.0
 cryptography >= 2.8


### PR DESCRIPTION
x-vcloud-authorization token has been deprecated for few vCD releases now. It's desirable to use JWT token based authorization instead. This PR adds the capability to parse JWT token from Authorization header in AMQP message, and use the token to create pyvcloud vcd clients which are JWT token based.

Also the cloudapi client has been cleaned up.

Testing done :  
Against a vCD 10.0.0.1 server,
* CSE server starts up normally with api v33.0 (JWT token based) as well as v32.0 (x-vcloud-authorization based). 
* Tested few CSE client commands and they were successful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/496)
<!-- Reviewable:end -->
