### PR TITLE
Workaround for GC bug in vCD leading to template creation failure

### DIFF
--- a/container_service_extension/template_builder.py
+++ b/container_service_extension/template_builder.py
@@ -202,8 +202,6 @@ class TemplateBuilder():
         except EntityNotFoundException:
             pass
 
-        init_script = self._get_init_script()
-
         msg = f"Creating vApp '{self.temp_vapp_name}'"
         self.msg_update_callback.info(msg)
         self.logger.info(msg)
@@ -221,7 +219,7 @@ class TemplateBuilder():
             memory=self.memory,
             cpu=self.cpu,
             password=None,
-            cust_script=init_script,
+            cust_script=None,
             accept_all_eulas=True,
             vm_name=self.temp_vm_name,
             hostname=self.temp_vm_name,
@@ -249,11 +247,13 @@ class TemplateBuilder():
         self.msg_update_callback.general(msg)
         self.logger.info(msg)
 
+        init_script = self._get_init_script()
         cust_script_filepath = ltm.get_script_filepath(
             self.template_name, self.template_revision, ScriptFile.CUST)
         cust_script = read_data_file(
             cust_script_filepath, logger=self.logger,
             msg_update_callback=self.msg_update_callback)
+        script_to_run = init_script + "\n" + cust_script
 
         vs = get_vsphere(self.sys_admin_client, vapp, vm_name,
                          logger=self.logger)
@@ -269,7 +269,7 @@ class TemplateBuilder():
                 vs.get_vm_by_moid(vapp.get_vm_moid(vm_name)),
                 'root',
                 password_auto,
-                cust_script,
+                script_to_run,
                 target_file=None,
                 wait_for_completion=True,
                 wait_time=10,

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -1623,17 +1623,6 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
         if storage_profile is not None:
             storage_profile = vdc.get_storage_profile(storage_profile)
 
-        cust_script = None
-        if ssh_key is not None:
-            cust_script = \
-                "#!/usr/bin/env bash\n" \
-                "if [ x$1=x\"postcustomization\" ];\n" \
-                "then\n" \
-                "mkdir -p /root/.ssh\n" \
-                f"echo '{ssh_key}' >> /root/.ssh/authorized_keys\n" \
-                "chmod -R go-rwx /root/.ssh\n" \
-                "fi"
-
         vapp.reload()
         for n in range(num_nodes):
             name = None
@@ -1652,8 +1641,6 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
                 'network': network_name,
                 'ip_allocation_mode': 'pool'
             }
-            if cust_script is not None:
-                spec['cust_script'] = cust_script
             if storage_profile is not None:
                 spec['storage_profile'] = storage_profile
             specs.append(spec)
@@ -1666,6 +1653,17 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
             num_cpu = template[LocalTemplateKey.CPU]
         if not memory_in_mb:
             memory_in_mb = template[LocalTemplateKey.MEMORY]
+        cust_script = None
+        if ssh_key is not None:
+            cust_script = \
+                "#!/usr/bin/env bash\n" \
+                "if [ x$1=x\"postcustomization\" ];\n" \
+                "then\n" \
+                "mkdir -p /root/.ssh\n" \
+                f"echo '{ssh_key}' >> /root/.ssh/authorized_keys\n" \
+                "chmod -R go-rwx /root/.ssh\n" \
+                "fi"
+
         for spec in specs:
             vm_name = spec['target_vm_name']
             vm_resource = vapp.get_vm(vm_name)
@@ -1681,6 +1679,16 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
             sysadmin_client.get_task_monitor().wait_for_status(task)
             vapp.reload()
 
+            if cust_script:
+                exec_results = execute_script_in_nodes(
+                    sysadmin_client, vapp=vapp, node_names=[vm_name],
+                    script=cust_script)
+                errors = get_script_execution_errors(exec_results)
+                if errors:
+                    raise e.ScriptExecutionError(
+                        "Execution failed for VM customization script to add "
+                        f"ssh key to node {vm_name}:{errors}")
+
             if node_type == NodeType.NFS:
                 LOGGER.debug(f"Enabling NFS server on {vm_name}")
                 script_filepath = ltm.get_script_filepath(
@@ -1694,8 +1702,8 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
                 errors = get_script_execution_errors(exec_results)
                 if errors:
                     raise e.ScriptExecutionError(
-                        f"VM customization script execution failed "
-                        f"on node {vm_name}:{errors}")
+                        "NFSD script execution failed on node "
+                        f"{vm_name}:{errors}")
     except Exception as err:
         # TODO: get details of the exception to determine cause of failure,
         # e.g. not enough resources available.


### PR DESCRIPTION
vCD recently consumed VC 7.0 imgcust build. The new imgcust build has a severe bug in it, and as a result guest customization(GC) is in broken in vCD. CSE uses GC to create k8s templates as well k8s clusters. This bug impacts CSE directly and hampers most basic workflows in CSE. To counter this issue, this PR removes all usage of GC in CSE and replaces them with vanilla script execution in vm via vCenter.

Testing done:
Created kubernetes 1.17 template - result : template creation successful
Created a cluster off the same template - result : cluster creation successful

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/618)
<!-- Reviewable:end -->
