### PR TITLE
[VCDA 1595,1603] apply - generate sample file, resize cluster CLI implementation

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -610,7 +610,7 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, output):
 
         cluster = Cluster(client, cluster_entity_kind=cluster_config.get('kind'))  # noqa: E501
         result = cluster.apply(cluster_config)
-        stdout(yaml.dump(result), ctx)
+        console_message_printer.general_no_color(yaml.dump(result))
         CLIENT_LOGGER.debug(result)
     except Exception as e:
         stderr(e, ctx)
@@ -1546,6 +1546,12 @@ def compute_policy_remove(ctx, org_name, ovdc_name, compute_policy_name,
 
 
 def _get_sample_cluster_configuration(output=None):
+    """Generate sample cluster configuration.
+
+    :param str output: full path of output file
+    :return: sample cluster configuration
+    :rtype: str
+    """
     metadata = def_models.Metadata('mycluster', 'myorg', 'myvdc')
     status = def_models.Status()
     settings = def_models.Settings(network='myNetwork', ssh_key=None, enable_nfs=False)  # noqa: E501

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -541,7 +541,7 @@ def cluster_resize(ctx, cluster_name, node_count, network_name, org_name,
 
 
 @cluster_group.command('apply',
-                       help="Example:vcd cse cluster apply -f input_spec.yaml"
+                       help="Example:vcd cse cluster apply input_spec.yaml"
                        " \n\nExample:vcd cse cluster apply --sample"
                        " \n\nExample:vcd cse cluster apply -s -o output.yaml",
                        short_help='apply the cluster configuration defined '
@@ -549,13 +549,11 @@ def cluster_resize(ctx, cluster_name, node_count, network_name, org_name,
                                   'or update the existing cluster or'
                                   'generate sample configuration file')
 @click.pass_context
-@click.option(
-    '-f',
+@click.argument(
     'cluster_config_file_path',
     required=False,
     metavar='CLUSTER_CONFIG_FILE_PATH',
-    type=click.Path(exists=True),
-    help="Full path of configuration file; This flag can't be used together with -s/-o")  # noqa: E501
+    type=click.Path(exists=True))
 @click.option(
     '-s',
     '--sample',
@@ -563,7 +561,7 @@ def cluster_resize(ctx, cluster_name, node_count, network_name, org_name,
     is_flag=True,
     required=False,
     default=False,
-    help="generate sample cluster configuration file; This flag can't be used together with -f")  # noqa: E501
+    help="generate sample cluster configuration file; This flag can't be used together with CLUSTER_CONFIG_FILE_PATH")  # noqa: E501
 @click.option(
     '-o',
     '--output',
@@ -571,14 +569,14 @@ def cluster_resize(ctx, cluster_name, node_count, network_name, org_name,
     required=False,
     default=None,
     metavar='OUTPUT_FILE_NAME',
-    help="Filepath to write sample configuration file to; This flag can only be used with -s")  # noqa: E501
+    help="Filepath to write sample configuration file to; This flag should be used with -s")  # noqa: E501
 def apply(ctx, cluster_config_file_path, generate_sample_config, output):
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
         console_message_printer = utils.ConsoleMessagePrinter()
         if cluster_config_file_path and (generate_sample_config or output):
             console_message_printer.general_no_color(ctx.get_help())
-            raise Exception("-s/-o flag can't be used together with -f")  # noqa: E501
+            raise Exception("-s/-o flag can't be used together with CLUSTER_CONFIG_FILE_PATH")  # noqa: E501
 
         if not cluster_config_file_path and not generate_sample_config:
             console_message_printer.general_no_color(ctx.get_help())

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -582,7 +582,7 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, output):
 
         if not cluster_config_file_path and not generate_sample_config:
             console_message_printer.general_no_color(ctx.get_help())
-            msg = "No option chosen"
+            msg = "No option chosen/invalid option"
             CLIENT_LOGGER.error(msg)
             raise Exception(msg)
 
@@ -1582,6 +1582,7 @@ def _get_sample_cluster_configuration(output=None):
     )
 
     sample_cluster_config = yaml.dump(dataclasses.asdict(cluster_entity))
+    CLIENT_LOGGER.info(sample_cluster_config)
 
     if output:
         with open(output, 'w') as f:

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -576,15 +576,15 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, output):
         console_message_printer = utils.ConsoleMessagePrinter()
         if cluster_config_file_path and (generate_sample_config or output):
             console_message_printer.general_no_color(ctx.get_help())
-            raise Exception("-s/-o flag can't be used together with CLUSTER_CONFIG_FILE_PATH")  # noqa: E501
+            msg = "-s/-o flag can't be used together with CLUSTER_CONFIG_FILE_PATH"  # noqa: E501
+            CLIENT_LOGGER.error(msg)
+            raise Exception(msg)
 
         if not cluster_config_file_path and not generate_sample_config:
             console_message_printer.general_no_color(ctx.get_help())
-            raise Exception("No option chosen")
-
-        if cluster_config_file_path and not os.path.exists(cluster_config_file_path):  # noqa: E501
-            console_message_printer.general_no_color(ctx.get_help())
-            raise Exception(f"{cluster_config_file_path} not found")
+            msg = "No option chosen"
+            CLIENT_LOGGER.error(msg)
+            raise Exception(msg)
 
         if generate_sample_config:
             sample_cluster_config = _get_sample_cluster_configuration(output=output)  # noqa: E501

--- a/container_service_extension/client/native_cluster.py
+++ b/container_service_extension/client/native_cluster.py
@@ -75,7 +75,3 @@ class NativeCluster(DefEntityCluster):
                 media_type='application/json',
                 accept_type='application/json')
         return response_processor.process_response(response)
-
-    def __getattr__(self, name):
-        msg = "Operation not supported; Under *** implementation"
-        raise vcd_exceptions.OperationNotSupportedException(msg)

--- a/container_service_extension/client/native_cluster.py
+++ b/container_service_extension/client/native_cluster.py
@@ -9,7 +9,6 @@ import container_service_extension.client.response_processor as response_process
 from container_service_extension.def_ import models as def_models
 import container_service_extension.def_.entity_service as def_entity_svc
 import container_service_extension.def_.utils as def_utils
-import container_service_extension.exceptions as exceptions
 import container_service_extension.shared_constants as shared_constants
 
 
@@ -50,17 +49,15 @@ class NativeCluster(DefEntityCluster):
 
         :param dict cluster_config: cluster configuration information
         :return: requests.models.Response response
-        :raises: exceptions.BadRequestError
         """
         uri = f"{self._uri}/clusters"
-        method = shared_constants.RequestMethod.POST
         entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
         cluster_spec = def_models.ClusterEntity(**cluster_config)
         cluster_name = cluster_spec.metadata.cluster_name
         def_entity = entity_svc.get_native_entity_by_name(cluster_name)
         if not def_entity:
             response = self._client._do_request_prim(
-                method,
+                shared_constants.RequestMethod.POST,
                 uri,
                 self._client._session,
                 contents=cluster_config,
@@ -68,10 +65,16 @@ class NativeCluster(DefEntityCluster):
                 accept_type='application/json')
             return response_processor.process_response(response)
         else:
-            # TODO(): Resize logic will be added here
-            raise exceptions.BadRequestError(
-                f"Defined Entity for '{cluster_name}' already exists.",
-                vcd_exceptions.ConflictException)
+            cluster_id = def_entity.id
+            uri = f"{self._uri}/cluster/{cluster_id}"
+            response = self._client._do_request_prim(
+                shared_constants.RequestMethod.PUT,
+                uri,
+                self._client._session,
+                contents=cluster_config,
+                media_type='application/json',
+                accept_type='application/json')
+        return response_processor.process_response(response)
 
     def __getattr__(self, name):
         msg = "Operation not supported; Under *** implementation"


### PR DESCRIPTION
- CLI implementation for generating sample cluster config and resize for apply command

- Usage: vcd cse cluster apply [OPTIONS]

  Example:vcd cse cluster apply input_spec.yaml

  Example:vcd cse cluster apply --sample

  Example:vcd cse cluster apply -s -o output.yaml

------

Options:
  -s, --sample                   generate sample cluster configuration file;
                                 This flag can't be used together with -f

  -o, --output OUTPUT_FILE_NAME  Filepath to write sample configuration file
                                 to; This flag can only be used with -s

  -h, --help                     Show this message and exit.

-----
- Manual testing completed
- Dependency on [VCDA1590] Cluster create and resize support to handle 0 worker nodes
------
![image](https://user-images.githubusercontent.com/5530442/87343957-7adafd80-c502-11ea-8a67-0694c84f59e7.png)



@andrew-ni @Anirudh9794 @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/651)
<!-- Reviewable:end -->
