### PR TITLE
Remove operation context from compute policy manager

### DIFF
--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -774,8 +774,6 @@ class ComputePolicyManager:
         :param lxml.objectify.Element task_resource: Task resource for
             the umbrella task
         """
-        org = vcd_utils.get_org(self._sysadmin_client)
-        org.reload()
         user_name = task_resource.User.get('name')
         user_href = task_resource.User.get('href')
         org_href = task_resource.Organization.get('href')
@@ -797,7 +795,7 @@ class ComputePolicyManager:
                 owner_type=vcd_client.EntityType.VDC.value,
                 user_href=user_href,
                 user_name=user_name,
-                org_href=org.href)
+                org_href=org_href)
         task_href = task_resource.get('href')
 
         try:
@@ -847,8 +845,7 @@ class ComputePolicyManager:
                     user_href=user_href,
                     user_name=user_name,
                     task_href=task_href,
-                    org_href=org.href,
-                )
+                    org_href=org_href)
 
                 task_monitor = self._sysadmin_client.get_task_monitor()
                 for vm_resource in target_vms:
@@ -880,8 +877,7 @@ class ComputePolicyManager:
                         user_href=user_href,
                         user_name=user_name,
                         task_href=task_href,
-                        org_href=org.href,
-                    )
+                        org_href=org_href)
                     task_monitor.wait_for_success(_task)
             final_status = vcd_client.TaskStatus.RUNNING.value \
                 if is_umbrella_task else vcd_client.TaskStatus.SUCCESS.value
@@ -899,8 +895,7 @@ class ComputePolicyManager:
                 user_href=user_href,
                 user_name=user_name,
                 task_href=task_href,
-                org_href=org.href,
-            )
+                org_href=org_href)
 
             vdc.remove_compute_policy(compute_policy_href)
         except Exception as err:
@@ -920,7 +915,7 @@ class ComputePolicyManager:
                     user_href=user_href,
                     user_name=self._session.get('user'),
                     task_href=task_href,
-                    org_href=org.href,
+                    org_href=org_href,
                     error_message=f"{err}",
                     stack_trace='')
 

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -13,7 +13,6 @@ import requests
 import container_service_extension.cloudapi.constants as cloudapi_constants
 import container_service_extension.exceptions as cse_exceptions
 import container_service_extension.logger as logger
-import container_service_extension.operation_context as ctx
 import container_service_extension.pyvcloud_utils as vcd_utils
 from container_service_extension.shared_constants import RequestMethod
 import container_service_extension.utils as utils
@@ -395,7 +394,7 @@ class ComputePolicyManager:
             'isSizingOnly': 'false',
             'name': f'{cloudapi_constants.CSE_COMPUTE_POLICY_PREFIX}*'
         }
-        self.list_compute_policies_on_vdc(vdc_id, filters=filters)
+        return self.list_compute_policies_on_vdc(vdc_id, filters=filters)
 
     def list_vdc_sizing_policies_on_vdc(self, vdc_id):
         """List all sizing policies created by CSE and assigned to a given vdc.
@@ -414,7 +413,7 @@ class ComputePolicyManager:
             'isSizingOnly': 'true',
             'name': f'{cloudapi_constants.CSE_COMPUTE_POLICY_PREFIX}*'
         }
-        self.list_compute_policies_on_vdc(vdc_id, filters=filters)
+        return self.list_compute_policies_on_vdc(vdc_id, filters=filters)
 
     def list_compute_policies_on_vdc(self, vdc_id, filters=None):
         """List all compute policies currently assigned to a given vdc.
@@ -433,10 +432,6 @@ class ComputePolicyManager:
         filter_string = ""
         if filters:
             filter_string = ";".join([f"{key}=={value}" for (key, value) in filters.items()]) # noqa: E501
-        response_body = self._cloudapi_client.do_request(
-            method=RequestMethod.GET,
-            cloudapi_version=cloudapi_constants.CLOUDAPI_VERSION_1_0_0,
-            resource_url_relative_path=relative_path)
         page_num = 0
         while True:
             page_num += 1
@@ -630,7 +625,33 @@ class ComputePolicyManager:
         """
         return f"{cloudapi_constants.CLOUDAPI_URN_PREFIX}:vdc:{vdc_id}"
 
-    def remove_vdc_compute_policy_from_vdc(self, op_ctx: ctx.OperationContext, # noqa: E501
+    def _get_vm_placement_policy_id(self, vm) -> str:
+        """Obtain VM's placement policy id if present.
+
+        :param lxml.objectify.ObjectifiedElement vm: VM object
+
+        :return: placement policy id of the vm
+        :rtype: str
+        """
+        if hasattr(vm, 'ComputePolicy') and \
+            hasattr(vm.ComputePolicy, 'VmPlacementPolicy') and \
+                vm.ComputePolicy.VmPlacementPolicy.get('id'):
+            return vm.ComputePolicy.VmPlacementPolicy.get('id')
+
+    def _get_vm_sizing_policy_id(self, vm) -> str:
+        """Obtain VM's sizing policy id if present.
+
+        :param lxml.objectify.ObjectifiedElement vm: VM object
+
+        :return: sizing policy id of the vm
+        :rtype: str
+        """
+        if hasattr(vm, 'ComputePolicy') and \
+            hasattr(vm.ComputePolicy, 'VmSizingPolicy') and \
+                vm.ComputePolicy.VmPSizingPolicy.get('id'):
+            return vm.ComputePolicy.VmSizingPolicy.get('id')
+
+    def remove_vdc_compute_policy_from_vdc(self, # noqa: E501
                                            ovdc_id,
                                            compute_policy_href,
                                            remove_compute_policy_from_vms=False): # noqa: E501
@@ -638,7 +659,7 @@ class ComputePolicyManager:
 
         Note: The VDC compute policy need not be created by CSE.
 
-        :param op_ctx: request context of remove compute policy
+        :param op_ctx: operation context of remove compute policy
             request
         :param str ovdc_id: id of the vdc to assign the policy
         :param compute_policy_href: policy href to remove
@@ -647,7 +668,7 @@ class ComputePolicyManager:
 
         :return: dictionary containing 'task_href'.
         """
-        # TODO find an efficient way without passing in request context
+        # TODO find an efficient way without passing in operation context
         vdc = vcd_utils.get_vdc(self._sysadmin_client, vdc_id=ovdc_id)
 
         org = vcd_utils.get_org(self._sysadmin_client)
@@ -672,15 +693,13 @@ class ComputePolicyManager:
             org_href=org.href)
 
         task_href = task_resource.get('href')
-        op_ctx.is_async = True
         self._remove_compute_policy_from_vdc_async(
-            op_ctx=op_ctx,
+            ovdc_id=ovdc_id,
+            compute_policy_href=compute_policy_href,
             task=task,
             task_href=task_href,
             user_href=user_href,
             org_href=org.href,
-            ovdc_id=ovdc_id,
-            compute_policy_href=compute_policy_href,
             remove_compute_policy_from_vms=remove_compute_policy_from_vms)
 
         return {
@@ -689,46 +708,106 @@ class ComputePolicyManager:
 
     @utils.run_async
     def _remove_compute_policy_from_vdc_async(self, *args,
-                                              op_ctx: ctx.OperationContext, # noqa: E501
+                                              ovdc_id,
+                                              compute_policy_href,
                                               task,
                                               task_href,
                                               user_href,
                                               org_href,
-                                              ovdc_id,
-                                              compute_policy_href,
                                               remove_compute_policy_from_vms):
-        user_name = self._session.get('user')
         vdc = vcd_utils.get_vdc(self._sysadmin_client, vdc_id=ovdc_id,
                                 is_admin_operation=True)
         try:
-            if remove_compute_policy_from_vms:
-                cp_list = self.list_compute_policies_on_vdc(ovdc_id)
-                system_default_href = None
-                for cp_dict in cp_list:
-                    if cp_dict['name'] == _SYSTEM_DEFAULT_COMPUTE_POLICY:
-                        system_default_href = cp_dict['href']
-                if system_default_href is None:
-                    raise EntityNotFoundException(
-                        f"Error: {_SYSTEM_DEFAULT_COMPUTE_POLICY} "
-                        f"compute policy not found")
+            self.remove_compute_policy_from_vdc(
+                vdc=vdc,
+                compute_policy_href=compute_policy_href,
+                task=task,
+                task_href=task_href,
+                remove_compute_policy_from_vms=remove_compute_policy_from_vms)
 
+            task.update(
+                status=vcd_client.TaskStatus.SUCCESS.value,
+                namespace='vcloud.cse',
+                operation=f"Removed compute policy (href: "
+                          f"{compute_policy_href}) from org VDC '{vdc.name}'",  # noqa: E501
+                operation_name='Updating VDC',
+                details='',
+                progress=None,
+                owner_href=vdc.href,
+                owner_name=vdc.name,
+                owner_type=vcd_client.EntityType.VDC.value,
+                user_href=user_href,
+                user_name=self._session.get('user'),
+                task_href=task_href,
+                org_href=org_href,
+            )
+        except Exception as err:
+            msg = f'Failed to remove compute policy: {err}'
+            logger.SERVER_LOGGER.error(msg)# noqa: E501
+            task.update(
+                status=vcd_client.TaskStatus.ERROR.value,
+                namespace='vcloud.cse',
+                operation=msg,
+                operation_name='Remove org VDC compute policy',
+                details='',
+                progress=None,
+                owner_href=vdc.href,
+                owner_name=vdc.name,
+                owner_type=vcd_client.EntityType.VDC.value,
+                user_href=user_href,
+                user_name=self._session.get('user'),
+                task_href=task_href,
+                org_href=org_href,
+                error_message=f"{err}",
+                stack_trace='')
+
+    # TODO Create task if necessary
+    def remove_compute_policy_from_vdc(self,
+                                       vdc, compute_policy_href,
+                                       task, task_href,
+                                       remove_compute_policy_from_vms=False,
+                                       is_placement_policy=False):
+        org = vcd_utils.get_org(self._sysadmin_client)
+        org.reload()
+        user_name = self._session.get('user')
+        user_href = org.get_user(user_name).get('href')
+        try:
+            if remove_compute_policy_from_vms:
                 compute_policy_id = retrieve_compute_policy_id_from_href(compute_policy_href) # noqa: E501
                 vapps = vcd_utils.get_all_vapps_in_ovdc(self._sysadmin_client,
-                                                        ovdc_id)
+                                                        vdc.id)
                 target_vms = []
-                for vapp in vapps:
-                    vm_resources = vapp.get_all_vms()
-                    for vm_resource in vm_resources:
-                        if vm_resource.VdcComputePolicy.get('id') == compute_policy_id: # noqa: E501
-                            target_vms.append(vm_resource)
-                vm_names = [vm.get('name') for vm in target_vms]
+                system_default_href = None
+                operation_msg = None
+                if is_placement_policy:
+                    for vapp in vapps:
+                        target_vms += \
+                            [vm for vm in vapp.get_all_vms()
+                                if self._get_vm_placement_policy_id(vm) == compute_policy_id] # noqa: E501
+                    vm_names = [vm.get('name') for vm in target_vms]
+                    operation_msg = f"Removing placement policy from " \
+                                    f"{len(vm_names)} VMs. " \
+                                    f"Affected VMs: {vm_names}"
+                else:
+                    for vapp in vapps:
+                        target_vms += \
+                            [vm for vm in vapp.get_all_vms()
+                                if self._get_vm_sizing_policy_id(vm) == compute_policy_id] # noqa: E501
+                    vm_names = [vm.get('name') for vm in target_vms]
+                    filter_by_name = {'name': _SYSTEM_DEFAULT_COMPUTE_POLICY}
+                    for cp_dict in self.list_compute_policies_on_vdc(vdc.id,
+                                                                     filters=filter_by_name):  # noqa: E501
+                        system_default_href = cp_dict['href']
+                        break
+                    operation_msg = "Setting sizing policy to " \
+                                    f"'{_SYSTEM_DEFAULT_COMPUTE_POLICY}' on " \
+                                    f"{len(vm_names)} VMs. " \
+                                    f"Affected VMs: {vm_names}"
 
                 task.update(
                     status=vcd_client.TaskStatus.RUNNING.value,
                     namespace='vcloud.cse',
-                    operation=f"Setting compute policy to "
-                              f"'{_SYSTEM_DEFAULT_COMPUTE_POLICY}' on "
-                              f"{len(vm_names)} affected VMs: {vm_names}",
+                    operation=operation_msg,
                     operation_name='Remove org VDC compute policy',
                     details='',
                     progress=None,
@@ -738,21 +817,30 @@ class ComputePolicyManager:
                     user_href=user_href,
                     user_name=user_name,
                     task_href=task_href,
-                    org_href=org_href,
+                    org_href=org.href,
                 )
 
                 task_monitor = self._sysadmin_client.get_task_monitor()
                 for vm_resource in target_vms:
                     vm = VM(self._sysadmin_client,
                             href=vm_resource.get('href'))
-                    _task = vm.update_compute_policy(system_default_href)
+                    _task = None
+                    operation_msg = None
+                    if is_placement_policy:
+                        _task = vm.remove_placement_policy()
+                        operation_msg = "Removing placement policy on VM " \
+                                        f"'{vm_resource.get('name')}'"
+                    else:
+                        _task = vm.update_compute_policy(
+                            compute_policy_href=system_default_href)
+                        operation_msg = "Setting compute policy to " \
+                                        f"'{_SYSTEM_DEFAULT_COMPUTE_POLICY}' "\
+                                        f"on VM '{vm_resource.get('name')}'"
 
                     task.update(
                         status=vcd_client.TaskStatus.RUNNING.value,
                         namespace='vcloud.cse',
-                        operation=f"Setting compute policy to "
-                                  f"'{_SYSTEM_DEFAULT_COMPUTE_POLICY}' on VM "
-                                  f"'{vm_resource.get('name')}'",
+                        operation=operation_msg,
                         operation_name='Remove org VDC compute policy',
                         details='',
                         progress=None,
@@ -762,10 +850,9 @@ class ComputePolicyManager:
                         user_href=user_href,
                         user_name=user_name,
                         task_href=task_href,
-                        org_href=org_href,
+                        org_href=org.href,
                     )
                     task_monitor.wait_for_success(_task)
-
             task.update(
                 status=vcd_client.TaskStatus.RUNNING.value,
                 namespace='vcloud.cse',
@@ -780,44 +867,10 @@ class ComputePolicyManager:
                 user_href=user_href,
                 user_name=user_name,
                 task_href=task_href,
-                org_href=org_href,
+                org_href=org.href,
             )
 
             vdc.remove_compute_policy(compute_policy_href)
-
-            task.update(
-                status=vcd_client.TaskStatus.SUCCESS.value,
-                namespace='vcloud.cse',
-                operation=f"Removed compute policy (href: "
-                          f"{compute_policy_href}) from org VDC '{vdc.name}'",
-                operation_name='Updating VDC',
-                details='',
-                progress=None,
-                owner_href=vdc.href,
-                owner_name=vdc.name,
-                owner_type=vcd_client.EntityType.VDC.value,
-                user_href=user_href,
-                user_name=user_name,
-                task_href=task_href,
-                org_href=org_href,
-            )
         except Exception as err:
             logger.SERVER_LOGGER.error(err, exc_info=True)
-            task.update(
-                status=vcd_client.TaskStatus.ERROR.value,
-                namespace='vcloud.cse',
-                operation='',
-                operation_name='Remove org VDC compute policy',
-                details='',
-                progress=None,
-                owner_href=vdc.href,
-                owner_name=vdc.name,
-                owner_type=vcd_client.EntityType.VDC.value,
-                user_href=user_href,
-                user_name=user_name,
-                task_href=task_href,
-                org_href=org_href,
-                error_message=f"{err}")
-        finally:
-            if op_ctx.sysadmin_client:
-                op_ctx.end()
+            raise err

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -312,7 +312,7 @@ def ovdc_compute_policy_update(request_data,
             response = cpm.remove_vdc_compute_policy_from_vdc(
                 ovdc_id,
                 cp_href,
-                remove_compute_policy_from_vms=remove_compute_policy_from_vms)
+                force=remove_compute_policy_from_vms)
             # Follow task_href to completion in a different thread and end
             # operation context
             _follow_task(op_ctx, response['task_href'], ovdc_id)

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -343,6 +343,7 @@ def _follow_task(op_ctx: ctx.OperationContext, task_href: str, ovdc_id: str):
         user_name = session.get('user')
         user_href = org.get_user(user_name).get('href')
         msg = "Remove ovdc compute policy"
+        # TODO(pyvcloud): Add method to retireve task from task href
         t = task.update(
             status=vcd_task.TaskStatus.RUNNING.value,
             namespace='vcloud.cse',

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -6,14 +6,17 @@ import copy
 import pyvcloud.vcd.client as vcd_client
 import pyvcloud.vcd.exceptions as vcd_e
 import pyvcloud.vcd.org as vcd_org
+import pyvcloud.vcd.task as vcd_task
 import pyvcloud.vcd.utils as pyvcd_utils
 
 import container_service_extension.compute_policy_manager as compute_policy_manager # noqa: E501
 import container_service_extension.exceptions as e
+import container_service_extension.logger as logger
 import container_service_extension.operation_context as ctx
 import container_service_extension.ovdc_utils as ovdc_utils
 import container_service_extension.pksbroker as pksbroker
 import container_service_extension.pksbroker_manager as pksbroker_manager
+import container_service_extension.pyvcloud_utils as vcd_utils
 import container_service_extension.request_handlers.request_utils as req_utils
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProvider
@@ -305,19 +308,22 @@ def ovdc_compute_policy_update(request_data,
             # TODO: fix remove_compute_policy by implementing a proper way
             # for calling async methods without having to pass op_ctx
             # outside handlers.
-            task_href = cpm.remove_vdc_compute_policy_from_vdc(
-                op_ctx,
+            op_ctx.is_async = True
+            response = cpm.remove_vdc_compute_policy_from_vdc(
                 ovdc_id,
                 cp_href,
                 remove_compute_policy_from_vms=remove_compute_policy_from_vms)
+            # Follow task_href to completion in a different thread and end
+            # operation context
+            _follow_task(op_ctx, response['task_href'], ovdc_id)
             # Record telemetry data
             record_user_action(CseOperation.OVDC_COMPUTE_POLICY_REMOVE)
-            return task_href
+            return response
 
         raise e.BadRequestError("Unsupported compute policy action")
 
     except Exception as err:
-        # Record telemetry data failure
+        # Record telemetry data failure`
         if action == ComputePolicyAction.ADD:
             record_user_action(CseOperation.OVDC_COMPUTE_POLICY_ADD,
                                status=OperationStatus.FAILED)
@@ -325,3 +331,35 @@ def ovdc_compute_policy_update(request_data,
             record_user_action(CseOperation.OVDC_COMPUTE_POLICY_REMOVE,
                                status=OperationStatus.FAILED)
         raise err
+
+
+@utils.run_async
+def _follow_task(op_ctx: ctx.OperationContext, task_href: str, ovdc_id: str):
+    try:
+        task = vcd_task.Task(client=op_ctx.sysadmin_client)
+        session = op_ctx.sysadmin_client.get_vcloud_session()
+        vdc = vcd_utils.get_vdc(op_ctx.sysadmin_client, vdc_id=ovdc_id)
+        org = vcd_utils.get_org(op_ctx.sysadmin_client)
+        user_name = session.get('user')
+        user_href = org.get_user(user_name).get('href')
+        msg = "Remove ovdc compute policy"
+        t = task.update(
+            status=vcd_task.TaskStatus.RUNNING.value,
+            namespace='vcloud.cse',
+            operation=msg,
+            operation_name=msg,
+            details='',
+            progress=None,
+            owner_href=vdc.href,
+            owner_name=vdc.name,
+            owner_type=vcd_client.EntityType.VDC.value,
+            user_href=user_href,
+            user_name=user_name,
+            org_href=op_ctx.user.org_href,
+            task_href=task_href)
+        op_ctx.sysadmin_client.get_task_monitor().wait_for_status(t)
+    except Exception as err:
+        logger.SERVER_LOGGER.error(f"{err}")
+    finally:
+        if op_ctx.sysadmin_client:
+            op_ctx.end()


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

- Having operation context in compute policy manager reduces flexibility of use.

- Ovdc_handler will follow the task that compute policy manager create (for removing compute policy from vdc) and ends operation context in a separate thread.

@rocknes @sahithi @andrew-ni @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/637)
<!-- Reviewable:end -->
