### PR TITLE
[VCDA-1451] Update cluster list to show Kubernetes info

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -189,7 +189,24 @@ def list_clusters(ctx, vdc, org_name):
         if not client.is_sysadmin() and org_name is None:
             org_name = ctx.obj['profiles'].get('org_in_use')
         result = cluster.get_clusters(vdc=vdc, org=org_name)
-        stdout(result, ctx, show_id=True, sort_headers=False)
+
+        clusters = []
+        for c in result:
+            # TODO cluster api response keys need to be more well defined
+            kubernetes = 'N/A'
+            if c.get('k8s_type') and c.get('k8s_version'):
+                kubernetes = f"{c.get('k8s_type')} {c['k8s_version']}"
+            cluster = {
+                'Name': c.get('name') or 'N/A',
+                'VDC': c.get('vdc') or 'N/A',
+                'Org': c.get('org_name') or 'N/A',
+                'Kubernetes': kubernetes,
+                'Status': c.get('status') or 'N/A',
+                'Provider': c.get('k8s_provider') or 'N/A',
+            }
+            clusters.append(cluster)
+
+        stdout(clusters, ctx, show_id=True, sort_headers=False)
     except Exception as e:
         stderr(e, ctx)
 

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -140,7 +140,7 @@ class PksBroker(AbstractBroker):
                                   proxy_uri=self.proxy_uri)
             return uaaClient.getToken()
         except Exception as err:
-            raise PksConnectionError(requests.code.bad_gateway,
+            raise PksConnectionError(requests.codes.bad_gateway,
                                      f'Connection establishment to PKS host'
                                      f' {self.uaac_uri} failed: {err}')
 

--- a/container_service_extension/request_handlers/cluster_handler.py
+++ b/container_service_extension/request_handlers/cluster_handler.py
@@ -211,8 +211,9 @@ def cluster_list(request_data, tenant_auth_token, is_jwt_token):
         'vdc',
         'status',
         'org_name',
+        'k8s_type',
         'k8s_version',
-        K8S_PROVIDER_KEY
+        K8S_PROVIDER_KEY,
     ]
 
     result = []

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -164,11 +164,13 @@ class VcdBroker(AbstractBroker):
 
         clusters = []
         for c in raw_clusters:
+            # TODO update these strings once cluster api keys are well defined
             clusters.append({
                 'name': c['name'],
                 'IP master': c['leader_endpoint'],
                 'template_name': c.get('template_name'),
                 'template_revision': c.get('template_revision'),
+                'k8s_type': c.get('kubernetes'),
                 'k8s_version': c.get('kubernetes_version'),
                 'VMs': c['number_of_vms'],
                 'vdc': c['vdc_name'],


### PR DESCRIPTION
- Fixed bug in pksbroker._get_token() error handling where `requests.code` was used instead of `requests.codes`. This issue would appear if the user's CSE-PKS integration was set up incorrectly

- Updated cluster list API to send back 'k8s_type' data

- Updated CLI cluster list to display cluster's Kubernetes and display more user friendly headers

Before this change:
![image](https://user-images.githubusercontent.com/29108945/78399643-242c6200-75aa-11ea-8217-3922dd0ab094.png)

After this change:
![image](https://user-images.githubusercontent.com/29108945/78399664-2ee6f700-75aa-11ea-91b4-8cb799559828.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/557)
<!-- Reviewable:end -->
