### PR TITLE
[VCDA-1695] Hide references to TKG PLUS unless opt-ed in

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -1714,22 +1714,29 @@ def _assign_placement_policy_to_vdc_with_existing_clusters(
             INSTALL_LOGGER.info(msg)
             msg_update_callback.general(msg)
 
-    if is_tkg_plus_enabled and tkg_plus_ovdcs:
+    if tkg_plus_ovdcs:
         msg = f"Found {len(tkg_plus_ovdcs)} vDC(s) hosting TKG PLUS clusters."
+        if not is_tkg_plus_enabled:
+            msg += " However TKG PLUS is not enabled in CSE. vDC(s) hosting " \
+                   "TKG PLUS clusters will not be processed. Please enable " \
+                   "TKG PLUS for CSE and re-run `cse upgrade` to process " \
+                   "these vDC(s)."
         msg_update_callback.info(msg)
         INSTALL_LOGGER.info(msg)
-        tkg_plus_policy = cpm.get_vdc_compute_policy(
-            policy_name=shared_constants.TKG_PLUS_CLUSTER_RUNTIME_POLICY,
-            is_placement_policy=True)
-        for vdc_id in tkg_plus_ovdcs:
-            cpm.add_compute_policy_to_vdc(
-                vdc_id=vdc_id,
-                compute_policy_href=tkg_plus_policy['href'])
-            msg = "Added compute policy " \
-                  f"'{tkg_plus_policy['display_name']}' to vDC " \
-                  f"'{vdc_names[vdc_id]}'"
-            INSTALL_LOGGER.info(msg)
-            msg_update_callback.general(msg)
+
+        if is_tkg_plus_enabled:
+            tkg_plus_policy = cpm.get_vdc_compute_policy(
+                policy_name=shared_constants.TKG_PLUS_CLUSTER_RUNTIME_POLICY,
+                is_placement_policy=True)
+            for vdc_id in tkg_plus_ovdcs:
+                cpm.add_compute_policy_to_vdc(
+                    vdc_id=vdc_id,
+                    compute_policy_href=tkg_plus_policy['href'])
+                msg = "Added compute policy " \
+                      f"'{tkg_plus_policy['display_name']}' to vDC " \
+                      f"'{vdc_names[vdc_id]}'"
+                INSTALL_LOGGER.info(msg)
+                msg_update_callback.general(msg)
 
 
 def _remove_old_cse_sizing_compute_policies(

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -124,6 +124,21 @@ def is_pks_enabled():
     return Service().is_pks_enabled()
 
 
+def is_tkg_plus_enabled(config: dict):
+    if not config:
+        try:
+            config = get_server_runtime_config()
+        except Exception:
+            return False
+    service_section = config.get('service', {})
+    tkg_plus_enabled = service_section.get('enable_tkg_plus', False)
+    if isinstance(tkg_plus_enabled, bool):
+        return tkg_plus_enabled
+    elif isinstance(tkg_plus_enabled, str):
+        return str_to_bool(tkg_plus_enabled)
+    return False
+
+
 def get_duplicate_items_in_list(items):
     """Find duplicate entries in a list.
 

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -124,7 +124,7 @@ def is_pks_enabled():
     return Service().is_pks_enabled()
 
 
-def is_tkg_plus_enabled(config: dict):
+def is_tkg_plus_enabled(config: dict = None):
     if not config:
         try:
             config = get_server_runtime_config()


### PR DESCRIPTION
TKG PLUS is not available to CSE users by default. As a result, any reference to it should not show up on console. The two major operations where TKG PLUS related messages are dumped onto console are 1. CSE install, 2. CSE upgrade. In this PR both these workflows have been modified to suppress the messages unless a particular flag is found in the config file.

Testing done:
Ran the workflows with and without the flag in the config file and verified that the messages are showing up on the console only if the flag is set to True.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/693)
<!-- Reviewable:end -->
