### PR TITLE
[VCDA-1431] resolve multiple telemetry calls

### DIFF
--- a/container_service_extension/abstract_broker.py
+++ b/container_service_extension/abstract_broker.py
@@ -30,7 +30,7 @@ class AbstractBroker(abc.ABC):
             self.tenant_client._get_wk_endpoint(_WellKnownEndpoint.LOGGED_IN_ORG) # noqa: E501
 
     @abc.abstractmethod
-    def create_cluster(self, data):
+    def create_cluster(self, **kwargs):
         """Create cluster.
 
         :return: response object
@@ -40,7 +40,7 @@ class AbstractBroker(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_cluster(self, data):
+    def delete_cluster(self, **kwargs):
         """Delete the given cluster.
 
         :return: response object
@@ -50,7 +50,7 @@ class AbstractBroker(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_cluster_info(self, data):
+    def get_cluster_info(self, **kwargs):
         """Get the information about the cluster.
 
         :return: response object
@@ -60,7 +60,7 @@ class AbstractBroker(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_cluster_config(self, data):
+    def get_cluster_config(self, **kwargs):
         """Get the configuration for the cluster.
 
         :return: Configuration of cluster
@@ -70,7 +70,7 @@ class AbstractBroker(abc.ABC):
         """
 
     @abc.abstractmethod
-    def list_clusters(self, data):
+    def list_clusters(self, **kwargs):
         """Get the list of clusters.
 
         :return: response object
@@ -81,7 +81,7 @@ class AbstractBroker(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def resize_cluster(self, data):
+    def resize_cluster(self, **kwargs):
         """Scale the cluster.
 
         :return: response object

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -39,7 +39,6 @@ def get_cluster_info(request_data, tenant_auth_token, is_jwt_token, **kwargs):
 
     :rtype: tuple
     """
-    telemetry = kwargs.get('telemetry', True)
     required = [
         RequestKey.CLUSTER_NAME
     ]
@@ -56,22 +55,19 @@ def get_cluster_info(request_data, tenant_auth_token, is_jwt_token, **kwargs):
                                                       include_nsxt_info=True)
         broker = get_broker_from_k8s_metadata(
             k8s_metadata, tenant_auth_token, is_jwt_token)
-        return broker.get_cluster_info(data=request_data,
-                                       telemetry=telemetry), \
+        return broker.get_cluster_info(data=request_data, **kwargs), \
             broker
 
     return get_cluster_and_broker(
-        request_data, tenant_auth_token, is_jwt_token, telemetry=telemetry)
+        request_data, tenant_auth_token, is_jwt_token, **kwargs)
 
 
 def get_cluster_and_broker(request_data, tenant_auth_token, is_jwt_token,
                            **kwargs):
-    telemetry = kwargs.get('telemetry', True)
     cluster_name = request_data[RequestKey.CLUSTER_NAME]
     vcd_broker = VcdBroker(tenant_auth_token, is_jwt_token)
     try:
-        return vcd_broker.get_cluster_info(data=request_data,
-                                           telemetry=telemetry), \
+        return vcd_broker.get_cluster_info(data=request_data, **kwargs), \
             vcd_broker
     except ClusterNotFoundError as err:
         # continue searching using PksBrokers

--- a/container_service_extension/broker_manager.py
+++ b/container_service_extension/broker_manager.py
@@ -23,7 +23,7 @@ from container_service_extension.vcdbroker import VcdBroker
 """Handles retrieving the correct broker/cluster to use during an operation."""
 
 
-def get_cluster_info(request_data, tenant_auth_token, is_jwt_token):
+def get_cluster_info(request_data, tenant_auth_token, is_jwt_token, **kwargs):
     """Get cluster details directly from cloud provider.
 
     Logic of the method is as follows.
@@ -39,6 +39,7 @@ def get_cluster_info(request_data, tenant_auth_token, is_jwt_token):
 
     :rtype: tuple
     """
+    telemetry = kwargs.get('telemetry', True)
     required = [
         RequestKey.CLUSTER_NAME
     ]
@@ -55,17 +56,23 @@ def get_cluster_info(request_data, tenant_auth_token, is_jwt_token):
                                                       include_nsxt_info=True)
         broker = get_broker_from_k8s_metadata(
             k8s_metadata, tenant_auth_token, is_jwt_token)
-        return broker.get_cluster_info(request_data), broker
+        return broker.get_cluster_info(data=request_data,
+                                       telemetry=telemetry), \
+            broker
 
     return get_cluster_and_broker(
-        request_data, tenant_auth_token, is_jwt_token)
+        request_data, tenant_auth_token, is_jwt_token, telemetry=telemetry)
 
 
-def get_cluster_and_broker(request_data, tenant_auth_token, is_jwt_token):
+def get_cluster_and_broker(request_data, tenant_auth_token, is_jwt_token,
+                           **kwargs):
+    telemetry = kwargs.get('telemetry', True)
     cluster_name = request_data[RequestKey.CLUSTER_NAME]
     vcd_broker = VcdBroker(tenant_auth_token, is_jwt_token)
     try:
-        return vcd_broker.get_cluster_info(request_data), vcd_broker
+        return vcd_broker.get_cluster_info(data=request_data,
+                                           telemetry=telemetry), \
+            vcd_broker
     except ClusterNotFoundError as err:
         # continue searching using PksBrokers
         LOGGER.debug(f"{err}")
@@ -86,7 +93,7 @@ def get_cluster_and_broker(request_data, tenant_auth_token, is_jwt_token):
                     f"failed on host '{pks_ctx['host']}' with error: "
         pks_broker = PksBroker(pks_ctx, tenant_auth_token, is_jwt_token)
         try:
-            return pks_broker.get_cluster_info(request_data), pks_broker
+            return pks_broker.get_cluster_info(data=request_data), pks_broker
         except (PksClusterNotFoundError, PksServerError) as err:
             # continue searching using other PksBrokers
             LOGGER.debug(f"{debug_msg}{err}")

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -205,7 +205,7 @@ class PksBroker(AbstractBroker):
             pks_plans_list.append(plan.to_dict())
         return pks_plans_list
 
-    def list_clusters(self, data):
+    def list_clusters(self, **kwargs):
         """Get list of clusters in PKS environment.
 
         System administrator gets all the clusters for the given service
@@ -215,6 +215,7 @@ class PksBroker(AbstractBroker):
 
         :rtype: list
         """
+        data = kwargs['data']
         cluster_list = self._list_clusters()
 
         # Required for all personae
@@ -266,20 +267,22 @@ class PksBroker(AbstractBroker):
         return list_of_cluster_dicts
 
     @secure(required_rights=[CSE_PKS_DEPLOY_RIGHT_NAME])
-    def create_cluster(self, data):
+    def create_cluster(self, **kwargs):
         """Create cluster in PKS environment.
 
         To retain the user context, user-id of the logged-in user is appended
         to the original cluster name before the actual cluster creation.
 
-        :param dict cluster_spec: named parameters necessary to create
-        cluster (cluster_name, node_count, pks_plan, pks_ext_host, compute-
-        profile_name)
+        :param **data:
+            dict cluster_spec: named parameters necessary to create
+            cluster (cluster_name, node_count, pks_plan, pks_ext_host, compute-
+            profile_name)
 
         :return: Details of the cluster
 
         :rtype: dict
         """
+        data = kwargs['data']
         required = [
             RequestKey.CLUSTER_NAME,
             RequestKey.PKS_PLAN_NAME,
@@ -363,18 +366,20 @@ class PksBroker(AbstractBroker):
 
         return cluster_dict
 
-    def get_cluster_info(self, data):
+    def get_cluster_info(self, **kwargs):
         """Get the details of a cluster with a given name in PKS environment.
 
         System administrator gets the given cluster information regardless of
         who is the owner of the cluster. Other users get info only on
         the cluster they own.
 
-        :param str cluster_name: Name of the cluster
+        :param **data dict
+            :str cluster_name: Name of the cluster
         :return: Details of the cluster.
 
         :rtype: dict
         """
+        data = kwargs['data']
         cluster_name = data[RequestKey.CLUSTER_NAME]
 
         if self.tenant_client.is_sysadmin() \
@@ -431,7 +436,7 @@ class PksBroker(AbstractBroker):
 
         return cluster_dict
 
-    def get_cluster_config(self, data):
+    def get_cluster_config(self, **kwargs):
         """Get the configuration of the cluster with the given name in PKS.
 
         System administrator gets the given cluster config regardless of
@@ -442,11 +447,12 @@ class PksBroker(AbstractBroker):
 
         :rtype: str
         """
+        data = kwargs['data']
         cluster_name = data[RequestKey.CLUSTER_NAME]
 
         if self.tenant_client.is_sysadmin() or \
                 is_org_admin(self.client_session):
-            cluster_info = self.get_cluster_info(data)
+            cluster_info = self.get_cluster_info(data=data)
             qualified_cluster_name = cluster_info['pks_cluster_name']
         else:
             qualified_cluster_name = self._append_user_id(cluster_name)
@@ -466,20 +472,21 @@ class PksBroker(AbstractBroker):
         return self.filter_traces_of_user_context(cluster_config)
 
     @secure(required_rights=[CSE_PKS_DEPLOY_RIGHT_NAME])
-    def delete_cluster(self, data):
+    def delete_cluster(self, **kwargs):
         """Delete the cluster with a given name in PKS environment.
 
         System administrator can delete the given cluster regardless of
         who is the owner of the cluster. Other users can only delete
         the cluster they own.
-
-        :param str cluster_name: Name of the cluster
+        :param **data
+            :param str cluster_name: Name of the cluster
         """
+        data = kwargs['data']
         cluster_name = data[RequestKey.CLUSTER_NAME]
 
         if self.tenant_client.is_sysadmin() \
                 or is_org_admin(self.client_session):
-            cluster_info = self.get_cluster_info(data)
+            cluster_info = self.get_cluster_info(data=data)
             qualified_cluster_name = cluster_info['pks_cluster_name']
         else:
             qualified_cluster_name = self._append_user_id(cluster_name)
@@ -517,7 +524,7 @@ class PksBroker(AbstractBroker):
         return result
 
     @secure(required_rights=[CSE_PKS_DEPLOY_RIGHT_NAME])
-    def resize_cluster(self, data):
+    def resize_cluster(self, **kwargs):
         """Resize the cluster of a given name to given number of worker nodes.
 
         System administrator can resize the given cluster regardless of
@@ -530,12 +537,13 @@ class PksBroker(AbstractBroker):
         :rtype: dict
 
         """
+        data = kwargs['data']
         cluster_name = data[RequestKey.CLUSTER_NAME]
         num_workers = data[RequestKey.NUM_WORKERS]
 
         if self.tenant_client.is_sysadmin() \
                 or is_org_admin(self.client_session):
-            cluster_info = self.get_cluster_info(data)
+            cluster_info = self.get_cluster_info(data=data)
             qualified_cluster_name = cluster_info['pks_cluster_name']
         else:
             qualified_cluster_name = self._append_user_id(cluster_name)

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -55,6 +55,7 @@ from container_service_extension.server_constants import \
     CSE_PKS_DEPLOY_RIGHT_NAME
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProvider
+from container_service_extension.server_constants import KwargKey
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
 from container_service_extension.shared_constants import RequestKey
 from container_service_extension.uaaclient.uaaclient import UaaClient
@@ -215,7 +216,7 @@ class PksBroker(AbstractBroker):
 
         :rtype: list
         """
-        data = kwargs['data']
+        data = kwargs[KwargKey.DATA]
         cluster_list = self._list_clusters()
 
         # Required for all personae
@@ -282,7 +283,7 @@ class PksBroker(AbstractBroker):
 
         :rtype: dict
         """
-        data = kwargs['data']
+        data = kwargs[KwargKey.DATA]
         required = [
             RequestKey.CLUSTER_NAME,
             RequestKey.PKS_PLAN_NAME,
@@ -379,7 +380,7 @@ class PksBroker(AbstractBroker):
 
         :rtype: dict
         """
-        data = kwargs['data']
+        data = kwargs[KwargKey.DATA]
         cluster_name = data[RequestKey.CLUSTER_NAME]
 
         if self.tenant_client.is_sysadmin() \
@@ -447,7 +448,7 @@ class PksBroker(AbstractBroker):
 
         :rtype: str
         """
-        data = kwargs['data']
+        data = kwargs[KwargKey.DATA]
         cluster_name = data[RequestKey.CLUSTER_NAME]
 
         if self.tenant_client.is_sysadmin() or \
@@ -481,7 +482,7 @@ class PksBroker(AbstractBroker):
         :param **data
             :param str cluster_name: Name of the cluster
         """
-        data = kwargs['data']
+        data = kwargs[KwargKey.DATA]
         cluster_name = data[RequestKey.CLUSTER_NAME]
 
         if self.tenant_client.is_sysadmin() \
@@ -537,7 +538,7 @@ class PksBroker(AbstractBroker):
         :rtype: dict
 
         """
-        data = kwargs['data']
+        data = kwargs[KwargKey.DATA]
         cluster_name = data[RequestKey.CLUSTER_NAME]
         num_workers = data[RequestKey.NUM_WORKERS]
 

--- a/container_service_extension/request_handlers/cluster_handler.py
+++ b/container_service_extension/request_handlers/cluster_handler.py
@@ -51,7 +51,7 @@ def cluster_create(request_data, tenant_auth_token, is_jwt_token):
 
     try:
         broker_manager.get_cluster_and_broker(
-            request_data, tenant_auth_token, is_jwt_token)
+            request_data, tenant_auth_token, is_jwt_token, telemetry=False)
         raise ClusterAlreadyExistsError(f"Cluster {cluster_name} "
                                         f"already exists.")
     except ClusterNotFoundError:
@@ -70,7 +70,7 @@ def cluster_create(request_data, tenant_auth_token, is_jwt_token):
     broker = broker_manager.get_broker_from_k8s_metadata(k8s_metadata,
                                                          tenant_auth_token,
                                                          is_jwt_token)
-    return broker.create_cluster(request_data)
+    return broker.create_cluster(data=request_data)
 
 
 @record_user_action_telemetry(cse_operation=CseOperation.CLUSTER_RESIZE)
@@ -89,8 +89,9 @@ def cluster_resize(request_data, tenant_auth_token, is_jwt_token):
     """
     _, broker = broker_manager.get_cluster_info(request_data,
                                                 tenant_auth_token,
-                                                is_jwt_token)
-    return broker.resize_cluster(request_data)
+                                                is_jwt_token,
+                                                telemetry=False)
+    return broker.resize_cluster(data=request_data)
 
 
 @record_user_action_telemetry(cse_operation=CseOperation.CLUSTER_DELETE)
@@ -106,8 +107,9 @@ def cluster_delete(request_data, tenant_auth_token, is_jwt_token):
     """
     _, broker = broker_manager.get_cluster_info(request_data,
                                                 tenant_auth_token,
-                                                is_jwt_token)
-    return broker.delete_cluster(request_data)
+                                                is_jwt_token,
+                                                telemetry=False)
+    return broker.delete_cluster(data=request_data)
 
 
 @record_user_action_telemetry(cse_operation=CseOperation.CLUSTER_INFO)
@@ -140,8 +142,9 @@ def cluster_config(request_data, tenant_auth_token, is_jwt_token):
     """
     _, broker = broker_manager.get_cluster_info(request_data,
                                                 tenant_auth_token,
-                                                is_jwt_token)
-    return broker.get_cluster_config(request_data)
+                                                is_jwt_token,
+                                                telemetry=False)
+    return broker.get_cluster_config(data=request_data)
 
 
 @record_user_action_telemetry(cse_operation=CseOperation.CLUSTER_UPGRADE_PLAN)
@@ -154,9 +157,10 @@ def cluster_upgrade_plan(request_data, tenant_auth_token, is_jwt_token):
     """
     _, broker = broker_manager.get_cluster_info(request_data,
                                                 tenant_auth_token,
-                                                is_jwt_token)
+                                                is_jwt_token,
+                                                telemetry=False)
     if isinstance(broker, vcdbroker.VcdBroker):
-        return broker.get_cluster_upgrade_plan(request_data)
+        return broker.get_cluster_upgrade_plan(data=request_data)
 
     raise BadRequestError(
         error_message="'cluster upgrade-plan' operation is not supported by "
@@ -173,9 +177,10 @@ def cluster_upgrade(request_data, tenant_auth_token, is_jwt_token):
     """
     _, broker = broker_manager.get_cluster_info(request_data,
                                                 tenant_auth_token,
-                                                is_jwt_token)
+                                                is_jwt_token,
+                                                telemetry=False)
     if isinstance(broker, vcdbroker.VcdBroker):
-        return broker.upgrade_cluster(request_data)
+        return broker.upgrade_cluster(data=request_data)
 
     raise BadRequestError(
         error_message="'cluster upgrade' operation is not supported by non "
@@ -197,7 +202,7 @@ def cluster_list(request_data, tenant_auth_token, is_jwt_token):
     :return: List
     """
     vcd_broker = vcdbroker.VcdBroker(tenant_auth_token, is_jwt_token)
-    vcd_clusters_info = vcd_broker.list_clusters(request_data)
+    vcd_clusters_info = vcd_broker.list_clusters(data=request_data)
 
     pks_clusters_info = []
     if utils.is_pks_enabled():
@@ -242,9 +247,10 @@ def node_create(request_data, tenant_auth_token, is_jwt_token):
     # Different from resize because this can create nfs nodes
     _, broker = broker_manager.get_cluster_info(request_data,
                                                 tenant_auth_token,
-                                                is_jwt_token)
+                                                is_jwt_token,
+                                                telemetry=False)
     if isinstance(broker, vcdbroker.VcdBroker):
-        return broker.create_nodes(request_data)
+        return broker.create_nodes(data=request_data)
 
     raise BadRequestError(
         error_message="'node create' operation is not supported by non native "
@@ -264,9 +270,10 @@ def node_delete(request_data, tenant_auth_token, is_jwt_token):
     """
     _, broker = broker_manager.get_cluster_info(request_data,
                                                 tenant_auth_token,
-                                                is_jwt_token)
+                                                is_jwt_token,
+                                                telemetry=False)
     if isinstance(broker, vcdbroker.VcdBroker):
-        return broker.delete_nodes(request_data)
+        return broker.delete_nodes(data=request_data)
 
     raise BadRequestError(
         error_message="'node delete' operation is not supported by non native "
@@ -287,9 +294,10 @@ def node_info(request_data, tenant_auth_token, is_jwt_token):
     # Currently node info is a vCD only operation.
     _, broker = broker_manager.get_cluster_info(request_data,
                                                 tenant_auth_token,
-                                                is_jwt_token)
+                                                is_jwt_token,
+                                                telemetry=False)
     if isinstance(broker, vcdbroker.VcdBroker):
-        return broker.get_node_info(request_data)
+        return broker.get_node_info(data=request_data)
 
     raise BadRequestError(
         error_message="'node info' operation is not supported by non native "

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -64,6 +64,14 @@ class K8sProvider(str, Enum):
 
 
 @unique
+class KwargKey(str, Enum):
+    """Types of keyword arguments for cluster brokers."""
+
+    DATA = 'data'
+    TELEMETRY = 'telemetry'
+
+
+@unique
 class ScriptFile(str, Enum):
     """Types of script for vApp template customizations in CSE."""
 

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -252,12 +252,14 @@ def get_payload_for_cluster_resize(params):
     return {
         PayloadKey.TYPE: CseOperation.CLUSTER_RESIZE.telemetry_table,
         PayloadKey.CLUSTER_ID: uuid_hash(params.get(PayloadKey.CLUSTER_ID)),
+        PayloadKey.CPU: params.get(LocalTemplateKey.CPU),
+        PayloadKey.MEMORY: params.get(LocalTemplateKey.MEMORY),
         PayloadKey.NUMBER_OF_WORKER_NODES: params.get(RequestKey.NUM_WORKERS),
         PayloadKey.TEMPLATE_NAME: params.get(RequestKey.TEMPLATE_NAME),
         PayloadKey.TEMPLATE_REVISION: params.get(RequestKey.TEMPLATE_REVISION),
         PayloadKey.WAS_ROLLBACK_ENABLED: bool(params.get(RequestKey.ROLLBACK)),
         PayloadKey.WAS_OVDC_SPECIFIED: bool(params.get(RequestKey.OVDC_NAME)),
-        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),
     }
 
 

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -45,6 +45,7 @@ from container_service_extension.server_constants import ClusterMetadataKey
 from container_service_extension.server_constants import CSE_NATIVE_DEPLOY_RIGHT_NAME # noqa: E501
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProvider
+from container_service_extension.server_constants import KwargKey
 from container_service_extension.server_constants import LocalTemplateKey
 from container_service_extension.server_constants import NodeType
 from container_service_extension.server_constants import ScriptFile
@@ -97,8 +98,7 @@ class VcdBroker(AbstractBroker):
             Optional data and default values: org_name=None, ovdc_name=None
         **telemetry: Optional
         """
-        data = kwargs['data']
-        telemetry = kwargs.get('telemetry', True)
+        data = kwargs[KwargKey.DATA]
         required = [
             RequestKey.CLUSTER_NAME
         ]
@@ -114,7 +114,7 @@ class VcdBroker(AbstractBroker):
                               org_name=validated_data[RequestKey.ORG_NAME],
                               ovdc_name=validated_data[RequestKey.OVDC_NAME])
 
-        if telemetry:
+        if kwargs.get(KwargKey.TELEMETRY, True):
             # Record the telemetry data
             cse_params = copy.deepcopy(validated_data)
             cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
@@ -153,19 +153,17 @@ class VcdBroker(AbstractBroker):
             Optional data and default values: org_name=None, ovdc_name=None
         **telemetry: Optional
         """
-        data = kwargs.get('data', {})
-        telemetry = kwargs.get('telemetry', True)
+        data = kwargs.get(KwargKey.DATA, {})
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None
         }
         validated_data = {**defaults, **data}
 
-        if telemetry:
+        if kwargs.get(KwargKey.TELEMETRY, True):
             # Record the data for telemetry
             record_user_action_details(cse_operation=CseOperation.CLUSTER_LIST,
-                                       cse_params=copy.deepcopy(validated_data)
-                                       )
+                                       cse_params=copy.deepcopy(validated_data)) # noqa: E501
 
         # "raw clusters" do not have well-defined cluster data keys
         raw_clusters = get_all_clusters(
@@ -202,8 +200,7 @@ class VcdBroker(AbstractBroker):
             Optional data and default values: org_name=None, ovdc_name=None
         **telemetry: Optional
         """
-        data = kwargs['data']
-        telemetry = kwargs.get('telemetry', True)
+        data = kwargs[KwargKey.DATA]
         required = [
             RequestKey.CLUSTER_NAME
         ]
@@ -223,7 +220,7 @@ class VcdBroker(AbstractBroker):
 
         all_results = []
 
-        if telemetry:
+        if kwargs.get(KwargKey.TELEMETRY, True):
             # Record the telemetry data
             cse_params = copy.deepcopy(validated_data)
             cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
@@ -263,8 +260,7 @@ class VcdBroker(AbstractBroker):
 
         :rtype: List[Dict]
         """
-        data = kwargs['data']
-        telemetry = kwargs.get('telemetry', True)
+        data = kwargs[KwargKey.DATA]
         required = [
             RequestKey.CLUSTER_NAME
         ]
@@ -280,7 +276,7 @@ class VcdBroker(AbstractBroker):
                               org_name=validated_data[RequestKey.ORG_NAME],
                               ovdc_name=validated_data[RequestKey.OVDC_NAME])
 
-        if telemetry:
+        if kwargs.get(KwargKey.TELEMETRY, True):
             # Record the telemetry data
             cse_params = copy.deepcopy(validated_data)
             cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
@@ -317,8 +313,7 @@ class VcdBroker(AbstractBroker):
                 enable_nfs=False,rollback=True
         **telemetry: Optional
         """
-        data = kwargs["data"]
-        telemetry = kwargs.get('telemetry', True)
+        data = kwargs[KwargKey.DATA]
         required = [
             RequestKey.CLUSTER_NAME,
             RequestKey.ORG_NAME,
@@ -390,7 +385,7 @@ class VcdBroker(AbstractBroker):
             enable_nfs=validated_data[RequestKey.ENABLE_NFS],
             rollback=validated_data[RequestKey.ROLLBACK])
 
-        if telemetry:
+        if kwargs.get(KwargKey.TELEMETRY, True):
             # Record the data for telemetry
             cse_params = copy.deepcopy(validated_data)
             cse_params[PayloadKey.CLUSTER_ID] = cluster_id
@@ -425,8 +420,7 @@ class VcdBroker(AbstractBroker):
                 rollback=True, template_name=None, template_revision=None
         **telemetry: Optional
         """
-        data = kwargs['data']
-        telemetry = kwargs.get('telemetry', True)
+        data = kwargs[KwargKey.DATA]
         # TODO default template for resizing should be master's template
         required = [
             RequestKey.CLUSTER_NAME,
@@ -468,7 +462,7 @@ class VcdBroker(AbstractBroker):
             raise CseServerError(f"Cluster '{cluster_name}' already has "
                                  f"{num_workers} worker nodes.")
 
-        if telemetry:
+        if kwargs.get(KwargKey.TELEMETRY, True):
             # Record the telemetry data
             cse_params = copy.deepcopy(validated_data)
             cse_params[PayloadKey.CLUSTER_ID] = cluster_info[PayloadKey.CLUSTER_ID] # noqa: E501
@@ -492,8 +486,7 @@ class VcdBroker(AbstractBroker):
             Optional data and default values: org_name=None, ovdc_name=None
         **telemetry: Optional
         """
-        data = kwargs['data']
-        telemetry = kwargs.get('telemetry', True)
+        data = kwargs[KwargKey.DATA]
         required = [
             RequestKey.CLUSTER_NAME
         ]
@@ -511,7 +504,7 @@ class VcdBroker(AbstractBroker):
                               ovdc_name=validated_data[RequestKey.OVDC_NAME])
         cluster_id = cluster['cluster_id']
 
-        if telemetry:
+        if kwargs.get(KwargKey.TELEMETRY, True):
             # Record the telemetry data
             cse_params = copy.deepcopy(validated_data)
             cse_params[PayloadKey.CLUSTER_ID] = cluster_id
@@ -545,8 +538,7 @@ class VcdBroker(AbstractBroker):
             Optional data and default values: org_name=None, ovdc_name=None
         **telemetry: Optional
         """
-        data = kwargs['data']
-        telemetry = kwargs.get('telemetry', True)
+        data = kwargs[KwargKey.DATA]
         required = [
             RequestKey.CLUSTER_NAME,
             RequestKey.TEMPLATE_NAME,
@@ -582,7 +574,7 @@ class VcdBroker(AbstractBroker):
         # get cluster data (including node names) to pass to async function
         cluster = self.get_cluster_info(data=validated_data, telemetry=False)
 
-        if telemetry:
+        if kwargs.get(KwargKey.TELEMETRY, True):
             # Record the telemetry data
             cse_params = copy.deepcopy(validated_data)
             cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
@@ -615,8 +607,7 @@ class VcdBroker(AbstractBroker):
             Optional data and default values: org_name=None, ovdc_name=None
         **telemetry: Optional
         """
-        data = kwargs['data']
-        telemetry = kwargs.get('telemetry', True)
+        data = kwargs[KwargKey.DATA]
         required = [
             RequestKey.CLUSTER_NAME,
             RequestKey.NODE_NAME
@@ -635,7 +626,7 @@ class VcdBroker(AbstractBroker):
                               org_name=validated_data[RequestKey.ORG_NAME],
                               ovdc_name=validated_data[RequestKey.OVDC_NAME])
 
-        if telemetry:
+        if kwargs.get(KwargKey.TELEMETRY, True):
             # Record the telemetry data
             cse_params = copy.deepcopy(validated_data)
             cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
@@ -691,8 +682,7 @@ class VcdBroker(AbstractBroker):
                 enable_nfs=False, rollback=True
         **telemetry: Optional
         """
-        data = kwargs['data']
-        telemetry = kwargs.get('telemetry', True)
+        data = kwargs[KwargKey.DATA]
         required = [
             RequestKey.CLUSTER_NAME,
             RequestKey.NETWORK_NAME
@@ -731,7 +721,7 @@ class VcdBroker(AbstractBroker):
                               ovdc_name=validated_data[RequestKey.OVDC_NAME])
         cluster_id = cluster['cluster_id']
 
-        if telemetry:
+        if kwargs.get(KwargKey.TELEMETRY, True):
             # Record the data for telemetry
             cse_params = copy.deepcopy(validated_data)
             cse_params[PayloadKey.CLUSTER_ID] = cluster_id
@@ -787,8 +777,7 @@ class VcdBroker(AbstractBroker):
             Optional data and default values: org_name=None, ovdc_name=None
         **telemetry: Optional
         """
-        data = kwargs['data']
-        telemetry = kwargs.get('telemetry', True)
+        data = kwargs[KwargKey.DATA]
         required = [
             RequestKey.CLUSTER_NAME,
             RequestKey.NODE_NAMES_LIST
@@ -817,7 +806,7 @@ class VcdBroker(AbstractBroker):
                               ovdc_name=validated_data[RequestKey.OVDC_NAME])
         cluster_id = cluster['cluster_id']
 
-        if telemetry:
+        if kwargs.get(KwargKey.TELEMETRY, True):
             # Record the telemetry data; record separate data for each node
             cse_params = copy.deepcopy(validated_data)
             cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -86,15 +86,19 @@ class VcdBroker(AbstractBroker):
             self._sys_admin_client.logout()
         self._sys_admin_client = None
 
-    def get_cluster_info(self, data):
+    def get_cluster_info(self, **kwargs):
         """Get cluster metadata as well as node data.
 
         Common broker function that validates data for the 'cluster info'
         operation and returns cluster/node metadata as dictionary.
 
-        Required data: cluster_name
-        Optional data and default values: org_name=None, ovdc_name=None
+        **data: Required
+            Required data: cluster_name
+            Optional data and default values: org_name=None, ovdc_name=None
+        **telemetry: Optional
         """
+        data = kwargs['data']
+        telemetry = kwargs.get('telemetry', True)
         required = [
             RequestKey.CLUSTER_NAME
         ]
@@ -110,11 +114,12 @@ class VcdBroker(AbstractBroker):
                               org_name=validated_data[RequestKey.ORG_NAME],
                               ovdc_name=validated_data[RequestKey.OVDC_NAME])
 
-        # Record the telemetry data
-        cse_params = copy.deepcopy(validated_data)
-        cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
-        record_user_action_details(cse_operation=CseOperation.CLUSTER_INFO,
-                                   cse_params=cse_params)
+        if telemetry:
+            # Record the telemetry data
+            cse_params = copy.deepcopy(validated_data)
+            cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
+            record_user_action_details(cse_operation=CseOperation.CLUSTER_INFO,
+                                       cse_params=cse_params)
 
         cluster[K8S_PROVIDER_KEY] = K8sProvider.NATIVE
         vapp = VApp(self.tenant_client, href=cluster['vapp_href'])
@@ -138,23 +143,29 @@ class VcdBroker(AbstractBroker):
 
         return cluster
 
-    def list_clusters(self, data):
+    def list_clusters(self, **kwargs):
         """List all native clusters and their relevant metadata.
 
         Common broker function that validates data for the 'list clusters'
         operation and returns a list of cluster data.
 
-        Optional data and default values: org_name=None, ovdc_name=None
+        **data: Optional
+            Optional data and default values: org_name=None, ovdc_name=None
+        **telemetry: Optional
         """
+        data = kwargs.get('data', {})
+        telemetry = kwargs.get('telemetry', True)
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None
         }
         validated_data = {**defaults, **data}
 
-        # Record the data for telemetry
-        record_user_action_details(cse_operation=CseOperation.CLUSTER_LIST,
-                                   cse_params=copy.deepcopy(validated_data))
+        if telemetry:
+            # Record the data for telemetry
+            record_user_action_details(cse_operation=CseOperation.CLUSTER_LIST,
+                                       cse_params=copy.deepcopy(validated_data)
+                                       )
 
         # "raw clusters" do not have well-defined cluster data keys
         raw_clusters = get_all_clusters(
@@ -179,16 +190,20 @@ class VcdBroker(AbstractBroker):
             })
         return clusters
 
-    def get_cluster_config(self, data):
+    def get_cluster_config(self, **kwargs):
         """Get the cluster's kube config contents.
 
         Common broker function that validates data for 'cluster config'
         operation and returns the cluster's kube config file contents
         as a string.
 
-        Required data: cluster_name
-        Optional data and default values: org_name=None, ovdc_name=None
+        **data: Required
+            Required data: cluster_name
+            Optional data and default values: org_name=None, ovdc_name=None
+        **telemetry: Optional
         """
+        data = kwargs['data']
+        telemetry = kwargs.get('telemetry', True)
         required = [
             RequestKey.CLUSTER_NAME
         ]
@@ -208,11 +223,12 @@ class VcdBroker(AbstractBroker):
 
         all_results = []
 
-        # Record the telemetry data
-        cse_params = copy.deepcopy(validated_data)
-        cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
-        record_user_action_details(cse_operation=CseOperation.CLUSTER_CONFIG,
-                                   cse_params=cse_params)
+        if telemetry:
+            # Record the telemetry data
+            cse_params = copy.deepcopy(validated_data)
+            cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
+            record_user_action_details(cse_operation=CseOperation.CLUSTER_CONFIG, # noqa: E501
+                                       cse_params=cse_params)
 
         try:
             for node_name in node_names:
@@ -235,16 +251,20 @@ class VcdBroker(AbstractBroker):
             raise ClusterOperationError("Couldn't get cluster configuration")
         return all_results[0].content.decode()
 
-    def get_cluster_upgrade_plan(self, data):
+    def get_cluster_upgrade_plan(self, **kwargs):
         """Get the template names/revisions that the cluster can upgrade to.
 
-        Required data: cluster_name
-        Optional data and default values: org_name=None, ovdc_name=None
+        **data: Required
+            Required data: cluster_name
+            Optional data and default values: org_name=None, ovdc_name=None
+        **telemetry: Optional
 
         :return: A list of dictionaries with keys defined in LocalTemplateKey
 
         :rtype: List[Dict]
         """
+        data = kwargs['data']
+        telemetry = kwargs.get('telemetry', True)
         required = [
             RequestKey.CLUSTER_NAME
         ]
@@ -260,10 +280,11 @@ class VcdBroker(AbstractBroker):
                               org_name=validated_data[RequestKey.ORG_NAME],
                               ovdc_name=validated_data[RequestKey.OVDC_NAME])
 
-        # Record the telemetry data
-        cse_params = copy.deepcopy(validated_data)
-        cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
-        record_user_action_details(cse_operation=CseOperation.CLUSTER_UPGRADE_PLAN, cse_params=cse_params)  # noqa: E501
+        if telemetry:
+            # Record the telemetry data
+            cse_params = copy.deepcopy(validated_data)
+            cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
+            record_user_action_details(cse_operation=CseOperation.CLUSTER_UPGRADE_PLAN, cse_params=cse_params)  # noqa: E501
 
         src_name = cluster['template_name']
         src_rev = cluster['template_revision']
@@ -279,7 +300,7 @@ class VcdBroker(AbstractBroker):
         return upgrades
 
     @secure(required_rights=[CSE_NATIVE_DEPLOY_RIGHT_NAME])
-    def create_cluster(self, data):
+    def create_cluster(self, **kwargs):
         """Start the cluster creation operation.
 
         Common broker function that validates data for the 'create cluster'
@@ -288,12 +309,16 @@ class VcdBroker(AbstractBroker):
         actually performs the work. The returned `result['task_href']` can
         be polled to get updates on task progress.
 
-        Required data: cluster_name, org_name, ovdc_name, network_name
-        Optional data and default values: num_nodes=2, num_cpu=None,
-            mb_memory=None, storage_profile_name=None, ssh_key=None,
-            template_name=default, template_revision=default, enable_nfs=False,
-            rollback=True
+        **data: Required
+            Required data: cluster_name, org_name, ovdc_name, network_name
+            Optional data and default values: num_nodes=2, num_cpu=None,
+                mb_memory=None, storage_profile_name=None, ssh_key=None,
+                template_name=default, template_revision=default,
+                enable_nfs=False,rollback=True
+        **telemetry: Optional
         """
+        data = kwargs["data"]
+        telemetry = kwargs.get('telemetry', True)
         required = [
             RequestKey.CLUSTER_NAME,
             RequestKey.ORG_NAME,
@@ -365,18 +390,19 @@ class VcdBroker(AbstractBroker):
             enable_nfs=validated_data[RequestKey.ENABLE_NFS],
             rollback=validated_data[RequestKey.ROLLBACK])
 
-        # Record the data for telemetry
-        cse_params = copy.deepcopy(validated_data)
-        cse_params[PayloadKey.CLUSTER_ID] = cluster_id
-        cse_params[LocalTemplateKey.MEMORY] = validated_data.get(RequestKey.MB_MEMORY)  # noqa: E501
-        cse_params[LocalTemplateKey.CPU] = validated_data.get(RequestKey.NUM_CPU) # noqa: E501
-        cse_params[LocalTemplateKey.KUBERNETES] = template.get(LocalTemplateKey.KUBERNETES)  # noqa: E501
-        cse_params[LocalTemplateKey.KUBERNETES_VERSION] = template.get(LocalTemplateKey.KUBERNETES_VERSION)  # noqa: E501
-        cse_params[LocalTemplateKey.OS] = template.get(LocalTemplateKey.OS)
-        cse_params[LocalTemplateKey.CNI] = template.get(LocalTemplateKey.CNI)
-        cse_params[LocalTemplateKey.CNI_VERSION] = template.get(LocalTemplateKey.CNI_VERSION)  # noqa: E501
-        record_user_action_details(cse_operation=CseOperation.CLUSTER_CREATE,
-                                   cse_params=cse_params)
+        if telemetry:
+            # Record the data for telemetry
+            cse_params = copy.deepcopy(validated_data)
+            cse_params[PayloadKey.CLUSTER_ID] = cluster_id
+            cse_params[LocalTemplateKey.MEMORY] = validated_data.get(RequestKey.MB_MEMORY)  # noqa: E501
+            cse_params[LocalTemplateKey.CPU] = validated_data.get(RequestKey.NUM_CPU) # noqa: E501
+            cse_params[LocalTemplateKey.KUBERNETES] = template.get(LocalTemplateKey.KUBERNETES)  # noqa: E501
+            cse_params[LocalTemplateKey.KUBERNETES_VERSION] = template.get(LocalTemplateKey.KUBERNETES_VERSION)  # noqa: E501
+            cse_params[LocalTemplateKey.OS] = template.get(LocalTemplateKey.OS)
+            cse_params[LocalTemplateKey.CNI] = template.get(LocalTemplateKey.CNI) # noqa: E501
+            cse_params[LocalTemplateKey.CNI_VERSION] = template.get(LocalTemplateKey.CNI_VERSION)  # noqa: E501
+            record_user_action_details(cse_operation=CseOperation.CLUSTER_CREATE, # noqa: E501
+                                    cse_params=cse_params)
 
         return {
             'name': cluster_name,
@@ -385,7 +411,7 @@ class VcdBroker(AbstractBroker):
         }
 
     @secure(required_rights=[CSE_NATIVE_DEPLOY_RIGHT_NAME])
-    def resize_cluster(self, data):
+    def resize_cluster(self, **kwargs):
         """Start the resize cluster operation.
 
         Common broker function that validates data for the 'resize cluster'
@@ -393,18 +419,32 @@ class VcdBroker(AbstractBroker):
         asynchronous task, so the returned `result['task_href']` can be polled
         to get updates on task progress.
 
-        Required data: cluster_name, network, num_nodes
-        Optional data and default values: org_name=None, ovdc_name=None,
-            rollback=True, template_name=None, template_revision=None
+        **data: Required
+            Required data: cluster_name, network, num_nodes
+            Optional data and default values: org_name=None, ovdc_name=None,
+                rollback=True, template_name=None, template_revision=None
+        **telemetry: Optional
         """
+        data = kwargs['data']
+        telemetry = kwargs.get('telemetry', True)
         # TODO default template for resizing should be master's template
         required = [
             RequestKey.CLUSTER_NAME,
             RequestKey.NUM_WORKERS,
             RequestKey.NETWORK_NAME
         ]
-        # default data values are taken care of in self.create_nodes()
-        validated_data = data
+        defaults = {
+            RequestKey.ORG_NAME: None,
+            RequestKey.OVDC_NAME: None,
+            RequestKey.NUM_WORKERS: 1,
+            RequestKey.NUM_CPU: None,
+            RequestKey.MB_MEMORY: None,
+            RequestKey.STORAGE_PROFILE_NAME: None,
+            RequestKey.SSH_KEY: None,
+            RequestKey.ENABLE_NFS: False,
+            RequestKey.ROLLBACK: True,
+        }
+        validated_data = {**defaults, **data}
         req_utils.validate_payload(validated_data, required)
 
         cluster_name = validated_data[RequestKey.CLUSTER_NAME]
@@ -417,7 +457,8 @@ class VcdBroker(AbstractBroker):
         # cluster_handler.py already makes a cluster info API call to vCD, but
         # that call does not return any node info, so this additional
         # cluster info call must be made
-        cluster_info = self.get_cluster_info(validated_data)
+        cluster_info = self.get_cluster_info(data=validated_data,
+                                             telemetry=False)
         num_workers = len(cluster_info['nodes'])
         if num_workers > num_workers_wanted:
             raise CseServerError(f"Automatic scale down is not supported for "
@@ -427,26 +468,32 @@ class VcdBroker(AbstractBroker):
             raise CseServerError(f"Cluster '{cluster_name}' already has "
                                  f"{num_workers} worker nodes.")
 
-        # Record the telemetry data
-        cse_params = copy.deepcopy(validated_data)
-        cse_params[PayloadKey.CLUSTER_ID] = cluster_info[PayloadKey.CLUSTER_ID]
-        record_user_action_details(cse_operation=CseOperation.CLUSTER_RESIZE,
-                                   cse_params=cse_params)
+        if telemetry:
+            # Record the telemetry data
+            cse_params = copy.deepcopy(validated_data)
+            cse_params[PayloadKey.CLUSTER_ID] = cluster_info[PayloadKey.CLUSTER_ID] # noqa: E501
+            cse_params[LocalTemplateKey.MEMORY] = validated_data.get(RequestKey.MB_MEMORY) # noqa: E501
+            cse_params[LocalTemplateKey.CPU] = validated_data.get(RequestKey.NUM_CPU) # noqa: E501
+            record_user_action_details(cse_operation=CseOperation.CLUSTER_RESIZE, cse_params=cse_params) # noqa: E501
 
         validated_data[RequestKey.NUM_WORKERS] = num_workers_wanted - num_workers # noqa: E501
-        return self.create_nodes(validated_data)
+        return self.create_nodes(data=validated_data, telemetry=False)
 
     @secure(required_rights=[CSE_NATIVE_DEPLOY_RIGHT_NAME])
-    def delete_cluster(self, data):
+    def delete_cluster(self, **kwargs):
         """Start the delete cluster operation.
 
         Common broker function that validates data for 'delete cluster'
         operation. Deleting nodes is an asynchronous task, so the returned
         `result['task_href']` can be polled to get updates on task progress.
 
-        Required data: cluster_name
-        Optional data and default values: org_name=None, ovdc_name=None
+        **data: Required
+            Required data: cluster_name
+            Optional data and default values: org_name=None, ovdc_name=None
+        **telemetry: Optional
         """
+        data = kwargs['data']
+        telemetry = kwargs.get('telemetry', True)
         required = [
             RequestKey.CLUSTER_NAME
         ]
@@ -464,11 +511,12 @@ class VcdBroker(AbstractBroker):
                               ovdc_name=validated_data[RequestKey.OVDC_NAME])
         cluster_id = cluster['cluster_id']
 
-        # Record the telemetry data
-        cse_params = copy.deepcopy(validated_data)
-        cse_params[PayloadKey.CLUSTER_ID] = cluster_id
-        record_user_action_details(cse_operation=CseOperation.CLUSTER_DELETE,
-                                   cse_params=cse_params)
+        if telemetry:
+            # Record the telemetry data
+            cse_params = copy.deepcopy(validated_data)
+            cse_params[PayloadKey.CLUSTER_ID] = cluster_id
+            record_user_action_details(cse_operation=CseOperation.CLUSTER_DELETE, # noqa: E501
+                                    cse_params=cse_params)
 
         # must _update_task here or else self.task_resource is None
         # do not logout of sys admin, or else in pyvcloud's session.request()
@@ -485,16 +533,20 @@ class VcdBroker(AbstractBroker):
         }
 
     @secure(required_rights=[CSE_NATIVE_DEPLOY_RIGHT_NAME])
-    def upgrade_cluster(self, data):
+    def upgrade_cluster(self, **kwargs):
         """Start the upgrade cluster operation.
 
         Validates data for 'upgrade cluster' operation.
         Upgrading cluster is an asynchronous task, so the returned
         `result['task_href']` can be polled to get updates on task progress.
 
-        Required data: cluster_name, template_name, template_revision
-        Optional data and default values: org_name=None, ovdc_name=None
+        **data: Required
+            Required data: cluster_name, template_name, template_revision
+            Optional data and default values: org_name=None, ovdc_name=None
+        **telemetry: Optional
         """
+        data = kwargs['data']
+        telemetry = kwargs.get('telemetry', True)
         required = [
             RequestKey.CLUSTER_NAME,
             RequestKey.TEMPLATE_NAME,
@@ -513,7 +565,8 @@ class VcdBroker(AbstractBroker):
 
         # check that the specified template is a valid upgrade target
         template = {}
-        valid_templates = self.get_cluster_upgrade_plan(validated_data)
+        valid_templates = self.get_cluster_upgrade_plan(data=validated_data,
+                                                        telemetry=False)
         for t in valid_templates:
             if t[LocalTemplateKey.NAME] == template_name and t[LocalTemplateKey.REVISION] == str(template_revision): # noqa: E501
                 template = t
@@ -527,13 +580,14 @@ class VcdBroker(AbstractBroker):
                 f"cluster '{cluster_name}'.")
 
         # get cluster data (including node names) to pass to async function
-        cluster = self.get_cluster_info(validated_data)
+        cluster = self.get_cluster_info(data=validated_data, telemetry=False)
 
-        # Record the telemetry data
-        cse_params = copy.deepcopy(validated_data)
-        cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
-        record_user_action_details(cse_operation=CseOperation.CLUSTER_UPGRADE,
-                                   cse_params=cse_params)
+        if telemetry:
+            # Record the telemetry data
+            cse_params = copy.deepcopy(validated_data)
+            cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
+            record_user_action_details(cse_operation=CseOperation.CLUSTER_UPGRADE, # noqa: E501
+                                    cse_params=cse_params)
 
         msg = f"Upgrading cluster '{cluster_name}' " \
               f"software to match template {template_name} (revision " \
@@ -553,12 +607,16 @@ class VcdBroker(AbstractBroker):
             'task_href': self.task_resource.get('href')
         }
 
-    def get_node_info(self, data):
+    def get_node_info(self, **kwargs):
         """Get node metadata as dictionary.
 
-        Required data: cluster_name, node_name
-        Optional data and default values: org_name=None, ovdc_name=None
+        **data: Required
+            Required data: cluster_name, node_name
+            Optional data and default values: org_name=None, ovdc_name=None
+        **telemetry: Optional
         """
+        data = kwargs['data']
+        telemetry = kwargs.get('telemetry', True)
         required = [
             RequestKey.CLUSTER_NAME,
             RequestKey.NODE_NAME
@@ -577,10 +635,11 @@ class VcdBroker(AbstractBroker):
                               org_name=validated_data[RequestKey.ORG_NAME],
                               ovdc_name=validated_data[RequestKey.OVDC_NAME])
 
-        # Record the telemetry data
-        cse_params = copy.deepcopy(validated_data)
-        cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
-        record_user_action_details(cse_operation=CseOperation.NODE_INFO, cse_params=cse_params)  # noqa: E501
+        if telemetry:
+            # Record the telemetry data
+            cse_params = copy.deepcopy(validated_data)
+            cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
+            record_user_action_details(cse_operation=CseOperation.NODE_INFO, cse_params=cse_params)  # noqa: E501
 
         vapp = VApp(self.tenant_client, href=cluster['vapp_href'])
         vms = vapp.get_all_vms()
@@ -617,19 +676,23 @@ class VcdBroker(AbstractBroker):
         return node_info
 
     @secure(required_rights=[CSE_NATIVE_DEPLOY_RIGHT_NAME])
-    def create_nodes(self, data):
+    def create_nodes(self, **kwargs):
         """Start the create nodes operation.
 
         Validates data for 'node create' operation. Creating nodes is an
         asynchronous task, so the returned `result['task_href']` can be polled
         to get updates on task progress.
 
-        Required data: cluster_name, network_name
-        Optional data and default values: num_nodes=2, num_cpu=None,
-            mb_memory=None, storage_profile_name=None, ssh_key=None,
-            template_name=default, template_revision=default, enable_nfs=False,
-            rollback=True
+        **data: Required
+            Required data: cluster_name, network_name
+            Optional data and default values: num_nodes=2, num_cpu=None,
+                mb_memory=None, storage_profile_name=None, ssh_key=None,
+                template_name=default, template_revision=default,
+                enable_nfs=False, rollback=True
+        **telemetry: Optional
         """
+        data = kwargs['data']
+        telemetry = kwargs.get('telemetry', True)
         required = [
             RequestKey.CLUSTER_NAME,
             RequestKey.NETWORK_NAME
@@ -668,18 +731,19 @@ class VcdBroker(AbstractBroker):
                               ovdc_name=validated_data[RequestKey.OVDC_NAME])
         cluster_id = cluster['cluster_id']
 
-        # Record the data for telemetry
-        cse_params = copy.deepcopy(validated_data)
-        cse_params[PayloadKey.CLUSTER_ID] = cluster_id
-        cse_params[LocalTemplateKey.MEMORY] = validated_data.get(RequestKey.MB_MEMORY)  # noqa: E501
-        cse_params[LocalTemplateKey.CPU] = validated_data.get(RequestKey.NUM_CPU) # noqa: E501
-        cse_params[LocalTemplateKey.KUBERNETES] = template.get(LocalTemplateKey.KUBERNETES)  # noqa: E501
-        cse_params[LocalTemplateKey.KUBERNETES_VERSION] = template.get(LocalTemplateKey.KUBERNETES_VERSION)  # noqa: E501
-        cse_params[LocalTemplateKey.OS] = template.get(LocalTemplateKey.OS)
-        cse_params[LocalTemplateKey.CNI] = template.get(LocalTemplateKey.CNI)
-        cse_params[LocalTemplateKey.CNI_VERSION] = template.get(LocalTemplateKey.CNI_VERSION)  # noqa: E501
-        record_user_action_details(cse_operation=CseOperation.NODE_CREATE,
-                                   cse_params=cse_params)
+        if telemetry:
+            # Record the data for telemetry
+            cse_params = copy.deepcopy(validated_data)
+            cse_params[PayloadKey.CLUSTER_ID] = cluster_id
+            cse_params[LocalTemplateKey.MEMORY] = validated_data.get(RequestKey.MB_MEMORY)  # noqa: E501
+            cse_params[LocalTemplateKey.CPU] = validated_data.get(RequestKey.NUM_CPU) # noqa: E501
+            cse_params[LocalTemplateKey.KUBERNETES] = template.get(LocalTemplateKey.KUBERNETES)  # noqa: E501
+            cse_params[LocalTemplateKey.KUBERNETES_VERSION] = template.get(LocalTemplateKey.KUBERNETES_VERSION)  # noqa: E501
+            cse_params[LocalTemplateKey.OS] = template.get(LocalTemplateKey.OS)
+            cse_params[LocalTemplateKey.CNI] = template.get(LocalTemplateKey.CNI) # noqa: E501
+            cse_params[LocalTemplateKey.CNI_VERSION] = template.get(LocalTemplateKey.CNI_VERSION)  # noqa: E501
+            record_user_action_details(cse_operation=CseOperation.NODE_CREATE,
+                                       cse_params=cse_params)
 
         # must _update_task here or else self.task_resource is None
         # do not logout of sys admin, or else in pyvcloud's session.request()
@@ -711,16 +775,20 @@ class VcdBroker(AbstractBroker):
         }
 
     @secure(required_rights=[CSE_NATIVE_DEPLOY_RIGHT_NAME])
-    def delete_nodes(self, data):
+    def delete_nodes(self, **kwargs):
         """Start the delete nodes operation.
 
         Validates data for the 'delete nodes' operation. Deleting nodes is an
         asynchronous task, so the returned `result['task_href']` can be polled
         to get updates on task progress.
 
-        Required data: cluster_name, node_names_list
-        Optional data and default values: org_name=None, ovdc_name=None
+        **data: Required
+            Required data: cluster_name, node_names_list
+            Optional data and default values: org_name=None, ovdc_name=None
+        **telemetry: Optional
         """
+        data = kwargs['data']
+        telemetry = kwargs.get('telemetry', True)
         required = [
             RequestKey.CLUSTER_NAME,
             RequestKey.NODE_NAMES_LIST
@@ -749,12 +817,13 @@ class VcdBroker(AbstractBroker):
                               ovdc_name=validated_data[RequestKey.OVDC_NAME])
         cluster_id = cluster['cluster_id']
 
-        # Record the telemetry data; record separate data for each node
-        cse_params = copy.deepcopy(validated_data)
-        cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
-        for node in node_names_list:
-            cse_params[PayloadKey.NODE_NAME] = node
-            record_user_action_details(cse_operation=CseOperation.NODE_DELETE, cse_params=cse_params)  # noqa: E501
+        if telemetry:
+            # Record the telemetry data; record separate data for each node
+            cse_params = copy.deepcopy(validated_data)
+            cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
+            for node in node_names_list:
+                cse_params[PayloadKey.NODE_NAME] = node
+                record_user_action_details(cse_operation=CseOperation.NODE_DELETE, cse_params=cse_params)  # noqa: E501
 
         # must _update_task here or else self.task_resource is None
         # do not logout of sys admin, or else in pyvcloud's session.request()


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

- - Avoid multiple calls to record telemetry details. Happens because the following functions which are supposed to be only by the request_processor are used in other functions as well:
  - get_cluster_info
  - create_nodes
  - get_cluster_upgrade_plan

- broker functions will now accept kwargs which can have data along with telemetry flag.
- record telemetry details only if telemetry flag is set

- testing done:
added debug statements to check if multiple calls to record telemetry are being made
`vcd cse cluster resize -N 3 -n mynet clus3`
`vcd cse cluster list`
`vcd cse cluster info clus3`
`vcd cse node info clus3 mstr-xkfv`

@rocknes @andrew-ni @sakthisunda @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/558)
<!-- Reviewable:end -->
