### PR TITLE
Change default Telemetry end point to VAC Production

### DIFF
--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -7,7 +7,7 @@ from enum import unique
 
 # End point of Vmware telemetry staging server
 # TODO() : This URL should reflect production server during release
-VAC_URL = "https://vcsa.vmware.com/ph-stg/api/hyper/send/"
+VAC_URL = "https://vcsa.vmware.com/ph/api/hyper/send"
 
 # Value of collector id that is required as part of HTTP request
 # to post sample data to telemetry server


### PR DESCRIPTION
Change default Telemetry end point to VAC Production

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/582)
<!-- Reviewable:end -->
