### PR TITLE
Change cluster upgrade k8s version check to >=

### DIFF
--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -1111,7 +1111,7 @@ class VcdBroker(AbstractBroker):
             t_cni = semver.Version(template[LocalTemplateKey.CNI_VERSION])
 
             upgrade_docker = t_docker > c_docker
-            upgrade_k8s = t_k8s > c_k8s
+            upgrade_k8s = t_k8s >= c_k8s
             upgrade_cni = t_cni > c_cni or t_k8s.major > c_k8s.major or t_k8s.minor > c_k8s.minor # noqa: E501
 
             if upgrade_k8s:


### PR DESCRIPTION
This change is required for photon k8s upgrades. Photon allows for differences between the same semantic version of kubernetes, so this allows upgrades from 1.14.6-2 -> 1.14.6-3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/521)
<!-- Reviewable:end -->
