### PR TITLE
[VCDA-1671] Def entity owner as part of console display on cluster list CLI

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -1596,7 +1596,7 @@ def _get_sample_cluster_configuration(output=None):
     """
     metadata = def_models.Metadata('mycluster', 'myorg', 'myvdc')
     status = def_models.Status()
-    settings = def_models.Settings(network='myNetwork', ssh_key=None, enable_nfs=False)  # noqa: E501
+    settings = def_models.Settings(network='myNetwork', ssh_key=None)
     k8_distribution = def_models.Distribution(
         template_name='ubuntu-16.04_k8-1.17_weave-2.6.0',
         template_revision=2

--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -151,9 +151,6 @@ class DefEntityClusterApi:
         for def_entity in native_entities:
             entity = def_entity.entity
             logger.CLIENT_LOGGER.debug(f"Native Defined entity list from server: {def_entity}")  # noqa: E501
-            # owner_id = \
-            # def_entity.ownerId if hasattr(def_entity, 'ownerId') else ' '
-            # TODO(Owner in CSE server response): REST call to fetch owner_name
             cluster = {
                 cli_constants.CLIOutputKey.CLUSTER_NAME.value: def_entity.name,
                 cli_constants.CLIOutputKey.VDC.value: entity.metadata.ovdc_name, # noqa: E501
@@ -161,7 +158,7 @@ class DefEntityClusterApi:
                 cli_constants.CLIOutputKey.K8S_RUNTIME.value: entity.kind, # noqa: E501
                 cli_constants.CLIOutputKey.K8S_VERSION.value: entity.status.kubernetes, # noqa: E501
                 cli_constants.CLIOutputKey.STATUS.value: entity.status.phase, # noqa: E501
-                cli_constants.CLIOutputKey.OWNER.value: ' '
+                cli_constants.CLIOutputKey.OWNER.value: def_entity.owner.name
             }
             clusters.append(cluster)
         return clusters

--- a/container_service_extension/def_/models.py
+++ b/container_service_extension/def_/models.py
@@ -108,8 +108,7 @@ class Distribution:
 class Settings:
     network: str
     ssh_key: str = None
-    enable_nfs: bool = False
-    rollback_on_failure = True
+    rollback_on_failure: bool = True
 
 
 @dataclass()
@@ -216,7 +215,7 @@ class ClusterEntity:
             "settings": {
                 "network": "net",
                 "ssh_key": null,
-                "enable_nfs": false
+                "rollback_on_failure": true
             },
             "k8_distribution": {
                 "template_name": "k81.17",

--- a/container_service_extension/def_/models.py
+++ b/container_service_extension/def_/models.py
@@ -282,6 +282,8 @@ class DefEntity:
     entityType: str = None
     externalId: str = None
     state: str = None
+    owner: Owner = None
+    org: Org = None
 
     def __init__(self, entity: ClusterEntity, name: str = None, id: str = None,
                  entityType: str = None, externalId: str = None,


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

-  Include owner name cluster list CLI
-  `vcd cse cluster list` has included owner of def entity 
- removed enable_nfs from cluster_entity->settings
- type hints added dataclass for successful instance creation with all properties
- Manually tested 
-----
![image](https://user-images.githubusercontent.com/5530442/88990157-1ce43f00-d292-11ea-89a8-e521cf195313.png)

@Anirudh9794 @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/679)
<!-- Reviewable:end -->
