### PR TITLE
[VCDA-1694] Disable --tkg-plus options for ovdc enable and disable based on environmen…

### DIFF
--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -92,9 +92,9 @@ UNSUPPORTED_SUBCOMMAND_OPTIONS_BY_VERSION = {
         },
         GroupKey.OVDC: {
             CommandNameKey.ENABLE: [] if str_to_bool(
-                os.getenv(cli_constants.ENV_CSE_TKG_PLUS_ENABLE)) else ['enable_tkg_plus'],  # noqa: E501
+                os.getenv(cli_constants.ENV_CSE_TKG_PLUS_ENABLED)) else ['enable_tkg_plus'],  # noqa: E501
             CommandNameKey.DISABLE: [] if str_to_bool(
-                os.getenv(cli_constants.ENV_CSE_TKG_PLUS_ENABLE)) else ['enable_tkg_plus']  # noqa: E501
+                os.getenv(cli_constants.ENV_CSE_TKG_PLUS_ENABLED)) else ['disable_tkg_plus']  # noqa: E501
         }
     }
 }

--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -4,12 +4,15 @@
 
 from enum import Enum
 from enum import unique
+import os
 
 import click
 import pyvcloud.vcd.client as vcd_client
 
+import container_service_extension.client.constants as cli_constants
 import container_service_extension.client.utils as client_utils
 from container_service_extension.logger import CLIENT_LOGGER
+from container_service_extension.utils import str_to_bool
 
 
 @unique
@@ -28,6 +31,8 @@ class CommandNameKey(str, Enum):
     UPGRADE_PLAN = 'upgrade-plan'
     INFO = 'info'
     NODE = 'node'
+    ENABLE = 'enable'
+    DISABLE = 'disable'
 
 
 # List of unsupported commands by Api Version
@@ -84,6 +89,12 @@ UNSUPPORTED_SUBCOMMAND_OPTIONS_BY_VERSION = {
     vcd_client.ApiVersion.VERSION_35.value: {
         GroupKey.CLUSTER: {
             CommandNameKey.CREATE: ['cpu', 'memory']
+        },
+        GroupKey.OVDC: {
+            CommandNameKey.ENABLE: [] if str_to_bool(
+                os.getenv(cli_constants.ENV_CSE_TKG_PLUS_ENABLE)) else ['enable_tkg_plus'],  # noqa: E501
+            CommandNameKey.DISABLE: [] if str_to_bool(
+                os.getenv(cli_constants.ENV_CSE_TKG_PLUS_ENABLE)) else ['enable_tkg_plus']  # noqa: E501
         }
     }
 }

--- a/container_service_extension/client/constants.py
+++ b/container_service_extension/client/constants.py
@@ -7,7 +7,10 @@ from enum import unique
 
 import container_service_extension.def_.utils as def_utils
 
+# Client environment variables
 ENV_CSE_CLIENT_WIRE_LOGGING = 'CSE_CLIENT_WIRE_LOGGING'
+ENV_CSE_TKG_PLUS_ENABLE = 'CSE_TKG_PLUS_ENABLE'
+
 TKG_ENTITY_TYPE_ID = def_utils.generate_entity_type_id(
     def_utils.DEF_VMWARE_VENDOR,
     def_utils.TKG_ENTITY_TYPE_NSS,

--- a/container_service_extension/client/constants.py
+++ b/container_service_extension/client/constants.py
@@ -9,7 +9,7 @@ import container_service_extension.def_.utils as def_utils
 
 # Client environment variables
 ENV_CSE_CLIENT_WIRE_LOGGING = 'CSE_CLIENT_WIRE_LOGGING'
-ENV_CSE_TKG_PLUS_ENABLE = 'CSE_TKG_PLUS_ENABLE'
+ENV_CSE_TKG_PLUS_ENABLED = 'CSE_TKG_PLUS_ENABLED'
 
 TKG_ENTITY_TYPE_ID = def_utils.generate_entity_type_id(
     def_utils.DEF_VMWARE_VENDOR,

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -1368,14 +1368,14 @@ def ovdc_enable(ctx, ovdc_name, org_name, enable_native, enable_tkg_plus):
 @click.option(
     '-n',
     '--native',
-    'enable_native',
+    'disable_native',
     is_flag=True,
     help="Enable OVDC for native cluster deployment"
 )
 @click.option(
     '-t',
     '--tkg-plus',
-    'enable_tkg_plus',
+    'disable_tkg_plus',
     is_flag=True,
     help="Enable OVDC for TKG plus cluster deployment"
 )
@@ -1387,18 +1387,18 @@ def ovdc_enable(ctx, ovdc_name, org_name, enable_native, enable_tkg_plus):
     help="Remove the compute policies from deployed VMs as well. "
          "Does not remove the compute policy from vApp templates in catalog. ")
 def ovdc_disable(ctx, ovdc_name, org_name,
-                 enable_native, enable_tkg_plus,
+                 disable_native, disable_tkg_plus,
                  remove_cp_from_vms_on_disable):
     """Disable Kubernetes cluster deployment for an org VDC."""
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
-    if not (enable_native or enable_tkg_plus):
+    if not (disable_native or disable_tkg_plus):
         msg = "Please specify at least one of --native or --tkg-plus to disable" # noqa:E501
         stderr(msg, ctx)
         CLIENT_LOGGER.error(msg)
     k8_runtime = []
-    if enable_native:
+    if disable_native:
         k8_runtime.append(shared_constants.NATIVE_CLUSTER_RUNTIME_POLICY)
-    if enable_tkg_plus:
+    if disable_tkg_plus:
         k8_runtime.append(shared_constants.TKG_PLUS_CLUSTER_RUNTIME_POLICY)
     try:
         client_utils.cse_restore_session(ctx)

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -1370,14 +1370,14 @@ def ovdc_enable(ctx, ovdc_name, org_name, enable_native, enable_tkg_plus):
     '--native',
     'disable_native',
     is_flag=True,
-    help="Enable OVDC for native cluster deployment"
+    help="Disable OVDC for native cluster deployment"
 )
 @click.option(
     '-t',
     '--tkg-plus',
     'disable_tkg_plus',
     is_flag=True,
-    help="Enable OVDC for TKG plus cluster deployment"
+    help="Disable OVDC for TKG plus cluster deployment"
 )
 @click.option(
     '-f',


### PR DESCRIPTION
…t variable

To help us process your pull request efficiently, please include: 

* Allow the option --tkg-plus for ovdc enable and disable only if environment variable `CSE_TKG_PLUS_ENABLE` is set.

<img width="772" alt="Screen Shot 2020-08-06 at 6 10 57 PM" src="https://user-images.githubusercontent.com/16699642/89597871-31838280-d810-11ea-8eac-e4bf842fd500.png">

@sakthisunda @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/684)
<!-- Reviewable:end -->
