### PR TITLE
[VCDA-1362] Edit cse.service and cse.sh to consider config encryption

### DIFF
--- a/cse.service
+++ b/cse.service
@@ -4,10 +4,10 @@ Wants=network-online.target,rabbitmq-server.service
 After=network-online.target,rabbitmq-server.service
 
 [Service]
-ExecStart=/home/vmware/cse.sh
+ExecStart=/root/cse.sh
+User=root
+WorkingDirectory=/root
 Type=simple
-User=vmware
-WorkingDirectory=/home/vmware
 Restart=always
 
 [Install]

--- a/cse.sh
+++ b/cse.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 
-USER_DIR=/home/vmware
-PYTHONPATH=$USER_DIR/.local/lib/python3.6/site-packages
-$USER_DIR/.local/bin/cse run $USER_DIR/config.yaml
-#$USER_DIR/.local/bin/cse run $USER_DIR/config.yaml --pks-config $USER_DIR/pks.yaml
+### recommended to use a virtual environment
+# CSE_VENV_PATH=/root/cse-venv
+# source $CSE_VENV_PATH/bin/activate
+
+### CSE config file should be encrypted for security (using `cse encrypt` command)
+### Encryption password should be stored in the environment variable `CSE_CONFIG_PASSWORD`
+### Environment variable can be declared 2 ways:
+### (1) Plaintext in this script
+# export CSE_CONFIG_PASSWORD=mypassword
+### (2) Create a file to store the environment variable. The file should contain the line: `CSE_CONFIG_PASSWORD=mypassword`
+### Add `EnvironmentFile=/path/to/file` under `[Service]` in `cse.service`
+### Note: If `EnvironmentFile=/path/to/file` exists under `[Service]` in `cse.service` but the file does not exist, CSE will fail to start
+
+### Edit this with your CSE config file path
+CSE_CONFIG_PATH=/root/cse-config.yaml
+### To use a plaintext CSE config file, add `-s` to the `cse run` command
+cse run $CSE_CONFIG_PATH


### PR DESCRIPTION
Added clear security recommendations in `cse.sh` to run CSE using an encrypted config file, where the password is provided as an environment variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/505)
<!-- Reviewable:end -->
