### PR TITLE
[VCDA-1365] Update OSL files of 2.6.0 GA

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,4 +1,4 @@
-container-service-extension 2.6 Beta
+container-service-extension 2.6 GA
 
 Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
 

--- a/open_source_license_container-service-extension_2.6_GA.txt
+++ b/open_source_license_container-service-extension_2.6_GA.txt
@@ -1,11 +1,11 @@
 LICENSE
 
-container-service-extension 2.6 Beta
+container-service-extension 2.6 GA
 
 Copyright 2018-2020 VMware, Inc.  All rights reserved.
 
 The BSD-2 license (the “License”) set forth below applies to all parts of the container-service-extension 2.6
-project. You may not use this file except in compliance with the License. 
+project.  You may not use this file except in compliance with the License. 
 
 BSD-2 License 
 
@@ -834,4 +834,4 @@ Source Files is valid for three years from the date you acquired this
 Software product. Alternatively, the Source Files may accompany the
 VMware service.
 
-[CONTAINERSERVICEEXTENSION26BAB012420]
+[CONTAINERSERVICEEXTENSION26GAAB012420]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from setuptools import setup
 
-osl = 'open_source_license_container-service-extension_2.6_Beta.txt'
+osl = 'open_source_license_container-service-extension_2.6_GA.txt'
 
 setup(
     setup_requires=['pbr>=1.9', 'setuptools>=17.1'],


### PR DESCRIPTION
Updated

* LICENSE
* NOTICE
* OSL 

for CSE 2.6.0 GA release

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/526)
<!-- Reviewable:end -->
