### PR TITLE
Fix cluster list to show PKS cluster k8s version

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -193,14 +193,12 @@ def list_clusters(ctx, vdc, org_name):
         clusters = []
         for c in result:
             # TODO cluster api response keys need to be more well defined
-            kubernetes = 'N/A'
-            if c.get('k8s_type') and c.get('k8s_version'):
-                kubernetes = f"{c.get('k8s_type')} {c['k8s_version']}"
             cluster = {
                 'Name': c.get('name') or 'N/A',
                 'VDC': c.get('vdc') or 'N/A',
                 'Org': c.get('org_name') or 'N/A',
-                'Kubernetes': kubernetes,
+                'K8s Runtime': c.get('k8s_type') or 'N/A',
+                'K8s Version': c.get('k8s_version') or 'N/A',
                 'Status': c.get('status') or 'N/A',
                 'Provider': c.get('k8s_provider') or 'N/A',
             }


### PR DESCRIPTION
- Split cluster list 'Kubernetes' column into 'K8s Runtime' and 'K8s Version'. This allows us to display PKS cluster Kubernetes version

- Previously, since PKS get cluster payload did not give us a Kubernetes runtime or Kubernetes version, we just displayed 'N/A' for the entire 'Kubernetes' column.

Cluster list:
![Screen Shot 2020-04-27 at 1 54 32 PM](https://user-images.githubusercontent.com/29108945/80419981-ea8c0580-888e-11ea-9857-1751af91ff61.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/575)
<!-- Reviewable:end -->
