### PR TITLE
[VCDA-1517] Ignore cse node commands for api version 35

### DIFF
--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -95,6 +95,12 @@ class GroupCommandFilter(click.Group):
     Returns set of supported sub-commands by specific API version
     """
 
+    # TODO(Make get_command hierarchy aware): Since get_command() cannot know
+    # the hierarchical context of 'cmd_name', there is a possibility that
+    # there will be unintended command ommition.
+    # Example: If 'node' command is ommited in cse group, and the filter is
+    # used in pks group (which is part of cse group), then the 'node' command
+    # under pks group also will be ommitted.
     def get_command(self, ctx, cmd_name):
         """Override this click method to customize.
 
@@ -114,8 +120,8 @@ class GroupCommandFilter(click.Group):
                 return None
 
             # Skip the subcommand if not supported
-            unsupported_commands = UNSUPPORTED_SUBCOMMANDS_BY_VERSION.get(version, {}).get(self.name, [])  # noqa: E501
-            if cmd_name in unsupported_commands:
+            unsupported_subcommands = UNSUPPORTED_SUBCOMMANDS_BY_VERSION.get(version, {}).get(self.name, [])  # noqa: E501
+            if cmd_name in unsupported_subcommands:
                 return None
 
             cmd = click.Group.get_command(self, ctx, cmd_name)

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -28,7 +28,8 @@ import container_service_extension.shared_constants as shared_constants
 import container_service_extension.utils as utils
 
 
-@vcd.group(short_help='Manage Native Kubernetes clusters')
+@vcd.group(short_help='Manage Native Kubernetes clusters',
+           cls=cmd_filter.GroupCommandFilter)
 @click.pass_context
 def cse(ctx):
     """Manage Native Kubernetes clusters.


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

- Ignore `vcd cse node ...` commands for api version >= 35

- Created command level filter for cse and ignored the  `node` command for apiVersion >= 35

Sample output:
![Screen Shot 2020-07-27 at 6 01 32 PM](https://user-images.githubusercontent.com/16699642/88607259-a0542500-d033-11ea-9c6b-b06a5019129c.png)


- (Optional) Names of reviewers using @ sign + name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/672)
<!-- Reviewable:end -->
