### PR TITLE
[VCDA-1518] Use sizing_class for creation of VMs in the cluster

### DIFF
--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -693,8 +693,6 @@ class ClusterService(abstract_broker.AbstractBroker):
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None,
             RequestKey.NUM_WORKERS: 1,
-            # placeholder code for sizing_class
-            RequestKey.SIZING_CLASS: None,
             RequestKey.STORAGE_PROFILE_NAME: None,
             RequestKey.SSH_KEY: None,
             RequestKey.TEMPLATE_NAME: template[LocalTemplateKey.NAME],
@@ -749,8 +747,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             template_revision=template_revision,
             num_workers=validated_data[RequestKey.NUM_WORKERS],
             network_name=validated_data[RequestKey.NETWORK_NAME],
-            # placeholder for sizing class
-            sizing_class=validated_data.get(RequestKey.SIZING_CLASS),
+            # TODO add sizing class from spec
             storage_profile_name=validated_data[RequestKey.STORAGE_PROFILE_NAME], # noqa: E501
             ssh_key=validated_data[RequestKey.SSH_KEY],
             enable_nfs=validated_data[RequestKey.ENABLE_NFS],
@@ -1475,9 +1472,9 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
         config = utils.get_server_runtime_config()
         cpm = compute_policy_manager.ComputePolicyManager(sysadmin_client,
                                                           log_wire=utils.str_to_bool(config['service']['log_wire']))  # noqa: E501
-        # convert sizing_class from name to href.
+        sizing_class_href = None
         if sizing_class:
-            sizing_class = cpm.get_vdc_compute_policy(sizing_class)['href']
+            sizing_class_href = cpm.get_vdc_compute_policy(sizing_class)['href']  # noqa: E501
         if storage_profile:
             storage_profile = vdc.get_storage_profile(storage_profile)
 
@@ -1510,8 +1507,8 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
                 'network': network_name,
                 'ip_allocation_mode': 'pool'
             }
-            if sizing_class:
-                spec['sizing_policy_href'] = sizing_class
+            if sizing_class_href:
+                spec['sizing_policy_href'] = sizing_class_href
             if cust_script is not None:
                 spec['cust_script'] = cust_script
             if storage_profile:

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -19,6 +19,7 @@ import pyvcloud.vcd.vm as vcd_vm
 import semantic_version as semver
 
 import container_service_extension.abstract_broker as abstract_broker
+import container_service_extension.compute_policy_manager as compute_policy_manager  # noqa: E501
 import container_service_extension.def_.entity_service as def_entity_svc
 import container_service_extension.def_.models as def_models
 import container_service_extension.def_.utils as def_utils
@@ -194,6 +195,9 @@ class ClusterService(abstract_broker.AbstractBroker):
         #  https://confluence.eng.vmware.com/display/VCD/%5BProposal%5D+Native+Clusters+Life+Cycle+Status  # noqa: E501
         def_entity.entity.status.phase = 'CREATE_IN_PROGRESS'
         self.context.is_async = True
+        # TODO pre-defined sizing classes needs to be defined.
+        # TODO validate sizing policies referenced in the request against
+        # a pre-defined set of sizing policies.
         self._create_cluster_async(def_entity)
         return def_entity
 
@@ -206,6 +210,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             org_name = cluster_entity.metadata.org_name
             ovdc_name = cluster_entity.metadata.ovdc_name
             num_workers = cluster_entity.spec.workers.count
+            master_sizing_class = cluster_entity.spec.control_plane.sizing_class  # noqa: E501
+            worker_sizing_class = cluster_entity.spec.workers.sizing_class
             master_storage_profile = cluster_entity.spec.control_plane.storage_profile  # noqa: E501
             worker_storage_profile = cluster_entity.spec.workers.storage_profile  # noqa: E501
             network_name = cluster_entity.spec.settings.network
@@ -273,7 +279,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                           template=template,
                           network_name=network_name,
                           storage_profile=master_storage_profile,
-                          ssh_key=ssh_key)
+                          ssh_key=ssh_key,
+                          sizing_class=master_sizing_class)
             except Exception as err:
                 raise e.MasterNodeCreationError("Error adding master node:",
                                                 str(err))
@@ -304,7 +311,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                           template=template,
                           network_name=network_name,
                           storage_profile=worker_storage_profile,
-                          ssh_key=ssh_key)
+                          ssh_key=ssh_key,
+                          sizing_class=worker_sizing_class)
             except Exception as err:
                 raise e.WorkerNodeCreationError("Error creating worker node:",
                                                 str(err))
@@ -685,8 +693,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None,
             RequestKey.NUM_WORKERS: 1,
-            RequestKey.NUM_CPU: None,
-            RequestKey.MB_MEMORY: None,
+            # placeholder code for sizing_class
+            RequestKey.SIZING_CLASS: None,
             RequestKey.STORAGE_PROFILE_NAME: None,
             RequestKey.SSH_KEY: None,
             RequestKey.TEMPLATE_NAME: template[LocalTemplateKey.NAME],
@@ -702,14 +710,6 @@ class ClusterService(abstract_broker.AbstractBroker):
         template_revision = validated_data[RequestKey.TEMPLATE_REVISION]
         num_workers = validated_data[RequestKey.NUM_WORKERS]
 
-        num_cpu = template.get(LocalTemplateKey.CPU)
-        if validated_data[RequestKey.NUM_CPU]:
-            num_cpu = validated_data[RequestKey.NUM_CPU]
-
-        mb_memory = template.get(LocalTemplateKey.MEMORY)
-        if validated_data[RequestKey.MB_MEMORY]:
-            mb_memory = validated_data[RequestKey.MB_MEMORY]
-
         if num_workers < 1:
             raise e.CseServerError(f"Worker node count must be > 0 "
                                    f"(received {num_workers}).")
@@ -723,8 +723,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             # Record the data for telemetry
             cse_params = copy.deepcopy(validated_data)
             cse_params[PayloadKey.CLUSTER_ID] = cluster_id
-            cse_params[LocalTemplateKey.MEMORY] = validated_data.get(RequestKey.MB_MEMORY)  # noqa: E501
-            cse_params[LocalTemplateKey.CPU] = validated_data.get(RequestKey.NUM_CPU) # noqa: E501
+            # TODO add sizing policy to telemetry
             cse_params[LocalTemplateKey.KUBERNETES] = template.get(LocalTemplateKey.KUBERNETES)  # noqa: E501
             cse_params[LocalTemplateKey.KUBERNETES_VERSION] = template.get(LocalTemplateKey.KUBERNETES_VERSION)  # noqa: E501
             cse_params[LocalTemplateKey.OS] = template.get(LocalTemplateKey.OS)
@@ -750,8 +749,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             template_revision=template_revision,
             num_workers=validated_data[RequestKey.NUM_WORKERS],
             network_name=validated_data[RequestKey.NETWORK_NAME],
-            num_cpu=num_cpu,
-            mb_memory=mb_memory,
+            # placeholder for sizing class
+            sizing_class=validated_data.get(RequestKey.SIZING_CLASS),
             storage_profile_name=validated_data[RequestKey.STORAGE_PROFILE_NAME], # noqa: E501
             ssh_key=validated_data[RequestKey.SSH_KEY],
             enable_nfs=validated_data[RequestKey.ENABLE_NFS],
@@ -834,7 +833,7 @@ class ClusterService(abstract_broker.AbstractBroker):
     def _create_nodes_async(self, *args,
                             cluster_name, cluster_vdc_href, vapp_href,
                             cluster_id, template_name, template_revision,
-                            num_workers, network_name, num_cpu, mb_memory,
+                            num_workers, network_name, sizing_class,
                             storage_profile_name, ssh_key, enable_nfs,
                             rollback):
         try:
@@ -865,10 +864,9 @@ class ClusterService(abstract_broker.AbstractBroker):
                                   catalog_name=catalog_name,
                                   template=template,
                                   network_name=network_name,
-                                  num_cpu=num_cpu,
-                                  memory_in_mb=mb_memory,
                                   storage_profile=storage_profile_name,
-                                  ssh_key=ssh_key)
+                                  ssh_key=ssh_key,
+                                  sizing_class=sizing_class)
 
             if node_type == NodeType.NFS:
                 msg = f"Created {num_workers} node(s) for cluster " \
@@ -1445,8 +1443,8 @@ def get_template(name=None, revision=None):
 
 
 def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
-              catalog_name, template, network_name, num_cpu=None,
-              memory_in_mb=None, storage_profile=None, ssh_key=None):
+              catalog_name, template, network_name, storage_profile=None,
+              ssh_key=None, sizing_class=None):
     vcd_utils.raise_error_if_not_sysadmin(sysadmin_client)
 
     specs = []
@@ -1472,6 +1470,15 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
         source_vapp = vcd_vapp.VApp(sysadmin_client, href=catalog_item_href)
         source_vm = source_vapp.get_all_vms()[0].get('name')
         if storage_profile is not None:
+            storage_profile = vdc.get_storage_profile(storage_profile)
+
+        config = utils.get_server_runtime_config()
+        cpm = compute_policy_manager.ComputePolicyManager(sysadmin_client,
+                                                          log_wire=utils.str_to_bool(config['service']['log_wire']))  # noqa: E501
+        # convert sizing_class from name to href.
+        if sizing_class:
+            sizing_class = cpm.get_vdc_compute_policy(sizing_class)['href']
+        if storage_profile:
             storage_profile = vdc.get_storage_profile(storage_profile)
 
         cust_script = None
@@ -1503,9 +1510,11 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
                 'network': network_name,
                 'ip_allocation_mode': 'pool'
             }
+            if sizing_class:
+                spec['sizing_policy_href'] = sizing_class
             if cust_script is not None:
                 spec['cust_script'] = cust_script
-            if storage_profile is not None:
+            if storage_profile:
                 spec['storage_profile'] = storage_profile
             specs.append(spec)
 
@@ -1513,20 +1522,10 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
         sysadmin_client.get_task_monitor().wait_for_status(task)
         vapp.reload()
 
-        if not num_cpu:
-            num_cpu = template[LocalTemplateKey.CPU]
-        if not memory_in_mb:
-            memory_in_mb = template[LocalTemplateKey.MEMORY]
         for spec in specs:
             vm_name = spec['target_vm_name']
             vm_resource = vapp.get_vm(vm_name)
             vm = vcd_vm.VM(sysadmin_client, resource=vm_resource)
-
-            task = vm.modify_cpu(num_cpu)
-            sysadmin_client.get_task_monitor().wait_for_status(task)
-
-            task = vm.modify_memory(memory_in_mb)
-            sysadmin_client.get_task_monitor().wait_for_status(task)
 
             task = vm.power_on()
             sysadmin_client.get_task_monitor().wait_for_status(task)

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -210,8 +210,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             org_name = cluster_entity.metadata.org_name
             ovdc_name = cluster_entity.metadata.ovdc_name
             num_workers = cluster_entity.spec.workers.count
-            master_sizing_class = cluster_entity.spec.control_plane.sizing_class  # noqa: E501
-            worker_sizing_class = cluster_entity.spec.workers.sizing_class
+            master_sizing_class_name = cluster_entity.spec.control_plane.sizing_class  # noqa: E501
+            worker_sizing_class_name = cluster_entity.spec.workers.sizing_class
             master_storage_profile = cluster_entity.spec.control_plane.storage_profile  # noqa: E501
             worker_storage_profile = cluster_entity.spec.workers.storage_profile  # noqa: E501
             network_name = cluster_entity.spec.settings.network
@@ -280,7 +280,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                           network_name=network_name,
                           storage_profile=master_storage_profile,
                           ssh_key=ssh_key,
-                          sizing_class=master_sizing_class)
+                          sizing_class_name=master_sizing_class_name)
             except Exception as err:
                 raise e.MasterNodeCreationError("Error adding master node:",
                                                 str(err))
@@ -312,7 +312,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                           network_name=network_name,
                           storage_profile=worker_storage_profile,
                           ssh_key=ssh_key,
-                          sizing_class=worker_sizing_class)
+                          sizing_class_name=worker_sizing_class_name)
             except Exception as err:
                 raise e.WorkerNodeCreationError("Error creating worker node:",
                                                 str(err))
@@ -830,7 +830,7 @@ class ClusterService(abstract_broker.AbstractBroker):
     def _create_nodes_async(self, *args,
                             cluster_name, cluster_vdc_href, vapp_href,
                             cluster_id, template_name, template_revision,
-                            num_workers, network_name, sizing_class,
+                            num_workers, network_name, sizing_class_name,
                             storage_profile_name, ssh_key, enable_nfs,
                             rollback):
         try:
@@ -863,7 +863,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                                   network_name=network_name,
                                   storage_profile=storage_profile_name,
                                   ssh_key=ssh_key,
-                                  sizing_class=sizing_class)
+                                  sizing_class_name=sizing_class_name)
 
             if node_type == NodeType.NFS:
                 msg = f"Created {num_workers} node(s) for cluster " \
@@ -1441,7 +1441,7 @@ def get_template(name=None, revision=None):
 
 def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
               catalog_name, template, network_name, storage_profile=None,
-              ssh_key=None, sizing_class=None):
+              ssh_key=None, sizing_class_name=None):
     vcd_utils.raise_error_if_not_sysadmin(sysadmin_client)
 
     specs = []
@@ -1473,8 +1473,8 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
         cpm = compute_policy_manager.ComputePolicyManager(sysadmin_client,
                                                           log_wire=utils.str_to_bool(config['service']['log_wire']))  # noqa: E501
         sizing_class_href = None
-        if sizing_class:
-            sizing_class_href = cpm.get_vdc_compute_policy(sizing_class)['href']  # noqa: E501
+        if sizing_class_name:
+            sizing_class_href = cpm.get_vdc_compute_policy(sizing_class_name)['href']  # noqa: E501
         if storage_profile:
             storage_profile = vdc.get_storage_profile(storage_profile)
 

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -178,8 +178,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         self.entity_svc.\
             create_entity(def_utils.get_registered_def_entity_type().id,
                           entity=def_entity)
-        def_entity: def_models.DefEntity = self.entity_svc.get_entity_by_name(
-            name=cluster_name)
+        def_entity: def_models.DefEntity = self.entity_svc.get_native_entity_by_name(name=cluster_name)  # noqa: E501
 
         # TODO(DEF) design and implement telemetry VCDA-1564 defined entity
         #  based clusters

--- a/container_service_extension/def_/entity_service.py
+++ b/container_service_extension/def_/entity_service.py
@@ -172,12 +172,14 @@ class DefEntityService():
         :param str name: Name of the native cluster.
         :return:
         """
-        filter_by_name = {def_utils.ClusterEntityFilterKey.CLUSTER_NAME: name}
+        filter_by_name = {def_utils.ClusterEntityFilterKey.CLUSTER_NAME.value: name}  # noqa: E501
         entity_type: DefEntityType = def_utils.get_registered_def_entity_type()
-        return self.list_entities_by_entity_type(vendor=entity_type.vendor,
-                                                 nss=entity_type.nss,
-                                                 version=entity_type.version,
-                                                 filters=filter_by_name)
+        for entity in \
+            self.list_entities_by_entity_type(vendor=entity_type.vendor,
+                                              nss=entity_type.nss,
+                                              version=entity_type.version,
+                                              filters=filter_by_name):
+            return entity
 
     def delete_entity(self, entity_id: str) -> None:
         """Delete the defined entity.

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -269,8 +269,8 @@ class Service(object, metaclass=Singleton):
 
         # # Read k8s catalog definition from catalog item metadata and append
         # # the same to to server run-time config
-        # self._load_template_definition_from_catalog(
-        #     msg_update_callback=msg_update_callback)
+        self._load_template_definition_from_catalog(
+            msg_update_callback=msg_update_callback)
 
         if float(self.config['vcd']['api_version']) < float(vCDApiVersion.VERSION_35.value): # noqa: E501
             # Read templates rules from config and update template deinfition

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -69,7 +69,6 @@ class RequestKey(str, Enum):
     CLUSTER_NAME = 'cluster_name'
     CLUSTER_ID = 'cluster_id'
     MB_MEMORY = 'mb_memory'
-    SIZING_CLASS = 'sizing_class'
     NUM_CPU = 'num_cpu'
     NETWORK_NAME = 'network_name'
     STORAGE_PROFILE_NAME = 'storage_profile_name'

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -69,6 +69,7 @@ class RequestKey(str, Enum):
     CLUSTER_NAME = 'cluster_name'
     CLUSTER_ID = 'cluster_id'
     MB_MEMORY = 'mb_memory'
+    SIZING_CLASS = 'sizing_class'
     NUM_CPU = 'num_cpu'
     NETWORK_NAME = 'network_name'
     STORAGE_PROFILE_NAME = 'storage_profile_name'


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Make use of existing sizing policy for creation of master and worker nodes instead of the old way of specifying num_cpu and memory.

- Change `add_nodes()` in `def_/cluster_svc.py` to support sizing policy and remove memory and cpu parameters

Testing done:
- created sizing policies and published to ovdcs in the UI
- created cluster from Postman using the sizing policies and made sure sizing policies were used for creation of cluster nodes

@sahithi @rocknes @sakthisunda @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/614)
<!-- Reviewable:end -->
