### PR TITLE
Set default values for hidden tkg-plus options

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -1308,20 +1308,20 @@ def list_ovdcs(ctx):
     '--native',
     'enable_native',
     is_flag=True,
-    help="Enable OVDC for native cluster deployment"
+    help="Enable OVDC for k8 runtime native"
 )
 @click.option(
     '-t',
     '--tkg-plus',
     'enable_tkg_plus',
     is_flag=True,
-    help="Enable OVDC for TKG plus cluster deployment"
+    help="Enable OVDC for k8 runtime TKG plus"
 )
-def ovdc_enable(ctx, ovdc_name, org_name, enable_native, enable_tkg_plus):
+def ovdc_enable(ctx, ovdc_name, org_name, enable_native, enable_tkg_plus=None):
     """Set Kubernetes provider for an org VDC."""
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     if not (enable_native or enable_tkg_plus):
-        msg = "Please specify at least one of --native or --tkg-plus to enable"
+        msg = "Please specify at least one k8 runtime to enable"
         stderr(msg, ctx)
         CLIENT_LOGGER.error(msg)
     k8_runtime = []
@@ -1370,14 +1370,14 @@ def ovdc_enable(ctx, ovdc_name, org_name, enable_native, enable_tkg_plus):
     '--native',
     'disable_native',
     is_flag=True,
-    help="Disable OVDC for native cluster deployment"
+    help="Disable OVDC for k8 runtime native cluster"
 )
 @click.option(
     '-t',
     '--tkg-plus',
     'disable_tkg_plus',
     is_flag=True,
-    help="Disable OVDC for TKG plus cluster deployment"
+    help="Disable OVDC for k8 runtime TKG plus"
 )
 @click.option(
     '-f',
@@ -1387,12 +1387,12 @@ def ovdc_enable(ctx, ovdc_name, org_name, enable_native, enable_tkg_plus):
     help="Remove the compute policies from deployed VMs as well. "
          "Does not remove the compute policy from vApp templates in catalog. ")
 def ovdc_disable(ctx, ovdc_name, org_name,
-                 disable_native, disable_tkg_plus,
-                 remove_cp_from_vms_on_disable):
+                 disable_native, disable_tkg_plus=None,
+                 remove_cp_from_vms_on_disable=False):
     """Disable Kubernetes cluster deployment for an org VDC."""
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     if not (disable_native or disable_tkg_plus):
-        msg = "Please specify at least one of --native or --tkg-plus to disable" # noqa:E501
+        msg = "Please specify at least one k8 runtime to disable"
         stderr(msg, ctx)
         CLIENT_LOGGER.error(msg)
     k8_runtime = []


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

This PR fixes an error where no value is passed to the flag parameter enable-tkg-plus and disable-tkg-plus for ovdc_enable() and ovdc_disable() functions in cse.py.

Testing done:
 checked if `vcd cse ovdc enable` and `vcd cse ovdc disable` commands are 
* showing correct options with and witout `CSE_TKG_PLUS_ENABLED` environment variable set
* no error is thrown when the commands are executed.

@rocknes @sahithi @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/695)
<!-- Reviewable:end -->
