### PR TITLE
[VCDA-1731-TestFest]  Input-validation-error-for-cluster-resize 

### DIFF
--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -386,8 +386,7 @@ def flatten_dictionary(input_dict, parent_key='', separator='.'):
         val = input_dict.get(k)
         key_prefix = f"{parent_key}{k}"
         if isinstance(val, dict):
-            parent_key = f"{key_prefix}{separator}"
-            flattened_dict.update(flatten_dictionary(val, parent_key))  # noqa: E501
+            flattened_dict.update(flatten_dictionary(val, f"{key_prefix}{separator}"))  # noqa: E501
         else:
             flattened_dict.update({key_prefix: val})
     return flattened_dict


### PR DESCRIPTION
-  Fixed the broken input validation
-  Error reproduced. Fixed passing the parent key while flattening  
- Tested again using `vcd cse cluster apply`

@Anirudh9794 @sahithi @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/687)
<!-- Reviewable:end -->
