### PR TITLE
Fix ovdc enable bug in system tests

### DIFF
--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -140,11 +140,13 @@ def cse_server():
     assert result.exit_code == 0,\
         testutils.format_command_info('vcd', cmd, result.exit_code,
                                       result.output)
-    cmd = f"cse ovdc enable {config['broker']['vdc']}"
-    result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0,\
-        testutils.format_command_info('vcd', cmd, result.exit_code,
-                                      result.output)
+    # TODO (metadata based enablement for < v35): Commenting this for now
+    # Should revisit after decision
+    # cmd = f"cse ovdc enable {config['broker']['vdc']}"
+    # result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
+    # assert result.exit_code == 0,\
+    #     testutils.format_command_info('vcd', cmd, result.exit_code,
+    #                                   result.output)
     cmd = f"catalog acl add {config['broker']['catalog']} " \
           f"\'org:{config['broker']['org']}:ReadOnly\'"
     result = env.CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Remove enabling ovdc in system test as ovdc enable / disable is not supported for API version < 35.

@sahithi @sakthisunda @rocknes @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/645)
<!-- Reviewable:end -->
