### PR TITLE
[VCDA-1488] Separate ovdc enable for Ent-PKS

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -1009,7 +1009,7 @@ def disable_service(ctx):
 @cse.group('ovdc', short_help='Manage Kubernetes provider for org VDCs')
 @click.pass_context
 def ovdc_group(ctx):
-    """Manage Kubernetes provider to be native for org VDCs.
+    """Manage Kubernetes provider for org VDCs.
 
 All commands execute in the context of user's currently logged-in
 organization. Use a different organization by using the '--org' option.

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -1009,27 +1009,17 @@ def disable_service(ctx):
 @cse.group('ovdc', short_help='Manage Kubernetes provider for org VDCs')
 @click.pass_context
 def ovdc_group(ctx):
-    """Manage Kubernetes provider for org VDCs.
+    """Manage Kubernetes provider to be native for org VDCs.
 
 All commands execute in the context of user's currently logged-in
 organization. Use a different organization by using the '--org' option.
 
-Currently supported Kubernetes-providers:
-
-- native (vCD)
-
-- ent-pks (Enterprise PKS)
 
 \b
 Examples
-    vcd cse ovdc enable ovdc1 --k8s-provider native
+    vcd cse ovdc enable ovdc1
         Set 'ovdc1' Kubernetes provider to be native (vCD).
-\b
-    vcd cse ovdc enable ovdc2 --k8s-provider ent-pks \\
-    --pks-plan 'plan1' --pks-cluster-domain 'myorg.com'
-        Set 'ovdc2' Kubernetes provider to be ent-pks.
-        Use pks plan 'plan1' for 'ovdc2'.
-        Set cluster domain to be 'myorg.com'.
+
 \b
     vcd cse ovdc disable ovdc3
         Set 'ovdc3' Kubernetes provider to be none,
@@ -1074,32 +1064,9 @@ def list_ovdcs(ctx, list_pks_plans):
 
 
 @ovdc_group.command('enable',
-                    short_help='Set Kubernetes provider for an org VDC')
+                    short_help='Set Kubernetes provider to be Native for an org VDC')  # noqa: E501
 @click.pass_context
 @click.argument('ovdc_name', required=True, metavar='VDC_NAME')
-@click.option(
-    '-k',
-    '--k8s-provider',
-    'k8s_provider',
-    required=True,
-    type=click.Choice([K8sProvider.NATIVE, K8sProvider.PKS]),
-    help="Name of the Kubernetes provider to use for this org VDC")
-@click.option(
-    '-p',
-    '--pks-plan',
-    'pks_plan',
-    required=False,
-    metavar='PLAN_NAME',
-    help=f"PKS plan to use for all cluster deployments in this org VDC "
-         f"(Exclusive to --k8s-provider={K8sProvider.PKS}) (Required)")
-@click.option(
-    '-d',
-    '--pks-cluster-domain',
-    'pks_cluster_domain',
-    required=False,
-    help=f"Domain name suffix used to construct FQDN of deployed clusters "
-         f"in this org VDC "
-         f"(Exclusive to --k8s-provider={K8sProvider.PKS}) (Required)")
 @click.option(
     '-o',
     '--org',
@@ -1108,15 +1075,8 @@ def list_ovdcs(ctx, list_pks_plans):
     required=False,
     metavar='ORG_NAME',
     help="Org to use. Defaults to currently logged-in org")
-def ovdc_enable(ctx, ovdc_name, k8s_provider, pks_plan,
-                pks_cluster_domain, org_name):
+def ovdc_enable(ctx, ovdc_name, org_name):
     """Set Kubernetes provider for an org VDC."""
-    if k8s_provider == K8sProvider.PKS and \
-            (pks_plan is None or pks_cluster_domain is None):
-        click.secho("One or both of the required params (--pks-plan,"
-                    " --pks-cluster-domain) are missing", fg='yellow')
-        return
-
     try:
         restore_session(ctx)
         client = ctx.obj['client']
@@ -1128,9 +1088,7 @@ def ovdc_enable(ctx, ovdc_name, k8s_provider, pks_plan,
                 enable=True,
                 ovdc_name=ovdc_name,
                 org_name=org_name,
-                k8s_provider=k8s_provider,
-                pks_plan=pks_plan,
-                pks_cluster_domain=pks_cluster_domain)
+                k8s_provider=K8sProvider.NATIVE)
             stdout(result, ctx)
         else:
             stderr("Insufficient permission to perform operation.", ctx)

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -64,6 +64,13 @@ def ovdc_update(request_data, tenant_auth_token, is_jwt_token):
             ]
             req_utils.validate_payload(validated_data, required)
 
+            # Check if target ovdc is not already enabled for other non PKS k8 providers # noqa: E501
+            ovdc_metadata = ovdc_utils.get_ovdc_k8s_provider_metadata(ovdc_id=validated_data[RequestKey.OVDC_ID])  # noqa: E501
+            ovdc_k8_provider = ovdc_metadata.get(K8S_PROVIDER_KEY)
+            if ovdc_k8_provider != K8sProvider.NONE and \
+                    ovdc_k8_provider != k8s_provider:
+                raise CseServerError("Ovdc already enabled for different K8 provider")  # noqa: E501
+
             k8s_provider_info = ovdc_utils.construct_k8s_metadata_from_pks_cache(  # noqa: E501
                 ovdc_id=validated_data[RequestKey.OVDC_ID],
                 org_name=validated_data[RequestKey.ORG_NAME],

--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -127,8 +127,7 @@ def cse_server():
     assert result.exit_code == 0,\
         testutils.format_command_info('vcd', cmd, result.exit_code,
                                       result.output)
-    cmd = f"cse ovdc enable {config['broker']['vdc']} -k " \
-          f"{constants.K8sProvider.NATIVE}"
+    cmd = f"cse ovdc enable {config['broker']['vdc']}"
     result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
     assert result.exit_code == 0,\
         testutils.format_command_info('vcd', cmd, result.exit_code,


### PR DESCRIPTION
- Ovdc enable for Ent-PKS moved to PKS command group 
- New command for ovdc enable Ent-PKS separated from `vcd cse ovdc enable`
   vcd cse pks ovdc ( set K8 provider to be Ent-PKS)
   vcd cse pks cluster [config|create|delete|info|list|resize]
   Removed option --k8s_provider
   Updated help and doc string 
   Exception on setting Ent-PKS k8 provider to ovdc already enabled for native k8 provider
   Test case update
- Tests Done
   Automated System tests
   `vcd cse pks ovdc` command on that is none, already enabled for native K8
    `vcd cse ovdc enable` commands
     Cluster tests
   
@andrew-ni @Anirudh9794 @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/576)
<!-- Reviewable:end -->
