### PR TITLE
[PR] Remote template url change

### DIFF
--- a/container_service_extension/sample_generator.py
+++ b/container_service_extension/sample_generator.py
@@ -123,7 +123,7 @@ SAMPLE_BROKER_CONFIG = {
         'storage_profile': '*',
         'default_template_name': 'my_template',
         'default_template_revision': 0,
-        'remote_template_cookbook_url': 'https://raw.githubusercontent.com/vmware/container-service-extension-templates/master/template.yaml', # noqa: E501
+        'remote_template_cookbook_url': 'https://raw.githubusercontent.com/vmware/container-service-extension-templates/upgrades/template.yaml', # noqa: E501
     }
 }
 

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -66,6 +66,6 @@ broker:
                                         #   Should have outbound access to the public internet
                                         #   CSE appliance doesn't need to be connected to this network
   org: '???'                            # vCD org that contains the shared catalog where the master templates will be stored
-  remote_template_cookbook_url: https://raw.githubusercontent.com/vmware/container-service-extension-templates/master/template.yaml
+  remote_template_cookbook_url: https://raw.githubusercontent.com/vmware/container-service-extension-templates/upgrades/template.yaml
   storage_profile: '*'                  # name of the storage profile to use when creating the temporary vApp used to build the template
   vdc: '???'                            # VDC within @org that will be used during the install process to build the template


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- remote_template_cookbook_url changed to upgrades branch copy
- sample_generator.py and base_config.yaml

@andrew-ni @rocknes @andrew-ni @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/620)
<!-- Reviewable:end -->
