### PR TITLE
[Vcda 1541] upgrade cluster workflow

### DIFF
--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -142,6 +142,28 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         return upgrades
 
+    def _get_cluster_upgrade_plan(self,
+                                  cluster_entity: def_models.ClusterEntity) -> List[dict]: # noqa: E501
+        """Get list of templates that a given cluster can upgrade to.
+
+        :param def_models.ClusterEntity cluster_entity: current cluster entity
+        :return: List of dictionary containing templates
+        :rtype: List[dict]
+        """
+        src_name = cluster_entity.spec.k8_distribution.template_name
+        src_rev = cluster_entity.spec.k8_distribution.template_revision
+
+        upgrades = []
+        config = utils.get_server_runtime_config()
+        for t in config['broker']['templates']:
+            if src_name in t[LocalTemplateKey.UPGRADE_FROM] \
+                    and t[LocalTemplateKey.NAME] != src_name \
+                    and int(t[LocalTemplateKey.REVISION]) > int(src_rev):
+                upgrades.append(t)
+
+        return upgrades
+
+
     def create_cluster(self, cluster_spec: def_models.ClusterEntity):
         """Start the cluster creation operation.
 
@@ -489,40 +511,27 @@ class ClusterService(abstract_broker.AbstractBroker):
         vdc_resource = org.get_vdc(name=ovdc_name)
         return vdc_resource.get('href')
 
-    def upgrade_cluster(self, **kwargs):
+    def upgrade_cluster(self, cluster_id: str,
+                        upgrade_spec: def_models.ClusterEntity):
         """Start the upgrade cluster operation.
 
-        Validates data for 'upgrade cluster' operation.
         Upgrading cluster is an asynchronous task, so the returned
         `result['task_href']` can be polled to get updates on task progress.
 
-        **data: Required
-            Required data: cluster_name, template_name, template_revision
-            Optional data and default values: org_name=None, ovdc_name=None
-        **telemetry: Optional
+        :param str cluster_id: id of the cluster to be upgraded
+        :param cluster_spec def_models.ClusterEntity: cluster spec with new kubernetes distribution and revision
         """
-        raise NotImplementedError
-        data = kwargs[KwargKey.DATA]
-        required = [
-            RequestKey.CLUSTER_NAME,
-            RequestKey.TEMPLATE_NAME,
-            RequestKey.TEMPLATE_REVISION
-        ]
-        defaults = {
-            RequestKey.ORG_NAME: None,
-            RequestKey.OVDC_NAME: None
-        }
-        validated_data = {**defaults, **data}
-        req_utils.validate_payload(validated_data, required)
-
-        cluster_name = validated_data[RequestKey.CLUSTER_NAME]
-        template_name = validated_data[RequestKey.TEMPLATE_NAME]
-        template_revision = validated_data[RequestKey.TEMPLATE_REVISION]
+        def_entity = self.entity_svc.get_entity(cluster_id)
+        cluster_name = def_entity.entity.metadata.cluster_name
+        current_template_name = def_entity.entity.spec.k8_distribution.template_name # noqa: E501
+        current_template_revision = def_entity.entity.spec.k8_distribution.template_revision # noqa: E501
+        new_template_name = upgrade_spec.spec.k8_distribution.template_name
+        new_template_revision = upgrade_spec.spec.k8_distribution.template_revision # noqa: E501
 
         # check that the specified template is a valid upgrade target
         template = {}
-        valid_templates = self.get_cluster_upgrade_plan(data=validated_data,
-                                                        telemetry=False)
+        valid_templates = self._get_cluster_upgrade_plan(def_entity.entity)
+
         for t in valid_templates:
             if t[LocalTemplateKey.NAME] == template_name and t[LocalTemplateKey.REVISION] == str(template_revision): # noqa: E501
                 template = t
@@ -531,24 +540,20 @@ class ClusterService(abstract_broker.AbstractBroker):
             # TODO all of these e.CseServerError instances related to request
             # should be changed to BadRequestError (400)
             raise e.CseServerError(
-                f"Specified template/revision ({template_name} revision "
-                f"{template_revision}) is not a valid upgrade target for "
+                f"Specified template/revision ({new_template_name} revision "
+                f"{new_template_revision}) is not a valid upgrade target for "
                 f"cluster '{cluster_name}'.")
 
         # get cluster data (including node names) to pass to async function
-        cluster = self.get_cluster_info(data=validated_data, telemetry=False)
+        # cluster = self.get_cluster_info(data=validated_data, telemetry=False)
 
-        if kwargs.get(KwargKey.TELEMETRY, True):
-            # Record the telemetry data
-            cse_params = copy.deepcopy(validated_data)
-            cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
-            record_user_action_details(cse_operation=CseOperation.CLUSTER_UPGRADE, # noqa: E501
-                                       cse_params=cse_params)
+        # TODO(DEF) design and implement telemetry VCDA-1564 defined entity
+        #  based clusters
 
         msg = f"Upgrading cluster '{cluster_name}' " \
-              f"software to match template {template_name} (revision " \
-              f"{template_revision}): Kubernetes: " \
-              f"{cluster['kubernetes_version']} -> " \
+              f"software to match template {new_template_name} (revision " \
+              f"{new_template_revision}): Kubernetes: " \
+              f"{def} -> " \
               f"{template[LocalTemplateKey.KUBERNETES_VERSION]}, Docker-CE: " \
               f"{cluster['docker_version']} -> " \
               f"{template[LocalTemplateKey.DOCKER_VERSION]}, CNI: " \

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -921,8 +921,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             # TODO use cluster status field to get the master and worker nodes
             cluster_vapp = vcd_vapp.VApp(self.context.client, href=vapp_href)
             all_node_names = [vm.get('name') for vm in cluster_vapp.get_all_vms()] # noqa: E501
-            master_node_names = [vm_name.startswith(NodeType.MASTER) for vm_name in all_node_names] # noqa: E501
-            worker_node_names = [vm_name.startswith(NodeType.WORKER) for vm_name in all_node_names] # noqa: E501
+            master_node_names = [vm_name for vm_name in all_node_names if vm_name.startswith(NodeType.MASTER)] # noqa: E501
+            worker_node_names = [vm_name for vm_name in all_node_names if vm_name.startswith(NodeType.WORKER)] # noqa: E501
 
             template_name = template[LocalTemplateKey.NAME]
             template_revision = template[LocalTemplateKey.REVISION]

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -489,6 +489,9 @@ class ClusterService(abstract_broker.AbstractBroker):
         :param str cluster_id: id of the cluster to be upgraded
         :param def_models.ClusterEntity upgrade_spec: cluster spec with new
             kubernetes distribution and revision
+
+        :return: Defined entity with upgrade in progress set
+        :rtype: def_models.DefEntity representing the cluster
         """
         curr_entity = self.entity_svc.get_entity(cluster_id)
         cluster_name = curr_entity.entity.metadata.cluster_name
@@ -547,10 +550,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         self.context.is_async = True
         self._upgrade_cluster_async(cluster_id=cluster_id,
                                     template=template)
-        return {
-            'cluster_name': cluster_name,
-            'task_href': self.task_resource.get('href')
-        }
+        return dataclasses.asdict(curr_entity)
 
     def get_node_info(self, **kwargs):
         """Get node metadata as dictionary.

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -500,9 +500,9 @@ class ClusterService(abstract_broker.AbstractBroker):
             curr_entity.entity.status.phase)
         state: str = curr_entity.state
         if state != def_utils.DEF_RESOLVED_STATE or phase.is_entity_busy():
-        raise e.CseServerError(
-            f"Cluster {cluster_name} with id {cluster_id} is not in a "
-            f"valid state to be deleted. Please contact administrator.")
+            raise e.CseServerError(
+                f"Cluster {cluster_name} with id {cluster_id} is not in a "
+                f"valid state to be deleted. Please contact administrator.")
 
         # check that the specified template is a valid upgrade target
         template = {}
@@ -538,10 +538,15 @@ class ClusterService(abstract_broker.AbstractBroker):
               f"{template[LocalTemplateKey.CNI_VERSION]}"
         self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
         LOGGER.info(f"{msg} ({curr_entity.externalId})")
-        self.context.is_async = True
-        self._upgrade_cluster_async(cluster_defined_entity=curr_entity,
-                                    template=template)
 
+        curr_entity.entity.status.phase = str(
+            DefEntityPhase(DefEntityOperation.UPGRADE, DefEntityOperationStatus.IN_PROGRESS)) # noqa: E501
+        curr_entity.entity.status.task_href = self.task_resource.get('href')
+        curr_entity = self.entity_svc.update_entity(cluster_id, curr_entity)
+
+        self.context.is_async = True
+        self._upgrade_cluster_async(cluster_id=cluster_id,
+                                    template=template)
         return {
             'cluster_name': cluster_name,
             'task_href': self.task_resource.get('href')
@@ -906,11 +911,12 @@ class ClusterService(abstract_broker.AbstractBroker):
     # all parameters following '*args' are required and keyword-only
     @utils.run_async
     def _upgrade_cluster_async(self, *args,
-                               cluster_defined_entity: def_models.DefEntity,
+                               cluster_id: str,
                                template):
         try:
-            cluster_name = cluster_defined_entity.entity.metadata.cluster_name
-            vapp_href = cluster_defined_entity.externalId
+            curr_entity: def_models.DefEntity = self.entity_svc.get_entity(cluster_id) # noqa: E501
+            cluster_name = curr_entity.entity.metadata.cluster_name
+            vapp_href = curr_entity.externalId
 
             # TODO use cluster status field to get the master and worker nodes
             cluster_vapp = vcd_vapp.VApp(self.context.client, href=vapp_href)
@@ -924,12 +930,12 @@ class ClusterService(abstract_broker.AbstractBroker):
             # semantic version doesn't allow leading zeros
             # docker's version format YY.MM.patch allows us to directly use
             # lexicographical string comparison
-            c_docker = cluster_defined_entity.entity.status.docker_version
+            c_docker = curr_entity.entity.status.docker_version
             t_docker = template[LocalTemplateKey.DOCKER_VERSION]
-            k8s_details = cluster_defined_entity.entity.status.kubernetes.split(' ') # noqa: E501
+            k8s_details = curr_entity.entity.status.kubernetes.split(' ')
             c_k8s = semver.Version(k8s_details[1])
             t_k8s = semver.Version(template[LocalTemplateKey.KUBERNETES_VERSION]) # noqa: E501
-            cni_details = cluster_defined_entity.entity.status.cni.split(' ')
+            cni_details = curr_entity.entity.status.cni.split(' ')
             c_cni = semver.Version(cni_details[1])
             t_cni = semver.Version(template[LocalTemplateKey.CNI_VERSION])
 
@@ -1007,7 +1013,7 @@ class ClusterService(abstract_broker.AbstractBroker):
 
             if upgrade_cni:
                 msg = "Applying CNI " \
-                      f"({cluster_defined_entity.entity.status.cni} " \
+                      f"({curr_entity.entity.status.cni} " \
                       f"-> {t_cni}) in master node {master_node_names}"
                 self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
                 filepath = ltm.get_script_filepath(template_name,
@@ -1039,19 +1045,22 @@ class ClusterService(abstract_broker.AbstractBroker):
             self.context.client.get_task_monitor().wait_for_status(task)
 
             # update defined entity of the cluster
-            cluster_defined_entity.entity.spec.k8_distribution.template_name = \
-                template[LocalTemplateKey.NAME] # noqa: E501
-            cluster_defined_entity.entity.spec.k8_distribution.template_revision = \
-                int(template[LocalTemplateKey.REVISION]) # noqa: E501
-            cluster_defined_entity.entity.status.cni = \
+            curr_entity.entity.spec.k8_distribution.template_name = \
+                template[LocalTemplateKey.NAME]
+            curr_entity.entity.spec.k8_distribution.template_revision = \
+                int(template[LocalTemplateKey.REVISION])
+            curr_entity.entity.status.cni = \
                 _create_k8s_software_string(template[LocalTemplateKey.CNI],
                                             template[LocalTemplateKey.CNI_VERSION]) # noqa: E501
-            cluster_defined_entity.entity.status.kubernetes = \
+            curr_entity.entity.status.kubernetes = \
                 _create_k8s_software_string(template[LocalTemplateKey.KUBERNETES], # noqa: E501
                                             template[LocalTemplateKey.KUBERNETES_VERSION]) # noqa: E501
-            cluster_defined_entity.entity.status.docker_version = template[LocalTemplateKey.DOCKER_VERSION] # noqa: E501
-            cluster_defined_entity.entity.status.os = template[LocalTemplateKey.OS] # noqa: E501
-            self.entity_svc.update_entity(cluster_defined_entity.id, cluster_defined_entity) # noqa: E501
+            curr_entity.entity.status.docker_version = template[LocalTemplateKey.DOCKER_VERSION] # noqa: E501
+            curr_entity.entity.status.os = template[LocalTemplateKey.OS]
+            curr_entity.entity.status.phase = str(
+                DefEntityPhase(DefEntityOperation.UPGRADE,
+                               DefEntityOperationStatus.SUCCEEDED))
+            self.entity_svc.update_entity(curr_entity.id, curr_entity)
 
             msg = f"Successfully upgraded cluster '{cluster_name}' software " \
                   f"to match template {template_name} (revision " \
@@ -1065,6 +1074,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                   f"'{cluster_name}': {err}"
             LOGGER.error(msg, exc_info=True)
             self._update_task(vcd_client.TaskStatus.ERROR, error_message=msg)
+            self._fail_operation_and_resolve_entity(cluster_id,
+                                                    DefEntityOperation.UPGRADE)
         finally:
             self.context.end()
 

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -101,7 +101,7 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         :rtype: List[Dict]
         """
-        def_entity = self.entity_svc.get_entity(cluster_id)
+        curr_entity = self.entity_svc.get_entity(cluster_id)
 
         # TODO(DEF) design and implement telemetry VCDA-1564 defined entity
         #  based clusters
@@ -109,25 +109,24 @@ class ClusterService(abstract_broker.AbstractBroker):
         # cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
         # record_user_action_details(cse_operation=CseOperation.CLUSTER_UPGRADE_PLAN, cse_params=cse_params)  # noqa: E501
 
-        return self._get_cluster_upgrade_plan(def_entity.entity)
+        return self._get_cluster_upgrade_plan(curr_entity.entity.spec.k8_distribution.template_name, # noqa: E501
+                                              curr_entity.entity.spec.k8_distribution.template_revision) # noqa: E501
 
-    def _get_cluster_upgrade_plan(self,
-                                  cluster_entity: def_models.ClusterEntity) -> List[dict]: # noqa: E501
+    def _get_cluster_upgrade_plan(self, source_template_name,
+                                  source_template_revision) -> List[dict]: # noqa: E501
         """Get list of templates that a given cluster can upgrade to.
 
-        :param def_models.ClusterEntity cluster_entity: current cluster entity
+        :param str source_template_name:
+        :param str source_template_revision:
         :return: List of dictionary containing templates
         :rtype: List[dict]
         """
-        src_name = cluster_entity.spec.k8_distribution.template_name
-        src_rev = cluster_entity.spec.k8_distribution.template_revision
-
         upgrades = []
         config = utils.get_server_runtime_config()
         for t in config['broker']['templates']:
-            if src_name in t[LocalTemplateKey.UPGRADE_FROM]:
-                if t[LocalTemplateKey.NAME] == src_name and \
-                        int(t[LocalTemplateKey.REVISION]) <= int(src_rev):
+            if source_template_name in t[LocalTemplateKey.UPGRADE_FROM]:
+                if t[LocalTemplateKey.NAME] == source_template_name and \
+                        int(t[LocalTemplateKey.REVISION]) <= int(source_template_revision): # noqa: E501
                     continue
                 upgrades.append(t)
 
@@ -491,14 +490,24 @@ class ClusterService(abstract_broker.AbstractBroker):
         :param def_models.ClusterEntity upgrade_spec: cluster spec with new
             kubernetes distribution and revision
         """
-        def_entity = self.entity_svc.get_entity(cluster_id)
-        cluster_name = def_entity.entity.metadata.cluster_name
+        curr_entity = self.entity_svc.get_entity(cluster_id)
+        cluster_name = curr_entity.entity.metadata.cluster_name
         new_template_name = upgrade_spec.spec.k8_distribution.template_name
         new_template_revision = upgrade_spec.spec.k8_distribution.template_revision # noqa: E501
 
+        # check if cluster is in a valid state
+        phase: DefEntityPhase = DefEntityPhase.from_phase(
+            curr_entity.entity.status.phase)
+        state: str = curr_entity.state
+        if state != def_utils.DEF_RESOLVED_STATE or phase.is_entity_busy():
+        raise e.CseServerError(
+            f"Cluster {cluster_name} with id {cluster_id} is not in a "
+            f"valid state to be deleted. Please contact administrator.")
+
         # check that the specified template is a valid upgrade target
         template = {}
-        valid_templates = self._get_cluster_upgrade_plan(def_entity.entity)
+        valid_templates = self._get_cluster_upgrade_plan(curr_entity.entity.spec.k8_distribution.template_name, # noqa: E501
+                                                         curr_entity.entity.spec.k8_distribution.template_revision) # noqa: E501
 
         for t in valid_templates:
             if t[LocalTemplateKey.NAME] == new_template_name and \
@@ -514,7 +523,6 @@ class ClusterService(abstract_broker.AbstractBroker):
                 f"cluster '{cluster_name}'.")
 
         # get cluster data (including node names) to pass to async function
-        # cluster = self.get_cluster_info(data=validated_data, telemetry=False)
 
         # TODO(DEF) design and implement telemetry VCDA-1564 defined entity
         #  based clusters
@@ -522,16 +530,16 @@ class ClusterService(abstract_broker.AbstractBroker):
         msg = f"Upgrading cluster '{cluster_name}' " \
               f"software to match template {new_template_name} (revision " \
               f"{new_template_revision}): Kubernetes: " \
-              f"{def_entity.entity.status.kubernetes} -> " \
+              f"{curr_entity.entity.status.kubernetes} -> " \
               f"{template[LocalTemplateKey.KUBERNETES_VERSION]}, Docker-CE: " \
-              f"{def_entity.entity.status.docker_version} -> " \
+              f"{curr_entity.entity.status.docker_version} -> " \
               f"{template[LocalTemplateKey.DOCKER_VERSION]}, CNI: " \
-              f"{def_entity.entity.status.cni} -> " \
+              f"{curr_entity.entity.status.cni} -> " \
               f"{template[LocalTemplateKey.CNI_VERSION]}"
         self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
-        LOGGER.info(f"{msg} ({def_entity.externalId})")
+        LOGGER.info(f"{msg} ({curr_entity.externalId})")
         self.context.is_async = True
-        self._upgrade_cluster_async(cluster_defined_entity=def_entity,
+        self._upgrade_cluster_async(cluster_defined_entity=curr_entity,
                                     template=template)
 
         return {

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1026,7 +1026,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                 ClusterMetadataKey.CNI: template[LocalTemplateKey.CNI],
                 ClusterMetadataKey.CNI_VERSION: template[LocalTemplateKey.CNI_VERSION] # noqa: E501
             }
-            # vapp = vcd_vapp.VApp(self.context.client, href=vapp_href)
+
             task = cluster_vapp.set_multiple_metadata(metadata)
             self.context.client.get_task_monitor().wait_for_status(task)
 

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -93,54 +93,23 @@ class ClusterService(abstract_broker.AbstractBroker):
         # Gets external_id (vapp id) from entity
         # Gets to master node and gets the config
 
-    def get_cluster_upgrade_plan(self, **kwargs):
+    def get_cluster_upgrade_plan(self, cluster_id: str):
         """Get the template names/revisions that the cluster can upgrade to.
 
-        **data: Required
-            Required data: cluster_name
-            Optional data and default values: org_name=None, ovdc_name=None
-        **telemetry: Optional
-
+        :param str cluster_id:
         :return: A list of dictionaries with keys defined in LocalTemplateKey
 
         :rtype: List[Dict]
         """
-        # Yet to be implemented
-        raise NotImplementedError
-        data = kwargs[KwargKey.DATA]
-        required = [
-            RequestKey.CLUSTER_NAME
-        ]
-        defaults = {
-            RequestKey.ORG_NAME: None,
-            RequestKey.OVDC_NAME: None
-        }
-        validated_data = {**defaults, **data}
-        req_utils.validate_payload(validated_data, required)
+        def_entity = self.entity_svc.get_entity(cluster_id)
 
-        cluster = get_cluster(self.context.client,
-                              validated_data[RequestKey.CLUSTER_NAME],
-                              org_name=validated_data[RequestKey.ORG_NAME],
-                              ovdc_name=validated_data[RequestKey.OVDC_NAME])
+        # TODO(DEF) design and implement telemetry VCDA-1564 defined entity
+        #  based clusters
+        # cse_params = copy.deepcopy(validated_data)
+        # cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
+        # record_user_action_details(cse_operation=CseOperation.CLUSTER_UPGRADE_PLAN, cse_params=cse_params)  # noqa: E501
 
-        if kwargs.get(KwargKey.TELEMETRY, True):
-            # Record the telemetry data
-            cse_params = copy.deepcopy(validated_data)
-            cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
-            record_user_action_details(cse_operation=CseOperation.CLUSTER_UPGRADE_PLAN, cse_params=cse_params)  # noqa: E501
-
-        src_name = cluster['template_name']
-        src_rev = cluster['template_revision']
-
-        upgrades = []
-        config = utils.get_server_runtime_config()
-        for t in config['broker']['templates']:
-            if src_name in t[LocalTemplateKey.UPGRADE_FROM]:
-                if t[LocalTemplateKey.NAME] == src_name and int(t[LocalTemplateKey.REVISION]) <= int(src_rev): # noqa: E501
-                    continue
-                upgrades.append(t)
-
-        return upgrades
+        return self._get_cluster_upgrade_plan(def_entity.entity)
 
     def _get_cluster_upgrade_plan(self,
                                   cluster_entity: def_models.ClusterEntity) -> List[dict]: # noqa: E501
@@ -156,13 +125,13 @@ class ClusterService(abstract_broker.AbstractBroker):
         upgrades = []
         config = utils.get_server_runtime_config()
         for t in config['broker']['templates']:
-            if src_name in t[LocalTemplateKey.UPGRADE_FROM] \
-                    and t[LocalTemplateKey.NAME] != src_name \
-                    and int(t[LocalTemplateKey.REVISION]) > int(src_rev):
+            if src_name in t[LocalTemplateKey.UPGRADE_FROM]:
+                if t[LocalTemplateKey.NAME] == src_name and \
+                        int(t[LocalTemplateKey.REVISION]) <= int(src_rev):
+                    continue
                 upgrades.append(t)
 
         return upgrades
-
 
     def create_cluster(self, cluster_spec: def_models.ClusterEntity):
         """Start the cluster creation operation.
@@ -519,12 +488,11 @@ class ClusterService(abstract_broker.AbstractBroker):
         `result['task_href']` can be polled to get updates on task progress.
 
         :param str cluster_id: id of the cluster to be upgraded
-        :param cluster_spec def_models.ClusterEntity: cluster spec with new kubernetes distribution and revision
+        :param def_models.ClusterEntity upgrade_spec: cluster spec with new
+            kubernetes distribution and revision
         """
         def_entity = self.entity_svc.get_entity(cluster_id)
         cluster_name = def_entity.entity.metadata.cluster_name
-        current_template_name = def_entity.entity.spec.k8_distribution.template_name # noqa: E501
-        current_template_revision = def_entity.entity.spec.k8_distribution.template_revision # noqa: E501
         new_template_name = upgrade_spec.spec.k8_distribution.template_name
         new_template_revision = upgrade_spec.spec.k8_distribution.template_revision # noqa: E501
 
@@ -533,7 +501,8 @@ class ClusterService(abstract_broker.AbstractBroker):
         valid_templates = self._get_cluster_upgrade_plan(def_entity.entity)
 
         for t in valid_templates:
-            if t[LocalTemplateKey.NAME] == template_name and t[LocalTemplateKey.REVISION] == str(template_revision): # noqa: E501
+            if t[LocalTemplateKey.NAME] == new_template_name and \
+                    t[LocalTemplateKey.REVISION] == str(new_template_revision): # noqa: E501
                 template = t
                 break
         if not template:
@@ -553,16 +522,17 @@ class ClusterService(abstract_broker.AbstractBroker):
         msg = f"Upgrading cluster '{cluster_name}' " \
               f"software to match template {new_template_name} (revision " \
               f"{new_template_revision}): Kubernetes: " \
-              f"{def} -> " \
+              f"{def_entity.entity.status.kubernetes} -> " \
               f"{template[LocalTemplateKey.KUBERNETES_VERSION]}, Docker-CE: " \
-              f"{cluster['docker_version']} -> " \
+              f"{def_entity.entity.status.docker_version} -> " \
               f"{template[LocalTemplateKey.DOCKER_VERSION]}, CNI: " \
-              f"{cluster['cni']} {cluster['cni_version']} -> " \
+              f"{def_entity.entity.status.cni} -> " \
               f"{template[LocalTemplateKey.CNI_VERSION]}"
         self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
-        LOGGER.info(f"{msg} ({cluster['vapp_href']})")
+        LOGGER.info(f"{msg} ({def_entity.externalId})")
         self.context.is_async = True
-        self._upgrade_cluster_async(cluster=cluster, template=template)
+        self._upgrade_cluster_async(cluster_defined_entity=def_entity,
+                                    template=template)
 
         return {
             'cluster_name': cluster_name,
@@ -927,24 +897,32 @@ class ClusterService(abstract_broker.AbstractBroker):
 
     # all parameters following '*args' are required and keyword-only
     @utils.run_async
-    def _upgrade_cluster_async(self, *args, cluster, template):
+    def _upgrade_cluster_async(self, *args,
+                               cluster_defined_entity: def_models.DefEntity,
+                               template):
         try:
-            cluster_name = cluster['name']
-            master_node_names = [n['name'] for n in cluster['master_nodes']]
-            worker_node_names = [n['name'] for n in cluster['nodes']]
-            all_node_names = master_node_names + worker_node_names
-            vapp_href = cluster['vapp_href']
+            cluster_name = cluster_defined_entity.entity.metadata.cluster_name
+            vapp_href = cluster_defined_entity.externalId
+
+            # TODO use cluster status field to get the master and worker nodes
+            cluster_vapp = vcd_vapp.VApp(self.context.client, href=vapp_href)
+            all_node_names = [vm.get('name') for vm in cluster_vapp.get_all_vms()] # noqa: E501
+            master_node_names = [vm_name.startswith(NodeType.MASTER) for vm_name in all_node_names] # noqa: E501
+            worker_node_names = [vm_name.startswith(NodeType.WORKER) for vm_name in all_node_names] # noqa: E501
+
             template_name = template[LocalTemplateKey.NAME]
             template_revision = template[LocalTemplateKey.REVISION]
 
             # semantic version doesn't allow leading zeros
             # docker's version format YY.MM.patch allows us to directly use
             # lexicographical string comparison
-            c_docker = cluster['docker_version']
+            c_docker = cluster_defined_entity.entity.status.docker_version
             t_docker = template[LocalTemplateKey.DOCKER_VERSION]
-            c_k8s = semver.Version(cluster['kubernetes_version'])
+            k8s_details = cluster_defined_entity.entity.status.kubernetes.split(' ') # noqa: E501
+            c_k8s = semver.Version(k8s_details[1])
             t_k8s = semver.Version(template[LocalTemplateKey.KUBERNETES_VERSION]) # noqa: E501
-            c_cni = semver.Version(cluster['cni_version'])
+            cni_details = cluster_defined_entity.entity.status.cni.split(' ')
+            c_cni = semver.Version(cni_details[1])
             t_cni = semver.Version(template[LocalTemplateKey.CNI_VERSION])
 
             upgrade_docker = t_docker > c_docker
@@ -1020,8 +998,9 @@ class ClusterService(abstract_broker.AbstractBroker):
                                     all_node_names, script)
 
             if upgrade_cni:
-                msg = f"Applying CNI ({cluster['cni']} {c_cni} -> {t_cni}) " \
-                      f"in master node {master_node_names}"
+                msg = "Applying CNI " \
+                      f"({cluster_defined_entity.entity.status.cni} " \
+                      f"-> {t_cni}) in master node {master_node_names}"
                 self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
                 filepath = ltm.get_script_filepath(template_name,
                                                    template_revision,
@@ -1047,9 +1026,24 @@ class ClusterService(abstract_broker.AbstractBroker):
                 ClusterMetadataKey.CNI: template[LocalTemplateKey.CNI],
                 ClusterMetadataKey.CNI_VERSION: template[LocalTemplateKey.CNI_VERSION] # noqa: E501
             }
-            vapp = vcd_vapp.VApp(self.context.client, href=vapp_href)
-            task = vapp.set_multiple_metadata(metadata)
+            # vapp = vcd_vapp.VApp(self.context.client, href=vapp_href)
+            task = cluster_vapp.set_multiple_metadata(metadata)
             self.context.client.get_task_monitor().wait_for_status(task)
+
+            # update defined entity of the cluster
+            cluster_defined_entity.entity.spec.k8_distribution.template_name = \
+                template[LocalTemplateKey.NAME] # noqa: E501
+            cluster_defined_entity.entity.spec.k8_distribution.template_revision = \
+                int(template[LocalTemplateKey.REVISION]) # noqa: E501
+            cluster_defined_entity.entity.status.cni = \
+                _create_k8s_software_string(template[LocalTemplateKey.CNI],
+                                            template[LocalTemplateKey.CNI_VERSION]) # noqa: E501
+            cluster_defined_entity.entity.status.kubernetes = \
+                _create_k8s_software_string(template[LocalTemplateKey.KUBERNETES], # noqa: E501
+                                            template[LocalTemplateKey.KUBERNETES_VERSION]) # noqa: E501
+            cluster_defined_entity.entity.status.docker_version = template[LocalTemplateKey.DOCKER_VERSION] # noqa: E501
+            cluster_defined_entity.entity.status.os = template[LocalTemplateKey.OS] # noqa: E501
+            self.entity_svc.update_entity(cluster_defined_entity.id, cluster_defined_entity) # noqa: E501
 
             msg = f"Successfully upgraded cluster '{cluster_name}' software " \
                   f"to match template {template_name} (revision " \

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -99,8 +99,6 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
 def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade-plan operation.
 
-    data validation handled in broker
-
     :return: List[Tuple(str, str)]
     """
     svc = cluster_svc.ClusterService(op_ctx)

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -110,16 +110,17 @@ def cluster_upgrade_plan(request_data, op_ctx: ctx.OperationContext):
 
 @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE)
 @request_utils.v35_api_exception_handler
-def cluster_upgrade(request_data, op_ctx: ctx.OperationContext):
+def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade operation.
 
     data validation handled in broker
 
     :return: Dict
     """
-    raise NotImplementedError
     svc = cluster_svc.ClusterService(op_ctx)
-    return svc.upgrade_cluster(data=request_data)
+    cluster_entity_spec = def_models.ClusterEntity(**data[RequestKey.V35_SPEC])
+    cluster_id = data[RequestKey.CLUSTER_ID]
+    return svc.upgrade_cluster(cluster_id, cluster_entity_spec)
 
 
 @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_LIST)

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -96,16 +96,15 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
 
 @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE_PLAN)  # noqa: E501
 @request_utils.v35_api_exception_handler
-def cluster_upgrade_plan(request_data, op_ctx: ctx.OperationContext):
+def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade-plan operation.
 
     data validation handled in broker
 
     :return: List[Tuple(str, str)]
     """
-    raise NotImplementedError
     svc = cluster_svc.ClusterService(op_ctx)
-    return svc.get_cluster_upgrade_plan(data=request_data)
+    return svc.get_cluster_upgrade_plan(data[RequestKey.CLUSTER_ID])
 
 
 @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE)


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

Change upgrade cluster to update defined entities.

- Change cluster handler to parse in cluster spec for update-cluster and upgrade plan
- Use defined entity in the update operation

Testing done:
- create a cluster using postman for api v 35 and 10.2 vcd. Update the cluster using the endpoint.

@sahithi @rocknes @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/635)
<!-- Reviewable:end -->
