### PR TITLE
[VCDA 1528] Added vCD api version check to CSE config validator

### DIFF
--- a/container_service_extension/config_validator.py
+++ b/container_service_extension/config_validator.py
@@ -212,8 +212,10 @@ def _validate_vcd_and_vcs_config(vcd_dict,
                                  log_wire=False):
     """Ensure that 'vcd' and vcs' section of config are correct.
 
-    Checks that 'vcd' and 'vcs' section of config have correct keys and value
-    types. Also checks that vCD and all registered VCs in vCD are accessible.
+    Checks that 
+        * 'vcd' and 'vcs' section of config have correct keys and value types.
+        * vCD and all registered VCs in vCD are accessible.
+        * api version specified for vcd is supported by CSE.
 
     :param dict vcd_dict: 'vcd' section of config file as a dict.
     :param list vcs: 'vcs' section of config file as a list of dicts.

--- a/container_service_extension/config_validator.py
+++ b/container_service_extension/config_validator.py
@@ -212,7 +212,7 @@ def _validate_vcd_and_vcs_config(vcd_dict,
                                  log_wire=False):
     """Ensure that 'vcd' and vcs' section of config are correct.
 
-    Checks that 
+    Checks that
         * 'vcd' and 'vcs' section of config have correct keys and value types.
         * vCD and all registered VCs in vCD are accessible.
         * api version specified for vcd is supported by CSE.

--- a/container_service_extension/config_validator.py
+++ b/container_service_extension/config_validator.py
@@ -33,6 +33,8 @@ from container_service_extension.sample_generator import \
     SAMPLE_PKS_NSXT_SERVERS_SECTION, SAMPLE_PKS_ORGS_SECTION, \
     SAMPLE_PKS_PVDCS_SECTION, SAMPLE_PKS_SERVERS_SECTION, \
     SAMPLE_SERVICE_CONFIG, SAMPLE_VCD_CONFIG, SAMPLE_VCS_CONFIG # noqa: H301
+from container_service_extension.server_constants import \
+    SUPPORTED_VCD_API_VERSIONS
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
 from container_service_extension.server_constants import VERSION_V1
 from container_service_extension.telemetry.telemetry_utils import\
@@ -197,7 +199,7 @@ def _validate_amqp_config(amqp_dict, msg_update_callback=NullPrinter()):
             "Connected to AMQP server "
             f"({amqp_dict['host']}:{amqp_dict['port']})")
     except Exception as err:
-        raise AmqpConnectionError("Amqp connection failed:", str(err))
+        raise AmqpConnectionError(f"AMQP server error : {str(err)}")
     finally:
         if connection is not None:
             connection.close()
@@ -237,8 +239,13 @@ def _validate_vcd_and_vcs_config(vcd_dict,
 
     client = None
     try:
+        api_version = vcd_dict['api_version']
+        if str(api_version) not in SUPPORTED_VCD_API_VERSIONS:
+            raise ValueError(f"vCD api version {api_version} is not supported "
+                             "by CSE. Supported api versions are "
+                             f"{SUPPORTED_VCD_API_VERSIONS}.")
         client = Client(vcd_dict['host'],
-                        api_version=vcd_dict['api_version'],
+                        api_version=api_version,
                         verify_ssl_certs=vcd_dict['verify'],
                         log_file=log_file,
                         log_requests=log_wire,

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -32,7 +32,6 @@ from container_service_extension.configure_cse import install_template
 from container_service_extension.encryption_engine import decrypt_file
 from container_service_extension.encryption_engine import encrypt_file
 from container_service_extension.encryption_engine import get_decrypted_file_contents # noqa: E501
-from container_service_extension.exceptions import AmqpConnectionError
 import container_service_extension.local_template_manager as ltm
 from container_service_extension.logger import NULL_LOGGER
 from container_service_extension.logger import SERVER_CLI_LOGGER
@@ -78,7 +77,6 @@ PASSWORD_FOR_CONFIG_ENCRYPTION_MSG = "Password for config file encryption"
 PASSWORD_FOR_CONFIG_DECRYPTION_MSG = "Password for config file decryption"
 
 # Error messages
-AMQP_ERROR_MSG = "Check amqp section of the config file."
 CONFIG_DECRYPTION_ERROR_MSG = \
     "Config file decryption failed: invalid decryption password"
 VCENTER_LOGIN_ERROR_MSG = "vCenter login failed (check config file for "\
@@ -574,8 +572,6 @@ def install(ctx, config_file_path, pks_config_file_path,
                         skip_config_decryption=skip_config_decryption,
                         decryption_password=password,
                         msg_update_callback=console_message_printer)
-        except AmqpConnectionError:
-            raise Exception(AMQP_ERROR_MSG)
         except requests.exceptions.SSLError as err:
             raise Exception(f"SSL verification failed: {str(err)}")
         except requests.exceptions.ConnectionError as err:
@@ -646,8 +642,6 @@ def run(ctx, config_file_path, pks_config_file_path, skip_check,
                               decryption_password=password)
             service.run(msg_update_callback=console_message_printer)
             cse_run_complete = True
-        except AmqpConnectionError:
-            raise Exception(AMQP_ERROR_MSG)
         except requests.exceptions.SSLError as err:
             raise Exception(f"SSL verification failed: {str(err)}")
         except requests.exceptions.ConnectionError as err:
@@ -1269,8 +1263,6 @@ def install_cse_template(ctx, template_name, template_revision,
                 skip_config_decryption=skip_config_decryption,
                 decryption_password=password,
                 msg_update_callback=console_message_printer)
-        except AmqpConnectionError:
-            raise Exception(AMQP_ERROR_MSG)
         except requests.exceptions.SSLError as err:
             raise Exception(f"SSL verification failed: {str(err)}")
         except requests.exceptions.ConnectionError as err:
@@ -1628,8 +1620,6 @@ def _get_config_dict(config_file_path,
         store_telemetry_settings(config_dict)
 
         return config_dict
-    except AmqpConnectionError:
-        raise Exception(AMQP_ERROR_MSG)
     except requests.exceptions.SSLError as err:
         raise Exception(f"SSL verification failed: {str(err)}")
     except requests.exceptions.ConnectionError as err:

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -41,6 +41,9 @@ PKS_COMPUTE_PROFILE_KEY = 'pks_compute_profile_name'
 # PKS API endpoint version
 VERSION_V1 = 'v1'
 
+# vCD API versions supported by CSE
+SUPPORTED_VCD_API_VERSIONS = ['33.0', '34.0', '35.0']
+
 
 @unique
 class NodeType(str, Enum):


### PR DESCRIPTION
Added logic in CSE config validator to validate that the vCD api version specified in the configuration file under `vcd` section is supported by CSE. For CSE 3.0, the values will be '33.0', '34.0' and '35.0'

Testing Done:
Ran the command `cse check` with various values of the vCD api version and made sure that the error messages are correct

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/604)
<!-- Reviewable:end -->
