### PR TITLE
[VCDA-1486] Fix converted cluster metadata with right docker and k8 version

### DIFF
--- a/container_service_extension/local_template_manager.py
+++ b/container_service_extension/local_template_manager.py
@@ -17,12 +17,12 @@ from container_service_extension.server_constants import LocalTemplateKey
 LOCAL_SCRIPTS_DIR = '.cse_scripts'
 
 
-def get_template_k8s_version(template_name):
+def get_k8s_version_from_template_name(template_name):
     try:
         tokens = template_name.split('_')
         if len(tokens) == 3:
             k8s_info = tokens[1].split('-')
-            if len(k8s_info) == 2 and k8s_info[0] in ('k8', 'esspks'):
+            if len(k8s_info) == 2 and k8s_info[0] in ('k8', 'tkg'):
                 return k8s_info[1]
     except Exception:
         pass
@@ -158,7 +158,7 @@ def save_metadata(client, org_name, catalog_name, catalog_item_name,
 def get_k8s_and_docker_versions(template_name, template_revision='0',
                                 cse_version=None):
     docker_version = '0.0.0'
-    k8s_version = get_template_k8s_version(template_name)
+    k8s_version = get_k8s_version_from_template_name(template_name)
     if 'photon' in template_name:
         docker_version = '17.06.0'
         if template_revision == '1':

--- a/container_service_extension/local_template_manager.py
+++ b/container_service_extension/local_template_manager.py
@@ -195,5 +195,11 @@ def get_k8s_and_docker_versions(template_name, template_revision='0',
             k8s_version = '1.15.3'
             if template_revision == '2':
                 k8s_version = '1.15.5'
+        elif '1.16' in template_name:
+            docker_version = '18.09.7'
+            k8s_version = '1.16.6'
+        elif '1.17' in template_name:
+            docker_version = '19.03.5'
+            k8s_version = '1.17.2'
 
     return k8s_version, docker_version

--- a/container_service_extension/local_template_manager.py
+++ b/container_service_extension/local_template_manager.py
@@ -157,8 +157,8 @@ def save_metadata(client, org_name, catalog_name, catalog_item_name,
 
 def get_k8s_and_docker_versions(template_name, template_revision='0',
                                 cse_version=None):
-    k8s_version = '0.0.0'
     docker_version = '0.0.0'
+    k8s_version = get_template_k8s_version(template_name)
     if 'photon' in template_name:
         docker_version = '17.06.0'
         if template_revision == '1':
@@ -195,11 +195,5 @@ def get_k8s_and_docker_versions(template_name, template_revision='0',
             k8s_version = '1.15.3'
             if template_revision == '2':
                 k8s_version = '1.15.5'
-        elif '1.16' in template_name:
-            docker_version = '18.09.7'
-            k8s_version = '1.16.6'
-        elif '1.17' in template_name:
-            docker_version = '19.03.5'
-            k8s_version = '1.17.2'
 
     return k8s_version, docker_version

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -802,7 +802,15 @@ def convert_cluster(ctx, config_file_path, skip_config_decryption,
             template_revision = str(metadata_dict.get(ClusterMetadataKey.TEMPLATE_REVISION, '0')) # noqa: E501
 
             if template_name:
-                k8s_version, docker_version = ltm.get_k8s_and_docker_versions(template_name, template_revision=template_revision, cse_version=cse_version) # noqa: E501
+                org_name = config['broker']['org']
+                catalog_name = config['broker']['catalog']
+                k8_templates = ltm.get_all_k8s_local_template_definition(
+                    client=client, catalog_name=catalog_name, org_name=org_name)  # noqa: E501
+                k8s_version, docker_version = '0.0.0', '0.0.0'
+                for k8_template in k8_templates:
+                    if (str(k8_template[LocalTemplateKey.REVISION]), k8_template[LocalTemplateKey.NAME]) == (template_revision, template_name):  # noqa: E501
+                        k8s_version, docker_version = k8_template[LocalTemplateKey.KUBERNETES_VERSION], k8_template[LocalTemplateKey.DOCKER_VERSION]  # noqa: E501
+                        break
                 tokens = template_name.split('_')
                 new_metadata = {
                     ClusterMetadataKey.OS: tokens[0],

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -1572,7 +1572,7 @@ def get_all_clusters(client, cluster_name=None, cluster_id=None,
 
         # pre-2.6 clusters may not have kubernetes version metadata
         if clusters[vapp_id]['kubernetes_version'] == '':
-            clusters[vapp_id]['kubernetes_version'] = ltm.get_template_k8s_version(clusters[vapp_id]['template_name']) # noqa: E501
+            clusters[vapp_id]['kubernetes_version'] = ltm.get_k8s_version_from_template_name(clusters[vapp_id]['template_name']) # noqa: E501
 
     # api query can fetch only 8 metadata at a time
     # since we have more than 8 metadata, we need to use 2 queries


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- Fixed cluster metadata with right docker and k8 version after convert cluster operation
- Clusters created with CSE 2.5.1 or earlier versions require `cse convert-cluster` to get the
   right metadata during upgrade of CSE 2.6.9.  In this fix, the converted cluster gets 
   updated metadata with correct docker version and k8 version.
   Before this fix, k8 version got wrongly set to 0.0.0.
- Tested and verified by manually : created ubuntu cluster with CSE 2.5.1, 
   then upgrade to CSE 2.6.0, applied `cse convert-cluster` on the cluster and verified the fix.
   Itempotency on cluster convert tested
   Cluster convert now updates cluster k8 and docker version with corresponding values from template metadata. Else fallback to default values.

@andrew-ni @Anirudh9794 @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/568)
<!-- Reviewable:end -->
