### PR TITLE
Add the placement policy final flag

### DIFF
--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -478,7 +478,8 @@ class ComputePolicyManager:
         return org.assign_placement_policy_to_vapp_template_vms(
             catalog_name=catalog_name,
             catalog_item_name=catalog_item_name,
-            placement_policy_href=compute_policy_href)
+            placement_policy_href=compute_policy_href,
+            placement_policy_final=True)
 
     def assign_vdc_sizing_policy_to_vapp_template_vms(self,
                                                       compute_policy_href,

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1580,6 +1580,9 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
             # TODO: get details of the exception to determine cause of failure,
             # e.g. not enough resources available.
             node_list = [entry.get('target_vm_name') for entry in specs]
+            if "throwImmutablePolicyException" in err.vcd_error.get('stackTrace', ''):  # noqa: E501
+                raise e.NodeCreationError(node_list,
+                                          f"OVDC not enabled for {template[LocalTemplateKey.KIND]}")  # noqa: E501
             raise e.NodeCreationError(node_list, str(err))
 
         vapp.reload()

--- a/container_service_extension/template_builder.py
+++ b/container_service_extension/template_builder.py
@@ -400,7 +400,7 @@ class TemplateBuilder():
                 self.org_name,
                 self.catalog_name,
                 self.catalog_item_name)
-            if task:
+            if task is not None:
                 self.client.get_task_monitor().wait_for_success(task)
                 msg = "Successfully tagged template " \
                       f"{self.catalog_item_name} with placement policy " \


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* Add `placement_policy_final=True` flag to prevent template compute policies being overridden during deployment
* Also includes the changes for more intuitive messages when cluster deployment fails because the ovdc was not enabled
* Requirements.txt change to bump up pyvcloud (TODO)

Testing done
* Created new templates and checked if an error is thrown if the placement policies are missing from the VDC.
* Checked if cluster create goes through if VDC has the required placement policies associated with it.

@rocknes @sahithi @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/667)
<!-- Reviewable:end -->
