### PR TITLE
[VCDA-1457] Add tests for cluster resize

### DIFF
--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -509,7 +509,56 @@ def test_0100_vcd_cse_cluster_config(test_runner_username):
 @pytest.mark.parametrize('test_runner_username', [env.SYS_ADMIN_NAME,
                                                   env.ORG_ADMIN_NAME,
                                                   env.VAPP_AUTHOR_NAME])
-def test_0110_vcd_cse_node_operation(test_runner_username, config):
+def test_0110_vcd_cse_cluster_resize(test_runner_username, config):
+    """Test 'vcd cse cluster resize ...' commands.
+    """
+    node_pattern = r'(node-\S+)'
+    cmd_binder = collections.namedtuple('UserCmdBinder',
+                                        'cmd exit_code validate_output_func '
+                                        'test_user')
+
+    print(f"Running cluster info operation for {test_runner_username}")
+    cmd_list = [
+        cmd_binder(cmd=env.USERNAME_TO_LOGIN_CMD[test_runner_username],
+                   exit_code=0,
+                   validate_output_func=None, test_user=test_runner_username),
+        cmd_binder(cmd=f"org use {config['broker']['org']}", exit_code=0,
+                   validate_output_func=None, test_user=test_runner_username),
+        cmd_binder(cmd=f"vdc use {config['broker']['vdc']}", exit_code=0,
+                   validate_output_func=None, test_user=test_runner_username),
+        cmd_binder(cmd=f"cse cluster info {env.USERNAME_TO_CLUSTER_NAME[test_runner_username]}",   # noqa
+                   exit_code=0,
+                   validate_output_func=None,
+                   test_user=test_runner_username)
+    ]
+    cmd_results = execute_commands(cmd_list)
+
+    num_nodes = len(re.findall(node_pattern, cmd_results[-1].output))
+
+    print(f"Running cluster resize operation for {test_runner_username}")
+
+    cmd_list = [
+        cmd_binder(cmd=f"cse cluster resize -N {num_nodes+1} -n {config['broker']['network']}"  # noqa
+                       f" {env.USERNAME_TO_CLUSTER_NAME[test_runner_username]}",
+                   exit_code=0, validate_output_func=None,
+                   test_user=test_runner_username),
+        cmd_binder(cmd=f"cse cluster resize -N 0 -n {config['broker']['network']}" # noqa
+                       f" {env.USERNAME_TO_CLUSTER_NAME[test_runner_username]}",
+                   exit_code=2, validate_output_func=None,
+                   test_user=test_runner_username),
+        cmd_binder(cmd=f"cse cluster resize -N {num_nodes} -n {config['broker']['network']}" # noqa
+                       f" {env.USERNAME_TO_CLUSTER_NAME[test_runner_username]}",
+                   exit_code=2, validate_output_func=None,
+                   test_user=test_runner_username)
+    ]
+    execute_commands(cmd_list)
+    print(f"Successful cluster resize on {env.USERNAME_TO_CLUSTER_NAME[test_runner_username]}.") # noqa
+
+
+@pytest.mark.parametrize('test_runner_username', [env.SYS_ADMIN_NAME,
+                                                  env.ORG_ADMIN_NAME,
+                                                  env.VAPP_AUTHOR_NAME])
+def test_0120_vcd_cse_node_operation(test_runner_username, config):
     """Test 'vcd cse node create/list/info/delete ...' commands.
 
     Test node creation from different persona's- sys_admin, org_admin
@@ -521,7 +570,7 @@ def test_0110_vcd_cse_node_operation(test_runner_username, config):
     different users
     """
     node_pattern = r'(node-\S+)'
-    num_nodes = 1
+    num_nodes = 2
     cmd_binder = collections.namedtuple('UserCmdBinder',
                                         'cmd exit_code validate_output_func '
                                         'test_user')


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

- client tests did not include tests for resizing the cluster

- Added tests for resize cluster for the following cases:
  - if number of workers is increased by 1 (command should execute)
  - if zero workers are given (command should fail with an error)
  - if N is number of currently existing workers (command should fail with an error)

Testing done:
- `pytest --disable-warnings -x -v -s test_cse_client.py > testlog`

- @rocknes @andrew-ni @sakthisunda @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/560)
<!-- Reviewable:end -->
