### PR TITLE
[VCDA-1431] resolve multiple telemetry calls

### DIFF
--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -55,7 +55,7 @@ def get_cluster_info(request_data, tenant_auth_token, is_jwt_token):
                                                       include_nsxt_info=True)
         broker = get_broker_from_k8s_metadata(
             k8s_metadata, tenant_auth_token, is_jwt_token)
-        return broker.get_cluster_info(request_data), broker
+        return broker.cluster_info(request_data), broker
 
     return get_cluster_and_broker(
         request_data, tenant_auth_token, is_jwt_token)
@@ -65,7 +65,7 @@ def get_cluster_and_broker(request_data, tenant_auth_token, is_jwt_token):
     cluster_name = request_data[RequestKey.CLUSTER_NAME]
     vcd_broker = VcdBroker(tenant_auth_token, is_jwt_token)
     try:
-        return vcd_broker.get_cluster_info(request_data), vcd_broker
+        return vcd_broker.cluster_info(request_data), vcd_broker
     except ClusterNotFoundError as err:
         # continue searching using PksBrokers
         LOGGER.debug(f"{err}")

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -364,6 +364,9 @@ class PksBroker(AbstractBroker):
         return cluster_dict
 
     def get_cluster_info(self, data):
+        return self.cluster_info(data)
+
+    def cluster_info(self, data):
         """Get the details of a cluster with a given name in PKS environment.
 
         System administrator gets the given cluster information regardless of
@@ -398,8 +401,6 @@ class PksBroker(AbstractBroker):
         self._restore_original_name(cluster_info)
         if not data.get('is_admin_request'):
             self._filter_pks_properties(cluster_info)
-
-        return cluster_info
 
     # this function is still being used by _list_clusters for some reason
     # ideally we would like to merge this function with the above function


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

- Avoid multiple calls to record telemetry details. Happens because the following functions which are supposed to be only by the request_processor are used in other functions as well:
  - get_cluster_info
  - create_nodes
  - get_cluster_upgrade_plan

- Create duplicate of the other functions and move logic to the new function, recording telemetry details in the old functions. Make use of the new functions in dependent function bodies.

- Testing:
- vcd cse cluster create -o myorg -v myorgvdc -n mynet clus5
- vcd cse cluster info clus1
- vcd cse node delete node-sjpj -v myorgvdc -o myorg
- vcd cse cluster upgrade-plan clus1
- vcd cse cluster upgrade clus1 ubuntu-16.04_k8-1.17_weave-2.6.0 1
- vcd cse cluster info clus1

@rocknes @andrew-ni @sakthisunda @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/554)
<!-- Reviewable:end -->
