### PR TITLE
Sort `cse template list` command's output

### DIFF
--- a/container_service_extension/request_handlers/template_handler.py
+++ b/container_service_extension/request_handlers/template_handler.py
@@ -14,12 +14,14 @@ def template_list(request_data, tenant_auth_token, is_jwt_token):
     config = utils.get_server_runtime_config()
     templates = []
     for t in config['broker']['templates']:
+        is_default = (t[LocalTemplateKey.NAME], str(t[LocalTemplateKey.REVISION])) == (config['broker']['default_template_name'], str(config['broker']['default_template_revision'])) # noqa: E501
         templates.append({
             'name': t[LocalTemplateKey.NAME],
             'revision': t[LocalTemplateKey.REVISION],
-            'is_default': t[LocalTemplateKey.NAME] == config['broker']['default_template_name'] and str(t[LocalTemplateKey.REVISION]) == str(config['broker']['default_template_revision']), # noqa: E501
+            'is_default': 'Yes' if is_default else 'No',
             'catalog': config['broker']['catalog'],
             'catalog_item': t[LocalTemplateKey.CATALOG_ITEM_NAME],
             'description': t[LocalTemplateKey.DESCRIPTION].replace("\\n", ", ")
         })
-    return templates
+
+    return sorted(templates, key=lambda i: (i['name'], i['revision']), reverse=True)  # noqa: E501

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -1015,18 +1015,19 @@ def list_template(ctx, config_file_name, skip_config_decryption,
                 for definition in local_template_definitions:
                     template = {}
                     template['name'] = definition[LocalTemplateKey.NAME]
+                    # Any metadata read from vCD is sting due to how pyvcloud
+                    # is coded, so we need to cast it back to int.
                     template['revision'] = \
-                        definition[LocalTemplateKey.REVISION]
+                        int(definition[LocalTemplateKey.REVISION])
                     template['compute_policy'] = \
                         definition[LocalTemplateKey.COMPUTE_POLICY]
-                    template['local'] = True
-                    template['remote'] = False
-                    if str(definition[LocalTemplateKey.REVISION]) == default_template_revision and definition[LocalTemplateKey.NAME] == default_template_name: # noqa: E501
-                        template['default'] = True
+                    template['local'] = 'Yes'
+                    template['remote'] = 'No'
+                    if (definition[LocalTemplateKey.NAME], str(definition[LocalTemplateKey.REVISION])) == (default_template_name, default_template_revision): # noqa: E501
+                        template['default'] = 'Yes'
                     else:
-                        template['default'] = False
-                    template['deprecated'] = \
-                        str_to_bool(definition[LocalTemplateKey.DEPRECATED])
+                        template['default'] = 'No'
+                    template['deprecated'] = 'Yes' if str_to_bool(definition[LocalTemplateKey.DEPRECATED]) else 'No' # noqa: E501
                     template['cpu'] = definition[LocalTemplateKey.CPU]
                     template['memory'] = definition[LocalTemplateKey.MEMORY]
                     template['description'] = \
@@ -1049,11 +1050,11 @@ def list_template(ctx, config_file_name, skip_config_decryption,
                 template['revision'] = definition[RemoteTemplateKey.REVISION]
                 template['compute_policy'] = \
                     definition[RemoteTemplateKey.COMPUTE_POLICY]
-                template['local'] = False
-                template['remote'] = True
-                template['default'] = False
-                template['deprecated'] = \
-                    str_to_bool(definition[RemoteTemplateKey.DEPRECATED])
+                template['local'] = 'No'
+                template['remote'] = 'Yes'
+                if display_option is DISPLAY_ALL:
+                    template['default'] = 'No'
+                template['deprecated'] = 'Yes' if str_to_bool(definition[RemoteTemplateKey.DEPRECATED]) else 'No' # noqa: E501
                 template['cpu'] = definition[RemoteTemplateKey.CPU]
                 template['memory'] = definition[RemoteTemplateKey.MEMORY]
                 template['description'] = \
@@ -1069,7 +1070,7 @@ def list_template(ctx, config_file_name, skip_config_decryption,
             for local_template in local_templates:
                 found = False
                 for remote_template in remote_templates:
-                    if str(local_template[LocalTemplateKey.REVISION]) == str(remote_template[RemoteTemplateKey.REVISION]) and local_template[LocalTemplateKey.NAME] == remote_template[RemoteTemplateKey.NAME]: # noqa: E501
+                    if (local_template[LocalTemplateKey.NAME], local_template[LocalTemplateKey.REVISION]) == (remote_template[RemoteTemplateKey.NAME], remote_template[RemoteTemplateKey.REVISION]): # noqa: E501
                         remote_template['compute_policy'] = \
                             local_template['compute_policy']
                         remote_template['local'] = local_template['local']
@@ -1082,7 +1083,7 @@ def list_template(ctx, config_file_name, skip_config_decryption,
             for remote_template in remote_templates:
                 found = False
                 for local_template in local_templates:
-                    if str(local_template[LocalTemplateKey.REVISION]) == str(remote_template[RemoteTemplateKey.REVISION]) and local_template[LocalTemplateKey.NAME] == remote_template[RemoteTemplateKey.NAME]: # noqa: E501
+                    if (local_template[LocalTemplateKey.NAME], local_template[LocalTemplateKey.REVISION]) == (remote_template[RemoteTemplateKey.NAME], remote_template[RemoteTemplateKey.REVISION]): # noqa: E501
                         found = True
                         break
                 if not found:
@@ -1092,6 +1093,7 @@ def list_template(ctx, config_file_name, skip_config_decryption,
         elif display_option in DISPLAY_REMOTE:
             result = remote_templates
 
+        result = sorted(result, key=lambda t: (t['name'], t['revision']), reverse=True)  # noqa: E501
         stdout(result, ctx, sort_headers=False)
         record_user_action(cse_operation=CseOperation.TEMPLATE_LIST,
                            telemetry_settings=config_dict['service']['telemetry'])  # noqa: E501


### PR DESCRIPTION
Sort `cse template list` command's output in reverse order to group template and their revision together with the latest templates being on top. Also minor change to value in columns local, default, remote, deprecated from True/False to yes/No.

Testing done:
Checked that the output of the concerned commands are sorted correctly and the fields have proper value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/508)
<!-- Reviewable:end -->
