### PR TITLE
[VCDA-1536] Suppress template rule checking for api v35 and above

### DIFF
--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -225,8 +225,8 @@ class Service(object, metaclass=Singleton):
             self._process_template_compute_policy_compliance(
                 msg_update_callback=msg_update_callback)
         else:
-            msg = "Template rules are not supported by this version of CSE." \
-                  " Skipping template rule processing."
+            msg = "Template rules are not supported by CSE for vCD api " \
+                  "version 35.0 or above. Skipping template rule processing."
             msg_update_callback.info(msg)
             logger.SERVER_LOGGER.debug(msg)
 


### PR DESCRIPTION
Template rules will be deprecated from CSE 3.0. As a result we should not process them if vCD api version 35.0 or above is specified in the config file.

Testing Done:
Tried to start up CSE server with api v33.0 and v35.0 and made sure that the template rules are not process in case api v35.0 was used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/605)
<!-- Reviewable:end -->
