### PR TITLE
[VCDA-1257] Add cpu, memory and ssh keys option for cluster resize

### DIFF
--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -156,7 +156,10 @@ class Cluster:
                        vdc=None,
                        rollback=True,
                        template_name=None,
-                       template_revision=None):
+                       template_revision=None,
+                       cpu=None,
+                       memory=None,
+                       ssh_key=None):
         method = RequestMethod.PUT
         uri = f"{self._uri}/cluster/{cluster_name}"
         data = {
@@ -168,6 +171,9 @@ class Cluster:
             RequestKey.ROLLBACK: rollback,
             RequestKey.TEMPLATE_NAME: template_name,
             RequestKey.TEMPLATE_REVISION: template_revision,
+            RequestKey.NUM_CPU: cpu,
+            RequestKey.MB_MEMORY: memory,
+            RequestKey.SSH_KEY: ssh_key
         }
         response = self.client._do_request_prim(
             method,

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -500,7 +500,7 @@ def cluster_resize(ctx, cluster_name, node_count, network_name, org_name,
             org_name = ctx.obj['profiles'].get('org_in_use')
 
         ssh_key = None
-        if ssh_key_file is not None:
+        if ssh_key_file:
             ssh_key = ssh_key_file.read()
         cluster = Cluster(client)
         result = cluster.resize_cluster(

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -454,9 +454,35 @@ def cluster_create(ctx, name, vdc, node_count, cpu, memory, network_name,
          'If not specified, server default will be used '
          '(Exclusive to native Kubernetes provider) '
          '(Must be used with --template-revision).')
+@click.option(
+    '-c',
+    '--cpu',
+    'cpu',
+    required=False,
+    default=None,
+    type=click.INT,
+    help='Number of virtual CPUs on each node '
+         '(Exclusive to native Kubernetes provider)')
+@click.option(
+    '-m',
+    '--memory',
+    'memory',
+    required=False,
+    default=None,
+    type=click.INT,
+    help='Megabytes of memory on each node '
+         '(Exclusive to native Kubernetes provider)')
+@click.option(
+    '-k',
+    '--ssh-key',
+    'ssh_key_file',
+    required=False,
+    default=None,
+    type=click.File('r'),
+    help='SSH public key filepath (Exclusive to native Kubernetes provider)')
 def cluster_resize(ctx, cluster_name, node_count, network_name, org_name,
                    vdc_name, disable_rollback, template_name,
-                   template_revision):
+                   template_revision, cpu, memory, ssh_key_file):
     """Resize the cluster to contain the specified number of worker nodes.
 
     Clusters that use native Kubernetes provider can not be sized down
@@ -472,6 +498,10 @@ def cluster_resize(ctx, cluster_name, node_count, network_name, org_name,
         client = ctx.obj['client']
         if not client.is_sysadmin() and org_name is None:
             org_name = ctx.obj['profiles'].get('org_in_use')
+
+        ssh_key = None
+        if ssh_key_file is not None:
+            ssh_key = ssh_key_file.read()
         cluster = Cluster(client)
         result = cluster.resize_cluster(
             network_name,
@@ -481,7 +511,10 @@ def cluster_resize(ctx, cluster_name, node_count, network_name, org_name,
             vdc=vdc_name,
             rollback=not disable_rollback,
             template_name=template_name,
-            template_revision=template_revision)
+            template_revision=template_revision,
+            cpu=cpu,
+            memory=memory,
+            ssh_key=ssh_key)
         stdout(result, ctx)
     except CseResponseError as e:
         minor_error_code_to_error_message = {

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -679,7 +679,7 @@ class VcdBroker(AbstractBroker):
         # Record the data for telemetry
         cse_params = copy.deepcopy(validated_data)
         cse_params[PayloadKey.CLUSTER_ID] = cluster_id
-        cse_params[LocalTemplateKey.MEMORY] = mb_memory  # noqa: E501
+        cse_params[LocalTemplateKey.MEMORY] = mb_memory
         cse_params[LocalTemplateKey.CPU] = num_cpu
         cse_params[LocalTemplateKey.KUBERNETES] = template.get(LocalTemplateKey.KUBERNETES)  # noqa: E501
         cse_params[LocalTemplateKey.KUBERNETES_VERSION] = template.get(LocalTemplateKey.KUBERNETES_VERSION)  # noqa: E501

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -659,6 +659,14 @@ class VcdBroker(AbstractBroker):
         template_revision = validated_data[RequestKey.TEMPLATE_REVISION]
         num_workers = validated_data[RequestKey.NUM_WORKERS]
 
+        num_cpu = template.get(LocalTemplateKey.CPU)
+        if validated_data[RequestKey.NUM_CPU]:
+            num_cpu = validated_data[RequestKey.NUM_CPU]
+
+        mb_memory = template.get(LocalTemplateKey.MEMORY)
+        if validated_data[RequestKey.MB_MEMORY]:
+            mb_memory = validated_data[RequestKey.MB_MEMORY]
+
         if num_workers < 1:
             raise CseServerError(f"Worker node count must be > 0 "
                                  f"(received {num_workers}).")
@@ -671,8 +679,8 @@ class VcdBroker(AbstractBroker):
         # Record the data for telemetry
         cse_params = copy.deepcopy(validated_data)
         cse_params[PayloadKey.CLUSTER_ID] = cluster_id
-        cse_params[LocalTemplateKey.MEMORY] = template.get(LocalTemplateKey.MEMORY)  # noqa: E501
-        cse_params[LocalTemplateKey.CPU] = template.get(LocalTemplateKey.CPU)
+        cse_params[LocalTemplateKey.MEMORY] = mb_memory  # noqa: E501
+        cse_params[LocalTemplateKey.CPU] = num_cpu
         cse_params[LocalTemplateKey.KUBERNETES] = template.get(LocalTemplateKey.KUBERNETES)  # noqa: E501
         cse_params[LocalTemplateKey.KUBERNETES_VERSION] = template.get(LocalTemplateKey.KUBERNETES_VERSION)  # noqa: E501
         cse_params[LocalTemplateKey.OS] = template.get(LocalTemplateKey.OS)
@@ -698,8 +706,8 @@ class VcdBroker(AbstractBroker):
             template_revision=template_revision,
             num_workers=validated_data[RequestKey.NUM_WORKERS],
             network_name=validated_data[RequestKey.NETWORK_NAME],
-            num_cpu=validated_data[RequestKey.NUM_CPU],
-            mb_memory=validated_data[RequestKey.MB_MEMORY],
+            num_cpu=num_cpu,
+            mb_memory=mb_memory,
             storage_profile_name=validated_data[RequestKey.STORAGE_PROFILE_NAME], # noqa: E501
             ssh_key=validated_data[RequestKey.SSH_KEY],
             enable_nfs=validated_data[RequestKey.ENABLE_NFS],


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

Following changes for `vcd cse cluster resize` command
- Added --cpu / -c option
- Added --memory / -m option
- Added --ssh-key / -k option

Testing done:
- `vcd cse cluster resize -N 4 -c 4 -m 4096 -k ~/.ssh/id_rsa.pub -n mynet mycluster `
- `vcd cse cluster resize -N 4 -n mynet clust1`
- `vcd cse cluster resize -c 4 -N 5 -n mynet clust1`
- `vcd cse cluster resize -m 4096 -N 5 -n mynet clust1`  (Adding 2 nodes)
- `vcd cse cluster resize -k ~/.ssh/id_rsa.pub -N 6 -n mynet clust1`

@rocknes @andrew-ni @sakthisunda