### PR TITLE
[VCDA-1681] cluster restriction with placement policies fixed

### DIFF
--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -478,7 +478,8 @@ class ComputePolicyManager:
         return org.assign_placement_policy_to_vapp_template_vms(
             catalog_name=catalog_name,
             catalog_item_name=catalog_item_name,
-            placement_policy_href=compute_policy_href)
+            placement_policy_href=compute_policy_href,
+            placement_policy_final=True)
 
     def assign_vdc_sizing_policy_to_vapp_template_vms(self,
                                                       compute_policy_href,

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -870,6 +870,7 @@ class ComputePolicyManager:
                     if is_placement_policy:
                         if hasattr(vm_resource, 'ComputePolicy') and \
                                 not hasattr(vm_resource.ComputePolicy, 'VmSizingPolicy'):  # noqa: E501
+                            # Updating sizing policy for the VM
                             _task = vm.update_compute_policy(
                                 compute_policy_href=system_default_href)
                             operation_msg = \

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -822,6 +822,10 @@ class ComputePolicyManager:
                 target_vms = []
                 system_default_href = None
                 operation_msg = None
+                for cp_dict in self.list_compute_policies_on_vdc(vdc_id):
+                    if cp_dict['name'] == _SYSTEM_DEFAULT_COMPUTE_POLICY:
+                        system_default_href = cp_dict['href']
+                        break
                 if is_placement_policy:
                     for vapp in vapps:
                         target_vms += \
@@ -837,10 +841,6 @@ class ComputePolicyManager:
                             [vm for vm in vapp.get_all_vms()
                                 if self._get_vm_sizing_policy_id(vm) == compute_policy_id] # noqa: E501
                     vm_names = [vm.get('name') for vm in target_vms]
-                    for cp_dict in self.list_compute_policies_on_vdc(vdc_id):
-                        if cp_dict['name'] == _SYSTEM_DEFAULT_COMPUTE_POLICY:
-                            system_default_href = cp_dict['href']
-                            break
                     operation_msg = "Setting sizing policy to " \
                                     f"'{_SYSTEM_DEFAULT_COMPUTE_POLICY}' on " \
                                     f"{len(vm_names)} VMs. " \
@@ -868,31 +868,69 @@ class ComputePolicyManager:
                     _task = None
                     operation_msg = None
                     if is_placement_policy:
+                        if hasattr(vm_resource, 'ComputePolicy') and \
+                                not hasattr(vm_resource.ComputePolicy, 'VmSizingPolicy'):  # noqa: E501
+                            _task = vm.update_compute_policy(
+                                compute_policy_href=system_default_href)
+                            operation_msg = \
+                                "Setting compute policy to " \
+                                f"'{_SYSTEM_DEFAULT_COMPUTE_POLICY}' "\
+                                f"on VM '{vm_resource.get('name')}'"
+                            task.update(
+                                status=vcd_client.TaskStatus.RUNNING.value,
+                                namespace='vcloud.cse',
+                                operation=operation_msg,
+                                operation_name=f'Setting sizing policy to {_SYSTEM_DEFAULT_COMPUTE_POLICY}',  # noqa: E501
+                                details='',
+                                progress=None,
+                                owner_href=vdc.href,
+                                owner_name=vdc.name,
+                                owner_type=vcd_client.EntityType.VDC.value,
+                                user_href=user_href,
+                                user_name=user_name,
+                                task_href=task_href,
+                                org_href=org_href)
+                            task_monitor.wait_for_success(_task)
                         _task = vm.remove_placement_policy()
                         operation_msg = "Removing placement policy on VM " \
                                         f"'{vm_resource.get('name')}'"
+                        task.update(
+                            status=vcd_client.TaskStatus.RUNNING.value,
+                            namespace='vcloud.cse',
+                            operation=operation_msg,
+                            operation_name='Remove org VDC compute policy',
+                            details='',
+                            progress=None,
+                            owner_href=vdc.href,
+                            owner_name=vdc.name,
+                            owner_type=vcd_client.EntityType.VDC.value,
+                            user_href=user_href,
+                            user_name=user_name,
+                            task_href=task_href,
+                            org_href=org_href)
+                        task_monitor.wait_for_success(_task)
                     else:
                         _task = vm.update_compute_policy(
                             compute_policy_href=system_default_href)
-                        operation_msg = "Setting compute policy to " \
+                        operation_msg = "Setting sizing policy to " \
                                         f"'{_SYSTEM_DEFAULT_COMPUTE_POLICY}' "\
                                         f"on VM '{vm_resource.get('name')}'"
+                        task.update(
+                            status=vcd_client.TaskStatus.RUNNING.value,
+                            namespace='vcloud.cse',
+                            operation=operation_msg,
+                            operation_name='Remove org VDC compute policy',
+                            details='',
+                            progress=None,
+                            owner_href=vdc.href,
+                            owner_name=vdc.name,
+                            owner_type=vcd_client.EntityType.VDC.value,
+                            user_href=user_href,
+                            user_name=user_name,
+                            task_href=task_href,
+                            org_href=org_href)
+                        task_monitor.wait_for_success(_task)
 
-                    task.update(
-                        status=vcd_client.TaskStatus.RUNNING.value,
-                        namespace='vcloud.cse',
-                        operation=operation_msg,
-                        operation_name='Remove org VDC compute policy',
-                        details='',
-                        progress=None,
-                        owner_href=vdc.href,
-                        owner_name=vdc.name,
-                        owner_type=vcd_client.EntityType.VDC.value,
-                        user_href=user_href,
-                        user_name=user_name,
-                        task_href=task_href,
-                        org_href=org_href)
-                    task_monitor.wait_for_success(_task)
             final_status = vcd_client.TaskStatus.RUNNING.value \
                 if is_umbrella_task else vcd_client.TaskStatus.SUCCESS.value
             task.update(

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -193,7 +193,6 @@ class ClusterService(abstract_broker.AbstractBroker):
                                         template[LocalTemplateKey.CNI_VERSION])
         def_entity.entity.status.docker_version = template[LocalTemplateKey.DOCKER_VERSION] # noqa: E501
         def_entity.entity.status.os = template[LocalTemplateKey.OS]
-        def_entity.entityType = def_utils.get_registered_def_entity_type().id
         self.entity_svc. \
             create_entity(def_utils.get_registered_def_entity_type().id,
                           entity=def_entity)

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1539,11 +1539,11 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
                     'hostname': name,
                     'password_auto': True,
                     'network': network_name,
-                    'ip_allocation_mode': 'pool',
-                    'placement_policy_href': config['placement_policy_hrefs'][template[LocalTemplateKey.KIND]]  # noqa: E501
+                    'ip_allocation_mode': 'pool'
                 }
                 if sizing_class_href:
                     spec['sizing_policy_href'] = sizing_class_href
+                    spec['placement_policy_href'] = config['placement_policy_hrefs'][template[LocalTemplateKey.KIND]]  # noqa: E501
                 if cust_script is not None:
                     spec['cust_script'] = cust_script
                 if storage_profile:

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -193,6 +193,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                                         template[LocalTemplateKey.CNI_VERSION])
         def_entity.entity.status.docker_version = template[LocalTemplateKey.DOCKER_VERSION] # noqa: E501
         def_entity.entity.status.os = template[LocalTemplateKey.OS]
+        def_entity.entityType = def_utils.get_registered_def_entity_type().id
         self.entity_svc. \
             create_entity(def_utils.get_registered_def_entity_type().id,
                           entity=def_entity)
@@ -1538,7 +1539,8 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
                     'hostname': name,
                     'password_auto': True,
                     'network': network_name,
-                    'ip_allocation_mode': 'pool'
+                    'ip_allocation_mode': 'pool',
+                    'placement_policy_href': config['placement_policy_hrefs'][template[LocalTemplateKey.KIND]]  # noqa: E501
                 }
                 if sizing_class_href:
                     spec['sizing_policy_href'] = sizing_class_href
@@ -1580,6 +1582,11 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
             # TODO: get details of the exception to determine cause of failure,
             # e.g. not enough resources available.
             node_list = [entry.get('target_vm_name') for entry in specs]
+            if hasattr(err, 'vcd_error') and \
+                "throwPolicyNotAvailableException" in err.vcd_error.get('stackTrace', ''):  # noqa: E501
+                raise e.NodeCreationError(node_list,
+                                          f"OVDC not enabled for {template[LocalTemplateKey.KIND]}")  # noqa: E501
+
             raise e.NodeCreationError(node_list, str(err))
 
         vapp.reload()

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1583,7 +1583,7 @@ def add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
             # e.g. not enough resources available.
             node_list = [entry.get('target_vm_name') for entry in specs]
             if hasattr(err, 'vcd_error') and \
-                "throwPolicyNotAvailableException" in err.vcd_error.get('stackTrace', ''):  # noqa: E501
+                    "throwPolicyNotAvailableException" in err.vcd_error.get('stackTrace', ''):  # noqa: E501
                 raise e.NodeCreationError(node_list,
                                           f"OVDC not enabled for {template[LocalTemplateKey.KIND]}")  # noqa: E501
 

--- a/container_service_extension/def_/ovdc_service.py
+++ b/container_service_extension/def_/ovdc_service.py
@@ -304,7 +304,6 @@ def _update_ovdc_using_placement_policy_async(operation_context: ctx.OperationCo
                     task_href=task_href,
                     org_href=operation_context.user.org_href,
                     error_message=f"{err}")
-        raise err
     finally:
         if operation_context.sysadmin_client:
             operation_context.end()

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -34,10 +34,6 @@ from container_service_extension.pks_cache import PksCache
 import container_service_extension.pyvcloud_utils as vcd_utils
 import container_service_extension.server_constants as server_constants
 import container_service_extension.shared_constants as shared_constants
-from container_service_extension.server_constants import LocalTemplateKey
-from container_service_extension.server_constants import SYSTEM_ORG_NAME
-from container_service_extension.shared_constants import CSE_SERVER_API_VERSION
-from container_service_extension.shared_constants import ServerAction
 from container_service_extension.telemetry.constants import CseOperation
 from container_service_extension.telemetry.constants import PayloadKey
 from container_service_extension.telemetry.telemetry_handler \
@@ -164,7 +160,7 @@ class Service(object, metaclass=Singleton):
 
     def info(self, get_sysadmin_info=False):
         result = utils.get_cse_info()
-        result[CSE_SERVER_API_VERSION] = utils.get_server_api_version()
+        result[shared_constants.CSE_SERVER_API_VERSION] = utils.get_server_api_version()  # noqa: E501
         if get_sysadmin_info:
             result['consumer_threads'] = len(self.threads)
             result['all_threads'] = threading.activeCount()
@@ -182,7 +178,7 @@ class Service(object, metaclass=Singleton):
     def get_native_cluster_entity_type(self) -> def_models.DefEntityType:
         return self._nativeEntityType
 
-    def update_status(self, server_action: ServerAction):
+    def update_status(self, server_action: shared_constants.ServerAction):
         def graceful_shutdown():
             message = 'Shutting down CSE'
             n = self.active_requests_count()
@@ -192,35 +188,35 @@ class Service(object, metaclass=Singleton):
             return message
 
         if self._state == ServerState.RUNNING:
-            if server_action == ServerAction.ENABLE:
+            if server_action == shared_constants.ServerAction.ENABLE:
                 return 'CSE is already enabled and running.'
-            if server_action == ServerAction.DISABLE:
+            if server_action == shared_constants.ServerAction.DISABLE:
                 self._state = ServerState.DISABLED
                 return 'CSE has been disabled.'
-            if server_action == ServerAction.STOP:
+            if server_action == shared_constants.ServerAction.STOP:
                 raise cse_exception.BadRequestError(
                     error_message='CSE must be disabled before '
                                   'it can be stopped.')
             raise cse_exception.BadRequestError(
                 error_message=f"Invalid server action: '{server_action}'")
         if self._state == ServerState.DISABLED:
-            if server_action == ServerAction.ENABLE:
+            if server_action == shared_constants.ServerAction.ENABLE:
                 self._state = ServerState.RUNNING
                 return 'CSE has been enabled and is running.'
-            if server_action == ServerAction.DISABLE:
+            if server_action == shared_constants.ServerAction.DISABLE:
                 return 'CSE is already disabled.'
-            if server_action == ServerAction.STOP:
+            if server_action == shared_constants.ServerAction.STOP:
                 return graceful_shutdown()
         if self._state == ServerState.STOPPING:
-            if server_action == ServerAction.ENABLE:
+            if server_action == shared_constants.ServerAction.ENABLE:
                 raise cse_exception.BadRequestError(
                     error_message='Cannot enable CSE while it is being'
                                   'stopped.')
-            if server_action == ServerAction.DISABLE:
+            if server_action == shared_constants.ServerAction.DISABLE:
                 raise cse_exception.BadRequestError(
                     error_message='Cannot disable CSE while it is being'
                                   ' stopped.')
-            if server_action == ServerAction.STOP:
+            if server_action == shared_constants.ServerAction.STOP:
                 return graceful_shutdown()
 
         raise cse_exception.CseServerError(f"Invalid server state: '{self._state}'")  # noqa: E501
@@ -422,12 +418,12 @@ class Service(object, metaclass=Singleton):
         msg = "Loading kubernetes runtime placement policies."
         logger.SERVER_LOGGER.info(msg)
         msg_update_callback.general(msg)
-        client = None
         try:
             sysadmin_client = vcd_utils.get_sys_admin_client()
-            if float(sysadmin_client.get_api_version()) < compute_policy_manager.GLOBAL_PVDC_COMPUTE_POLICY_MIN_VERSION:
-                msg = f"Placement policies for kubernetes runtimes not"\
-                      f" supported in api version {sysadmin_client.get_api_version()}"  # noqa: E501
+            if float(sysadmin_client.get_api_version()) < compute_policy_manager.GLOBAL_PVDC_COMPUTE_POLICY_MIN_VERSION:  # noqa: E501
+                msg = "Placement policies for kubernetes runtimes not " \
+                      " supported in api version " \
+                      f"{sysadmin_client.get_api_version()}"  # noqa: E501
                 logger.SERVER_LOGGER.debug(msg)
                 msg_update_callback.info(msg)
                 return
@@ -466,7 +462,7 @@ class Service(object, metaclass=Singleton):
                             log_headers=log_wire,
                             log_bodies=log_wire)
             credentials = BasicLoginCredentials(self.config['vcd']['username'],
-                                                SYSTEM_ORG_NAME,
+                                                server_constants.SYSTEM_ORG_NAME,  # noqa: E501
                                                 self.config['vcd']['password'])
             client.set_credentials(credentials)
 
@@ -490,7 +486,8 @@ class Service(object, metaclass=Singleton):
                 str(self.config['broker']['default_template_revision'])
             found_default_template = False
             for template in k8_templates:
-                if str(template[LocalTemplateKey.REVISION]) == default_template_revision and template[LocalTemplateKey.NAME] == default_template_name: # noqa: E501
+                if str(template[server_constants.LocalTemplateKey.REVISION]) == default_template_revision and \
+                        template[server_constants.LocalTemplateKey.NAME] == default_template_name: # noqa: E501
                     found_default_template = True
 
                 msg = f"Found K8 template '{template['name']}' at revision " \
@@ -558,8 +555,8 @@ class Service(object, metaclass=Singleton):
                                                               log_wire=self.config['service'].get('log_wire')) # noqa: E501
 
             for template in self.config['broker']['templates']:
-                policy_name = template[LocalTemplateKey.COMPUTE_POLICY]
-                catalog_item_name = template[LocalTemplateKey.CATALOG_ITEM_NAME] # noqa: E501
+                policy_name = template[server_constants.LocalTemplateKey.COMPUTE_POLICY]  # noqa: E501
+                catalog_item_name = template[server_constants.LocalTemplateKey.CATALOG_ITEM_NAME] # noqa: E501
                 # if policy name is not empty, stamp it on the template
                 if policy_name:
                     try:

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -438,7 +438,7 @@ class Service(object, metaclass=Singleton):
             msg = f"Failed to load placement policies to server runtime configt: {str(e)}" # noqa: E501
             msg_update_callback.error(e)
             logger.SERVER_LOGGER.error(e)
-            raise(e)
+            raise
 
     def _load_template_definition_from_catalog(self,
                                                msg_update_callback=utils.NullPrinter()): # noqa: E501

--- a/container_service_extension/template_builder.py
+++ b/container_service_extension/template_builder.py
@@ -400,7 +400,7 @@ class TemplateBuilder():
                 self.org_name,
                 self.catalog_name,
                 self.catalog_item_name)
-            if task:
+            if task is not None:
                 self.client.get_task_monitor().wait_for_success(task)
                 msg = "Successfully tagged template " \
                       f"{self.catalog_item_name} with placement policy " \

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pika >= 0.11.2, < 1.0.0
 
 # pyvcloud 22.0.1
 # pyvcloud >= 22.0.1, < 23.0.0
-pyvcloud == 22.0.2.dev13
+pyvcloud == 22.0.2.dev25
 
 # pyvmomi 6.7.3
 pyvmomi >= 6.7.0 , < 7.0.0


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

* Mark the templates with placement policy as non modifiable
  - Set the flag `placement_policy_final` to True when assigning placement policies to the templates.
* Server config cache in the placement policy href for the kubernetes runtimes available
* Specify the respective placement policy which is obtained from the server runtime config during cluster creation
  - spec for vapp.add_vm() should also specify the placement policy
* Ovdc disable to set sizing policy when only placement policy is present in the VM (Cannot remove placement policy directly if it is the only policy present in the VM)
  - check if the vm has a sizing policy before removing the placement policy. If not present, set the sizing policy to default sizing policy.

Also tested against api version 33.0 to check if `vcd cse ovdc compute-policy` commands were working as expected.

Dependent on PR https://github.com/vmware/pyvcloud/pull/698

@rocknes @sahithi @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/675)
<!-- Reviewable:end -->
