### PR TITLE
Skip Photon template installation during system tests

### DIFF
--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -58,7 +58,7 @@ service:
 
 broker:
   catalog: cse                          # public shared catalog within org where the template will be published
-  default_template_name: photon-v2_k8-1.14_weave-2.5.2
+  default_template_name: ubuntu-16.04_k8-1.17_weave-2.6.0
                                         # name of the default template to use if none is specified
   default_template_revision: 2          # revision of the default template to use if none is specified
   ip_allocation_mode: pool              # dhcp or pool

--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -108,8 +108,8 @@ def cse_server():
     result = env.CLI_RUNNER.invoke(cli, template_install_cmd,
                                    catch_exceptions=False)
     assert result.exit_code == 0,\
-        testutils.format_command_info('cse', template_install_cmd, result.exit_code,
-                                      result.output)
+        testutils.format_command_info('cse', template_install_cmd,
+                                      result.exit_code, result.output)
 
     # start cse server as subprocess
     cmd = f"cse run -c {env.ACTIVE_CONFIG_FILEPATH} --skip-config-decryption"

--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -87,13 +87,28 @@ def cse_server():
     install_cmd = ['install',
                    '--config', env.ACTIVE_CONFIG_FILEPATH,
                    '--ssh-key', env.SSH_KEY_FILEPATH,
-                   '--skip-config-decryption']
-    env.setup_active_config()
+                   '--skip-config-decryption',
+                   # TODO Remove after Guest Customization fix
+                   '--skip-template-creation']
+    config = env.setup_active_config()
     result = env.CLI_RUNNER.invoke(cli, install_cmd,
                                    input='y',
                                    catch_exceptions=False)
     assert result.exit_code == 0,\
         testutils.format_command_info('cse', install_cmd, result.exit_code,
+                                      result.output)
+
+    # TODO Remove after Guest Customization fix
+    template_install_cmd = ['template', 'install',
+                            '--config', env.ACTIVE_CONFIG_FILEPATH,
+                            '--ssh-key', env.SSH_KEY_FILEPATH,
+                            '--skip-config-decryption',
+                            config['broker']['default_template_name'],
+                            str(config['broker']['default_template_revision'])]
+    result = env.CLI_RUNNER.invoke(cli, template_install_cmd,
+                                   catch_exceptions=False)
+    assert result.exit_code == 0,\
+        testutils.format_command_info('cse', template_install_cmd, result.exit_code,
                                       result.output)
 
     # start cse server as subprocess

--- a/system_tests/test_cse_server.py
+++ b/system_tests/test_cse_server.py
@@ -69,9 +69,11 @@ def _remove_cse_artifacts():
         env.delete_catalog_item(template['source_ova_name'])
         catalog_item_name = ltm.get_revisioned_template_name(
             template['name'], template['revision'])
-        env.delete_catalog_item(catalog_item_name)
-        temp_vapp_name = testutils.get_temp_vapp_name(template['name'])
-        env.delete_vapp(temp_vapp_name)
+        # TODO Remove after Guest Customization fix
+        if "photon" not in template['name']:
+            env.delete_catalog_item(catalog_item_name)
+            temp_vapp_name = testutils.get_temp_vapp_name(template['name'])
+            env.delete_vapp(temp_vapp_name)
     env.delete_catalog()
     env.unregister_cse()
 
@@ -295,7 +297,7 @@ def test_0080_install_skip_template_creation(config,
         assert not env.vapp_exists(temp_vapp_name), \
             'vApp exists when it should not.'
 
-
+# TODO Remove after Guest Customization fix
 def test_0090_install_retain_temp_vapp(config, unregister_cse_before_test):
     """Test install.
 
@@ -316,7 +318,8 @@ def test_0090_install_retain_temp_vapp(config, unregister_cse_before_test):
         temp vapps exist, k8s templates exist.
     """
     cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
-          f"{env.SSH_KEY_FILEPATH} --retain-temp-vapp --skip-config-decryption"
+          f"{env.SSH_KEY_FILEPATH} --retain-temp-vapp --skip-config-decryption" \
+          f" --skip-template-creation" # noqa:E501
     result = env.CLI_RUNNER.invoke(cli, cmd.split(),
                                    catch_exceptions=False)
     assert result.exit_code == 0,\
@@ -330,6 +333,21 @@ def test_0090_install_retain_temp_vapp(config, unregister_cse_before_test):
     vdc = VDC(env.CLIENT, href=env.VDC_HREF)
     for template_config in env.TEMPLATE_DEFINITIONS:
         # check that source ova file exists in catalog
+        
+        # TODO remove after Guest Customization fix
+        if 'photon' in template_config['source_ova_name']:
+            continue
+        template_install_cmd  = \
+            f"template install --config {env.ACTIVE_CONFIG_FILEPATH} " \
+            f"--ssh-key {env.SSH_KEY_FILEPATH} --retain-temp-vapp " \
+            f"--skip-config-decryption {template_config['name']} " \
+            f"{template_config['revision']}"
+        result = env.CLI_RUNNER.invoke(cli, template_install_cmd.split(),
+                                       catch_exceptions=False)
+        assert result.exit_code == 0,\
+            testutils.format_command_info('cse', template_install_cmd,
+                                          result.exit_code, result.output)
+
         assert env.catalog_item_exists(
             template_config['source_ova_name']), \
             'Source ova file does not exist when it should.'
@@ -350,49 +368,49 @@ def test_0090_install_retain_temp_vapp(config, unregister_cse_before_test):
             assert False, 'vApp does not exist when it should.'
 
 
-def test_0100_install_force_update(config, unregister_cse_before_test):
-    """Tests installation option: '--force-update'.
+# def test_0100_install_force_update(config, unregister_cse_before_test):
+#     """Tests installation option: '--force-update'.
 
-    Tests that installation:
-    - creates all templates correctly,
-    - customizes temp vapps correctly.
+#     Tests that installation:
+#     - creates all templates correctly,
+#     - customizes temp vapps correctly.
 
-    command: cse install --config cse_test_config.yaml
-        --ssh-key ~/.ssh/id_rsa.pub --force-update --skip-config-decryption
-    required files: cse_test_config.yaml, ~/.ssh/id_rsa.pub,
-        ubuntu/photon init/cust scripts
-    expected: cse registered, source ovas exist, k8s templates exist and
-        temp vapps don't exist.
-    """
-    cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
-          f"{env.SSH_KEY_FILEPATH} --force-update --skip-config-decryption"
-    result = env.CLI_RUNNER.invoke(
-        cli, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0,\
-        testutils.format_command_info('cse', cmd, result.exit_code,
-                                      result.output)
+#     command: cse install --config cse_test_config.yaml
+#         --ssh-key ~/.ssh/id_rsa.pub --force-update --skip-config-decryption
+#     required files: cse_test_config.yaml, ~/.ssh/id_rsa.pub,
+#         ubuntu/photon init/cust scripts
+#     expected: cse registered, source ovas exist, k8s templates exist and
+#         temp vapps don't exist.
+#     """
+#     cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
+#           f"{env.SSH_KEY_FILEPATH} --force-update --skip-config-decryption"
+#     result = env.CLI_RUNNER.invoke(
+#         cli, cmd.split(), catch_exceptions=False)
+#     assert result.exit_code == 0,\
+#         testutils.format_command_info('cse', cmd, result.exit_code,
+#                                       result.output)
 
-    # check that cse was registered correctly
-    env.check_cse_registration(config['amqp']['routing_key'],
-                               config['amqp']['exchange'])
+#     # check that cse was registered correctly
+#     env.check_cse_registration(config['amqp']['routing_key'],
+#                                config['amqp']['exchange'])
 
-    for template_config in env.TEMPLATE_DEFINITIONS:
-        # check that source ova file exists in catalog
-        assert env.catalog_item_exists(
-            template_config['source_ova_name']), \
-            'Source ova file does not exists when it should.'
+#     for template_config in env.TEMPLATE_DEFINITIONS:
+#         # check that source ova file exists in catalog
+#         assert env.catalog_item_exists(
+#             template_config['source_ova_name']), \
+#             'Source ova file does not exists when it should.'
 
-        # check that k8s templates exist
-        catalog_item_name = ltm.get_revisioned_template_name(
-            template_config['name'], template_config['revision'])
-        assert env.catalog_item_exists(catalog_item_name), \
-            'k8s template does not exist when it should.'
+#         # check that k8s templates exist
+#         catalog_item_name = ltm.get_revisioned_template_name(
+#             template_config['name'], template_config['revision'])
+#         assert env.catalog_item_exists(catalog_item_name), \
+#             'k8s template does not exist when it should.'
 
-        # check that temp vapp does not exists
-        temp_vapp_name = testutils.get_temp_vapp_name(
-            template_config['name'])
-        assert not env.vapp_exists(temp_vapp_name), \
-            'vApp exists when it should not.'
+#         # check that temp vapp does not exists
+#         temp_vapp_name = testutils.get_temp_vapp_name(
+#             template_config['name'])
+#         assert not env.vapp_exists(temp_vapp_name), \
+#             'vApp exists when it should not.'
 
 
 def test_0110_cse_check_valid_installation(config):

--- a/system_tests/test_cse_server.py
+++ b/system_tests/test_cse_server.py
@@ -297,7 +297,7 @@ def test_0080_install_skip_template_creation(config,
         assert not env.vapp_exists(temp_vapp_name), \
             'vApp exists when it should not.'
 
-# TODO Remove after Guest Customization fix
+
 def test_0090_install_retain_temp_vapp(config, unregister_cse_before_test):
     """Test install.
 
@@ -333,11 +333,11 @@ def test_0090_install_retain_temp_vapp(config, unregister_cse_before_test):
     vdc = VDC(env.CLIENT, href=env.VDC_HREF)
     for template_config in env.TEMPLATE_DEFINITIONS:
         # check that source ova file exists in catalog
-        
+
         # TODO remove after Guest Customization fix
         if 'photon' in template_config['source_ova_name']:
             continue
-        template_install_cmd  = \
+        template_install_cmd = \
             f"template install --config {env.ACTIVE_CONFIG_FILEPATH} " \
             f"--ssh-key {env.SSH_KEY_FILEPATH} --retain-temp-vapp " \
             f"--skip-config-decryption {template_config['name']} " \
@@ -367,7 +367,7 @@ def test_0090_install_retain_temp_vapp(config, unregister_cse_before_test):
         except EntityNotFoundException:
             assert False, 'vApp does not exist when it should.'
 
-
+# TODO Uncomment after Guest Customization fix
 # def test_0100_install_force_update(config, unregister_cse_before_test):
 #     """Tests installation option: '--force-update'.
 


### PR DESCRIPTION

* Change _remove_cse_artifacts() to skip photon
* Skip tests   test_0100_install_force_update
* Modified test_0090_install_retain_temp_vapp
* Change pytest fixture cse_server() : Skip installation of templates and manually install only the default template
*  change default template from photon template to an ubuntu template in 

@rocknes @sakthisunda @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/627)
<!-- Reviewable:end -->
