### PR TITLE
Update base_config.yaml to lay down the foundation of running tests in a separate org

### DIFF
--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -2,19 +2,25 @@
 # Fill in fields marked with '???'
 
 test:
-  teardown_installation: true  # Affects test_cse_server.py.
-                               #   if true, delete all installation entities (even on test failure).
-                               #   if false, do not delete installation entities (even on test success).
-                               #   if this key is omitted, defaults to true.
-  teardown_clusters: true      # Affects test_cse_client.py.
-                               #   if true, delete test cluster (env.TEST_CLUSTER_NAME) on test failure.
-                               #   if false, do not delete test cluster on test failure.
-                               #   if this key is omitted, defaults to true.
-                               # Successful client tests will not leave clusters up.
-  test_all_templates: false    # Affects test_cse_client.py.
-                               #   if true, tests cluster deployment on all templates found.
-                               #   if false, tests cluster deployment only for first template found.
-                               #   if this key is omitted, defaults to false.
+  teardown_installation: true       # Affects test_cse_server.py.
+                                    #   if true, delete all installation entities (even on test failure).
+                                    #   if false, do not delete installation entities (even on test success).
+                                    #   if this key is omitted, defaults to true.
+  teardown_clusters: true           # Affects test_cse_client.py.
+                                    #   if true, delete test cluster (env.TEST_CLUSTER_NAME) on test failure.
+                                    #   if false, do not delete test cluster on test failure.
+                                    #   if this key is omitted, defaults to true.
+                                    # Successful client tests will not leave clusters up.
+  test_all_templates: false         # Affects test_cse_client.py.
+                                    #   if true, tests cluster deployment on all templates found.
+                                    #   if false, tests cluster deployment only for first template found.
+                                    #   if this key is omitted, defaults to false.
+  upgrade_template_repo_url: '???'  #
+  network: '???'                    # org network within @vdc that will be used during testing
+                                    #   Should have outbound access to the public internet
+  org: '???'                        # vCD org where all the test will be run
+  storage_profile: '???'            # name of the storage profile to use while creating clusters on this org vdc
+  vdc: '???'                        # Org VDC powering the org
 
 amqp:
   exchange: test-exchange # cse exclusive exchange used by amqp server


### PR DESCRIPTION
Update base_config.yaml to lay down the foundation of running tests in a separate org from the org that hosts the native templates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/579)
<!-- Reviewable:end -->
