### PR TITLE
[VCDA-1704] Default down to tkg only operations when cse server is not running

### DIFF
--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -17,6 +17,10 @@ class GroupKey(str, Enum):
     CLUSTER = 'cluster'
     NODE = 'node'
     OVDC = 'ovdc'
+    PKS = 'pks'
+    SYSTEM = 'system'
+    TEMPLATE = 'template'
+    VERSION = 'version'
 
 
 @unique
@@ -88,8 +92,10 @@ UNSUPPORTED_SUBCOMMAND_OPTIONS_BY_VERSION = {
     }
 }
 
-SUPPORTED_SUBCOMMANDS_WHEN_SERVER_NOT_RUNNING_BY_VERSION = {
-    vcd_client.ApiVersion.
+UNSUPPORTED_SUBCOMMANDS_WITH_SERVER_NOT_RUNNING_BY_VERSION = {
+    vcd_client.ApiVersion.VERSION_35.value: [GroupKey.VERSION, GroupKey.OVDC,
+                                             GroupKey.SYSTEM, GroupKey.TEMPLATE,  # noqa: E501
+                                             GroupKey.PKS]
 }
 
 
@@ -118,6 +124,10 @@ class GroupCommandFilter(click.Group):
                 client_utils.cse_restore_session(ctx)
             client = ctx.obj['client']
             version = client.get_api_version()
+
+            # Skipping some commands when CSE server is not running
+            if cmd_name in UNSUPPORTED_SUBCOMMANDS_WITH_SERVER_NOT_RUNNING_BY_VERSION.get(version, []) and client_utils.is_cli_for_tkg_only():  # noqa: E501
+                return None
 
             # Skip the command if not supported
             if cmd_name in UNSUPPORTED_COMMANDS_BY_VERSION.get(version, []):

--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -88,6 +88,10 @@ UNSUPPORTED_SUBCOMMAND_OPTIONS_BY_VERSION = {
     }
 }
 
+SUPPORTED_SUBCOMMANDS_WHEN_SERVER_NOT_RUNNING_BY_VERSION = {
+    vcd_client.ApiVersion.
+}
+
 
 class GroupCommandFilter(click.Group):
     """Filter for CLI group commands.

--- a/container_service_extension/client/constants.py
+++ b/container_service_extension/client/constants.py
@@ -15,6 +15,10 @@ TKG_ENTITY_TYPE_ID = def_utils.generate_entity_type_id(
 
 TKG_CLUSTER_RUNTIME = 'TkgCluster'
 
+# Profile variables
+CSE_SERVER_API_VERSION = 'cse_server_api_version'
+CSE_SERVER_RUNNING = 'cse_server_running'
+
 
 @unique
 class CLIOutputKey(str, Enum):

--- a/container_service_extension/client/constants.py
+++ b/container_service_extension/client/constants.py
@@ -15,7 +15,10 @@ TKG_ENTITY_TYPE_ID = def_utils.generate_entity_type_id(
 
 TKG_CLUSTER_RUNTIME = 'TkgCluster'
 
-# CLI Profile key
+# if cse_server_running key is set to false in profiles.yaml, CSE CLI can
+# only be used to work with TKG clusters. This key is set when the first call
+# to CSE server is made. If CSE server starts running after the first call
+# fails, a re-login is needed to reset the key in profiles.yaml
 CSE_SERVER_RUNNING = 'cse_server_running'
 
 

--- a/container_service_extension/client/constants.py
+++ b/container_service_extension/client/constants.py
@@ -15,8 +15,7 @@ TKG_ENTITY_TYPE_ID = def_utils.generate_entity_type_id(
 
 TKG_CLUSTER_RUNTIME = 'TkgCluster'
 
-# Profile variables
-CSE_SERVER_API_VERSION = 'cse_server_api_version'
+# CLI Profile key
 CSE_SERVER_RUNNING = 'cse_server_running'
 
 

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -243,11 +243,7 @@ def cluster_delete(ctx, name, vdc, org, k8_runtime=None):
             if k8_runtime in [ClusterEntityKind.NATIVE.value,
                               ClusterEntityKind.TANZU_PLUS.value]:
                 # Cannot run the command as cse cli is enabled only for native
-                raise CseServerNotRunningError(
-                    "Please contact administrator, CSE server seems to be"
-                    " down. CSE- CLI can now only be used to manage TKG "
-                    " clusters (but not native). Once CSE server is up, please"
-                    " re-login to manage both native and tkg clusters.")
+                raise CseServerNotRunningError()
             k8_runtime = ClusterEntityKind.TKG.value
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org is None:
@@ -619,11 +615,7 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, output):
             if k8_runtime in [ClusterEntityKind.NATIVE.value,
                               ClusterEntityKind.TANZU_PLUS.value]:
                 # Cannot run the command as cse cli is enabled only for native
-                raise CseServerNotRunningError(
-                    "Please contact administrator, CSE server seems to be"
-                    " down. CSE- CLI can now only be used to manage TKG "
-                    " clusters (but not native). Once CSE server is up, please"
-                    " re-login to manage both native and tkg clusters.")
+                raise CseServerNotRunningError()
             k8_runtime = ClusterEntityKind.TKG.value
         metadata = cluster_config.get('metadata', {})
         metadata_vdc_key = ''
@@ -692,11 +684,7 @@ def cluster_upgrade_plan(ctx, cluster_name, vdc, org_name, k8_runtime=None):
             if k8_runtime in [ClusterEntityKind.NATIVE.value,
                               ClusterEntityKind.TANZU_PLUS.value]:
                 # Cannot run the command as cse cli is enabled only for native
-                raise CseServerNotRunningError(
-                    "Please contact administrator, CSE server seems to be"
-                    " down. CSE- CLI can now only be used to manage TKG "
-                    " clusters (but not native). Once CSE server is up, please"
-                    " re-login to manage both native and tkg clusters.")
+                raise CseServerNotRunningError()
             k8_runtime = ClusterEntityKind.TKG.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
@@ -770,11 +758,7 @@ def cluster_upgrade(ctx, cluster_name, template_name, template_revision,
             if k8_runtime in [ClusterEntityKind.NATIVE.value,
                               ClusterEntityKind.TANZU_PLUS.value]:
                 # Cannot run the command as cse cli is enabled only for native
-                raise CseServerNotRunningError(
-                    "Please contact administrator, CSE server seems to be"
-                    " down. CSE- CLI can now only be used to manage TKG "
-                    " clusters (but not native). Once CSE server is up, please"
-                    " re-login to manage both native and tkg clusters.")
+                raise CseServerNotRunningError()
             k8_runtime = ClusterEntityKind.TKG.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
@@ -833,11 +817,7 @@ def cluster_config(ctx, name, vdc, org, k8_runtime=None):
             if k8_runtime in [ClusterEntityKind.NATIVE.value,
                               ClusterEntityKind.TANZU_PLUS.value]:
                 # Cannot run the command as cse cli is enabled only for native
-                raise CseServerNotRunningError(
-                    "Please contact administrator, CSE server seems to be"
-                    " down. CSE- CLI can now only be used to manage TKG "
-                    " clusters (but not native). Once CSE server is up, please"
-                    " re-login to manage both native and tkg clusters.")
+                raise CseServerNotRunningError()
             k8_runtime = ClusterEntityKind.TKG.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
@@ -892,11 +872,7 @@ def cluster_info(ctx, name, org, vdc, k8_runtime=None):
             if k8_runtime in [ClusterEntityKind.NATIVE.value,
                               ClusterEntityKind.TANZU_PLUS.value]:
                 # Cannot run the command as cse cli is enabled only for native
-                raise CseServerNotRunningError(
-                    "Please contact administrator, CSE server seems to be"
-                    " down. CSE- CLI can now only be used to manage TKG "
-                    " clusters (but not native). Once CSE server is up, please"
-                    " re-login to manage both native and tkg clusters.")
+                raise CseServerNotRunningError()
             k8_runtime = ClusterEntityKind.TKG.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -20,6 +20,7 @@ import container_service_extension.client.utils as client_utils
 import container_service_extension.def_.models as def_models
 import container_service_extension.def_.utils as def_utils
 from container_service_extension.exceptions import CseResponseError
+from container_service_extension.exceptions import CseServerNotRunningError
 from container_service_extension.logger import CLIENT_LOGGER
 from container_service_extension.minor_error_codes import MinorErrorCode
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
@@ -614,9 +615,12 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, output):
         if client_utils.is_cli_for_tkg_only():
             if k8_runtime in [ClusterEntityKind.NATIVE.value,
                               ClusterEntityKind.TANZU_PLUS.value]:
-                # Cannot run the command as cse cli is enabled only for native:
-                raise Exception("CSE cli is enabled only for "
-                                "TanzuKubernetesCluster runtime.")
+                # Cannot run the command as cse cli is enabled only for native
+                raise CseServerNotRunningError(
+                    "Please contact administrator, CSE server seems to be down."
+                    " CSE- CLI can now only be used to manage TKG clusters"
+                    " (but not native). Once CSE server is up, please re-login"
+                    " to manage both native and tkg clusters.")
             k8_runtime = ClusterEntityKind.TKG.value
         metadata = cluster_config.get('metadata', {})
         metadata_vdc_key = ''

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -617,10 +617,10 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, output):
                               ClusterEntityKind.TANZU_PLUS.value]:
                 # Cannot run the command as cse cli is enabled only for native
                 raise CseServerNotRunningError(
-                    "Please contact administrator, CSE server seems to be down."
-                    " CSE- CLI can now only be used to manage TKG clusters"
-                    " (but not native). Once CSE server is up, please re-login"
-                    " to manage both native and tkg clusters.")
+                    "Please contact administrator, CSE server seems to be"
+                    " down. CSE- CLI can now only be used to manage TKG "
+                    " clusters (but not native). Once CSE server is up, please"
+                    " re-login to manage both native and tkg clusters.")
             k8_runtime = ClusterEntityKind.TKG.value
         metadata = cluster_config.get('metadata', {})
         metadata_vdc_key = ''

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -242,9 +242,12 @@ def cluster_delete(ctx, name, vdc, org, k8_runtime=None):
         if client_utils.is_cli_for_tkg_only():
             if k8_runtime in [ClusterEntityKind.NATIVE.value,
                               ClusterEntityKind.TANZU_PLUS.value]:
-                # Cannot run the command as cse cli is enabled only for native:
-                raise Exception("CSE cli is enabled only for "
-                                "TanzuKubernetesCluster runtime.")
+                # Cannot run the command as cse cli is enabled only for native
+                raise CseServerNotRunningError(
+                    "Please contact administrator, CSE server seems to be"
+                    " down. CSE- CLI can now only be used to manage TKG "
+                    " clusters (but not native). Once CSE server is up, please"
+                    " re-login to manage both native and tkg clusters.")
             k8_runtime = ClusterEntityKind.TKG.value
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org is None:
@@ -688,9 +691,12 @@ def cluster_upgrade_plan(ctx, cluster_name, vdc, org_name, k8_runtime=None):
         if client_utils.is_cli_for_tkg_only():
             if k8_runtime in [ClusterEntityKind.NATIVE.value,
                               ClusterEntityKind.TANZU_PLUS.value]:
-                # Cannot run the command as cse cli is enabled only for native:
-                raise Exception("CSE cli is enabled only for "
-                                "TanzuKubernetesCluster runtime.")
+                # Cannot run the command as cse cli is enabled only for native
+                raise CseServerNotRunningError(
+                    "Please contact administrator, CSE server seems to be"
+                    " down. CSE- CLI can now only be used to manage TKG "
+                    " clusters (but not native). Once CSE server is up, please"
+                    " re-login to manage both native and tkg clusters.")
             k8_runtime = ClusterEntityKind.TKG.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
@@ -763,9 +769,12 @@ def cluster_upgrade(ctx, cluster_name, template_name, template_revision,
         if client_utils.is_cli_for_tkg_only():
             if k8_runtime in [ClusterEntityKind.NATIVE.value,
                               ClusterEntityKind.TANZU_PLUS.value]:
-                # Cannot run the command as cse cli is enabled only for native:
-                raise Exception("CSE cli is enabled only for "
-                                "TanzuKubernetesCluster runtime.")
+                # Cannot run the command as cse cli is enabled only for native
+                raise CseServerNotRunningError(
+                    "Please contact administrator, CSE server seems to be"
+                    " down. CSE- CLI can now only be used to manage TKG "
+                    " clusters (but not native). Once CSE server is up, please"
+                    " re-login to manage both native and tkg clusters.")
             k8_runtime = ClusterEntityKind.TKG.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
@@ -823,9 +832,12 @@ def cluster_config(ctx, name, vdc, org, k8_runtime=None):
         if client_utils.is_cli_for_tkg_only():
             if k8_runtime in [ClusterEntityKind.NATIVE.value,
                               ClusterEntityKind.TANZU_PLUS.value]:
-                # Cannot run the command as cse cli is enabled only for native:
-                raise Exception("CSE cli is enabled only for "
-                                "TanzuKubernetesCluster runtime.")
+                # Cannot run the command as cse cli is enabled only for native
+                raise CseServerNotRunningError(
+                    "Please contact administrator, CSE server seems to be"
+                    " down. CSE- CLI can now only be used to manage TKG "
+                    " clusters (but not native). Once CSE server is up, please"
+                    " re-login to manage both native and tkg clusters.")
             k8_runtime = ClusterEntityKind.TKG.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
@@ -879,9 +891,12 @@ def cluster_info(ctx, name, org, vdc, k8_runtime=None):
         if client_utils.is_cli_for_tkg_only():
             if k8_runtime in [ClusterEntityKind.NATIVE.value,
                               ClusterEntityKind.TANZU_PLUS.value]:
-                # Cannot run the command as cse cli is enabled only for native:
-                raise Exception("CSE cli is enabled only for "
-                                "TanzuKubernetesCluster runtime.")
+                # Cannot run the command as cse cli is enabled only for native
+                raise CseServerNotRunningError(
+                    "Please contact administrator, CSE server seems to be"
+                    " down. CSE- CLI can now only be used to manage TKG "
+                    " clusters (but not native). Once CSE server is up, please"
+                    " re-login to manage both native and tkg clusters.")
             k8_runtime = ClusterEntityKind.TKG.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -238,6 +238,13 @@ def cluster_delete(ctx, name, vdc, org, k8_runtime=None):
     try:
         client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
+        if client_utils.is_cli_for_tkg_only():
+            if k8_runtime in [ClusterEntityKind.NATIVE.value,
+                              ClusterEntityKind.TANZU_PLUS.value]:
+                # Cannot run the command as cse cli is enabled only for native:
+                raise Exception("CSE cli is enabled only for "
+                                "TanzuKubernetesCluster runtime.")
+            k8_runtime = ClusterEntityKind.TKG.value
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org is None:
             org = ctx.obj['profiles'].get('org_in_use')
@@ -604,7 +611,13 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, output):
         k8_runtime = cluster_config.get('kind')
         if not k8_runtime:
             raise Exception("Cluster kind missing from the spec.")
-
+        if client_utils.is_cli_for_tkg_only():
+            if k8_runtime in [ClusterEntityKind.NATIVE.value,
+                              ClusterEntityKind.TANZU_PLUS.value]:
+                # Cannot run the command as cse cli is enabled only for native:
+                raise Exception("CSE cli is enabled only for "
+                                "TanzuKubernetesCluster runtime.")
+            k8_runtime = ClusterEntityKind.TKG.value
         metadata = cluster_config.get('metadata', {})
         metadata_vdc_key = ''
         if k8_runtime == ClusterEntityKind.NATIVE.value or \
@@ -668,6 +681,13 @@ def cluster_upgrade_plan(ctx, cluster_name, vdc, org_name, k8_runtime=None):
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
         client_utils.cse_restore_session(ctx)
+        if client_utils.is_cli_for_tkg_only():
+            if k8_runtime in [ClusterEntityKind.NATIVE.value,
+                              ClusterEntityKind.TANZU_PLUS.value]:
+                # Cannot run the command as cse cli is enabled only for native:
+                raise Exception("CSE cli is enabled only for "
+                                "TanzuKubernetesCluster runtime.")
+            k8_runtime = ClusterEntityKind.TKG.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org_name is None:
@@ -736,6 +756,13 @@ def cluster_upgrade(ctx, cluster_name, template_name, template_revision,
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
         client_utils.cse_restore_session(ctx)
+        if client_utils.is_cli_for_tkg_only():
+            if k8_runtime in [ClusterEntityKind.NATIVE.value,
+                              ClusterEntityKind.TANZU_PLUS.value]:
+                # Cannot run the command as cse cli is enabled only for native:
+                raise Exception("CSE cli is enabled only for "
+                                "TanzuKubernetesCluster runtime.")
+            k8_runtime = ClusterEntityKind.TKG.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org_name is None:
@@ -789,6 +816,13 @@ def cluster_config(ctx, name, vdc, org, k8_runtime=None):
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
         client_utils.cse_restore_session(ctx)
+        if client_utils.is_cli_for_tkg_only():
+            if k8_runtime in [ClusterEntityKind.NATIVE.value,
+                              ClusterEntityKind.TANZU_PLUS.value]:
+                # Cannot run the command as cse cli is enabled only for native:
+                raise Exception("CSE cli is enabled only for "
+                                "TanzuKubernetesCluster runtime.")
+            k8_runtime = ClusterEntityKind.TKG.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org is None:
@@ -838,6 +872,13 @@ def cluster_info(ctx, name, org, vdc, k8_runtime=None):
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
         client_utils.cse_restore_session(ctx)
+        if client_utils.is_cli_for_tkg_only():
+            if k8_runtime in [ClusterEntityKind.NATIVE.value,
+                              ClusterEntityKind.TANZU_PLUS.value]:
+                # Cannot run the command as cse cli is enabled only for native:
+                raise Exception("CSE cli is enabled only for "
+                                "TanzuKubernetesCluster runtime.")
+            k8_runtime = ClusterEntityKind.TKG.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org is None:

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -119,6 +119,27 @@ class TKGClusterApi:
             tkg_def_entities = response[3]
         return entities, tkg_def_entities
 
+    def get_cluster_info(self, cluster_name, org=None, vdc=None):
+        """Get cluster information of a TKG cluster API.
+
+        :param str cluster_name: name of the cluster
+        :param str vdc: name of vdc
+        :param str org: name of org
+
+        :return: cluster information
+        :rtype: str
+        :raises ClusterNotFoundError
+        """
+        tkg_entities, _ = self.get_tkg_clusters_by_name(cluster_name, vdc=vdc, org=org)  # noqa: E501
+        if len(tkg_entities) == 0:
+            msg = f"Cluster '{cluster_name}' not found."
+            logger.CLIENT_LOGGER.error(msg)
+            raise cse_exceptions.ClusterNotFoundError(msg)
+        cluster_dict = tkg_entities[0].to_dict()
+        logger.CLIENT_LOGGER.debug(
+            f"Received defined entity of cluster {cluster_name} : {cluster_dict}")  # noqa: E501
+        return yaml.dump(cluster_dict)
+
     def apply(self, cluster_config: dict):
         """Apply the configuration either to create or update the cluster.
 
@@ -179,9 +200,9 @@ class TKGClusterApi:
             raise
 
     def delete_cluster(self, cluster_name, org=None, vdc=None):
-        """Delete DEF native cluster by name.
+        """Delete TKG cluster by name.
 
-        :param str cluster_name: native cluster name
+        :param str cluster_name: TKG cluster name
         :param str org: name of the org
         :param str vdc: name of the vdc
         :return: deleted cluster information
@@ -208,3 +229,15 @@ class TKGClusterApi:
         except Exception as e:
             logger.CLIENT_LOGGER.error(f"{e}")
             raise
+
+    def get_cluster_config(self, cluster_name, vdc=None, org=None):
+        """Get kubernetes cluster config of the cluster.
+
+        :param str cluster_name: TKG cluster name
+        :param str org: name of the org
+        :param str vdc: name of the vdc
+        :return: Cluster kubeconfig information
+        :rtype: str
+        :raises ClusterNotFoundError, CseDuplicateClusterError
+        """
+        raise NotImplementedError()

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -7,9 +7,9 @@ import requests
 from vcd_cli.profiles import Profiles
 
 from container_service_extension.client import system as syst
-from container_service_extension.client.constants import CSE_SERVER_API_VERSION
 from container_service_extension.client.constants import CSE_SERVER_RUNNING
 import container_service_extension.def_.utils as def_utils
+from container_service_extension.shared_constants import CSE_SERVER_API_VERSION
 
 _ENABLE_ONLY_TKG_OPERATIONS = False
 
@@ -87,9 +87,9 @@ def _override_client(ctx) -> None:
     :param <click.core.Context> ctx: click context
     """
     profiles = Profiles.load()
-    is_cse_server_running = profiles.get(CSE_SERVER_RUNNING)
+    is_cse_server_running = profiles.get(CSE_SERVER_RUNNING, default=True)
     cse_server_api_version = profiles.get(CSE_SERVER_API_VERSION)
-    if is_cse_server_running is None or is_cse_server_running:
+    if is_cse_server_running:
         # Get server_api_version; save it in profiles if doesn't exist
         if not cse_server_api_version:
             try:
@@ -105,6 +105,7 @@ def _override_client(ctx) -> None:
                 # enable CLI for only TKG operations
                 enable_cli_for_only_tkg_operations()
                 ctx.obj['profiles'] = profiles
+                profiles.save()
                 return
         client = Client(
             profiles.get('host'),

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -67,7 +67,7 @@ def cse_restore_session(ctx, vdc_required=False) -> None:
         client.rehydrate_from_token(
             profiles.get('token'), profiles.get('is_jwt_token'))
 
-        ctx.obj = dict()
+        ctx.obj = {}
         ctx.obj['client'] = client
 
     _override_client(ctx)
@@ -105,7 +105,10 @@ def _override_client(ctx) -> None:
             profiles.set(CSE_SERVER_API_VERSION, cse_server_api_version)
             profiles.set(CSE_SERVER_RUNNING, True)
             profiles.save()
-        except Exception:
+        except Exception as e:
+            from container_service_extension.utils import ConsoleMessagePrinter
+            cb = ConsoleMessagePrinter()
+            cb.general(f"{e}")
             # If request to CSE server times out
             profiles.set(CSE_SERVER_RUNNING, False)
             # enable CLI for only TKG operations

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -9,6 +9,7 @@ from vcd_cli.profiles import Profiles
 from container_service_extension.client import system as syst
 from container_service_extension.client.constants import CSE_SERVER_RUNNING
 import container_service_extension.def_.utils as def_utils
+from container_service_extension.exceptions import CseResponseError
 from container_service_extension.shared_constants import CSE_SERVER_API_VERSION
 
 _RESTRICT_CLI_TO_TKG_OPERATIONS = False
@@ -105,13 +106,10 @@ def _override_client(ctx) -> None:
             profiles.set(CSE_SERVER_API_VERSION, cse_server_api_version)
             profiles.set(CSE_SERVER_RUNNING, True)
             profiles.save()
-        except Exception as e:
-            from container_service_extension.utils import ConsoleMessagePrinter
-            cb = ConsoleMessagePrinter()
-            cb.general(f"{e}")
+        except CseResponseError:
             # If request to CSE server times out
             profiles.set(CSE_SERVER_RUNNING, False)
-            # enable CLI for only TKG operations
+            # restrict CLI for only TKG operations
             restrict_cli_to_tkg_operations()
             ctx.obj['profiles'] = profiles
             profiles.save()

--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -36,6 +36,17 @@ class CseServerError(Exception):
 class CseServerNotRunningError(CseServerError):
     """Raised when CLI makes requests to CSE server when it is not available."""  # noqa: E501
 
+    def __init__(self, msg=None):
+        self.msg = msg
+
+    def __str__(self):
+        if self.msg:
+            return self.msg
+        return "Please contact administrator, CSE server seems to be" \
+               " down. CSE- CLI can now only be used to manage TKG " \
+               " clusters (but not native). Once CSE server is up, please" \
+               " re-login to manage both native and tkg clusters."
+
 
 class CseRequestError(CseServerError):
     """Base class for all incoming CSE REST request errors."""

--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -33,6 +33,10 @@ class CseServerError(Exception):
     """Base class for cse server side exceptions."""
 
 
+class CseServerNotRunningError(CseServerError):
+    """Raised when CLI makes requests to CSE server when it is not available"""
+
+
 class CseRequestError(CseServerError):
     """Base class for all incoming CSE REST request errors."""
 

--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -34,7 +34,7 @@ class CseServerError(Exception):
 
 
 class CseServerNotRunningError(CseServerError):
-    """Raised when CLI makes requests to CSE server when it is not available"""
+    """Raised when CLI makes requests to CSE server when it is not available."""  # noqa: E501
 
 
 class CseRequestError(CseServerError):

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -17,6 +17,7 @@ UNKNOWN_ERROR_MESSAGE = "Unknown error. Please contact your System " \
                         "Administrator"
 
 RESPONSE_MESSAGE_KEY = "message"
+CSE_SERVER_API_VERSION = 'cse_server_api_version'
 
 NATIVE_CLUSTER_RUNTIME_POLICY = 'native'
 TKG_PLUS_CLUSTER_RUNTIME_POLICY = 'tkg_plus'

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -17,7 +17,6 @@ UNKNOWN_ERROR_MESSAGE = "Unknown error. Please contact your System " \
                         "Administrator"
 
 RESPONSE_MESSAGE_KEY = "message"
-CSE_SERVER_API_VERSION = 'cse_server_api_version'
 
 NATIVE_CLUSTER_RUNTIME_POLICY = 'native'
 TKG_PLUS_CLUSTER_RUNTIME_POLICY = 'tkg_plus'


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Decisions made:
* When run for the first time, the cse cli tries to contact cse server. If the server is not running, it will set the flag `cse_server_running` in profiles.yaml
* Subsequent calls will first check two keys `cse_server_running` and `cse_server_api_version` in the profiles yaml
* If CSE server is not running, all the cli calls will land to `tkg_cluster_api.yaml`
* If the CSE server starts running after the flag `cse_server_running` is set, the user has to log out

Screenshot:
<img width="1103" alt="Screen Shot 2020-08-11 at 2 49 08 PM" src="https://user-images.githubusercontent.com/16699642/89957060-5b132400-dbeb-11ea-81ea-3d9d72d218e3.png">

@sahithi @rocknes @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/690)
<!-- Reviewable:end -->
