### PR TITLE
[VCDA-1572] CLI-To-Use-CSE-Server-Api-Version

### DIFF
--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -27,7 +27,7 @@ class Cluster:
         :return: instance of version specific client side cluster
         """
         api_version = client.get_api_version()
-        if float(api_version) == float(vcd_client.ApiVersion.VERSION_33.value) or float(api_version) == float(vcd_client.ApiVersion.VERSION_34.value):  # noqa: E501
+        if float(api_version) == float(vcd_client.ApiVersion.VERSION_33.value) or float(api_version) == float(vcd_client.ApiVersion.VERSION_34.value):   # noqa: E501
             return LegacyNativeCluster(client)
         elif float(api_version) == float(vcd_client.ApiVersion.VERSION_35):
             if cluster_kind == ClusterKind.NATIVE or cluster_kind == ClusterKind.TKG_PLUS:  # noqa: E501

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -27,8 +27,7 @@ class Cluster:
         :return: instance of version specific client side cluster
         """
         api_version = client.get_api_version()
-        if float(api_version) == float(vcd_client.ApiVersion.VERSION_33.value)\
-              or float(api_version) == float(vcd_client.ApiVersion.VERSION_34.value):  # noqa: E501
+        if float(api_version) == float(vcd_client.ApiVersion.VERSION_33.value) or float(api_version) == float(vcd_client.ApiVersion.VERSION_34.value):  # noqa: E501
             return LegacyNativeCluster(client)
         elif float(api_version) == float(vcd_client.ApiVersion.VERSION_35):
             if cluster_kind == ClusterKind.NATIVE or cluster_kind == ClusterKind.TKG_PLUS:  # noqa: E501

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -4,12 +4,11 @@
 
 import pyvcloud.vcd.client as vcd_client
 
+from container_service_extension.client.command_filter import ClusterKind
 from container_service_extension.client.def_entity_cluster import DefEntityCluster # noqa: E501
 from container_service_extension.client.legacy_native_cluster import LegacyNativeCluster  # noqa: E501
 from container_service_extension.client.native_cluster import NativeCluster  # noqa: E501
 from container_service_extension.client.tkg_cluster import TKGCluster
-from container_service_extension.client.utils import ApiVersion
-from container_service_extension.client.utils import ClusterKind
 
 
 class Cluster:
@@ -28,10 +27,10 @@ class Cluster:
         :return: instance of version specific client side cluster
         """
         api_version = client.get_api_version()
-        if api_version == vcd_client.ApiVersion.VERSION_33.value \
-                or api_version == ApiVersion.VERSION_34:  # noqa: E501
+        if float(api_version) == float(vcd_client.ApiVersion.VERSION_33.value)\
+              or float(api_version) == float(vcd_client.ApiVersion.VERSION_34.value):  # noqa: E501
             return LegacyNativeCluster(client)
-        elif api_version == ApiVersion.VERSION_35:
+        elif float(api_version) == float(vcd_client.ApiVersion.VERSION_35):
             if cluster_kind == ClusterKind.NATIVE or cluster_kind == ClusterKind.TKG_PLUS:  # noqa: E501
                 return NativeCluster(client)
             elif cluster_kind == ClusterKind.TKG:

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -27,9 +27,9 @@ class Cluster:
         :return: instance of version specific client side cluster
         """
         api_version = client.get_api_version()
-        if float(api_version) == float(vcd_client.ApiVersion.VERSION_33.value) or float(api_version) == float(vcd_client.ApiVersion.VERSION_34.value):   # noqa: E501
+        if float(api_version) < float(vcd_client.ApiVersion.VERSION_35.value):   # noqa: E501
             return LegacyNativeCluster(client)
-        elif float(api_version) == float(vcd_client.ApiVersion.VERSION_35):
+        elif float(api_version) >= float(vcd_client.ApiVersion.VERSION_35.value):  # noqa: E501
             if cluster_kind == ClusterKind.NATIVE or cluster_kind == ClusterKind.TKG_PLUS:  # noqa: E501
                 return NativeCluster(client)
             elif cluster_kind == ClusterKind.TKG:

--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -1,0 +1,104 @@
+# container-service-extension
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from enum import Enum
+from enum import unique
+
+import click
+import pyvcloud.vcd.client as vcd_client
+
+import container_service_extension.client.utils as client_utils
+from container_service_extension.logger import CLIENT_LOGGER
+
+
+class ApiVersion(str, Enum):  # TODO(): use pyvcloud constant
+    VERSION_34 = '34.0'
+    VERSION_35 = '35.0'
+
+
+class ClusterKind(str, Enum):
+    NATIVE = 'native'
+    TKG = 'tkg'
+    TKG_PLUS = 'tkg-plus'
+
+
+@unique
+class GroupKey(str, Enum):
+    CLUSTER = 'cluster'
+    NODE = 'node'
+
+
+@unique
+class CommandNameKey(str, Enum):
+    CREATE = 'create'
+    NODE = 'node'
+
+
+# List of unsupported commands by Api Version
+UNSUPPORTED_COMMANDS_BY_VERSION = {
+    vcd_client.ApiVersion.VERSION_33.value: {
+        GroupKey.CLUSTER: ['apply']
+    },
+    ApiVersion.VERSION_34: {
+        GroupKey.CLUSTER: ['apply']
+    }
+}
+
+# List of unsupported commands by Api Version
+# TODO: All unsupported options depending on the command will go here
+UNSUPPORTED_COMMAND_OPTIONS_BY_VERSION = {
+    vcd_client.ApiVersion.VERSION_33.value: {
+        GroupKey.CLUSTER: {
+            CommandNameKey.CREATE: ['sizing_class']
+        }
+    },
+
+    ApiVersion.VERSION_34: {
+        GroupKey.CLUSTER: {
+            CommandNameKey.CREATE: ['sizing_class']
+        }
+    },
+
+    ApiVersion.VERSION_35: {
+        GroupKey.CLUSTER: {
+            CommandNameKey.CREATE: ['cpu', 'memory']
+        }
+    }
+}
+
+
+class GroupCommandFilter(click.Group):
+    """Filter for CLI group commands.
+
+    Returns set of supported sub-commands by specific API version
+    """
+
+    def get_command(self, ctx, cmd_name):
+        """Override this click method to customize.
+
+        :param click.core.Context ctx: Click Context
+        :param str cmd_name: name of the command (ex:create, delete, resize)
+        :return: Click command object for 'cmd_name'
+        :rtype: click.Core.Command
+        """
+        try:
+            if not type(ctx.obj) is dict or not ctx.obj.get('client'):
+                client_utils.cse_restore_session(ctx)
+            client = ctx.obj['client']
+            version = client.get_api_version()
+            # Skip the command if not supported
+            unsupported_commands = UNSUPPORTED_COMMANDS_BY_VERSION.get(version, {}).get(self.name, [])  # noqa: E501
+            if cmd_name in unsupported_commands:
+                return None
+
+            cmd = click.Group.get_command(self, ctx, cmd_name)
+            unsupported_params = UNSUPPORTED_COMMAND_OPTIONS_BY_VERSION.get(version, {}).get(self.name, {}).get(cmd_name, [])  # noqa: E501
+            # Remove all unsupported options for this command, if any
+            filtered_params = [param for param in cmd.params if param.name not in unsupported_params]  # noqa: E501
+            cmd.params = filtered_params
+        except Exception as e:
+            CLIENT_LOGGER.debug(f'exception while filtering {cmd_name}: {e}')
+            pass
+
+        return click.Group.get_command(self, ctx, cmd_name)

--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -12,11 +12,6 @@ import container_service_extension.client.utils as client_utils
 from container_service_extension.logger import CLIENT_LOGGER
 
 
-class ApiVersion(str, Enum):  # TODO(): use pyvcloud constant
-    VERSION_34 = '34.0'
-    VERSION_35 = '35.0'
-
-
 class ClusterKind(str, Enum):
     NATIVE = 'native'
     TKG = 'tkg'
@@ -40,7 +35,7 @@ UNSUPPORTED_COMMANDS_BY_VERSION = {
     vcd_client.ApiVersion.VERSION_33.value: {
         GroupKey.CLUSTER: ['apply']
     },
-    ApiVersion.VERSION_34: {
+    vcd_client.ApiVersion.VERSION_34.value: {
         GroupKey.CLUSTER: ['apply']
     }
 }
@@ -54,13 +49,13 @@ UNSUPPORTED_COMMAND_OPTIONS_BY_VERSION = {
         }
     },
 
-    ApiVersion.VERSION_34: {
+    vcd_client.ApiVersion.VERSION_34.value: {
         GroupKey.CLUSTER: {
             CommandNameKey.CREATE: ['sizing_class']
         }
     },
 
-    ApiVersion.VERSION_35: {
+    vcd_client.ApiVersion.VERSION_35.value: {
         GroupKey.CLUSTER: {
             CommandNameKey.CREATE: ['cpu', 'memory']
         }

--- a/container_service_extension/client/pks.py
+++ b/container_service_extension/client/pks.py
@@ -5,12 +5,12 @@
 import os
 
 import click
-from vcd_cli.utils import restore_session
 from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
 
 from container_service_extension.client.ovdc import Ovdc
 from container_service_extension.client.pks_cluster import PksCluster
+import container_service_extension.client.utils as client_utils
 from container_service_extension.logger import CLIENT_LOGGER
 from container_service_extension.server_constants import K8sProvider
 from container_service_extension.shared_constants import RESPONSE_MESSAGE_KEY
@@ -97,7 +97,7 @@ def list_clusters(ctx, vdc, org_name):
     """Display clusters in Ent-PKS that are visible to the logged in user."""
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
-        restore_session(ctx)
+        client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
         cluster = PksCluster(client)
         if not client.is_sysadmin() and org_name is None:
@@ -135,7 +135,7 @@ def cluster_delete(ctx, cluster_name, vdc, org):
     """Delete an Ent-PKS cluster."""
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
-        restore_session(ctx)
+        client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
         cluster = PksCluster(client)
         if not client.is_sysadmin() and org is None:
@@ -189,7 +189,7 @@ def cluster_create(ctx, cluster_name, vdc, node_count, org_name):
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
 
-        restore_session(ctx)
+        client_utils.cse_restore_session(ctx)
         if vdc is None:
             vdc = ctx.obj['profiles'].get('vdc_in_use')
             if not vdc:
@@ -249,7 +249,7 @@ def cluster_resize(ctx, cluster_name, node_count, org_name, vdc_name):
     """
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
-        restore_session(ctx)
+        client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
         if not client.is_sysadmin() and org_name is None:
             org_name = ctx.obj['profiles'].get('org_in_use')
@@ -292,7 +292,7 @@ def cluster_config(ctx, cluster_name, vdc, org):
     """
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
-        restore_session(ctx)
+        client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
         cluster = PksCluster(client)
         if not client.is_sysadmin() and org is None:
@@ -334,7 +334,7 @@ def cluster_info(ctx, cluster_name, org, vdc):
     """Display info about an Ent-PKS K8 cluster."""
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
-        restore_session(ctx)
+        client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
         cluster = PksCluster(client)
         if not client.is_sysadmin() and org is None:
@@ -399,7 +399,7 @@ def ovdc_enable(ctx, ovdc_name, pks_plan,
     """Set Kubernetes provider to be Ent-PKS for an org VDC."""
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
-        restore_session(ctx)
+        client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
         if client.is_sysadmin():
             ovdc = Ovdc(client)

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -1,100 +1,93 @@
 # container-service-extension
 # Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-
-from enum import Enum
-from enum import unique
-
 import click
-import pyvcloud.vcd.client as vcd_client
-from vcd_cli.utils import restore_session
+from pyvcloud.vcd.client import Client
+import requests
+from vcd_cli.profiles import Profiles
+
+from container_service_extension.client import system as syst
 
 
-class ApiVersion(str, Enum):  # TODO(): use pyvcloud constant
-    VERSION_34 = '34.0'
-    VERSION_35 = '35.0'
+def cse_restore_session(ctx, vdc_required=False) -> None:
+    """Restores the session with vcd client with right server api version.
 
+    Replace the vcd client in ctx.obj with new client created with server api
+    version. Also saves the server api version in profiles.
 
-class ClusterKind(str, Enum):
-    NATIVE = 'native'
-    TKG = 'tkg'
-    TKG_PLUS = 'tkg-plus'
-
-
-@unique
-class GroupKey(str, Enum):
-    CLUSTER = 'cluster'
-    NODE = 'node'
-
-
-@unique
-class CommandNameKey(str, Enum):
-    CREATE = 'create'
-    NODE = 'node'
-
-
-# List of unsupported commands by Api Version
-UNSUPPORTED_COMMANDS_BY_VERSION = {
-    vcd_client.ApiVersion.VERSION_33.value: {
-        GroupKey.CLUSTER: ['apply']
-    },
-    ApiVersion.VERSION_34: {
-        GroupKey.CLUSTER: ['apply']
-    }
-}
-
-# List of unsupported commands by Api Version
-# TODO: All unsupported options depending on the command will go here
-UNSUPPORTED_COMMAND_OPTIONS_BY_VERSION = {
-    vcd_client.ApiVersion.VERSION_33.value: {
-        GroupKey.CLUSTER: {
-            CommandNameKey.CREATE: ['sizing_class']
-        }
-    },
-
-    ApiVersion.VERSION_34: {
-        GroupKey.CLUSTER: {
-            CommandNameKey.CREATE: ['sizing_class']
-        }
-    },
-
-    ApiVersion.VERSION_35: {
-        GroupKey.CLUSTER: {
-            CommandNameKey.CREATE: ['cpu', 'memory']
-        }
-    }
-}
-
-
-class GroupCommandFilter(click.Group):
-    """Filter for CLI group commands.
-
-    Returns set of supported sub-commands by specific API version
+    :param <click.core.Context> ctx: click context
+    :param bool vdc_required: is vdc required or not
+    :return:
     """
+    # User initiated and expired logout overwrites the profiles.yaml in vcd_cli
+    # So,override the vcd_client by new client with server api version.
+    if type(ctx.obj) is dict and 'client' in ctx.obj and ctx.obj['client']:
+        _override_client(ctx)
+        return
 
-    def get_command(self, ctx, cmd_name):
-        """Override this click method to customize.
-
-        :param click.core.Context ctx: Click Context
-        :param str cmd_name: name of the command (ex:create, delete, resize)
-        :return: Click command object for 'cmd_name'
-        :rtype: click.Core.Command
-        """
-        try:
-            restore_session(ctx)
-            client = ctx.obj['client']
-            version = client.get_api_version()
-            # Skip the command if not supported
-            unsupported_commands = UNSUPPORTED_COMMANDS_BY_VERSION.get(version, {}).get(self.name, [])  # noqa: E501
-            if cmd_name in unsupported_commands:
-                return None
-
-            cmd = click.Group.get_command(self, ctx, cmd_name)
-            unsupported_params = UNSUPPORTED_COMMAND_OPTIONS_BY_VERSION.get(version, {}).get(self.name, {}).get(cmd_name, [])  # noqa: E501
-            # Remove all unsupported options for this command, if any
-            filtered_params = [param for param in cmd.params if param.name not in unsupported_params]  # noqa: E501
-            cmd.params = filtered_params
-        except Exception:
+    profiles = Profiles.load()
+    token = profiles.get('token')
+    if token is None or len(token) == 0:
+        raise Exception('Can\'t restore session, please login again.')
+    if not profiles.get('verify'):
+        if profiles.get('disable_warnings'):
             pass
+        else:
+            click.secho(
+                'InsecureRequestWarning: '
+                'Unverified HTTPS request is being made. '
+                'Adding certificate verification is strongly '
+                'advised.',
+                fg='yellow',
+                err=True)
+        requests.packages.urllib3.disable_warnings()
 
-        return click.Group.get_command(self, ctx, cmd_name)
+    client = Client(
+        profiles.get('host'),
+        api_version=profiles.get('api_version'),
+        verify_ssl_certs=profiles.get('verify'),
+        log_file='vcd.log',
+        log_requests=profiles.get('log_request'),
+        log_headers=profiles.get('log_header'),
+        log_bodies=profiles.get('log_body'))
+    client.rehydrate_from_token(
+        profiles.get('token'), profiles.get('is_jwt_token'))
+
+    ctx.obj = {}
+    ctx.obj['client'] = client
+    _override_client(ctx)
+
+    if vdc_required:
+        if not ctx.obj['profiles'].get('vdc_in_use') or \
+                not ctx.obj['profiles'].get('vdc_href'):
+            raise Exception('select a virtual datacenter')
+
+
+def _override_client(ctx) -> None:
+    """Replace the vcd client in ctx.obj with new one.
+
+    New vcd client takes the server_api_version as api_version param.
+    Save profile also with 'server_api_version' for subsequent commands.
+
+    :param <click.core.Context> ctx: click context
+    """
+    profiles = Profiles.load()
+    server_api_version = profiles.get('server_api_version')
+    # Get server_api_version; save it in profiles if doesn't exist
+    if not server_api_version:
+        system = syst.System(ctx.obj['client'])
+        sys_info = system.get_info()
+        server_api_version = sys_info.get('server_api_version')
+        profiles.set('server_api_version', server_api_version)
+        profiles.save()
+    client = Client(
+        profiles.get('host'),
+        api_version=server_api_version,
+        verify_ssl_certs=profiles.get('verify'),
+        log_file='vcd.log',
+        log_requests=profiles.get('log_request'),
+        log_headers=profiles.get('log_header'),
+        log_bodies=profiles.get('log_body'))
+    client.rehydrate_from_token(profiles.get('token'), profiles.get('is_jwt_token'))  # noqa: E501
+    ctx.obj['client'] = client
+    ctx.obj['profiles'] = profiles

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -7,6 +7,7 @@ import requests
 from vcd_cli.profiles import Profiles
 
 from container_service_extension.client import system as syst
+from container_service_extension.shared_constants import CSE_SERVER_API_VERSION
 
 
 def cse_restore_session(ctx, vdc_required=False) -> None:
@@ -19,42 +20,37 @@ def cse_restore_session(ctx, vdc_required=False) -> None:
     :param bool vdc_required: is vdc required or not
     :return:
     """
-    # User initiated and expired logout overwrites the profiles.yaml in vcd_cli
-    # So,override the vcd_client by new client with server api version.
-    if type(ctx.obj) is dict and 'client' in ctx.obj and ctx.obj['client']:
-        _override_client(ctx)
-        return
+    # Always override the vcd_client by new client with CSE server api version.
+    if type(ctx.obj) is not dict or not ctx.obj.get('client'):
+        profiles = Profiles.load()
+        token = profiles.get('token')
+        if token is None or len(token) == 0:
+            raise Exception('Can\'t restore session, please login again.')
+        if not profiles.get('verify'):
+            if not profiles.get('disable_warnings'):
+                click.secho(
+                    'InsecureRequestWarning: '
+                    'Unverified HTTPS request is being made. '
+                    'Adding certificate verification is strongly '
+                    'advised.',
+                    fg='yellow',
+                    err=True)
+            requests.packages.urllib3.disable_warnings()
 
-    profiles = Profiles.load()
-    token = profiles.get('token')
-    if token is None or len(token) == 0:
-        raise Exception('Can\'t restore session, please login again.')
-    if not profiles.get('verify'):
-        if profiles.get('disable_warnings'):
-            pass
-        else:
-            click.secho(
-                'InsecureRequestWarning: '
-                'Unverified HTTPS request is being made. '
-                'Adding certificate verification is strongly '
-                'advised.',
-                fg='yellow',
-                err=True)
-        requests.packages.urllib3.disable_warnings()
+        client = Client(
+            profiles.get('host'),
+            api_version=profiles.get('api_version'),
+            verify_ssl_certs=profiles.get('verify'),
+            log_file='vcd.log',
+            log_requests=profiles.get('log_request'),
+            log_headers=profiles.get('log_header'),
+            log_bodies=profiles.get('log_body'))
+        client.rehydrate_from_token(
+            profiles.get('token'), profiles.get('is_jwt_token'))
 
-    client = Client(
-        profiles.get('host'),
-        api_version=profiles.get('api_version'),
-        verify_ssl_certs=profiles.get('verify'),
-        log_file='vcd.log',
-        log_requests=profiles.get('log_request'),
-        log_headers=profiles.get('log_header'),
-        log_bodies=profiles.get('log_body'))
-    client.rehydrate_from_token(
-        profiles.get('token'), profiles.get('is_jwt_token'))
+        ctx.obj = {}
+        ctx.obj['client'] = client
 
-    ctx.obj = {}
-    ctx.obj['client'] = client
     _override_client(ctx)
 
     if vdc_required:
@@ -66,23 +62,23 @@ def cse_restore_session(ctx, vdc_required=False) -> None:
 def _override_client(ctx) -> None:
     """Replace the vcd client in ctx.obj with new one.
 
-    New vcd client takes the server_api_version as api_version param.
-    Save profile also with 'server_api_version' for subsequent commands.
+    New vcd client takes the CSE server_api_version as api_version param.
+    Save profile also with 'cse_server_api_version' for subsequent commands.
 
     :param <click.core.Context> ctx: click context
     """
     profiles = Profiles.load()
-    server_api_version = profiles.get('server_api_version')
+    cse_server_api_version = profiles.get(CSE_SERVER_API_VERSION)
     # Get server_api_version; save it in profiles if doesn't exist
-    if not server_api_version:
+    if not cse_server_api_version:
         system = syst.System(ctx.obj['client'])
         sys_info = system.get_info()
-        server_api_version = sys_info.get('server_api_version')
-        profiles.set('server_api_version', server_api_version)
+        cse_server_api_version = sys_info.get(CSE_SERVER_API_VERSION)
+        profiles.set(CSE_SERVER_API_VERSION, cse_server_api_version)
         profiles.save()
     client = Client(
         profiles.get('host'),
-        api_version=server_api_version,
+        api_version=cse_server_api_version,
         verify_ssl_certs=profiles.get('verify'),
         log_file='vcd.log',
         log_requests=profiles.get('log_request'),

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -40,6 +40,7 @@ from container_service_extension.server_constants import CSE_SERVICE_NAME
 from container_service_extension.server_constants import CSE_SERVICE_NAMESPACE
 from container_service_extension.server_constants import LocalTemplateKey
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
+from container_service_extension.shared_constants import CSE_SERVER_API_VERSION
 from container_service_extension.shared_constants import ServerAction
 from container_service_extension.telemetry.constants import CseOperation
 from container_service_extension.telemetry.constants import PayloadKey
@@ -181,7 +182,7 @@ class Service(object, metaclass=Singleton):
 
     def info(self, get_sysadmin_info=False):
         result = utils.get_cse_info()
-        result['server_api_version'] = utils.get_server_api_version()
+        result[CSE_SERVER_API_VERSION] = utils.get_server_api_version()
         if get_sysadmin_info:
             result['consumer_threads'] = len(self.threads)
             result['all_threads'] = threading.activeCount()

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -181,6 +181,7 @@ class Service(object, metaclass=Singleton):
 
     def info(self, get_sysadmin_info=False):
         result = utils.get_cse_info()
+        result['server_api_version'] = utils.get_server_api_version()
         if get_sysadmin_info:
             result['consumer_threads'] = len(self.threads)
             result['all_threads'] = threading.activeCount()

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -13,6 +13,7 @@ UNKNOWN_ERROR_MESSAGE = "Unknown error. Please contact your System " \
                         "Administrator"
 
 RESPONSE_MESSAGE_KEY = "message"
+CSE_SERVER_API_VERSION = 'cse_server_api_version'
 
 
 @unique


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- CSE has own restore session that replaces vcd_client with server side api version (utils.py)
- Separate module - command_filter.py for client side CSE commands,options filtering
- service.py to also return server api version
- cse.py, pks.py changes to use new restore session.
- Fixed cluster_create() missing 2 required positional arguments: 'cpu' and 'memory'
- Manually tested the commands

@andrew-ni @Anirudh9794 @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/623)
<!-- Reviewable:end -->
