### PR TITLE
[VCDA 1564] telemetry for defined entities

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -651,8 +651,7 @@ def _register_right(client, right_name, description, category, bundle_key,
 def _setup_placement_policies(client, policy_list,
                               msg_update_callback=utils.NullPrinter(),
                               log_wire=False):
-    """
-    Create placement policies for each cluster type.
+    """Create placement policies for each cluster type.
 
     Create the global pvdc compute policy if not present and create placement
     policy for each policy in the policy list. This should be done only for
@@ -958,8 +957,6 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
 
     client = None
     try:
-        # Todo: Record telemetry detail call
-
         log_filename = None
         log_wire = utils.str_to_bool(config['service'].get('log_wire'))
         if log_wire:
@@ -984,6 +981,20 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
         try:
             ext_cse_version, ext_vcd_api_version = \
                 parse_cse_extension_description(client)
+
+            telemetry_data = {
+                PayloadKey.SOURCE_CSE_VERSION: str(ext_cse_version),
+                PayloadKey.SOURCE_VCD_API_VERSION: ext_vcd_api_version,
+                PayloadKey.WERE_TEMPLATES_SKIPPED: bool(skip_template_creation),  # noqa: E501
+                PayloadKey.WAS_TEMP_VAPP_RETAINED: bool(retain_temp_vapp),
+                PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(ssh_key)
+            }
+
+            # Telemetry - Record detailed telemetry data on upgrade
+            record_user_action_details(CseOperation.SERVICE_UPGRADE,
+                                       telemetry_data,
+                                       telemetry_settings=config['service']['telemetry'])  # noqa: E501
+
             if ext_cse_version == server_constants.UNKNOWN_CSE_VERSION or \
                     ext_vcd_api_version == server_constants.UNKNOWN_VCD_API_VERSION: # noqa: E501
                 msg = "Found CSE api extension registered with vCD, but " \
@@ -1062,7 +1073,9 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
         else:
             raise Exception(update_path_not_valid_msg)
 
-        # Todo: Telemetry - Record successful upgrade
+        record_user_action(CseOperation.SERVICE_UPGRADE,
+                           status=OperationStatus.SUCCESS,
+                           telemetry_settings=config['service']['telemetry'])
 
         msg = "Upgraded CSE successfully."
         msg_update_callback.general(msg)
@@ -1071,7 +1084,9 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
         msg_update_callback.error(
             "CSE Installation Error. Check CSE install logs")
         INSTALL_LOGGER.error("CSE Installation Error", exc_info=True)
-        # Todo: Telemetry - Record failed upgrade
+        record_user_action(CseOperation.SERVICE_UPGRADE,
+                           status=OperationStatus.FAILED,
+                           telemetry_settings=config['service']['telemetry'])
         raise
     finally:
         if client is not None:

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1,7 +1,6 @@
 # container-service-extension
 # Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-
 import copy
 import random
 import re
@@ -110,6 +109,9 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         if not result:
             raise e.ClusterOperationError("Couldn't get cluster configuration")
+
+        record_user_action_details(cse_operation=CseOperation.V35_CLUSTER_CONFIG, # noqa: E501
+                                   cse_params=curr_entity)
 
         return result.content.decode()
 
@@ -221,6 +223,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                           entity=def_entity)
         self.context.is_async = True
         def_entity = self.entity_svc.get_native_entity_by_name(cluster_name)
+        record_user_action_details(cse_operation=CseOperation.V35_CLUSTER_APPLY,  # noqa: E501
+                                   cse_params=def_entity)
         self._create_cluster_async(def_entity.id, cluster_spec)
         return def_entity
 
@@ -555,6 +559,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             DefEntityPhase(DefEntityOperation.UPDATE,
                            DefEntityOperationStatus.IN_PROGRESS))
         curr_entity = self.entity_svc.update_entity(cluster_id, curr_entity)
+        record_user_action_details(cse_operation=CseOperation.V35_CLUSTER_APPLY,  # noqa: E501
+                                   cse_params=curr_entity)
 
         # trigger async operation
         self.context.is_async = True

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1,7 +1,6 @@
 # container-service-extension
 # Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-import copy
 import random
 import re
 import string
@@ -40,10 +39,8 @@ from container_service_extension.shared_constants import DefEntityOperation
 from container_service_extension.shared_constants import DefEntityOperationStatus  # noqa: E501
 from container_service_extension.shared_constants import DefEntityPhase
 from container_service_extension.shared_constants import RequestKey
-from container_service_extension.telemetry.constants import CseOperation
-from container_service_extension.telemetry.constants import PayloadKey
-from container_service_extension.telemetry.telemetry_handler import \
-    record_user_action_details
+import container_service_extension.telemetry.constants as telemetry_constants
+import container_service_extension.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
 import container_service_extension.utils as utils
 import container_service_extension.vsphere_utils as vs_utils
 
@@ -91,8 +88,9 @@ class ClusterService(abstract_broker.AbstractBroker):
         """
         curr_entity = self.entity_svc.get_entity(cluster_id)
 
-        # TODO(DEF) design and implement telemetry VCDA-1564 defined entity
-        #  based clusters
+        telemetry_handler.record_user_action_details(
+            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_CONFIG,
+            cse_params=curr_entity)
 
         vapp = vcd_vapp.VApp(self.context.client, href=curr_entity.externalId)
         master_node_name = curr_entity.entity.status.nodes.master.name
@@ -110,9 +108,6 @@ class ClusterService(abstract_broker.AbstractBroker):
         if not result:
             raise e.ClusterOperationError("Couldn't get cluster configuration")
 
-        record_user_action_details(cse_operation=CseOperation.V35_CLUSTER_CONFIG, # noqa: E501
-                                   cse_params=curr_entity)
-
         return result.content.decode()
 
     def get_cluster_upgrade_plan(self, cluster_id: str):
@@ -124,12 +119,10 @@ class ClusterService(abstract_broker.AbstractBroker):
         :rtype: List[Dict]
         """
         curr_entity = self.entity_svc.get_entity(cluster_id)
-
-        # TODO(DEF) design and implement telemetry VCDA-1564 defined entity
-        #  based clusters
-        # cse_params = copy.deepcopy(validated_data)
-        # cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
-        # record_user_action_details(cse_operation=CseOperation.CLUSTER_UPGRADE_PLAN, cse_params=cse_params)  # noqa: E501
+        telemetry_handler.record_user_action_details(
+            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE_PLAN,  # noqa: E501
+            cse_params=curr_entity
+        )
 
         return self._get_cluster_upgrade_plan(curr_entity.entity.spec.k8_distribution.template_name, # noqa: E501
                                               curr_entity.entity.spec.k8_distribution.template_revision) # noqa: E501
@@ -223,8 +216,9 @@ class ClusterService(abstract_broker.AbstractBroker):
                           entity=def_entity)
         self.context.is_async = True
         def_entity = self.entity_svc.get_native_entity_by_name(cluster_name)
-        record_user_action_details(cse_operation=CseOperation.V35_CLUSTER_APPLY,  # noqa: E501
-                                   cse_params=def_entity)
+        telemetry_handler.record_user_action_details(
+            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY,
+            cse_params=def_entity)
         self._create_cluster_async(def_entity.id, cluster_spec)
         return def_entity
 
@@ -559,8 +553,9 @@ class ClusterService(abstract_broker.AbstractBroker):
             DefEntityPhase(DefEntityOperation.UPDATE,
                            DefEntityOperationStatus.IN_PROGRESS))
         curr_entity = self.entity_svc.update_entity(cluster_id, curr_entity)
-        record_user_action_details(cse_operation=CseOperation.V35_CLUSTER_APPLY,  # noqa: E501
-                                   cse_params=curr_entity)
+        telemetry_handler.record_user_action_details(
+            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY,
+            cse_params=curr_entity)
 
         # trigger async operation
         self.context.is_async = True
@@ -679,7 +674,9 @@ class ClusterService(abstract_broker.AbstractBroker):
                 f"Cluster {cluster_name} with id {cluster_id} is not in a "
                 f"valid state to be deleted. Please contact administrator.")
 
-        # TODO(DEF) Handle Telemetry
+        telemetry_handler.record_user_action_details(
+            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_DELETE,
+            cse_params=curr_entity)
 
         # must _update_task here or else self.task_resource is None
         # do not logout of sys admin, or else in pyvcloud's session.request()
@@ -809,12 +806,6 @@ class ClusterService(abstract_broker.AbstractBroker):
         cluster = get_cluster(self.context.client, cluster_name,
                               org_name=validated_data[RequestKey.ORG_NAME],
                               ovdc_name=validated_data[RequestKey.OVDC_NAME])
-
-        if kwargs.get(KwargKey.TELEMETRY, True):
-            # Record the telemetry data
-            cse_params = copy.deepcopy(validated_data)
-            cse_params[PayloadKey.CLUSTER_ID] = cluster[PayloadKey.CLUSTER_ID]
-            record_user_action_details(cse_operation=CseOperation.NODE_INFO, cse_params=cse_params)  # noqa: E501
 
         vapp = vcd_vapp.VApp(self.context.client, href=cluster['vapp_href'])
         vms = vapp.get_all_vms()

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -540,8 +540,11 @@ class ClusterService(abstract_broker.AbstractBroker):
         elif num_nfs_to_add < 0:
             raise e.CseServerError("Scaling down nfs nodes is not supported")
 
-        # TODO(DEF) design and implement telemetry VCDA-1564 defined entity
-        #  based clusters
+        # Record telemetry details
+        telemetry_data: def_models.DefEntity = def_models.DefEntity(id=cluster_id, entity=cluster_spec)  # noqa: E501
+        telemetry_handler.record_user_action_details(
+            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY,
+            cse_params=telemetry_data)
 
         # update the task and defined entity.
         msg = f"Resizing the cluster '{cluster_name}' ({cluster_id}) to the " \
@@ -553,9 +556,6 @@ class ClusterService(abstract_broker.AbstractBroker):
             DefEntityPhase(DefEntityOperation.UPDATE,
                            DefEntityOperationStatus.IN_PROGRESS))
         curr_entity = self.entity_svc.update_entity(cluster_id, curr_entity)
-        telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY,
-            cse_params=curr_entity)
 
         # trigger async operation
         self.context.is_async = True

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -752,10 +752,9 @@ class ClusterService(abstract_broker.AbstractBroker):
                 f"{new_template_revision}) is not a valid upgrade target for "
                 f"cluster '{cluster_name}'.")
 
-        # get cluster data (including node names) to pass to async function
-
-        # TODO(DEF) design and implement telemetry VCDA-1564 defined entity
-        #  based clusters
+        telemetry_handler.record_user_action_details(
+            telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE,
+            cse_params=curr_entity)
 
         msg = f"Upgrading cluster '{cluster_name}' " \
               f"software to match template {new_template_name} (revision " \

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -50,7 +50,7 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     return asdict(svc.resize_cluster(cluster_id, cluster_entity_spec))
 
 
-# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_DELETE)
+@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_DELETE)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster delete operation.
@@ -97,7 +97,7 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     return svc.get_cluster_config(cluster_id)
 
 
-# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE_PLAN)  # noqa: E501
+@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE_PLAN)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade-plan operation.
@@ -128,7 +128,6 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     return asdict(svc.upgrade_cluster(cluster_id, cluster_entity_spec))
 
 
-# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_LIST)   # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_list(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster list operation.
@@ -159,7 +158,6 @@ def node_create(request_data, op_ctx: ctx.OperationContext):
     return svc.create_nodes(data=request_data)
 
 
-# @record_user_action_telemetry(cse_operation=const.CseOperation.NODE_DELETE)
 @request_utils.v35_api_exception_handler
 def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     """Request handler for node delete operation.
@@ -177,7 +175,6 @@ def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     return asdict(svc.delete_nodes(cluster_id, [node_name]))
 
 
-# @record_user_action_telemetry(cse_operation=const.CseOperation.NODE_INFO)
 @request_utils.v35_api_exception_handler
 def node_info(request_data, op_ctx: ctx.OperationContext):
     """Request handler for node info operation.

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -7,16 +7,16 @@ import container_service_extension.def_.cluster_service as cluster_svc
 import container_service_extension.def_.models as def_models
 import container_service_extension.operation_context as ctx
 import container_service_extension.request_handlers.request_utils as request_utils  # noqa: E501
-import container_service_extension.server_constants as const
 from container_service_extension.shared_constants import FlattenedClusterSpecKey  # noqa: E501
 from container_service_extension.shared_constants import RequestKey
+import container_service_extension.telemetry.constants as telemetry_constants
 from container_service_extension.telemetry.telemetry_handler import \
     record_user_action_telemetry
 
 _OPERATION_KEY = 'operation'
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_CREATE)
+@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster create operation.
@@ -29,7 +29,7 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     return asdict(svc.create_cluster(cluster_entity_spec))
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_RESIZE)
+@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster resize operation.
@@ -50,7 +50,7 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     return asdict(svc.resize_cluster(cluster_id, cluster_entity_spec))
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_DELETE)
+# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_DELETE)
 @request_utils.v35_api_exception_handler
 def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster delete operation.
@@ -67,7 +67,6 @@ def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
     return asdict(svc.delete_cluster(cluster_id))
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_INFO)
 @request_utils.v35_api_exception_handler
 def cluster_info(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster info operation.
@@ -84,7 +83,7 @@ def cluster_info(data: dict, op_ctx: ctx.OperationContext):
     return asdict(svc.get_cluster_info(cluster_id))
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_CONFIG)
+@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_CONFIG)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster config operation.
@@ -98,7 +97,7 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     return svc.get_cluster_config(cluster_id)
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE_PLAN)  # noqa: E501
+# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE_PLAN)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade-plan operation.
@@ -109,7 +108,7 @@ def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     return svc.get_cluster_upgrade_plan(data[RequestKey.CLUSTER_ID])
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE)
+# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE)
 @request_utils.v35_api_exception_handler
 def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade operation.
@@ -129,7 +128,7 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     return asdict(svc.upgrade_cluster(cluster_id, cluster_entity_spec))
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_LIST)
+# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_LIST)   # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_list(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster list operation.
@@ -141,7 +140,6 @@ def cluster_list(data: dict, op_ctx: ctx.OperationContext):
             svc.list_clusters(data.get(RequestKey.V35_QUERY, None))]
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.NODE_CREATE)
 @request_utils.v35_api_exception_handler
 def node_create(request_data, op_ctx: ctx.OperationContext):
     """Request handler for node create operation.
@@ -161,7 +159,7 @@ def node_create(request_data, op_ctx: ctx.OperationContext):
     return svc.create_nodes(data=request_data)
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.NODE_DELETE)
+# @record_user_action_telemetry(cse_operation=const.CseOperation.NODE_DELETE)
 @request_utils.v35_api_exception_handler
 def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     """Request handler for node delete operation.
@@ -179,7 +177,7 @@ def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     return asdict(svc.delete_nodes(cluster_id, [node_name]))
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.NODE_INFO)
+# @record_user_action_telemetry(cse_operation=const.CseOperation.NODE_INFO)
 @request_utils.v35_api_exception_handler
 def node_info(request_data, op_ctx: ctx.OperationContext):
     """Request handler for node info operation.

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -108,7 +108,7 @@ def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     return svc.get_cluster_upgrade_plan(data[RequestKey.CLUSTER_ID])
 
 
-# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE)
+@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade operation.

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -76,6 +76,8 @@ class CseOperation(Enum):
 
     V35_CLUSTER_CONFIG = ('DEF cluster config', 'CLUSTER', 'V35_CONFIG', 'CSE_V35_CLUSTER_CONFIG')   # noqa: E501
     V35_CLUSTER_APPLY = ('DEF cluster create', 'CLUSTER', 'V35_APPLY', 'CSE_V35_CLUSTER_APPLY')  # noqa: E501
+    V35_CLUSTER_DELETE = ('DEF cluster delete', 'CLUSTER', 'V35_DELETE', 'CSE_V35_CLUSTER_DELETE')  # noqa: E501
+    V35_CLUSTER_UPGRADE_PLAN = ('DEF cluster upgrade plan', 'CLUSTER', 'V35_UPGRADE_PLAN', 'CSE_V35_CLUSTER_UPGRADE_PLAN')  # noqa: E501
 
     # Following operations do not require telemetry details. Hence the VAC
     # table name field is empty

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -124,6 +124,8 @@ class PayloadKey(str, Enum):
     NFS_SIZING_CLASS = 'nfs_sizing_class'
     NFS_STORAGE_PROFILE = 'nfs_storage_profile'
     OS = 'os'
+    SOURCE_CSE_VERSION = 'source_cse_version'
+    SOURCE_VCD_API_VERSION = 'source_vcd_api_version'
     STATUS = 'status'
     TARGET = 'target',
     TEMPLATE_NAME = 'template_name'

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -78,6 +78,7 @@ class CseOperation(Enum):
     V35_CLUSTER_APPLY = ('DEF cluster create', 'CLUSTER', 'V35_APPLY', 'CSE_V35_CLUSTER_APPLY')  # noqa: E501
     V35_CLUSTER_DELETE = ('DEF cluster delete', 'CLUSTER', 'V35_DELETE', 'CSE_V35_CLUSTER_DELETE')  # noqa: E501
     V35_CLUSTER_UPGRADE_PLAN = ('DEF cluster upgrade plan', 'CLUSTER', 'V35_UPGRADE_PLAN', 'CSE_V35_CLUSTER_UPGRADE_PLAN')  # noqa: E501
+    V35_CLUSTER_UPGRADE = ('DEF cluster upgrade', 'CLUSTER', 'V35_UPGRADE', 'CSE_V35_CLUSTER_UPGRADE')  # noqa: E501
 
     # Following operations do not require telemetry details. Hence the VAC
     # table name field is empty

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -11,7 +11,7 @@ VAC_URL = "https://vcsa.vmware.com/ph-stg/api/hyper/send/"
 
 # Value of collector id that is required as part of HTTP request
 # to post sample data to telemetry server
-COLLECTOR_ID = "CSE.2_6"
+COLLECTOR_ID = "CSE.3_0"
 
 
 @unique
@@ -74,6 +74,9 @@ class CseOperation(Enum):
     PKS_CLUSTER_LIST = ('pks-cluster list', 'PKS_CLUSTER', 'LIST', 'PKS_CLUSTER_LIST')  # noqa: E501
     PKS_CLUSTER_RESIZE = ('cluster resize', 'PKS_CLUSTER', 'RESIZE', 'PKS_CLUSTER_RESIZE')  # noqa: E501
 
+    V35_CLUSTER_CONFIG = ('DEF cluster config', 'CLUSTER', 'V35_CONFIG', 'CSE_V35_CLUSTER_CONFIG')   # noqa: E501
+    V35_CLUSTER_APPLY = ('DEF cluster create', 'CLUSTER', 'V35_APPLY', 'CSE_V35_CLUSTER_APPLY')  # noqa: E501
+
     # Following operations do not require telemetry details. Hence the VAC
     # table name field is empty
     OVDC_COMPUTE_POLICY_ADD = ('ovdc compute policy', 'COMPUTE_POLICY', 'ADD', '')  # noqa: E501
@@ -97,8 +100,11 @@ class PayloadKey(str, Enum):
     ACTION = 'action',
     ADDED_NFS_NODE = 'added_nfs_node'
     CLUSTER_ID = 'cluster_id'
+    CLUSTER_KIND = 'cluster_kind'
     CNI = 'cni'
     CNI_VERSION = 'cni_version'
+    CONTROL_PLANE_SIZING_CLASS = 'control_plane_sizing_class'
+    CONTROL_PLANE_STORAGE_PROFILE = 'control_plane_storage_class'
     CPU = 'cpu'
     DISPLAY_OPTION = 'display_option'
     K8S_DISTRIBUTION = 'k8s_distribution'
@@ -111,6 +117,9 @@ class PayloadKey(str, Enum):
     NUMBER_OF_MASTER_NODES = 'number_of_master_nodes'
     NUMBER_OF_NODES = 'number_of_nodes'
     NUMBER_OF_WORKER_NODES = 'number_of_worker_nodes'
+    NUMBER_OF_NFS_NODES = 'number_of_nfs_nodes'
+    NFS_SIZING_CLASS = 'nfs_sizing_class'
+    NFS_STORAGE_PROFILE = 'nfs_storage_profile'
     OS = 'os'
     STATUS = 'status'
     TARGET = 'target',
@@ -138,6 +147,8 @@ class PayloadKey(str, Enum):
     WAS_TEMP_VAPP_RETAINED = 'was_temp_vapp_retained'
     WERE_TEMPLATES_FORCE_UPDATED = 'were_templates_force_updated'
     WERE_TEMPLATES_SKIPPED = 'were_templates_skipped'
+    WORKERS_SIZING_CLASS = 'workers_sizing_class'
+    WORKERS_STORAGE_PROFILE = 'workers_storage_profile'
 
 
 @unique

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -509,3 +509,21 @@ def get_payload_for_v35_cluster_upgrade_plan(def_entity: DefEntity):
         PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
         PayloadKey.CLUSTER_KIND: def_entity.entity.kind
     }
+
+
+def get_payload_for_v35_cluster_upgrade(def_entity: DefEntity):
+    """Construct telemetry payload of v35 cluster upgrade.
+
+    :param DefEntity def_entity: defined entity instance
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V35_CLUSTER_UPGRADE.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
+        PayloadKey.TEMPLATE_NAME: def_entity.entity.spec.k8_distribution.template_name,  # noqa: E501
+        PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision  # noqa: E501
+    }

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -444,6 +444,7 @@ def get_payload_for_v35_cluster_config(def_entity: DefEntity):
     return {
         PayloadKey.TYPE: CseOperation.V35_CLUSTER_CONFIG.telemetry_table,
         PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
         PayloadKey.TEMPLATE_NAME: def_entity.entity.spec.k8_distribution.template_name,  # noqa: E501
         PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision  # noqa: E501
     }
@@ -475,4 +476,36 @@ def get_payload_for_v35_cluster_apply(def_entity: DefEntity):
         PayloadKey.NFS_STORAGE_PROFILE: def_entity.entity.spec.nfs.storage_profile,  # noqa: E501
         PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(def_entity.entity.spec.settings.ssh_key),  # noqa: E501
         PayloadKey.WAS_ROLLBACK_ENABLED: bool(def_entity.entity.spec.settings.rollback_on_failure)  # noqa: E501
+    }
+
+
+def get_payload_for_v35_cluster_delete(def_entity: DefEntity):
+    """Construct telemetry payload of v35 cluster delete.
+
+    :param DefEntity def_entity: defined entity instance
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V35_CLUSTER_DELETE.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind
+    }
+
+
+def get_payload_for_v35_cluster_upgrade_plan(def_entity: DefEntity):
+    """Construct telemetry payload of v35 cluster upgrade plan.
+
+    :param DefEntity def_entity: defined entity instance
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V35_CLUSTER_UPGRADE_PLAN.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind
     }

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -1,7 +1,9 @@
 # container-service-extension
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
+import pyvcloud.vcd.utils as pyvcd_utils
 
+from container_service_extension.def_.models import DefEntity
 from container_service_extension.server_constants import LocalTemplateKey
 from container_service_extension.shared_constants import RequestKey
 from container_service_extension.telemetry.constants import CseOperation
@@ -427,4 +429,50 @@ def get_payload_for_ovdc_list(params):
     return {
         PayloadKey.TYPE: CseOperation.OVDC_LIST.telemetry_table,
         PayloadKey.WAS_PKS_PLAN_SPECIFIED: bool(params.get(RequestKey.LIST_PKS_PLANS))  # noqa: E501
+    }
+
+
+def get_payload_for_v35_cluster_config(def_entity: DefEntity):
+    """Construct telemetry payload of v35 cluster config.
+
+    :param DefEntity def_entity: defined entity instance
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V35_CLUSTER_CONFIG.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.TEMPLATE_NAME: def_entity.entity.spec.k8_distribution.template_name,  # noqa: E501
+        PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision  # noqa: E501
+    }
+
+
+def get_payload_for_v35_cluster_apply(def_entity: DefEntity):
+    """Construct telemetry payload of v35 cluster apply.
+
+    :param DefEntity def_entity: defined entity instance
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V35_CLUSTER_APPLY.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
+        PayloadKey.TEMPLATE_NAME: def_entity.entity.spec.k8_distribution.template_name,  # noqa: E501
+        PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision,  # noqa: E501
+        PayloadKey.NUMBER_OF_MASTER_NODES: def_entity.entity.spec.control_plane.count,  # noqa: E501
+        PayloadKey.NUMBER_OF_WORKER_NODES: def_entity.entity.spec.workers.count,  # noqa: E501
+        PayloadKey.NUMBER_OF_NFS_NODES: def_entity.entity.spec.nfs.count,  # noqa: E501
+        PayloadKey.CONTROL_PLANE_SIZING_CLASS: def_entity.entity.spec.control_plane.sizing_class,  # noqa: E501
+        PayloadKey.CONTROL_PLANE_STORAGE_PROFILE: def_entity.entity.spec.control_plane.storage_profile,  # noqa: E501
+        PayloadKey.WORKERS_SIZING_CLASS: def_entity.entity.spec.workers.sizing_class,  # noqa: E501
+        PayloadKey.WORKERS_STORAGE_PROFILE: def_entity.entity.spec.workers.storage_profile,  # noqa: E501
+        PayloadKey.NFS_SIZING_CLASS: def_entity.entity.spec.nfs.sizing_class,  # noqa: E501
+        PayloadKey.NFS_STORAGE_PROFILE: def_entity.entity.spec.nfs.storage_profile,  # noqa: E501
+        PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(def_entity.entity.spec.settings.ssh_key),  # noqa: E501
+        PayloadKey.WAS_ROLLBACK_ENABLED: bool(def_entity.entity.spec.settings.rollback_on_failure)  # noqa: E501
     }

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -90,6 +90,25 @@ def get_payload_for_install_server(params):
     }
 
 
+def get_payload_for_upgrade_server(params):
+    """Construct telemetry payload of server upgrade operation.
+
+    :param params: parameters provided to the operation
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.SERVICE_UPGRADE.telemetry_table,
+        PayloadKey.SOURCE_CSE_VERSION: params.get(PayloadKey.SOURCE_CSE_VERSION),  # noqa: E501
+        PayloadKey.SOURCE_VCD_API_VERSION: params.get(PayloadKey.SOURCE_VCD_API_VERSION),  # noqa: E501
+        PayloadKey.WERE_TEMPLATES_SKIPPED: bool(params.get(PayloadKey.WERE_TEMPLATES_SKIPPED)),  # noqa: E501
+        PayloadKey.WAS_TEMP_VAPP_RETAINED: bool(params.get(PayloadKey.WAS_TEMP_VAPP_RETAINED)),  # noqa: E501
+        PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(params.get(PayloadKey.WAS_SSH_KEY_SPECIFIED))  # noqa: E501
+    }
+
+
 def get_payload_for_run_server(params):
     """Construct telemetry payload of server run operation.
 

--- a/container_service_extension/telemetry/telemetry_handler.py
+++ b/container_service_extension/telemetry/telemetry_handler.py
@@ -46,7 +46,10 @@ OPERATION_TO_PAYLOAD_GENERATOR = {
     CseOperation.OVDC_DISABLE: payload_generator.get_payload_for_ovdc_disable,
     CseOperation.OVDC_ENABLE: payload_generator.get_payload_for_ovdc_enable,
     CseOperation.OVDC_INFO: payload_generator.get_payload_for_ovdc_info,
-    CseOperation.OVDC_LIST: payload_generator.get_payload_for_ovdc_list
+    CseOperation.OVDC_LIST: payload_generator.get_payload_for_ovdc_list,
+
+    CseOperation.V35_CLUSTER_CONFIG: payload_generator.get_payload_for_v35_cluster_config,  # noqa: E501
+    CseOperation.V35_CLUSTER_APPLY: payload_generator.get_payload_for_v35_cluster_apply  # noqa: E501
 }
 
 

--- a/container_service_extension/telemetry/telemetry_handler.py
+++ b/container_service_extension/telemetry/telemetry_handler.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import functools
-import json
+
 
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.telemetry.constants import CseOperation
@@ -25,6 +25,7 @@ OPERATION_TO_PAYLOAD_GENERATOR = {
     CseOperation.CONFIG_CHECK: payload_generator.get_payload_for_config_check,
 
     CseOperation.SERVICE_INSTALL: payload_generator.get_payload_for_install_server,   # noqa: E501
+    CseOperation.SERVICE_UPGRADE: payload_generator.get_payload_for_upgrade_server,  # noqa: E501
     CseOperation.SERVICE_RUN: payload_generator.get_payload_for_run_server,
 
     CseOperation.TEMPLATE_INSTALL: payload_generator.get_payload_for_install_template,  # noqa: E501
@@ -109,7 +110,6 @@ def record_user_action(cse_operation, status=OperationStatus.SUCCESS,
 
         if telemetry_settings['enable']:
             payload = get_payload_for_user_action(cse_operation, status, message)  # noqa: E501
-            print(json.dumps(payload))
             _send_data_to_telemetry_server(payload, telemetry_settings)
     except Exception as err:
         LOGGER.warning(f"Error in recording user action information:{str(err)}")  # noqa: E501
@@ -131,7 +131,6 @@ def record_user_action_details(cse_operation, cse_params,
 
         if telemetry_settings['enable']:
             payload = OPERATION_TO_PAYLOAD_GENERATOR[cse_operation](cse_params)
-            print(json.dumps(payload))
             _send_data_to_telemetry_server(payload, telemetry_settings)
     except Exception as err:
         LOGGER.warning(f"Error in recording CSE operation details :{str(err)}")  # noqa: E501

--- a/container_service_extension/telemetry/telemetry_handler.py
+++ b/container_service_extension/telemetry/telemetry_handler.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import functools
+import json
 
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.telemetry.constants import CseOperation
@@ -49,7 +50,10 @@ OPERATION_TO_PAYLOAD_GENERATOR = {
     CseOperation.OVDC_LIST: payload_generator.get_payload_for_ovdc_list,
 
     CseOperation.V35_CLUSTER_CONFIG: payload_generator.get_payload_for_v35_cluster_config,  # noqa: E501
-    CseOperation.V35_CLUSTER_APPLY: payload_generator.get_payload_for_v35_cluster_apply  # noqa: E501
+    CseOperation.V35_CLUSTER_APPLY: payload_generator.get_payload_for_v35_cluster_apply,  # noqa: E501
+    CseOperation.V35_CLUSTER_DELETE: payload_generator.get_payload_for_v35_cluster_delete,  # noqa: E501
+    CseOperation.V35_CLUSTER_UPGRADE_PLAN: payload_generator.get_payload_for_v35_cluster_upgrade_plan  # noqa: E501
+
 }
 
 
@@ -104,6 +108,7 @@ def record_user_action(cse_operation, status=OperationStatus.SUCCESS,
 
         if telemetry_settings['enable']:
             payload = get_payload_for_user_action(cse_operation, status, message)  # noqa: E501
+            print(json.dumps(payload))
             _send_data_to_telemetry_server(payload, telemetry_settings)
     except Exception as err:
         LOGGER.warning(f"Error in recording user action information:{str(err)}")  # noqa: E501
@@ -125,6 +130,7 @@ def record_user_action_details(cse_operation, cse_params,
 
         if telemetry_settings['enable']:
             payload = OPERATION_TO_PAYLOAD_GENERATOR[cse_operation](cse_params)
+            print(json.dumps(payload))
             _send_data_to_telemetry_server(payload, telemetry_settings)
     except Exception as err:
         LOGGER.warning(f"Error in recording CSE operation details :{str(err)}")  # noqa: E501

--- a/container_service_extension/telemetry/telemetry_handler.py
+++ b/container_service_extension/telemetry/telemetry_handler.py
@@ -52,7 +52,8 @@ OPERATION_TO_PAYLOAD_GENERATOR = {
     CseOperation.V35_CLUSTER_CONFIG: payload_generator.get_payload_for_v35_cluster_config,  # noqa: E501
     CseOperation.V35_CLUSTER_APPLY: payload_generator.get_payload_for_v35_cluster_apply,  # noqa: E501
     CseOperation.V35_CLUSTER_DELETE: payload_generator.get_payload_for_v35_cluster_delete,  # noqa: E501
-    CseOperation.V35_CLUSTER_UPGRADE_PLAN: payload_generator.get_payload_for_v35_cluster_upgrade_plan  # noqa: E501
+    CseOperation.V35_CLUSTER_UPGRADE_PLAN: payload_generator.get_payload_for_v35_cluster_upgrade_plan,  # noqa: E501
+    CseOperation.V35_CLUSTER_UPGRADE: payload_generator.get_payload_for_v35_cluster_upgrade  # noqa: E501
 
 }
 


### PR DESCRIPTION

- Record telemetry data for defined entities
- Record telemetry data for CLI that uses server side DEF entity operations when CSE server is up and running.
- Tested manually using Super Collider Staging SQL workbench
- Client side DEF operations are excluded as telemetry is a server side operation
- Few screen shots of recorded data in table format ( actions and details)

-----------
![image](https://user-images.githubusercontent.com/5530442/90096199-7d8a6780-dce7-11ea-9449-8cb9c7bcf089.png)
![image](https://user-images.githubusercontent.com/5530442/90096214-8844fc80-dce7-11ea-9c76-bbfd959bc505.png)
![image](https://user-images.githubusercontent.com/5530442/90096225-8f6c0a80-dce7-11ea-8ec6-b45229c993c8.png)
![image](https://user-images.githubusercontent.com/5530442/90096235-93982800-dce7-11ea-98fa-2629f57a5756.png)
![image](https://user-images.githubusercontent.com/5530442/90096242-998e0900-dce7-11ea-9f5b-10b5471b3086.png)
![image](https://user-images.githubusercontent.com/5530442/90096256-9f83ea00-dce7-11ea-8053-a0c561efa2da.png)

@Anirudh9794 @rocknes @sahithi 