### PR TITLE
[VCDA-1501] - Better error message on connectivity failure due to self-signed certificates 

### DIFF
--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -576,6 +576,8 @@ def install(ctx, config_file_path, pks_config_file_path,
                         msg_update_callback=console_message_printer)
         except AmqpConnectionError:
             raise Exception(AMQP_ERROR_MSG)
+        except requests.exceptions.SSLError as err:
+            raise Exception(f"SSL verification failed: {str(err)}")
         except requests.exceptions.ConnectionError as err:
             raise Exception(f"Cannot connect to {err.request.url}.")
         except vim.fault.InvalidLogin:
@@ -646,6 +648,8 @@ def run(ctx, config_file_path, pks_config_file_path, skip_check,
             cse_run_complete = True
         except AmqpConnectionError:
             raise Exception(AMQP_ERROR_MSG)
+        except requests.exceptions.SSLError as err:
+            raise Exception(f"SSL verification failed: {str(err)}")
         except requests.exceptions.ConnectionError as err:
             raise Exception(f"Cannot connect to {err.request.url}.")
         except vim.fault.InvalidLogin:
@@ -1267,6 +1271,8 @@ def install_cse_template(ctx, template_name, template_revision,
                 msg_update_callback=console_message_printer)
         except AmqpConnectionError:
             raise Exception(AMQP_ERROR_MSG)
+        except requests.exceptions.SSLError as err:
+            raise Exception(f"SSL verification failed: {str(err)}")
         except requests.exceptions.ConnectionError as err:
             raise Exception(f"Cannot connect to {err.request.url}.")
         except vim.fault.InvalidLogin:
@@ -1624,6 +1630,8 @@ def _get_config_dict(config_file_path,
         return config_dict
     except AmqpConnectionError:
         raise Exception(AMQP_ERROR_MSG)
+    except requests.exceptions.SSLError as err:
+        raise Exception(f"SSL verification failed: {str(err)}")
     except requests.exceptions.ConnectionError as err:
         raise Exception(f"Cannot connect to {err.request.url}.")
     except cryptography.fernet.InvalidToken:


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

- The error message which was shown didn't give the actual reason for connectivity failure.

- Added error message which shows up when certificate verification fails.
- Testing done: 
  - cse check 
  - cse run
  with verify=true in config.yaml

output:
```
(venv) shamasundara@shamasundar-a01 ~/w/container-service-extension> cse run -c ~/confs/config.yaml -s                                                                                                       1 vcda-1501!?
Required Python version: >= 3.7.3
Installed Python version: 3.7.4 (v3.7.4:e09359112e, Jul  8 2019, 14:36:03) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
Validating config file '/Users/shamasundara/confs/config.yaml'
Connected to AMQP server (bos1-vcd-sp-static-198-126.eng.vmware.com:5672)
SSL verification failed: HTTPSConnectionPool(host='bos1-vcd-sp-static-198-125.eng.vmware.com', port=443): Max retries exceeded with url: /api/sessions (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:1076)')))
CSE Server failure. Please check the logs.
```

@rocknes @andrew-ni @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/589)
<!-- Reviewable:end -->
