### PR TITLE
Add flake8 ignore to manage_plugin.py

### DIFF
--- a/cse_ui/1.0.0.0b1/manage_plugin.py
+++ b/cse_ui/1.0.0.0b1/manage_plugin.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 import argparse, json, os, requests, sys, time
 from pathlib import Path
 


### PR DESCRIPTION
Placed ignore rule in the file itself so later we don't have to change the tox.ini when manage_plugin.py is removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/520)
<!-- Reviewable:end -->
