### PR TITLE
[PR] CTOT Fix - cluster resize with no worker node is a positive test case

### DIFF
--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -584,7 +584,7 @@ def test_0110_vcd_cse_cluster_resize(test_runner_username, config):
                    test_user=test_runner_username),
         cmd_binder(cmd=f"cse cluster resize -N 0 -n {config['broker']['network']}" # noqa
                        f" {env.USERNAME_TO_CLUSTER_NAME[test_runner_username]}", # noqa: E501
-                   exit_code=2, validate_output_func=generate_validate_node_count_func(num_nodes+1), # noqa
+                   exit_code=0, validate_output_func=generate_validate_node_count_func(1), # noqa
                    test_user=test_runner_username),
         cmd_binder(cmd=f"cse cluster resize -N {num_nodes} -n {config['broker']['network']}" # noqa
                        f" {env.USERNAME_TO_CLUSTER_NAME[test_runner_username]}", # noqa: E501

--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -434,7 +434,7 @@ def test_0070_vcd_cse_cluster_create(config, test_runner_username):
                    validate_output_func=None, test_user=test_runner_username),
         cmd_binder(cmd=f"cse cluster create "
                        f"{env.USERNAME_TO_CLUSTER_NAME[test_runner_username]}"
-                       f" -n {config['broker']['network']} -N 1 ", exit_code=0,
+                       f" -n {config['broker']['network']} -N 0 ", exit_code=0,
                    validate_output_func=None, test_user=test_runner_username),
         cmd_binder(cmd=env.USER_LOGOUT_CMD, exit_code=0,
                    validate_output_func=None, test_user=test_runner_username)
@@ -584,11 +584,7 @@ def test_0110_vcd_cse_cluster_resize(test_runner_username, config):
                    test_user=test_runner_username),
         cmd_binder(cmd=f"cse cluster resize -N 0 -n {config['broker']['network']}" # noqa
                        f" {env.USERNAME_TO_CLUSTER_NAME[test_runner_username]}", # noqa: E501
-                   exit_code=0, validate_output_func=generate_validate_node_count_func(1), # noqa
-                   test_user=test_runner_username),
-        cmd_binder(cmd=f"cse cluster resize -N {num_nodes} -n {config['broker']['network']}" # noqa
-                       f" {env.USERNAME_TO_CLUSTER_NAME[test_runner_username]}", # noqa: E501
-                   exit_code=2, validate_output_func=generate_validate_node_count_func(num_nodes+1), # noqa
+                   exit_code=0, validate_output_func=generate_validate_node_count_func(0), # noqa
                    test_user=test_runner_username)
     ]
     execute_commands(cmd_list)


### PR DESCRIPTION
- Fixed failing cluster resize with no worker node

-  `vcd cse cluster resize -N 0` is a valid test case. Changes made to check proper exit code. Also, removed redundant test case of scale down as -N 0 takes care of scale down as well.
-   Also updated test case to support `vcd cse cluster create -N 0` 

@Anirudh9794 @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/656)
<!-- Reviewable:end -->
