### PR TITLE
VCDA-1589 Implemennt cluster-delete new endpoint.

### DIFF
--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -647,10 +647,14 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         :rtype: DefEntity
         """
+        curr_entity: def_models.DefEntity = self.entity_svc.get_entity(
+            cluster_id)  # noqa: E501
         cluster_name = cluster_spec.metadata.cluster_name
         worker_count = cluster_spec.spec.workers.count
-        template_name = cluster_spec.spec.k8_distribution.template_name
-        template_revision = cluster_spec.spec.k8_distribution.template_revision  # noqa: E501
+
+        # Resize using the template with which cluster was originally created.
+        template_name = curr_entity.entity.spec.k8_distribution.template_name
+        template_revision = curr_entity.entity.spec.k8_distribution.template_revision  #
 
         # check that requested/default template is valid
         get_template(name=template_name, revision=template_revision)
@@ -749,21 +753,24 @@ class ClusterService(abstract_broker.AbstractBroker):
                             cluster_spec: def_models.ClusterEntity):
         try:
             cluster_id = cluster_id
-            curr_entity: def_models.DefEntity = self.entity_svc.get_entity(cluster_id)  # noqa: E501
+            curr_entity: def_models.DefEntity = self.entity_svc.get_entity(
+                cluster_id)  # noqa: E501
             vapp_href = curr_entity.externalId
-            cluster_name = cluster_spec.metadata.cluster_name
-            org_name = cluster_spec.metadata.org_name
-            ovdc_name = cluster_spec.metadata.ovdc_name
+            cluster_name = curr_entity.entity.metadata.cluster_name
+            org_name = curr_entity.entity.metadata.org_name
+            ovdc_name = curr_entity.entity.metadata.ovdc_name
             num_workers = cluster_spec.spec.workers.count
             worker_storage_profile = cluster_spec.spec.workers.storage_profile  # noqa: E501
             worker_sizing_class = cluster_spec.spec.workers.sizing_class
             network_name = cluster_spec.spec.settings.network
-            template_name = cluster_spec.spec.k8_distribution.template_name
-            template_revision = cluster_spec.spec.k8_distribution.template_revision  # noqa: E501
-            template = get_template(template_name, template_revision)
             ssh_key = cluster_spec.spec.settings.ssh_key
             rollback = cluster_spec.spec.settings.rollback_on_failure
             enable_nfs = cluster_spec.spec.settings.enable_nfs
+
+            # Use the template with which cluster was originally created.
+            template_name = curr_entity.entity.spec.k8_distribution.template_name  # noqa: E501
+            template_revision = curr_entity.entity.spec.k8_distribution.template_revision  # noqa: E501
+            template = get_template(template_name, template_revision)
 
             server_config = utils.get_server_runtime_config()
             catalog_name = server_config['broker']['catalog']

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -415,7 +415,6 @@ class ClusterService(abstract_broker.AbstractBroker):
         # Get the existing defined entity for the given cluster id
         curr_entity: def_models.DefEntity = self.entity_svc.get_entity(cluster_id)  # noqa: E501
         name: str = curr_entity.name
-        kind: str = curr_entity.entity.kind
         curr_worker_count: int = curr_entity.entity.spec.workers.count
         state: str = curr_entity.state
         phase: DefEntityPhase = DefEntityPhase.from_phase(
@@ -458,8 +457,6 @@ class ClusterService(abstract_broker.AbstractBroker):
         state: str = curr_entity.state
         phase: DefEntityPhase = DefEntityPhase.from_phase(
             curr_entity.entity.status.phase)
-        org_name = curr_entity.entity.metadata.org_name
-        ovdc_name = curr_entity.entity.metadata.ovdc_name
 
         # Check if cluster is in a valid state
         if state != def_utils.DEF_RESOLVED_STATE or phase.is_entity_busy():
@@ -652,7 +649,7 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         # Resize using the template with which cluster was originally created.
         template_name = curr_entity.entity.spec.k8_distribution.template_name
-        template_revision = curr_entity.entity.spec.k8_distribution.template_revision  #
+        template_revision = curr_entity.entity.spec.k8_distribution.template_revision  # noqa: E501
 
         # check that requested/default template is valid
         get_template(name=template_name, revision=template_revision)

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -481,9 +481,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                            DefEntityOperationStatus.IN_PROGRESS))
         curr_entity = self.entity_svc.update_entity(cluster_id, curr_entity)
         self.context.is_async = True
-        self._delete_cluster_async(cluster_id=cluster_id,
-                                   cluster_vdc_href=self._get_vdc_href(
-                                       org_name, ovdc_name))
+        self._delete_cluster_async(cluster_id=cluster_id)
         return curr_entity
 
     def _get_vdc_href(self, org_name, ovdc_name):
@@ -900,11 +898,14 @@ class ClusterService(abstract_broker.AbstractBroker):
             self.context.end()
 
     @utils.run_async
-    def _delete_cluster_async(self, cluster_id, cluster_vdc_href):
+    def _delete_cluster_async(self, cluster_id):
         try:
             curr_entity: def_models.DefEntity = self.entity_svc.get_entity(
                 cluster_id)
             cluster_name = curr_entity.name
+            org_name = curr_entity.entity.metadata.org_name
+            ovdc_name = curr_entity.entity.metadata.ovdc_name
+            cluster_vdc_href = self._get_vdc_href(org_name, ovdc_name)
             msg = f"Deleting cluster '{cluster_name}'"
             self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
             _delete_vapp(self.context.client, cluster_vdc_href, cluster_name)

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -421,10 +421,6 @@ class ClusterService(abstract_broker.AbstractBroker):
         phase: DefEntityPhase = DefEntityPhase.from_phase(
             curr_entity.entity.status.phase)
 
-        # Check if entity is of kind native.
-        if kind == def_utils.ClusterEntityKind.TKG.value:
-            raise e.CseServerError(f"CSE cannot resize an entity of type {kind}")  # noqa: E501
-
         # Check if cluster is in a valid state
         if state != def_utils.DEF_RESOLVED_STATE or phase.is_entity_busy():
             raise e.CseServerError(
@@ -459,17 +455,11 @@ class ClusterService(abstract_broker.AbstractBroker):
         curr_entity: def_models.DefEntity = self.entity_svc.get_entity(
             cluster_id)
         cluster_name: str = curr_entity.name
-        kind: str = curr_entity.entity.kind
         state: str = curr_entity.state
         phase: DefEntityPhase = DefEntityPhase.from_phase(
             curr_entity.entity.status.phase)
         org_name = curr_entity.entity.metadata.org_name
         ovdc_name = curr_entity.entity.metadata.ovdc_name
-
-        # Check if entity is of kind native.
-        if kind == def_utils.ClusterEntityKind.TKG.value:
-            raise e.CseServerError(
-                f"CSE cannot delete an entity of type {kind}")  # noqa: E501
 
         # Check if cluster is in a valid state
         if state != def_utils.DEF_RESOLVED_STATE or phase.is_entity_busy():

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -33,14 +33,8 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
 def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster resize operation.
 
-    Required data: cluster_name, num_nodes
-    Optional data and default values: org_name=None, ovdc_name=None
-    Conditional data and default values:
-            network_name, rollback=True
-
-    (data validation handled in broker)
-
-    :return: Dict
+    :return: Defined entity of the native cluster
+    :rtype: container_service_extension.def_.models.DefEntity
     """
     svc = cluster_svc.ClusterService(op_ctx)
     cluster_id = data[RequestKey.CLUSTER_ID]
@@ -60,7 +54,6 @@ def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
 
     :return: Dict
     """
-    raise NotImplementedError
     svc = cluster_svc.ClusterService(op_ctx)
     cluster_id = data[RequestKey.CLUSTER_ID]
     return svc.delete_cluster(cluster_id)

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -282,12 +282,12 @@ def _get_url_data(method, url):
     tokens = url.split('/')
     num_tokens = len(tokens)
 
+    if num_tokens < 4:
+        raise cse_exception.NotFoundRequestError()
+
     is_v35_request = utils.is_v35_supported_by_cse_server() and _is_v35_endpoint(url)  # noqa: E501
     if is_v35_request:
         return _get_v35_cluster_url_data(method, url)
-
-    if num_tokens < 4:
-        raise cse_exception.NotFoundRequestError()
 
     if tokens[2] == PKS_SERVICE_NAME:
         return _get_pks_url_data(method, url)

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -148,3 +148,9 @@ class DefEntityPhase:
             return self.status == DefEntityOperationStatus.SUCCEEDED
         except Exception:
             return False
+
+    def is_entity_busy(self) -> bool:
+        try:
+            return self.status == DefEntityOperationStatus.IN_PROGRESS
+        except Exception:
+            return False

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -150,7 +150,5 @@ class DefEntityPhase:
             return False
 
     def is_entity_busy(self) -> bool:
-        try:
-            return self.status == DefEntityOperationStatus.IN_PROGRESS
-        except Exception:
-            return False
+        return self.status == DefEntityOperationStatus.IN_PROGRESS
+

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -151,4 +151,3 @@ class DefEntityPhase:
 
     def is_entity_busy(self) -> bool:
         return self.status == DefEntityOperationStatus.IN_PROGRESS
-


### PR DESCRIPTION
1. Implemented Delete cluster operation for new v35 endpoint.

Other fixes:
1. Replaced compute-intensive _get_cluster()_ with _get_native_entity_by_name()_ to check if cluster already exists in _create_cluster_ operation.
2. Fixed index out of range exception in _request_processor.py_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/636)
<!-- Reviewable:end -->
