### PR TITLE
[VCDA-1645] Validate PUT Def Entity Payload

### DIFF
--- a/container_service_extension/request_handlers/request_utils.py
+++ b/container_service_extension/request_handlers/request_utils.py
@@ -109,7 +109,7 @@ def validate_def_native_payload(desired_spec: dict, actual_spec: dict,
                 continue
             expected_val = actual_spec.get(payload_key)
             if payload_val != expected_val:
-                error_msg = f"Invalid cluster configuration: {dict_name}-->{payload_key} has incorrect value"  # noqa: E501
+                error_msg = f"Invalid input configuration: {dict_name}-->{payload_key} has incorrect value"  # noqa: E501
                 raise BadRequestError(error_msg)
 
     return True

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -8,6 +8,7 @@ import container_service_extension.def_.models as def_models
 import container_service_extension.operation_context as ctx
 import container_service_extension.request_handlers.request_utils as request_utils  # noqa: E501
 import container_service_extension.server_constants as const
+from container_service_extension.shared_constants import FlattenedClusterSpecKey  # noqa: E501
 from container_service_extension.shared_constants import RequestKey
 from container_service_extension.telemetry.telemetry_handler import \
     record_user_action_telemetry
@@ -42,12 +43,10 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     cluster_id = data[RequestKey.CLUSTER_ID]
     cluster_entity_spec = def_models.ClusterEntity(**data[RequestKey.V35_SPEC])
     curr_entity = svc.entity_svc.get_entity(cluster_id)
-    request_utils.validate_def_native_payload(
+    request_utils.validate_request_payload(
         asdict(cluster_entity_spec.spec), asdict(curr_entity.entity.spec),
-        exclude_fields={
-            RequestKey.WORKERS: [RequestKey.COUNT],
-            RequestKey.NFS: [RequestKey.COUNT]
-        })
+        exclude_fields=[FlattenedClusterSpecKey.WORKERS_COUNT.value,
+                        FlattenedClusterSpecKey.NFS_COUNT.value])
     return asdict(svc.resize_cluster(cluster_id, cluster_entity_spec))
 
 
@@ -123,11 +122,10 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     cluster_entity_spec = def_models.ClusterEntity(**data[RequestKey.V35_SPEC])
     cluster_id = data[RequestKey.CLUSTER_ID]
     curr_entity = svc.entity_svc.get_entity(cluster_id)
-    request_utils.validate_def_native_payload(
+    request_utils.validate_request_payload(
         asdict(cluster_entity_spec.spec), asdict(curr_entity.entity.spec),
-        exclude_fields={
-            RequestKey.K8_DISTRIBUTION: [RequestKey.TEMPLATE_NAME, RequestKey.TEMPLATE_REVISION]  # noqa: E501
-        })
+        exclude_fields=[FlattenedClusterSpecKey.TEMPLATE_NAME.value,
+                        FlattenedClusterSpecKey.TEMPLATE_REVISION.value])
     return asdict(svc.upgrade_cluster(cluster_id, cluster_entity_spec))
 
 

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -92,10 +92,6 @@ class RequestKey(str, Enum):
     NODE_NAMES_LIST = 'node_names'
     SSH_KEY = 'ssh_key'
     ROLLBACK = 'rollback'
-    WORKERS = 'workers'
-    COUNT = 'count'
-    NFS = 'nfs'
-    K8_DISTRIBUTION = 'k8_distribution'
 
     # keys related to ovdc requests
     K8S_PROVIDER = 'k8s_provider'
@@ -129,6 +125,14 @@ class DefEntityOperationStatus(str, Enum):
     SUCCEEDED = 'SUCCEEDED'
     FAILED = 'FAILED'
     UNKNOWN = 'UNKNOWN'
+
+
+@unique
+class FlattenedClusterSpecKey(Enum):
+    WORKERS_COUNT = 'workers.count'
+    NFS_COUNT = 'nfs.count'
+    TEMPLATE_NAME = 'k8_distribution.template_name'
+    TEMPLATE_REVISION = 'k8_distribution.template_revision'
 
 
 @dataclass

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -92,6 +92,10 @@ class RequestKey(str, Enum):
     NODE_NAMES_LIST = 'node_names'
     SSH_KEY = 'ssh_key'
     ROLLBACK = 'rollback'
+    WORKERS = 'workers'
+    COUNT = 'count'
+    NFS = 'nfs'
+    K8_DISTRIBUTION = 'k8_distribution'
 
     # keys related to ovdc requests
     K8S_PROVIDER = 'k8s_provider'

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -365,3 +365,29 @@ def run_async(func):
 def generate_thread_name(function_name):
     parent_thread_id = threading.current_thread().ident
     return function_name + ':' + str(parent_thread_id)
+
+
+def flatten_dictionary(input_dict, parent_key='', separator='.'):
+    """Flatten a given dictionary with nested dictionaries if any.
+
+    Example: { 'a' : {'b':'c', 'd': {'e' : 'f'}}, 'g' : 'h'} will be flattened
+    to {'a.b': 'c', 'a.d.e': 'f', 'g': 'h'}
+
+    This will flatten only the values of dict type.
+
+    :param dict input_dict:
+    :param str parent_key: parent key that gets prefixed while forming flattened key  # noqa: E501
+    :param str separator: use the separator to form flattened key
+    :return: flattened dictionary
+    :rtype: dict
+    """
+    flattened_dict = {}
+    for k in input_dict.keys():
+        val = input_dict.get(k)
+        key_prefix = f"{parent_key}{k}"
+        if isinstance(val, dict):
+            parent_key = f"{key_prefix}{separator}"
+            flattened_dict.update(flatten_dictionary(val, parent_key))  # noqa: E501
+        else:
+            flattened_dict.update({key_prefix: val})
+    return flattened_dict


### PR DESCRIPTION
-  Validate the defined entity payload PUT requests
-  Process the PUT requests payload and raise error on encountering invalid value with reference to current state of the cluster.
- Currently generates generic error message with key->value that fails first in the validation (screenshot below)
- Tested with `vcd cse cluster apply` and `vcd cse cluster upgrade` with incorrect payloads 

----------------
Most recent console output after all review comments.

![image](https://user-images.githubusercontent.com/5530442/88848683-ae25b980-d19d-11ea-9260-b56011de9f42.png)

@Anirudh9794 @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/671)
<!-- Reviewable:end -->
