### PR TITLE
[VCDA-1596] Hide ovdc info command as it doesnt display any more info than list

### DIFF
--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -33,17 +33,17 @@ UNSUPPORTED_COMMANDS_BY_VERSION = {
         GroupKey.CLUSTER: ['apply'],
         # TODO(metadata based enablement for < v35): Revisit after decision
         # to support metadata way of enabling for native clusters
-        GroupKey.OVDC: ['enable', 'disable']
+        GroupKey.OVDC: ['enable', 'disable', 'info']
     },
     vcd_client.ApiVersion.VERSION_34.value: {
         GroupKey.CLUSTER: ['apply'],
         # TODO(metadata based enablement for < v35): Revisit after decision
         # to support metadata way of enabling for native clusters
-        GroupKey.OVDC: ['enable', 'disable']
+        GroupKey.OVDC: ['enable', 'disable', 'info']
     },
     vcd_client.ApiVersion.VERSION_35.value: {
         GroupKey.CLUSTER: ['create'],
-        GroupKey.OVDC: ['compute-policy']
+        GroupKey.OVDC: ['compute-policy', 'info']
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

- Hide ovdc info command as it doesn't display any more information than list

- Add a command filter for ovdc info for v33, v34 and v35

- Testing done:
checked if `vcd cse ovdc -h` doesn't show info as a subcommand
checked if `vcd cse ovdc info` will give command not found

@sakthisunda @sahithi @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/663)
<!-- Reviewable:end -->
