### PR TITLE
[VCDA-1424]Change default Telemetry end point to VAC Production

### DIFF
--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -5,9 +5,8 @@
 from enum import Enum
 from enum import unique
 
-# End point of Vmware telemetry staging server
-# TODO() : This URL should reflect production server during release
-VAC_URL = "https://vcsa.vmware.com/ph-stg/api/hyper/send/"
+# End point of Vmware telemetry production server
+VAC_URL = "https://vcsa.vmware.com/ph/api/hyper/send"
 
 # Value of collector id that is required as part of HTTP request
 # to post sample data to telemetry server


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

To help us process your pull request efficiently, please include: 

Signed-off-by: Sakthi Sundaram sakthisunda@yahoo.com

Changed the default telemetry endpoint to production VAC url
Tests done
- Manually tested with production url with successful POST
- Tested with staging end point as override url thru configuration
@rocknes @andrew-ni @Anirudh9794 @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/547)
<!-- Reviewable:end -->
