### PR TITLE
[VCDA-1580] Move to pre-defined kubernetes interface

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -527,7 +527,7 @@ def _register_def_schema(client: Client,
         defKey = def_utils.DefKey
         kubernetes_interface = def_models.\
             DefInterface(name=keys_map[defKey.INTERFACE_NAME],
-                         vendor=keys_map[defKey.VMWARE_VENDOR],
+                         vendor=keys_map[defKey.INTERFACE_VENDOR],
                          nss=keys_map[defKey.INTERFACE_NSS],
                          version=keys_map[defKey.INTERFACE_VERSION], # noqa: E501
                          readonly=False)
@@ -547,7 +547,7 @@ def _register_def_schema(client: Client,
         native_entity_type = def_models.\
             DefEntityType(name=keys_map[defKey.ENTITY_TYPE_NAME],
                           description='',
-                          vendor=keys_map[defKey.VENDOR],
+                          vendor=keys_map[defKey.ENTITY_TYPE_VENDOR],
                           nss=keys_map[defKey.ENTITY_TYPE_NSS],
                           version=keys_map[defKey.ENTITY_TYPE_VERSION],
                           schema=json.load(schema_file),

--- a/container_service_extension/def_/entity_service.py
+++ b/container_service_extension/def_/entity_service.py
@@ -273,7 +273,7 @@ class DefEntityService():
         schema_svc = def_schema_svc.DefSchemaService(self._cloudapi_client)
         keys_map = def_utils.MAP_API_VERSION_TO_KEYS[float(self._cloudapi_client.get_api_version())]  # noqa: E501
         entity_type_id = def_utils.generate_entity_type_id(
-            vendor=keys_map[def_utils.DefKey.VENDOR],
+            vendor=keys_map[def_utils.DefKey.ENTITY_TYPE_VENDOR],
             nss=keys_map[def_utils.DefKey.ENTITY_TYPE_NSS],
             version=keys_map[def_utils.DefKey.ENTITY_TYPE_VERSION])
         return schema_svc.get_entity_type(entity_type_id)

--- a/container_service_extension/def_/models.py
+++ b/container_service_extension/def_/models.py
@@ -13,9 +13,9 @@ class DefInterface:
     """Provides interface for the defined entity type."""
 
     name: str
-    vendor: str = def_utils.DEF_CSE_VENDOR
-    nss: str = def_utils.DEF_NATIVE_INTERFACE_NSS
-    version: str = def_utils.DEF_NATIVE_INTERFACE_VERSION
+    vendor: str = def_utils.DEF_VMWARE_VENDOR
+    nss: str = def_utils.DEF_VMWARE_INTERFACE_NSS
+    version: str = def_utils.DEF_VMWARE_INTERFACE_VERSION
     id: str = None
     readonly: bool = False
 
@@ -209,7 +209,7 @@ class ClusterEntity:
     api_version: str = ''
 
     def __init__(self, metadata: Metadata, spec: ClusterSpec, status=Status(),
-                 kind: str = def_utils.DEF_NATIVE_INTERFACE_NSS,
+                 kind: str = def_utils.DEF_VMWARE_INTERFACE_NSS,
                  api_version: str = ''):
 
         self.metadata = Metadata(**metadata) \

--- a/container_service_extension/def_/utils.py
+++ b/container_service_extension/def_/utils.py
@@ -10,9 +10,9 @@ import container_service_extension.exceptions as excptn
 # Defined Entity Framework related constants
 DEF_CSE_VENDOR = 'cse'
 DEF_VMWARE_VENDOR = 'vmware'
-DEF_NATIVE_INTERFACE_NSS = 'k8s'
-DEF_NATIVE_INTERFACE_VERSION = '1.0.0'
-DEF_NATIVE_INTERFACE_NAME = 'Kubernetes'
+DEF_VMWARE_INTERFACE_NSS = 'k8s'
+DEF_VMWARE_INTERFACE_VERSION = '1.0.0'
+DEF_VMWARE_INTERFACE_NAME = 'Kubernetes'
 DEF_INTERFACE_ID_PREFIX = 'urn:vcloud:interface'
 DEF_NATIVE_ENTITY_TYPE_NSS = 'nativeCluster'
 DEF_NATIVE_ENTITY_TYPE_VERSION = '1.0.0'
@@ -28,11 +28,11 @@ DEF_RESOLVED_STATE = 'RESOLVED'
 
 @unique
 class DefKey(str, Enum):
-    VMWARE_VENDOR = 'vmware'
-    VENDOR = 'vendor'
+    INTERFACE_VENDOR = 'interface_vendor'
     INTERFACE_NSS = 'interface_nss'
     INTERFACE_VERSION = 'interface_version'
     INTERFACE_NAME = 'interface_name'
+    ENTITY_TYPE_VENDOR = 'entity_type_vendor'
     ENTITY_TYPE_NAME = 'entity_type_name'
     ENTITY_TYPE_NSS = 'entity_type_nss'
     ENTITY_TYPE_VERSION = 'entity_type_version'
@@ -41,11 +41,11 @@ class DefKey(str, Enum):
 
 MAP_API_VERSION_TO_KEYS = {
     35.0: {
-        DefKey.VMWARE_VENDOR: DEF_VMWARE_VENDOR,
-        DefKey.VENDOR: DEF_CSE_VENDOR,
-        DefKey.INTERFACE_NSS: DEF_NATIVE_INTERFACE_NSS,
-        DefKey.INTERFACE_VERSION: DEF_NATIVE_INTERFACE_VERSION,
-        DefKey.INTERFACE_NAME: DEF_NATIVE_INTERFACE_NAME,
+        DefKey.INTERFACE_VENDOR: DEF_VMWARE_VENDOR,
+        DefKey.INTERFACE_NSS: DEF_VMWARE_INTERFACE_NSS,
+        DefKey.INTERFACE_VERSION: DEF_VMWARE_INTERFACE_VERSION,
+        DefKey.INTERFACE_NAME: DEF_VMWARE_INTERFACE_NAME,
+        DefKey.ENTITY_TYPE_VENDOR: DEF_CSE_VENDOR,
         DefKey.ENTITY_TYPE_NSS: DEF_NATIVE_ENTITY_TYPE_NSS,
         DefKey.ENTITY_TYPE_VERSION: DEF_NATIVE_ENTITY_TYPE_VERSION,
         DefKey.ENTITY_TYPE_NAME: DEF_NATIVE_ENTITY_TYPE_NAME,

--- a/container_service_extension/def_/utils.py
+++ b/container_service_extension/def_/utils.py
@@ -9,9 +9,10 @@ import container_service_extension.exceptions as excptn
 
 # Defined Entity Framework related constants
 DEF_CSE_VENDOR = 'cse'
-DEF_NATIVE_INTERFACE_NSS = 'native'
+DEF_VMWARE_VENDOR = 'vmware'
+DEF_NATIVE_INTERFACE_NSS = 'k8s'
 DEF_NATIVE_INTERFACE_VERSION = '1.0.0'
-DEF_NATIVE_INTERFACE_NAME = 'nativeClusterInterface'
+DEF_NATIVE_INTERFACE_NAME = 'Kubernetes'
 DEF_INTERFACE_ID_PREFIX = 'urn:vcloud:interface'
 DEF_NATIVE_ENTITY_TYPE_NSS = 'nativeCluster'
 DEF_NATIVE_ENTITY_TYPE_VERSION = '1.0.0'
@@ -27,6 +28,7 @@ DEF_RESOLVED_STATE = 'RESOLVED'
 
 @unique
 class DefKey(str, Enum):
+    VMWARE_VENDOR = 'vmware'
     VENDOR = 'vendor'
     INTERFACE_NSS = 'interface_nss'
     INTERFACE_VERSION = 'interface_version'
@@ -39,6 +41,7 @@ class DefKey(str, Enum):
 
 MAP_API_VERSION_TO_KEYS = {
     35.0: {
+        DefKey.VMWARE_VENDOR: DEF_VMWARE_VENDOR,
         DefKey.VENDOR: DEF_CSE_VENDOR,
         DefKey.INTERFACE_NSS: DEF_NATIVE_INTERFACE_NSS,
         DefKey.INTERFACE_VERSION: DEF_NATIVE_INTERFACE_VERSION,
@@ -92,7 +95,7 @@ def raise_error_if_def_not_supported(cloudapi_client: CloudApiClient):
 def get_registered_def_interface():
     """Fetch the native cluster interface loaded during server startup."""
     from container_service_extension.service import Service
-    return Service().get_native_cluster_interface()
+    return Service().get_kubernetes_interface()
 
 
 def get_registered_def_entity_type():

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -175,6 +175,7 @@ class Service(object, metaclass=Singleton):
         return result
 
     def get_kubernetes_interface(self) -> def_models.DefInterface:
+        """Get the built-in kubernetes interface from vCD."""
         return self._kubernetesInterface
 
     def get_native_cluster_entity_type(self) -> def_models.DefEntityType:
@@ -382,10 +383,10 @@ class Service(object, metaclass=Singleton):
             schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
             defKey = def_utils.DefKey
             keys_map = def_utils.MAP_API_VERSION_TO_KEYS[float(sysadmin_client.get_api_version())] # noqa: E501
-            interface_id = def_utils.generate_interface_id(vendor=keys_map[defKey.VMWARE_VENDOR], # noqa: E501
+            interface_id = def_utils.generate_interface_id(vendor=keys_map[defKey.INTERFACE_VENDOR], # noqa: E501
                                                            nss=keys_map[defKey.INTERFACE_NSS], # noqa: E501
                                                            version=keys_map[defKey.INTERFACE_VERSION]) # noqa: E501
-            entity_type_id = def_utils.generate_entity_type_id(vendor=keys_map[defKey.VENDOR], # noqa: E501
+            entity_type_id = def_utils.generate_entity_type_id(vendor=keys_map[defKey.ENTITY_TYPE_VENDOR], # noqa: E501
                                                                nss=keys_map[defKey.ENTITY_TYPE_NSS], # noqa: E501
                                                                version=keys_map[defKey.ENTITY_TYPE_VERSION]) # noqa: E501
             self._kubernetesInterface = schema_svc.get_interface(interface_id)

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -134,7 +134,7 @@ class Service(object, metaclass=Singleton):
         self.threads = []
         self.pks_cache = None
         self._state = ServerState.STOPPED
-        self._nativeInterface: def_models.DefInterface = None
+        self._kubernetesInterface: def_models.DefInterface = None
         self._nativeEntityType: def_models.DefEntityType = None
 
     def get_service_config(self):
@@ -174,8 +174,8 @@ class Service(object, metaclass=Singleton):
             del result['python']
         return result
 
-    def get_native_cluster_interface(self) -> def_models.DefInterface:
-        return self._nativeInterface
+    def get_kubernetes_interface(self) -> def_models.DefInterface:
+        return self._kubernetesInterface
 
     def get_native_cluster_entity_type(self) -> def_models.DefEntityType:
         return self._nativeEntityType
@@ -382,13 +382,13 @@ class Service(object, metaclass=Singleton):
             schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
             defKey = def_utils.DefKey
             keys_map = def_utils.MAP_API_VERSION_TO_KEYS[float(sysadmin_client.get_api_version())] # noqa: E501
-            interface_id = def_utils.generate_interface_id(vendor=keys_map[defKey.VENDOR], # noqa: E501
+            interface_id = def_utils.generate_interface_id(vendor=keys_map[defKey.VMWARE_VENDOR], # noqa: E501
                                                            nss=keys_map[defKey.INTERFACE_NSS], # noqa: E501
                                                            version=keys_map[defKey.INTERFACE_VERSION]) # noqa: E501
             entity_type_id = def_utils.generate_entity_type_id(vendor=keys_map[defKey.VENDOR], # noqa: E501
                                                                nss=keys_map[defKey.ENTITY_TYPE_NSS], # noqa: E501
                                                                version=keys_map[defKey.ENTITY_TYPE_VERSION]) # noqa: E501
-            self._nativeInterface = schema_svc.get_interface(interface_id)
+            self._kubernetesInterface = schema_svc.get_interface(interface_id)
             self._nativeEntityType = schema_svc.get_entity_type(entity_type_id)
             msg = "Successfully loaded defined entity schema to global context"
             msg_update_callback.general(msg)


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

Make use of built in kubernetes interface for creating native cluster defined entity type

Testing done:
 `cse upgrade -c config -st`
checked to see if kubernetes interface was loaded on `cse run`

@sahithi @sakthisunda @rocknes @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/641)
<!-- Reviewable:end -->
