### PR TITLE
Add cse def schema to CSE whl package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ osl = 'open_source_license_container-service-extension_2.6_GA.txt'
 
 setup(
     setup_requires=['pbr>=1.9', 'setuptools>=17.1'],
-    packages=['container_service_extension'],
+    packages=['container_service_extension', 'cse_def_schema'],
     data_files=[
         (str(Path('/')), ['LICENSE.txt', 'NOTICE.txt', osl]),
     ],


### PR DESCRIPTION
Currently if a whl package is created for CSE and installed, `cse install` command will fail because the CSE DEF schema file is not packaged in the whl file. This PR fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/688)
<!-- Reviewable:end -->
