### PR TITLE
Fix how Kubernetes version is fetched in get_all_clusters()

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -535,7 +535,7 @@ def cluster_upgrade_plan(ctx, cluster_name, vdc, org_name):
                 'Template Revision': template[LocalTemplateKey.REVISION],
                 'Kubernetes': template[LocalTemplateKey.KUBERNETES_VERSION],
                 'Docker-CE': template[LocalTemplateKey.DOCKER_VERSION],
-                'CNI': f"{template[LocalTemplateKey.CNI]}-{template[LocalTemplateKey.CNI_VERSION]}" # noqa: E501
+                'CNI': f"{template[LocalTemplateKey.CNI]} {template[LocalTemplateKey.CNI_VERSION]}" # noqa: E501
             })
 
         if not templates:

--- a/container_service_extension/config_validator.py
+++ b/container_service_extension/config_validator.py
@@ -295,13 +295,8 @@ def _validate_broker_config(broker_dict, msg_update_callback=None):
                          f"'{broker_dict['ip_allocation_mode']}' when it "
                          f"should be either 'dhcp' or 'pool'")
 
-    remote_template_cookbook = None
-    try:
-        rtm = RemoteTemplateManager(
-            remote_template_cookbook_url=broker_dict['remote_template_cookbook_url']) # noqa: E501
-        remote_template_cookbook = rtm.get_remote_template_cookbook()
-    except Exception:
-        raise ValueError("Invalid value in field remote_template_cookbook")
+    rtm = RemoteTemplateManager(remote_template_cookbook_url=broker_dict['remote_template_cookbook_url']) # noqa: E501
+    remote_template_cookbook = rtm.get_remote_template_cookbook()
 
     if not remote_template_cookbook:
         raise Exception("Remote template cookbook is invalid.")

--- a/container_service_extension/remote_template_manager.py
+++ b/container_service_extension/remote_template_manager.py
@@ -59,8 +59,7 @@ class RemoteTemplateManager():
         tokens = self.url.split('/')
         if tokens[-1] == REMOTE_TEMPLATE_COOKBOOK_FILENAME:
             return '/'.join(tokens[:-1])
-        else:
-            raise ValueError("Inalid url for template cookbook.")
+        raise ValueError("Invalid url for template cookbook.")
 
     def _get_remote_script_url(self, template_name, revision,
                                script_file_name):
@@ -83,11 +82,10 @@ class RemoteTemplateManager():
         :param str script_file_name:
         """
         base_url = self._get_base_url_from_remote_template_cookbook_url()
-        url = base_url + \
+        return base_url + \
             f"/{REMOTE_SCRIPTS_DIR}" \
             f"/{ltm.get_revisioned_template_name(template_name, revision)}" \
             f"/{script_file_name}"
-        return url
 
     def get_remote_template_cookbook(self):
         """Get the remote template cookbook as a dictionary.

--- a/container_service_extension/remote_template_manager.py
+++ b/container_service_extension/remote_template_manager.py
@@ -32,8 +32,7 @@ def download_file_into_memory(url):
     response = requests.get(url, headers={'Cache-Control': 'no-cache'})
     if response.status_code == requests.codes.ok:
         return response.text
-    else:
-        return None
+    response.raise_for_status()
 
 
 class RemoteTemplateManager():

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -680,7 +680,7 @@ def run(ctx, config, pks_config, skip_check, skip_config_decryption):
 def convert_cluster(ctx, config_file_name, skip_config_decryption,
                     cluster_name, admin_password,
                     org_name, vdc_name, skip_wait_for_gc):
-    """Convert pre CSE 2.5.2 clusters to CSE 2.5.2+ cluster format.
+    """Convert pre CSE 2.6.0 clusters to CSE 2.6.0 cluster format.
 
     Use '*' as cluster name to convert all clusters.
     """

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -169,6 +169,14 @@ def cli(ctx):
             not specified the decrypted content will be printed onto console.
             User will be prompted for the password required for decryption.
 \b
+        cse template install mytemplate 1 myconfig.yaml
+            Installs mytemplate at revision 1 specified in the remote template
+            repository URL specified in myconfig.yaml
+\b
+        cse template install * * myconfig.yaml decrypt config.yaml --output ~./configs/encrypted-config.yaml
+            Installs all templates specified in the remote template
+            repository URL specified in myconfig.yaml
+\b
     Environment Variables
         CSE_CONFIG
             If this environment variable is set, the CSE commands will use the
@@ -629,7 +637,10 @@ def run(ctx, config, pks_config, skip_check, skip_config_decryption):
                                message=error_message)
 
 
-@cli.command('convert-cluster', short_help='Converts pre CSE 2.5.2 clusters to CSE 2.5.2+ cluster format') # noqa: E501
+@cli.command('convert-cluster',
+             short_help="Converts pre CSE 2.5.2 clusters to CSE 2.5.2+ "
+                        "cluster format. Use '*' as cluster name to "
+                        "convert all clusters.")
 @click.pass_context
 @click.argument('cluster_name', metavar='CLUSTER_NAME', default=None)
 @click.argument('config_file_name', metavar='CONFIG_FILE_NAME',
@@ -669,6 +680,8 @@ def run(ctx, config, pks_config, skip_check, skip_config_decryption):
 def convert_cluster(ctx, config_file_name, skip_config_decryption,
                     cluster_name, admin_password,
                     org_name, vdc_name, skip_wait_for_gc):
+    """Converts pre CSE 2.5.2 clusters to CSE 2.5.2+ cluster format.
+    Use '*' as cluster name to convert all clusters."""
     console_message_printer = ConsoleMessagePrinter()
 
     try:
@@ -1082,7 +1095,11 @@ def list_template(ctx, config_file_name, skip_config_decryption,
         sys.exit(1)
 
 
-@template.command('install', short_help='Create Kubernetes templates')
+@template.command('install',
+                  short_help="Create Kubernetes templates listed in remote "
+                             "template repository. Use '*' for TEMPLATE_NAME "
+                             "and TEMPLATE_REVISION to install all listed "
+                             "templates.")
 @click.pass_context
 @click.argument('template_name', metavar='TEMPLATE_NAME', default='*')
 @click.argument('template_revision', metavar='TEMPLATE_REVISION', default='*')
@@ -1120,7 +1137,9 @@ def install_cse_template(ctx, template_name, template_revision,
                          config_file_name, skip_config_decryption,
                          force_create, retain_temp_vapp,
                          ssh_key_file):
-    """Create CSE k8s templates."""
+    """Create Kubernetes templates listed in remote template repository.
+    Use '*' for TEMPLATE_NAME and TEMPLATE_REVISION to install
+    all listed templates."""
     console_message_printer = ConsoleMessagePrinter()
 
     try:

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -680,8 +680,10 @@ def run(ctx, config, pks_config, skip_check, skip_config_decryption):
 def convert_cluster(ctx, config_file_name, skip_config_decryption,
                     cluster_name, admin_password,
                     org_name, vdc_name, skip_wait_for_gc):
-    """Converts pre CSE 2.5.2 clusters to CSE 2.5.2+ cluster format.
-    Use '*' as cluster name to convert all clusters."""
+    """Convert pre CSE 2.5.2 clusters to CSE 2.5.2+ cluster format.
+
+    Use '*' as cluster name to convert all clusters.
+    """
     console_message_printer = ConsoleMessagePrinter()
 
     try:
@@ -1138,8 +1140,10 @@ def install_cse_template(ctx, template_name, template_revision,
                          force_create, retain_temp_vapp,
                          ssh_key_file):
     """Create Kubernetes templates listed in remote template repository.
+
     Use '*' for TEMPLATE_NAME and TEMPLATE_REVISION to install
-    all listed templates."""
+    all listed templates.
+    """
     console_message_printer = ConsoleMessagePrinter()
 
     try:

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -173,7 +173,7 @@ def cli(ctx):
             Installs mytemplate at revision 1 specified in the remote template
             repository URL specified in myconfig.yaml
 \b
-        cse template install * * myconfig.yaml decrypt config.yaml --output ~./configs/encrypted-config.yaml
+        cse template install * * myconfig.yaml
             Installs all templates specified in the remote template
             repository URL specified in myconfig.yaml
 \b

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -156,6 +156,7 @@ class VcdBroker(AbstractBroker):
         record_user_action_details(cse_operation=CseOperation.CLUSTER_LIST,
                                    cse_params=copy.deepcopy(validated_data))
 
+        # "raw clusters" do not have well-defined cluster data keys
         raw_clusters = get_all_clusters(
             self.tenant_client,
             org_name=validated_data[RequestKey.ORG_NAME],
@@ -168,7 +169,7 @@ class VcdBroker(AbstractBroker):
                 'IP master': c['leader_endpoint'],
                 'template_name': c.get('template_name'),
                 'template_revision': c.get('template_revision'),
-                'k8s_version': c.get('k8s_version'),
+                'k8s_version': c.get('kubernetes_version'),
                 'VMs': c['number_of_vms'],
                 'vdc': c['vdc_name'],
                 'status': c['status'],


### PR DESCRIPTION
- Update invalid 'k8s_version' cluster key to correct 'kubernetes_version' cluster key in get_all_clusters()
- Update download_file_into_memory() to raise exception on bad status. Fixes vague error messages related to template repository URL errors
- Update convert-cluster and template install help strings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/507)
<!-- Reviewable:end -->
