### PR TITLE
[VCDA-1400] Post the telemetry data in a separate async thread

### DIFF
--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -602,16 +602,6 @@ def run(ctx, config_file_path, pks_config_file_path, skip_check,
                           decryption_password=password)
         service.run(msg_update_callback=console_message_printer)
         cse_run_complete = True
-
-        # Record telemetry on user action and details of operation.
-        cse_params = {
-            PayloadKey.WAS_DECRYPTION_SKIPPED: bool(skip_config_decryption),
-            PayloadKey.WAS_PKS_CONFIG_FILE_PROVIDED: bool(pks_config_file_path), # noqa: E501
-            PayloadKey.WAS_INSTALLATION_CHECK_SKIPPED: bool(skip_check)
-        }
-        record_user_action_details(cse_operation=CseOperation.SERVICE_RUN,
-                                   cse_params=cse_params)
-        record_user_action(cse_operation=CseOperation.SERVICE_RUN)
     except AmqpConnectionError:
         raise Exception(AMQP_ERROR_MSG)
     except requests.exceptions.ConnectionError as err:

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -39,6 +39,12 @@ from container_service_extension.server_constants import LocalTemplateKey
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
 from container_service_extension.shared_constants import RequestKey
 from container_service_extension.shared_constants import ServerAction
+from container_service_extension.telemetry.constants import CseOperation
+from container_service_extension.telemetry.constants import PayloadKey
+from container_service_extension.telemetry.telemetry_handler \
+    import record_user_action
+from container_service_extension.telemetry.telemetry_handler import \
+    record_user_action_details
 from container_service_extension.template_rule import TemplateRule
 import container_service_extension.utils as utils
 from container_service_extension.vsphere_utils import populate_vsphere_list
@@ -268,6 +274,16 @@ class Service(object, metaclass=Singleton):
         if msg_update_callback:
             msg_update_callback.general_no_color(message)
         LOGGER.info(message)
+
+        # Record telemetry on user action and details of operation.
+        cse_params = {
+            PayloadKey.WAS_DECRYPTION_SKIPPED: bool(self.skip_config_decryption), # noqa: E501
+            PayloadKey.WAS_PKS_CONFIG_FILE_PROVIDED: bool(self.pks_config_file),  # noqa: E501
+            PayloadKey.WAS_INSTALLATION_CHECK_SKIPPED: bool(self.should_check_config)  # noqa: E501
+        }
+        record_user_action_details(cse_operation=CseOperation.SERVICE_RUN,
+                                   cse_params=cse_params)
+        record_user_action(cse_operation=CseOperation.SERVICE_RUN)
 
         while True:
             try:

--- a/container_service_extension/telemetry/telemetry_handler.py
+++ b/container_service_extension/telemetry/telemetry_handler.py
@@ -13,6 +13,7 @@ from container_service_extension.telemetry.payload_generator \
     import get_payload_for_user_action
 from container_service_extension.telemetry.vac_client import VacClient
 from container_service_extension.utils import get_server_runtime_config
+from container_service_extension.utils import run_async
 
 # Payload generator function mappings for CSE operations
 # Each command has its own payload generator
@@ -119,6 +120,7 @@ def record_user_action_details(cse_operation, cse_params,
             LOGGER.warning(f"Error in recording CSE operation details :{str(err)}")  # noqa: E501
 
 
+@run_async
 def _send_data_to_telemetry_server(payload, telemetry_settings):
     """Send the given payload to telemetry server.
 

--- a/container_service_extension/telemetry/vac_client.py
+++ b/container_service_extension/telemetry/vac_client.py
@@ -63,7 +63,7 @@ class VacClient(object):
         try:
             response = self._do_request(RequestMethod.POST, payload)
         except RequestException as err:
-            msg = f"{err.response.text}.{SEND_FAILED_MSG}:{payload}"
+            msg = f"{err}.{SEND_FAILED_MSG}:{payload}"
             self.LOGGER.error(msg)
         except Exception as err:
             msg = f"{err}.{SEND_FAILED_MSG}:{payload}"


### PR DESCRIPTION
- Record telemetry data in a separate thread
- Currently, telemetry record data action blocks the main logic of all CSE functions. This PR makes all telemetry related operations non-blocking. This is required to handle the bad latency in case of vac service.

Testing done:
- Verified with working vac url
- Verified with vac_url that times out
- Verified with url that does not exist

@andrew-ni @rocknes @sahithi 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/528)
<!-- Reviewable:end -->
