### PR TITLE
[VCDA-1382] Expose CSE server CLI commands to manage life-cycle of CSE UI plugin

### DIFF
--- a/container_service_extension/cloudapi/cloudapi_client.py
+++ b/container_service_extension/cloudapi/cloudapi_client.py
@@ -39,8 +39,8 @@ class CloudApiClient(object):
         self._log_body = log_body
         self._last_response = None
 
-    def get_base_uri(self):
-        return self._base_uri
+    def get_base_url(self):
+        return self._base_url
 
     def get_last_response(self):
         return self._last_response
@@ -62,13 +62,15 @@ class CloudApiClient(object):
 
         :param shared_constants.RequestMethod method: One of the HTTP verb
             defined in the enum.
-        :param str cloudapi_version:
+        :param str cloudapi_version: cloudapi version that's part of the url
+            e.g. 1.0.0 in /cloudapi/1.0.0/vdcComputePolicies
         :param str resource_url_relative_path: part of the url that identifies
             just the resource (the host and the common /cloudapi/ should be
             omitted). E.g .vdcComputePolicies,
             vdcComputePolicies/urn:vcloud:vdcComputePolicy:ac313b07-21df-45d2
             etc.
-        :param str resource_url_absolute_path:
+        :param str resource_url_absolute_path: absolute path for a resource,
+            e.g. https://<vcd fqdn>/transfer/{id}/{file name}
         :param dict payload: JSON payload for the REST call.
 
         :return: body of the response text (JSON) in form of a dictionary.

--- a/container_service_extension/cloudapi/cloudapi_client.py
+++ b/container_service_extension/cloudapi/cloudapi_client.py
@@ -48,8 +48,6 @@ class CloudApiClient(object):
     def get_last_response_headers(self):
         if self._last_response:
             return self._last_response.headers
-        else:
-            return None
 
     def do_request(self,
                    method,

--- a/container_service_extension/cloudapi/constants.py
+++ b/container_service_extension/cloudapi/constants.py
@@ -4,7 +4,7 @@
 
 from enum import Enum
 
-CLOUDAPI_DEFAULT_VERSION = '1.0.0'
+CLOUDAPI_VERSION_1_0_0 = '1.0.0'
 CSE_COMPUTE_POLICY_PREFIX = 'cse----'
 
 
@@ -12,3 +12,4 @@ class CloudApiResource(str, Enum):
     """Keys that are used to get the cloudapi resource names."""
 
     VDC_COMPUTE_POLICIES = 'vdcComputePolicies'
+    EXTENSION_UI = 'extensions/ui'

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -355,7 +355,7 @@ def check(ctx, config_file_path, pks_config_file_path, skip_config_decryption,
 
     config_dict = None
     try:
-        config_dict = _construct_config_dict(
+        config_dict = _get_config_dict(
             config_file_path=config_file_path,
             pks_config_file_path=pks_config_file_path,
             skip_config_decryption=skip_config_decryption,
@@ -523,9 +523,8 @@ def install(ctx, config_file_path, pks_config_file_path,
     if ssh_key_file is not None:
         ssh_key = ssh_key_file.read()
 
-    if skip_config_decryption:
-        password = None
-    else:
+    password = None
+    if not skip_config_decryption:
         password = os.getenv('CSE_CONFIG_PASSWORD') or prompt_text(
             PASSWORD_FOR_CONFIG_DECRYPTION_MSG,
             color='green', hide_input=True)
@@ -587,9 +586,8 @@ def run(ctx, config_file_path, pks_config_file_path, skip_check,
     console_message_printer = ConsoleMessagePrinter()
     check_python_version(console_message_printer)
 
-    if skip_config_decryption:
-        password = None
-    else:
+    password = None
+    if not skip_config_decryption:
         password = os.getenv('CSE_CONFIG_PASSWORD') or prompt_text(
             PASSWORD_FOR_CONFIG_DECRYPTION_MSG,
             color='green', hide_input=True)
@@ -629,7 +627,7 @@ def run(ctx, config_file_path, pks_config_file_path, skip_check,
         sys.exit(1)
     finally:
         if not cse_run_complete:
-            config_dict = _construct_config_dict(
+            config_dict = _get_config_dict(
                 config_file_path=config_file_path,
                 pks_config_file_path=None,
                 skip_config_decryption=skip_config_decryption,
@@ -700,7 +698,7 @@ def convert_cluster(ctx, config_file_path, skip_config_decryption,
 
     client = None
     try:
-        config = _construct_config_dict(
+        config = _get_config_dict(
             config_file_path=config_file_path,
             pks_config_file_path=None,
             skip_config_decryption=skip_config_decryption,
@@ -957,7 +955,7 @@ def list_template(ctx, config_file_path, skip_config_decryption,
         # installation is not being performed. If values in config file are
         # missing or bad, appropriate exception will be raised while accessing
         # or using them.
-        config_dict = _construct_config_dict(
+        config_dict = _get_config_dict(
             config_file_path=config_file_path,
             pks_config_file_path=None,
             skip_config_decryption=skip_config_decryption,
@@ -1158,9 +1156,8 @@ def install_cse_template(ctx, template_name, template_revision,
             "inaccessible")
         sys.exit(1)
 
-    if skip_config_decryption:
-        password = None
-    else:
+    password = None
+    if not skip_config_decryption:
         password = os.getenv('CSE_CONFIG_PASSWORD') or prompt_text(
             PASSWORD_FOR_CONFIG_DECRYPTION_MSG,
             color='green', hide_input=True)
@@ -1226,7 +1223,7 @@ def register_ui_plugin(ctx, plugin_file_path, config_file_path,
         # installation is not being performed. If values in config file are
         # missing or bad, appropriate exception will be raised while accessing
         # or using them.
-        config_dict = _construct_config_dict(
+        config_dict = _get_config_dict(
             config_file_path=config_file_path,
             pks_config_file_path=None,
             skip_config_decryption=skip_config_decryption,
@@ -1363,7 +1360,7 @@ def deregister_ui_plugin(ctx, plugin_id, config_file_path,
         # installation is not being performed. If values in config file are
         # missing or bad, appropriate exception will be raised while accessing
         # or using them.
-        config_dict = _construct_config_dict(
+        config_dict = _get_config_dict(
             config_file_path=config_file_path,
             pks_config_file_path=None,
             skip_config_decryption=skip_config_decryption,
@@ -1423,7 +1420,7 @@ def list_ui_plugin(ctx, config_file_path, skip_config_decryption):
         # installation is not being performed. If values in config file are
         # missing or bad, appropriate exception will be raised while accessing
         # or using them.
-        config_dict = _construct_config_dict(
+        config_dict = _get_config_dict(
             config_file_path=config_file_path,
             pks_config_file_path=None,
             skip_config_decryption=skip_config_decryption,
@@ -1460,14 +1457,13 @@ def list_ui_plugin(ctx, config_file_path, skip_config_decryption):
             client.logout()
 
 
-def _construct_config_dict(config_file_path,
-                           pks_config_file_path,
-                           skip_config_decryption,
-                           msg_update_callback,
-                           validate=True):
-    if skip_config_decryption:
-        password = None
-    else:
+def _get_config_dict(config_file_path,
+                     pks_config_file_path,
+                     skip_config_decryption,
+                     msg_update_callback,
+                     validate=True):
+    password = None
+    if not skip_config_decryption:
         password = os.getenv('CSE_CONFIG_PASSWORD') or prompt_text(
             PASSWORD_FOR_CONFIG_DECRYPTION_MSG,
             color='green', hide_input=True)

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -1523,7 +1523,7 @@ def _get_clients_from_config(config, log_filename, log_wire):
         is_jwt_token = False
 
     # TODO : Remove this later
-    LOGGER=None
+    LOGGER = None
     if log_filename:
         LOGGER = logging.getLogger('CSE server CLI cloudapi request logger')
         LOGGER.addFilter(RedactingFilter())

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -1277,8 +1277,7 @@ def register_ui_plugin(ctx, plugin_file_path, config_file_path,
                 raise Exception("Plugin is already registered. Please "
                                 "de-register it first if you wish to register "
                                 "it again.")
-            else:
-                raise
+            raise
 
         console_message_printer.info("Preparing to upload plugin to vCD.")
         transferRequest = {

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -134,17 +134,22 @@ def check_keys_and_value_types(dikt, ref_dict, location='dictionary',
 def check_python_version(msg_update_callback=None):
     """Ensure that user's Python version >= 3.7.3.
 
-    :param utils.ConsoleMessagePrinter msg_update_callback: Callback object
-        that writes messages onto console.
+    If the check fails, will exit the python interpretor with error status.
 
-    :raises Exception: if user's Python version < 3.7.3
+    :param utils.ConsoleMessagePrinter msg_update_callback: Callback object
+        that sends back error messages.
     """
-    if msg_update_callback:
-        msg_update_callback.general_no_color(
-            "Required Python version: >= 3.7.3\n"
-            f"Installed Python version: {sys.version}")
-    if sys.version_info < (3, 7, 3):
-        raise Exception("Python version should be 3.7.3 or greater")
+    try:
+        if msg_update_callback:
+            msg_update_callback.general_no_color(
+                "Required Python version: >= 3.7.3\n"
+                f"Installed Python version: {sys.version}")
+        if sys.version_info < (3, 7, 3):
+            raise Exception("Python version should be 3.7.3 or greater")
+    except Exception as err:
+        if msg_update_callback:
+            msg_update_callback.error(str(err))
+        sys.exit(1)
 
 
 def str_to_bool(s):


### PR DESCRIPTION
Added the following CLI commands to CSE server CLI
* cse ui-plugin register
* cse ui-plugin list
* cse ui-plugin deregister

Additional changes:
* Updated cloudapi client to support Accept header, multiple payload type and arbitrary target url.
* Refactored server cli commands to remove redundant code.
* Updated compute policy manager to accommodate the changes in cloud api
* Added logging support for server cli commands.

Testing Done :
Ran the server cli commands under various scenarios and got the expected results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/524)
<!-- Reviewable:end -->
