### PR TITLE
[VCDA-1515] Report users at the end of CSE upgrade who needs to be assigned DEF entity RBAC rights

### DIFF
--- a/container_service_extension/client/legacy_native_cluster_api.py
+++ b/container_service_extension/client/legacy_native_cluster_api.py
@@ -38,13 +38,14 @@ class LegacyNativeClusterApi:
         for c in result:
             # TODO cluster api response keys need to be more well defined
             cluster = {
-                'Name': c.get('name') or 'N/A',
-                'VDC': c.get('vdc') or 'N/A',
-                'Org': c.get('org_name') or 'N/A',
-                'K8s Runtime': c.get('k8s_type') or 'N/A',
-                'K8s Version': c.get('k8s_version') or 'N/A',
-                'Status': c.get('status') or 'N/A',
-                'Provider': c.get('k8s_provider') or 'N/A',
+                'Name': c.get('name', 'N/A'),
+                'Owner': c.get('owner_name', 'N/A'),
+                'VDC': c.get('vdc', 'N/A'),
+                'Org': c.get('org_name', 'N/A'),
+                'K8s Runtime': c.get('k8s_type', 'N/A'),
+                'K8s Version': c.get('k8s_version', 'N/A'),
+                'Status': c.get('status', 'N/A'),
+                'Provider': c.get('k8s_provider', 'N/A'),
             }
             clusters.append(cluster)
         return clusters

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -1255,6 +1255,11 @@ def _upgrade_to_35(client, config, ext_vcd_api_version,
         msg_update_callback=msg_update_callback,
         log_wire=log_wire)
 
+    # Print list of users categorized by org, who currently owns CSE clusters
+    # and will need DEF entity rights.
+    _print_users_in_need_of_def_rights(
+        cse_clusters=clusters, msg_update_callback=msg_update_callback)
+
 
 def _fix_cluster_metadata(client,
                           config,
@@ -1904,3 +1909,21 @@ def _create_def_entity_for_existing_clusters(
     msg = "Finished processing all clusters."
     INSTALL_LOGGER.info(msg)
     msg_update_callback.general(msg)
+
+
+def _print_users_in_need_of_def_rights(
+        cse_clusters, msg_update_callback=utils.NullPrinter()):
+    org_user_dict = {}
+    for cluster in cse_clusters:
+        if cluster['org_name'] not in org_user_dict:
+            org_user_dict[cluster['org_name']] = []
+        org_user_dict[cluster['org_name']].append(cluster['owner_name'])
+
+    msg = "The following users own CSE k8s clusters and will require [TODO] rights to access them in CSE 3.0"  # noqa: E501
+    msg_update_callback.info(msg)
+    INSTALL_LOGGER.info(msg)
+
+    for org_name, user_list in org_user_dict.items():
+        msg = f"Org : {org_name} -> Users : {', '.join(set(user_list))}"
+        msg_update_callback.general(msg)
+        INSTALL_LOGGER.info(msg)

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -169,6 +169,11 @@ class ClusterService(abstract_broker.AbstractBroker):
         ovdc_name = cluster_spec.metadata.ovdc_name
         template_name = cluster_spec.spec.k8_distribution.template_name
         template_revision = cluster_spec.spec.k8_distribution.template_revision
+        if not (template_name or template_revision):
+            default_dist = utils.get_default_k8_distribution()
+            cluster_spec.spec.k8_distribution = default_dist
+            template_name = default_dist.template_name
+            template_revision = default_dist.template_revision
 
         # check that cluster name is syntactically valid
         if not is_valid_cluster_name(cluster_name):

--- a/container_service_extension/def_/models.py
+++ b/container_service_extension/def_/models.py
@@ -94,14 +94,12 @@ class Workers:
 
 @dataclass()
 class Distribution:
-    template_name: str = None
-    template_revision: int = 1
+    template_name: str = ""
+    template_revision: int = 0
 
-    def __init__(self, template_name: str = None, template_revision: int = None):  # noqa: E501
-        if not template_name:
-            default_dist = utils.get_default_k8_distribution()
-        self.template_name = template_name or default_dist.template_name
-        self.template_revision = template_revision or default_dist.template_revision  # noqa: E501
+    def __init__(self, template_name: str, template_revision: int):
+        self.template_name = template_name
+        self.template_revision = template_revision
 
 
 @dataclass()

--- a/container_service_extension/def_/models.py
+++ b/container_service_extension/def_/models.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import List
 
 import container_service_extension.def_.utils as def_utils
-import container_service_extension.utils as utils
 
 
 @dataclass(frozen=True)

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -140,6 +140,7 @@ class VcdBroker(abstract_broker.AbstractBroker):
                 'status': c['status'],
                 'vdc_id': c['vdc_id'],
                 'org_name': org_name,
+                'owner_name': c['owner_name'],
                 K8S_PROVIDER_KEY: K8sProvider.NATIVE
             })
         return clusters
@@ -1554,6 +1555,7 @@ def get_all_clusters(client, cluster_name=None, cluster_id=None,
             'org_name': '',
             'org_href': '',
             'os': '',
+            'owner_name': record.get('ownerName'),
             'status': record.get('status'),
             'storage_profile_name': '',
             'template_name': '',


### PR DESCRIPTION
Once DEF entities are created corresponding to existing native CSE k8s clusters, the owners of the cluster should be assigned appropriate DEF RBAC rights so that they can continue to interact with the clusters with CSE 3.0. Added a new section in the upgrade process that lists users per org who needs the new rights.

Also the following changes were made in this PR
* Display cluster owner information in output of `vcd cse cluster list` for api version 33.0 and 34.0
* Get rid of the default values in Distribution class that were dependent on CSE server being running.

Testing Done:
Ran upgrade and verified the list of user is printed at the end of upgrade process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/666)
<!-- Reviewable:end -->
