### PR TITLE
[VCDA-1564] Telemetry for defined entities

### DIFF
--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -60,7 +60,7 @@ UNSUPPORTED_SUBCOMMANDS_BY_VERSION = {
         GroupKey.OVDC: ['enable', 'disable', 'info']
     },
     vcd_client.ApiVersion.VERSION_35.value: {
-        GroupKey.CLUSTER: ['create'],
+        GroupKey.CLUSTER: ['create', 'resize'],
         GroupKey.OVDC: ['compute-policy', 'info']
     }
 }

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -1166,19 +1166,6 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
             ext_cse_version, ext_vcd_api_version = \
                 parse_cse_extension_description(client)
 
-            telemetry_data = {
-                PayloadKey.SOURCE_CSE_VERSION: str(ext_cse_version),
-                PayloadKey.SOURCE_VCD_API_VERSION: ext_vcd_api_version,
-                PayloadKey.WERE_TEMPLATES_SKIPPED: bool(skip_template_creation),  # noqa: E501
-                PayloadKey.WAS_TEMP_VAPP_RETAINED: bool(retain_temp_vapp),
-                PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(ssh_key)
-            }
-
-            # Telemetry - Record detailed telemetry data on upgrade
-            record_user_action_details(CseOperation.SERVICE_UPGRADE,
-                                       telemetry_data,
-                                       telemetry_settings=config['service']['telemetry'])  # noqa: E501
-
             if ext_cse_version == server_constants.UNKNOWN_CSE_VERSION or \
                     ext_vcd_api_version == server_constants.UNKNOWN_VCD_API_VERSION: # noqa: E501
                 msg = "Found CSE api extension registered with vCD, but " \
@@ -1215,6 +1202,21 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
 
         target_vcd_api_version = config['vcd']['api_version']
         target_cse_version = utils.get_installed_cse_version()
+
+        telemetry_data = {
+            PayloadKey.SOURCE_CSE_VERSION: str(ext_cse_version),
+            PayloadKey.SOURCE_VCD_API_VERSION: ext_vcd_api_version,
+            PayloadKey.TARGET_CSE_VERSION: str(target_cse_version),
+            PayloadKey.TARGET_VCD_API_VERSION: target_vcd_api_version,
+            PayloadKey.WERE_TEMPLATES_SKIPPED: bool(skip_template_creation),  # noqa: E501
+            PayloadKey.WAS_TEMP_VAPP_RETAINED: bool(retain_temp_vapp),
+            PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(ssh_key)
+        }
+
+        # Telemetry - Record detailed telemetry data on upgrade
+        record_user_action_details(CseOperation.SERVICE_UPGRADE,
+                                   telemetry_data,
+                                   telemetry_settings=config['service']['telemetry'])  # noqa: E501
 
         # Handle various upgrade scenarios
         # Post CSE 3.0.0 only the following upgrades should be allowed

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -1162,26 +1162,6 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
             # Upgrading from MQTT to AMQP extension
             msg = "Upgrading from MQTT extension to AMQP extension is not " \
                   "supported"
-        try:
-            ext_cse_version, ext_vcd_api_version = \
-                parse_cse_extension_description(client)
-
-            if ext_cse_version == server_constants.UNKNOWN_CSE_VERSION or \
-                    ext_vcd_api_version == server_constants.UNKNOWN_VCD_API_VERSION: # noqa: E501
-                msg = "Found CSE api extension registered with vCD, but " \
-                      "couldn't determine version of CSE and/or vCD api " \
-                      "used previously."
-                msg_update_callback.info(msg)
-                INSTALL_LOGGER.info(msg)
-            else:
-                msg = "Found CSE api extension registered by CSE " \
-                      f"'{ext_cse_version}' at vCD api version " \
-                      f"'v{ext_vcd_api_version}'."
-                msg_update_callback.general(msg)
-                INSTALL_LOGGER.info(msg)
-        except MissingRecordException:
-            msg = "CSE api extension not registered with vCD. Please use " \
-                  "`cse install' instead of 'cse upgrade'."
             raise Exception(msg)
         ext_cse_version, ext_vcd_api_version = \
             parse_cse_extension_description(

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -749,10 +749,9 @@ class ClusterService(abstract_broker.AbstractBroker):
                 f"{new_template_revision}) is not a valid upgrade target for "
                 f"cluster '{cluster_name}'.")
 
-        # get cluster data (including node names) to pass to async function
-
-        # TODO(DEF) design and implement telemetry VCDA-1564 defined entity
-        #  based clusters
+        telemetry_handler.record_user_action_details(
+            telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE,
+            cse_params=curr_entity)
 
         msg = f"Upgrading cluster '{cluster_name}' " \
               f"software to match template {new_template_name} (revision " \

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -68,10 +68,18 @@ class ClusterService(abstract_broker.AbstractBroker):
         It syncs the defined entity with the state of the cluster vApp before
         returning the defined entity.
         """
+        telemetry_handler.record_user_action_details(
+            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_INFO,
+            cse_params={telemetry_constants.PayloadKey.CLUSTER_ID: cluster_id}
+        )
         return self._sync_def_entity(cluster_id)
 
-    def list_clusters(self, filters: dict) -> List[def_models.DefEntity]:
+    def list_clusters(self, filters: dict = {}) -> List[def_models.DefEntity]:
         """List corresponding defined entities of all native clusters."""
+        telemetry_handler.record_user_action_details(
+            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_LIST,
+            cse_params={telemetry_constants.PayloadKey.FILTER_KEYS: ','.join(filters.keys())}  # noqa: E501
+        )
         ent_type: def_models.DefEntityType = def_utils.get_registered_def_entity_type()  # noqa: E501
         return self.entity_svc.list_entities_by_entity_type(
             vendor=ent_type.vendor,

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -537,8 +537,11 @@ class ClusterService(abstract_broker.AbstractBroker):
         elif num_nfs_to_add < 0:
             raise e.CseServerError("Scaling down nfs nodes is not supported")
 
-        # TODO(DEF) design and implement telemetry VCDA-1564 defined entity
-        #  based clusters
+        # Record telemetry details
+        telemetry_data: def_models.DefEntity = def_models.DefEntity(id=cluster_id, entity=cluster_spec)  # noqa: E501
+        telemetry_handler.record_user_action_details(
+            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY,
+            cse_params=telemetry_data)
 
         # update the task and defined entity.
         msg = f"Resizing the cluster '{cluster_name}' ({cluster_id}) to the " \
@@ -550,9 +553,6 @@ class ClusterService(abstract_broker.AbstractBroker):
             DefEntityPhase(DefEntityOperation.UPDATE,
                            DefEntityOperationStatus.IN_PROGRESS))
         curr_entity = self.entity_svc.update_entity(cluster_id, curr_entity)
-        telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY,
-            cse_params=curr_entity)
 
         # trigger async operation
         self.context.is_async = True

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1,7 +1,6 @@
 # container-service-extension
 # Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-
 import copy
 import random
 import re
@@ -110,6 +109,9 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         if not result:
             raise e.ClusterOperationError("Couldn't get cluster configuration")
+
+        record_user_action_details(cse_operation=CseOperation.V35_CLUSTER_CONFIG, # noqa: E501
+                                   cse_params=curr_entity)
 
         return result.content.decode()
 
@@ -221,6 +223,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                           entity=def_entity)
         self.context.is_async = True
         def_entity = self.entity_svc.get_native_entity_by_name(cluster_name)
+        record_user_action_details(cse_operation=CseOperation.V35_CLUSTER_APPLY,  # noqa: E501
+                                   cse_params=def_entity)
         self._create_cluster_async(def_entity.id, cluster_spec)
         return def_entity
 
@@ -552,6 +556,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             DefEntityPhase(DefEntityOperation.UPDATE,
                            DefEntityOperationStatus.IN_PROGRESS))
         curr_entity = self.entity_svc.update_entity(cluster_id, curr_entity)
+        record_user_action_details(cse_operation=CseOperation.V35_CLUSTER_APPLY,  # noqa: E501
+                                   cse_params=curr_entity)
 
         # trigger async operation
         self.context.is_async = True

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -50,7 +50,7 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     return asdict(svc.resize_cluster(cluster_id, cluster_entity_spec))
 
 
-# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_DELETE)
+@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_DELETE)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster delete operation.
@@ -97,7 +97,7 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     return svc.get_cluster_config(cluster_id)
 
 
-# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE_PLAN)  # noqa: E501
+@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE_PLAN)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade-plan operation.
@@ -128,7 +128,6 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     return asdict(svc.upgrade_cluster(cluster_id, cluster_entity_spec))
 
 
-# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_LIST)   # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_list(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster list operation.
@@ -159,7 +158,6 @@ def node_create(request_data, op_ctx: ctx.OperationContext):
     return svc.create_nodes(data=request_data)
 
 
-# @record_user_action_telemetry(cse_operation=const.CseOperation.NODE_DELETE)
 @request_utils.v35_api_exception_handler
 def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     """Request handler for node delete operation.
@@ -177,7 +175,6 @@ def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     return asdict(svc.delete_nodes(cluster_id, [node_name]))
 
 
-# @record_user_action_telemetry(cse_operation=const.CseOperation.NODE_INFO)
 @request_utils.v35_api_exception_handler
 def node_info(request_data, op_ctx: ctx.OperationContext):
     """Request handler for node info operation.

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -7,16 +7,16 @@ import container_service_extension.def_.cluster_service as cluster_svc
 import container_service_extension.def_.models as def_models
 import container_service_extension.operation_context as ctx
 import container_service_extension.request_handlers.request_utils as request_utils  # noqa: E501
-import container_service_extension.server_constants as const
 from container_service_extension.shared_constants import FlattenedClusterSpecKey  # noqa: E501
 from container_service_extension.shared_constants import RequestKey
+import container_service_extension.telemetry.constants as telemetry_constants
 from container_service_extension.telemetry.telemetry_handler import \
     record_user_action_telemetry
 
 _OPERATION_KEY = 'operation'
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_CREATE)
+@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster create operation.
@@ -29,7 +29,7 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     return asdict(svc.create_cluster(cluster_entity_spec))
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_RESIZE)
+@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster resize operation.
@@ -50,7 +50,7 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     return asdict(svc.resize_cluster(cluster_id, cluster_entity_spec))
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_DELETE)
+# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_DELETE)
 @request_utils.v35_api_exception_handler
 def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster delete operation.
@@ -67,7 +67,6 @@ def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
     return asdict(svc.delete_cluster(cluster_id))
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_INFO)
 @request_utils.v35_api_exception_handler
 def cluster_info(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster info operation.
@@ -84,7 +83,7 @@ def cluster_info(data: dict, op_ctx: ctx.OperationContext):
     return asdict(svc.get_cluster_info(cluster_id))
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_CONFIG)
+@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_CONFIG)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster config operation.
@@ -98,7 +97,7 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     return svc.get_cluster_config(cluster_id)
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE_PLAN)  # noqa: E501
+# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE_PLAN)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade-plan operation.
@@ -109,7 +108,7 @@ def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     return svc.get_cluster_upgrade_plan(data[RequestKey.CLUSTER_ID])
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE)
+# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE)
 @request_utils.v35_api_exception_handler
 def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade operation.
@@ -129,7 +128,7 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     return asdict(svc.upgrade_cluster(cluster_id, cluster_entity_spec))
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_LIST)
+# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_LIST)   # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_list(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster list operation.
@@ -141,7 +140,6 @@ def cluster_list(data: dict, op_ctx: ctx.OperationContext):
             svc.list_clusters(data.get(RequestKey.V35_QUERY, None))]
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.NODE_CREATE)
 @request_utils.v35_api_exception_handler
 def node_create(request_data, op_ctx: ctx.OperationContext):
     """Request handler for node create operation.
@@ -161,7 +159,7 @@ def node_create(request_data, op_ctx: ctx.OperationContext):
     return svc.create_nodes(data=request_data)
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.NODE_DELETE)
+# @record_user_action_telemetry(cse_operation=const.CseOperation.NODE_DELETE)
 @request_utils.v35_api_exception_handler
 def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     """Request handler for node delete operation.
@@ -179,7 +177,7 @@ def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     return asdict(svc.delete_nodes(cluster_id, [node_name]))
 
 
-@record_user_action_telemetry(cse_operation=const.CseOperation.NODE_INFO)
+# @record_user_action_telemetry(cse_operation=const.CseOperation.NODE_INFO)
 @request_utils.v35_api_exception_handler
 def node_info(request_data, op_ctx: ctx.OperationContext):
     """Request handler for node info operation.

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -10,13 +10,13 @@ import container_service_extension.request_handlers.request_utils as request_uti
 from container_service_extension.shared_constants import FlattenedClusterSpecKey  # noqa: E501
 from container_service_extension.shared_constants import RequestKey
 import container_service_extension.telemetry.constants as telemetry_constants
-from container_service_extension.telemetry.telemetry_handler import \
-    record_user_action_telemetry
+import container_service_extension.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
+
 
 _OPERATION_KEY = 'operation'
 
 
-@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY)  # noqa: E501
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster create operation.
@@ -29,7 +29,7 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     return asdict(svc.create_cluster(cluster_entity_spec))
 
 
-@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY)  # noqa: E501
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster resize operation.
@@ -50,7 +50,7 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     return asdict(svc.resize_cluster(cluster_id, cluster_entity_spec))
 
 
-@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_DELETE)  # noqa: E501
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_DELETE)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster delete operation.
@@ -67,6 +67,7 @@ def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
     return asdict(svc.delete_cluster(cluster_id))
 
 
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_INFO)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_info(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster info operation.
@@ -83,7 +84,7 @@ def cluster_info(data: dict, op_ctx: ctx.OperationContext):
     return asdict(svc.get_cluster_info(cluster_id))
 
 
-@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_CONFIG)  # noqa: E501
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_CONFIG)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster config operation.
@@ -97,7 +98,7 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     return svc.get_cluster_config(cluster_id)
 
 
-@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE_PLAN)  # noqa: E501
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE_PLAN)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade-plan operation.
@@ -108,7 +109,7 @@ def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     return svc.get_cluster_upgrade_plan(data[RequestKey.CLUSTER_ID])
 
 
-@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE)  # noqa: E501
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade operation.
@@ -128,6 +129,7 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     return asdict(svc.upgrade_cluster(cluster_id, cluster_entity_spec))
 
 
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_LIST)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_list(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster list operation.
@@ -136,7 +138,7 @@ def cluster_list(data: dict, op_ctx: ctx.OperationContext):
     """
     svc = cluster_svc.ClusterService(op_ctx)
     return [asdict(def_entity) for def_entity in
-            svc.list_clusters(data.get(RequestKey.V35_QUERY, None))]
+            svc.list_clusters(data.get(RequestKey.V35_QUERY, {}))]
 
 
 @request_utils.v35_api_exception_handler
@@ -158,6 +160,7 @@ def node_create(request_data, op_ctx: ctx.OperationContext):
     return svc.create_nodes(data=request_data)
 
 
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_NODE_DELETE)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     """Request handler for node delete operation.
@@ -172,6 +175,15 @@ def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     svc = cluster_svc.ClusterService(op_ctx)
     cluster_id = data[RequestKey.CLUSTER_ID]
     node_name = data[RequestKey.NODE_NAME]
+
+    telemetry_handler.record_user_action_details(
+        cse_operation=telemetry_constants.CseOperation.V35_NODE_DELETE,
+        cse_params={
+            telemetry_constants.PayloadKey.CLUSTER_ID: cluster_id,
+            telemetry_constants.PayloadKey.NODE_NAME: node_name
+        }
+    )
+
     return asdict(svc.delete_nodes(cluster_id, [node_name]))
 
 

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -108,7 +108,7 @@ def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     return svc.get_cluster_upgrade_plan(data[RequestKey.CLUSTER_ID])
 
 
-# @record_user_action_telemetry(cse_operation=const.CseOperation.CLUSTER_UPGRADE)
+@record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade operation.

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -76,6 +76,8 @@ class CseOperation(Enum):
 
     V35_CLUSTER_CONFIG = ('DEF cluster config', 'CLUSTER', 'V35_CONFIG', 'CSE_V35_CLUSTER_CONFIG')   # noqa: E501
     V35_CLUSTER_APPLY = ('DEF cluster create', 'CLUSTER', 'V35_APPLY', 'CSE_V35_CLUSTER_APPLY')  # noqa: E501
+    V35_CLUSTER_DELETE = ('DEF cluster delete', 'CLUSTER', 'V35_DELETE', 'CSE_V35_CLUSTER_DELETE')  # noqa: E501
+    V35_CLUSTER_UPGRADE_PLAN = ('DEF cluster upgrade plan', 'CLUSTER', 'V35_UPGRADE_PLAN', 'CSE_V35_CLUSTER_UPGRADE_PLAN')  # noqa: E501
 
     # Following operations do not require telemetry details. Hence the VAC
     # table name field is empty

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -74,11 +74,14 @@ class CseOperation(Enum):
     PKS_CLUSTER_LIST = ('pks-cluster list', 'PKS_CLUSTER', 'LIST', 'PKS_CLUSTER_LIST')  # noqa: E501
     PKS_CLUSTER_RESIZE = ('cluster resize', 'PKS_CLUSTER', 'RESIZE', 'PKS_CLUSTER_RESIZE')  # noqa: E501
 
+    V35_CLUSTER_LIST = ('DEF cluster list', 'CLUSTER', 'V35_LIST', 'CSE_V35_CLUSTER_LIST')  # noqa: E501
+    V35_CLUSTER_INFO = ('DEF cluster info', 'CLUSTER', 'V35_INFO', 'CSE_V35_CLUSTER_INFO')  # noqa: E501
     V35_CLUSTER_CONFIG = ('DEF cluster config', 'CLUSTER', 'V35_CONFIG', 'CSE_V35_CLUSTER_CONFIG')   # noqa: E501
     V35_CLUSTER_APPLY = ('DEF cluster create', 'CLUSTER', 'V35_APPLY', 'CSE_V35_CLUSTER_APPLY')  # noqa: E501
     V35_CLUSTER_DELETE = ('DEF cluster delete', 'CLUSTER', 'V35_DELETE', 'CSE_V35_CLUSTER_DELETE')  # noqa: E501
     V35_CLUSTER_UPGRADE_PLAN = ('DEF cluster upgrade plan', 'CLUSTER', 'V35_UPGRADE_PLAN', 'CSE_V35_CLUSTER_UPGRADE_PLAN')  # noqa: E501
     V35_CLUSTER_UPGRADE = ('DEF cluster upgrade', 'CLUSTER', 'V35_UPGRADE', 'CSE_V35_CLUSTER_UPGRADE')  # noqa: E501
+    V35_NODE_DELETE = ('DEF nfs node delete', 'NODE', 'V35_DELETE', 'CSE_V35_NODE_DELETE')  # noqa: E501
 
     # Following operations do not require telemetry details. Hence the VAC
     # table name field is empty
@@ -110,6 +113,7 @@ class PayloadKey(str, Enum):
     CONTROL_PLANE_STORAGE_PROFILE = 'control_plane_storage_class'
     CPU = 'cpu'
     DISPLAY_OPTION = 'display_option'
+    FILTER_KEYS = 'filter_keys'
     K8S_DISTRIBUTION = 'k8s_distribution'
     K8S_PROVIDER = 'k8s_provider'
     K8S_VERSION = 'k8s_version',

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -124,6 +124,8 @@ class PayloadKey(str, Enum):
     NFS_SIZING_CLASS = 'nfs_sizing_class'
     NFS_STORAGE_PROFILE = 'nfs_storage_profile'
     OS = 'os'
+    SOURCE_CSE_VERSION = 'source_cse_version'
+    SOURCE_VCD_API_VERSION = 'source_vcd_api_version'
     STATUS = 'status'
     TARGET = 'target',
     TEMPLATE_NAME = 'template_name'

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -78,6 +78,7 @@ class CseOperation(Enum):
     V35_CLUSTER_APPLY = ('DEF cluster create', 'CLUSTER', 'V35_APPLY', 'CSE_V35_CLUSTER_APPLY')  # noqa: E501
     V35_CLUSTER_DELETE = ('DEF cluster delete', 'CLUSTER', 'V35_DELETE', 'CSE_V35_CLUSTER_DELETE')  # noqa: E501
     V35_CLUSTER_UPGRADE_PLAN = ('DEF cluster upgrade plan', 'CLUSTER', 'V35_UPGRADE_PLAN', 'CSE_V35_CLUSTER_UPGRADE_PLAN')  # noqa: E501
+    V35_CLUSTER_UPGRADE = ('DEF cluster upgrade', 'CLUSTER', 'V35_UPGRADE', 'CSE_V35_CLUSTER_UPGRADE')  # noqa: E501
 
     # Following operations do not require telemetry details. Hence the VAC
     # table name field is empty

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -109,8 +109,6 @@ class PayloadKey(str, Enum):
     CLUSTER_KIND = 'cluster_kind'
     CNI = 'cni'
     CNI_VERSION = 'cni_version'
-    CONTROL_PLANE_SIZING_CLASS = 'control_plane_sizing_class'
-    CONTROL_PLANE_STORAGE_PROFILE = 'control_plane_storage_class'
     CPU = 'cpu'
     DISPLAY_OPTION = 'display_option'
     FILTER_KEYS = 'filter_keys'
@@ -125,13 +123,13 @@ class PayloadKey(str, Enum):
     NUMBER_OF_NODES = 'number_of_nodes'
     NUMBER_OF_WORKER_NODES = 'number_of_worker_nodes'
     NUMBER_OF_NFS_NODES = 'number_of_nfs_nodes'
-    NFS_SIZING_CLASS = 'nfs_sizing_class'
-    NFS_STORAGE_PROFILE = 'nfs_storage_profile'
     OS = 'os'
     SOURCE_CSE_VERSION = 'source_cse_version'
     SOURCE_VCD_API_VERSION = 'source_vcd_api_version'
     STATUS = 'status'
     TARGET = 'target',
+    TARGET_CSE_VERSION = 'target_cse_version'
+    TARGET_VCD_API_VERSION = 'target_vcd_api_version'
     TEMPLATE_NAME = 'template_name'
     TEMPLATE_REVISION = 'template_revision'
     TYPE = '@type',
@@ -156,8 +154,6 @@ class PayloadKey(str, Enum):
     WAS_TEMP_VAPP_RETAINED = 'was_temp_vapp_retained'
     WERE_TEMPLATES_FORCE_UPDATED = 'were_templates_force_updated'
     WERE_TEMPLATES_SKIPPED = 'were_templates_skipped'
-    WORKERS_SIZING_CLASS = 'workers_sizing_class'
-    WORKERS_STORAGE_PROFILE = 'workers_storage_profile'
 
 
 @unique

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -11,7 +11,7 @@ VAC_URL = "https://vcsa.vmware.com/ph-stg/api/hyper/send/"
 
 # Value of collector id that is required as part of HTTP request
 # to post sample data to telemetry server
-COLLECTOR_ID = "CSE.2_6"
+COLLECTOR_ID = "CSE.3_0"
 
 
 @unique
@@ -74,6 +74,9 @@ class CseOperation(Enum):
     PKS_CLUSTER_LIST = ('pks-cluster list', 'PKS_CLUSTER', 'LIST', 'PKS_CLUSTER_LIST')  # noqa: E501
     PKS_CLUSTER_RESIZE = ('cluster resize', 'PKS_CLUSTER', 'RESIZE', 'PKS_CLUSTER_RESIZE')  # noqa: E501
 
+    V35_CLUSTER_CONFIG = ('DEF cluster config', 'CLUSTER', 'V35_CONFIG', 'CSE_V35_CLUSTER_CONFIG')   # noqa: E501
+    V35_CLUSTER_APPLY = ('DEF cluster create', 'CLUSTER', 'V35_APPLY', 'CSE_V35_CLUSTER_APPLY')  # noqa: E501
+
     # Following operations do not require telemetry details. Hence the VAC
     # table name field is empty
     OVDC_COMPUTE_POLICY_ADD = ('ovdc compute policy', 'COMPUTE_POLICY', 'ADD', '')  # noqa: E501
@@ -97,8 +100,11 @@ class PayloadKey(str, Enum):
     ACTION = 'action',
     ADDED_NFS_NODE = 'added_nfs_node'
     CLUSTER_ID = 'cluster_id'
+    CLUSTER_KIND = 'cluster_kind'
     CNI = 'cni'
     CNI_VERSION = 'cni_version'
+    CONTROL_PLANE_SIZING_CLASS = 'control_plane_sizing_class'
+    CONTROL_PLANE_STORAGE_PROFILE = 'control_plane_storage_class'
     CPU = 'cpu'
     DISPLAY_OPTION = 'display_option'
     K8S_DISTRIBUTION = 'k8s_distribution'
@@ -111,6 +117,9 @@ class PayloadKey(str, Enum):
     NUMBER_OF_MASTER_NODES = 'number_of_master_nodes'
     NUMBER_OF_NODES = 'number_of_nodes'
     NUMBER_OF_WORKER_NODES = 'number_of_worker_nodes'
+    NUMBER_OF_NFS_NODES = 'number_of_nfs_nodes'
+    NFS_SIZING_CLASS = 'nfs_sizing_class'
+    NFS_STORAGE_PROFILE = 'nfs_storage_profile'
     OS = 'os'
     STATUS = 'status'
     TARGET = 'target',
@@ -138,6 +147,8 @@ class PayloadKey(str, Enum):
     WAS_TEMP_VAPP_RETAINED = 'was_temp_vapp_retained'
     WERE_TEMPLATES_FORCE_UPDATED = 'were_templates_force_updated'
     WERE_TEMPLATES_SKIPPED = 'were_templates_skipped'
+    WORKERS_SIZING_CLASS = 'workers_sizing_class'
+    WORKERS_STORAGE_PROFILE = 'workers_storage_profile'
 
 
 @unique

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -509,3 +509,21 @@ def get_payload_for_v35_cluster_upgrade_plan(def_entity: DefEntity):
         PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
         PayloadKey.CLUSTER_KIND: def_entity.entity.kind
     }
+
+
+def get_payload_for_v35_cluster_upgrade(def_entity: DefEntity):
+    """Construct telemetry payload of v35 cluster upgrade.
+
+    :param DefEntity def_entity: defined entity instance
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V35_CLUSTER_UPGRADE.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
+        PayloadKey.TEMPLATE_NAME: def_entity.entity.spec.k8_distribution.template_name,  # noqa: E501
+        PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision  # noqa: E501
+    }

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -444,6 +444,7 @@ def get_payload_for_v35_cluster_config(def_entity: DefEntity):
     return {
         PayloadKey.TYPE: CseOperation.V35_CLUSTER_CONFIG.telemetry_table,
         PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
         PayloadKey.TEMPLATE_NAME: def_entity.entity.spec.k8_distribution.template_name,  # noqa: E501
         PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision  # noqa: E501
     }
@@ -475,4 +476,36 @@ def get_payload_for_v35_cluster_apply(def_entity: DefEntity):
         PayloadKey.NFS_STORAGE_PROFILE: def_entity.entity.spec.nfs.storage_profile,  # noqa: E501
         PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(def_entity.entity.spec.settings.ssh_key),  # noqa: E501
         PayloadKey.WAS_ROLLBACK_ENABLED: bool(def_entity.entity.spec.settings.rollback_on_failure)  # noqa: E501
+    }
+
+
+def get_payload_for_v35_cluster_delete(def_entity: DefEntity):
+    """Construct telemetry payload of v35 cluster delete.
+
+    :param DefEntity def_entity: defined entity instance
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V35_CLUSTER_DELETE.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind
+    }
+
+
+def get_payload_for_v35_cluster_upgrade_plan(def_entity: DefEntity):
+    """Construct telemetry payload of v35 cluster upgrade plan.
+
+    :param DefEntity def_entity: defined entity instance
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V35_CLUSTER_UPGRADE_PLAN.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind
     }

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -451,6 +451,36 @@ def get_payload_for_ovdc_list(params):
     }
 
 
+def get_payload_for_v35_cluster_list(params):
+    """Construct telemetry payload of v35 cluster list.
+
+    :param dict params: parameters provided to the operation
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V35_CLUSTER_LIST.telemetry_table,
+        PayloadKey.FILTER_KEYS: params.get(PayloadKey.FILTER_KEYS)
+    }
+
+
+def get_payload_for_v35_cluster_info(params):
+    """Construct telemetry payload of v35 cluster info.
+
+    :param dict params: parameters provided to the operation
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V35_CLUSTER_INFO.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(params.get(PayloadKey.CLUSTER_ID)))  # noqa: E501
+    }
+
+
 def get_payload_for_v35_cluster_config(def_entity: DefEntity):
     """Construct telemetry payload of v35 cluster config.
 
@@ -545,4 +575,20 @@ def get_payload_for_v35_cluster_upgrade(def_entity: DefEntity):
         PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
         PayloadKey.TEMPLATE_NAME: def_entity.entity.spec.k8_distribution.template_name,  # noqa: E501
         PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision  # noqa: E501
+    }
+
+
+def get_payload_for_v35_node_delete(params):
+    """Construct telemetry payload of v35 cluster info.
+
+    :param dict params: parameters provided to the operation
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V35_NODE_DELETE.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(params.get(PayloadKey.CLUSTER_ID))),  # noqa: E501
+        PayloadKey.NODE_NAME: params.get(PayloadKey.NODE_NAME)
     }

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -1,7 +1,9 @@
 # container-service-extension
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
+import pyvcloud.vcd.utils as pyvcd_utils
 
+from container_service_extension.def_.models import DefEntity
 from container_service_extension.server_constants import LocalTemplateKey
 from container_service_extension.shared_constants import RequestKey
 from container_service_extension.telemetry.constants import CseOperation
@@ -427,4 +429,50 @@ def get_payload_for_ovdc_list(params):
     return {
         PayloadKey.TYPE: CseOperation.OVDC_LIST.telemetry_table,
         PayloadKey.WAS_PKS_PLAN_SPECIFIED: bool(params.get(RequestKey.LIST_PKS_PLANS))  # noqa: E501
+    }
+
+
+def get_payload_for_v35_cluster_config(def_entity: DefEntity):
+    """Construct telemetry payload of v35 cluster config.
+
+    :param DefEntity def_entity: defined entity instance
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V35_CLUSTER_CONFIG.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.TEMPLATE_NAME: def_entity.entity.spec.k8_distribution.template_name,  # noqa: E501
+        PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision  # noqa: E501
+    }
+
+
+def get_payload_for_v35_cluster_apply(def_entity: DefEntity):
+    """Construct telemetry payload of v35 cluster apply.
+
+    :param DefEntity def_entity: defined entity instance
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V35_CLUSTER_APPLY.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
+        PayloadKey.TEMPLATE_NAME: def_entity.entity.spec.k8_distribution.template_name,  # noqa: E501
+        PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision,  # noqa: E501
+        PayloadKey.NUMBER_OF_MASTER_NODES: def_entity.entity.spec.control_plane.count,  # noqa: E501
+        PayloadKey.NUMBER_OF_WORKER_NODES: def_entity.entity.spec.workers.count,  # noqa: E501
+        PayloadKey.NUMBER_OF_NFS_NODES: def_entity.entity.spec.nfs.count,  # noqa: E501
+        PayloadKey.CONTROL_PLANE_SIZING_CLASS: def_entity.entity.spec.control_plane.sizing_class,  # noqa: E501
+        PayloadKey.CONTROL_PLANE_STORAGE_PROFILE: def_entity.entity.spec.control_plane.storage_profile,  # noqa: E501
+        PayloadKey.WORKERS_SIZING_CLASS: def_entity.entity.spec.workers.sizing_class,  # noqa: E501
+        PayloadKey.WORKERS_STORAGE_PROFILE: def_entity.entity.spec.workers.storage_profile,  # noqa: E501
+        PayloadKey.NFS_SIZING_CLASS: def_entity.entity.spec.nfs.sizing_class,  # noqa: E501
+        PayloadKey.NFS_STORAGE_PROFILE: def_entity.entity.spec.nfs.storage_profile,  # noqa: E501
+        PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(def_entity.entity.spec.settings.ssh_key),  # noqa: E501
+        PayloadKey.WAS_ROLLBACK_ENABLED: bool(def_entity.entity.spec.settings.rollback_on_failure)  # noqa: E501
     }

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -103,6 +103,8 @@ def get_payload_for_upgrade_server(params):
         PayloadKey.TYPE: CseOperation.SERVICE_UPGRADE.telemetry_table,
         PayloadKey.SOURCE_CSE_VERSION: params.get(PayloadKey.SOURCE_CSE_VERSION),  # noqa: E501
         PayloadKey.SOURCE_VCD_API_VERSION: params.get(PayloadKey.SOURCE_VCD_API_VERSION),  # noqa: E501
+        PayloadKey.TARGET_CSE_VERSION: params.get(PayloadKey.TARGET_CSE_VERSION),  # noqa: E501
+        PayloadKey.TARGET_VCD_API_VERSION: params.get(PayloadKey.TARGET_VCD_API_VERSION),  # noqa: E501
         PayloadKey.WERE_TEMPLATES_SKIPPED: bool(params.get(PayloadKey.WERE_TEMPLATES_SKIPPED)),  # noqa: E501
         PayloadKey.WAS_TEMP_VAPP_RETAINED: bool(params.get(PayloadKey.WAS_TEMP_VAPP_RETAINED)),  # noqa: E501
         PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(params.get(PayloadKey.WAS_SSH_KEY_SPECIFIED))  # noqa: E501
@@ -517,12 +519,6 @@ def get_payload_for_v35_cluster_apply(def_entity: DefEntity):
         PayloadKey.NUMBER_OF_MASTER_NODES: def_entity.entity.spec.control_plane.count,  # noqa: E501
         PayloadKey.NUMBER_OF_WORKER_NODES: def_entity.entity.spec.workers.count,  # noqa: E501
         PayloadKey.NUMBER_OF_NFS_NODES: def_entity.entity.spec.nfs.count,  # noqa: E501
-        PayloadKey.CONTROL_PLANE_SIZING_CLASS: def_entity.entity.spec.control_plane.sizing_class,  # noqa: E501
-        PayloadKey.CONTROL_PLANE_STORAGE_PROFILE: def_entity.entity.spec.control_plane.storage_profile,  # noqa: E501
-        PayloadKey.WORKERS_SIZING_CLASS: def_entity.entity.spec.workers.sizing_class,  # noqa: E501
-        PayloadKey.WORKERS_STORAGE_PROFILE: def_entity.entity.spec.workers.storage_profile,  # noqa: E501
-        PayloadKey.NFS_SIZING_CLASS: def_entity.entity.spec.nfs.sizing_class,  # noqa: E501
-        PayloadKey.NFS_STORAGE_PROFILE: def_entity.entity.spec.nfs.storage_profile,  # noqa: E501
         PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(def_entity.entity.spec.settings.ssh_key),  # noqa: E501
         PayloadKey.WAS_ROLLBACK_ENABLED: bool(def_entity.entity.spec.settings.rollback_on_failure)  # noqa: E501
     }

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -90,6 +90,25 @@ def get_payload_for_install_server(params):
     }
 
 
+def get_payload_for_upgrade_server(params):
+    """Construct telemetry payload of server upgrade operation.
+
+    :param params: parameters provided to the operation
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.SERVICE_UPGRADE.telemetry_table,
+        PayloadKey.SOURCE_CSE_VERSION: params.get(PayloadKey.SOURCE_CSE_VERSION),  # noqa: E501
+        PayloadKey.SOURCE_VCD_API_VERSION: params.get(PayloadKey.SOURCE_VCD_API_VERSION),  # noqa: E501
+        PayloadKey.WERE_TEMPLATES_SKIPPED: bool(params.get(PayloadKey.WERE_TEMPLATES_SKIPPED)),  # noqa: E501
+        PayloadKey.WAS_TEMP_VAPP_RETAINED: bool(params.get(PayloadKey.WAS_TEMP_VAPP_RETAINED)),  # noqa: E501
+        PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(params.get(PayloadKey.WAS_SSH_KEY_SPECIFIED))  # noqa: E501
+    }
+
+
 def get_payload_for_run_server(params):
     """Construct telemetry payload of server run operation.
 

--- a/container_service_extension/telemetry/telemetry_handler.py
+++ b/container_service_extension/telemetry/telemetry_handler.py
@@ -46,7 +46,10 @@ OPERATION_TO_PAYLOAD_GENERATOR = {
     CseOperation.OVDC_DISABLE: payload_generator.get_payload_for_ovdc_disable,
     CseOperation.OVDC_ENABLE: payload_generator.get_payload_for_ovdc_enable,
     CseOperation.OVDC_INFO: payload_generator.get_payload_for_ovdc_info,
-    CseOperation.OVDC_LIST: payload_generator.get_payload_for_ovdc_list
+    CseOperation.OVDC_LIST: payload_generator.get_payload_for_ovdc_list,
+
+    CseOperation.V35_CLUSTER_CONFIG: payload_generator.get_payload_for_v35_cluster_config,  # noqa: E501
+    CseOperation.V35_CLUSTER_APPLY: payload_generator.get_payload_for_v35_cluster_apply  # noqa: E501
 }
 
 

--- a/container_service_extension/telemetry/telemetry_handler.py
+++ b/container_service_extension/telemetry/telemetry_handler.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import functools
-import json
+
 
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.telemetry.constants import CseOperation
@@ -25,6 +25,7 @@ OPERATION_TO_PAYLOAD_GENERATOR = {
     CseOperation.CONFIG_CHECK: payload_generator.get_payload_for_config_check,
 
     CseOperation.SERVICE_INSTALL: payload_generator.get_payload_for_install_server,   # noqa: E501
+    CseOperation.SERVICE_UPGRADE: payload_generator.get_payload_for_upgrade_server,  # noqa: E501
     CseOperation.SERVICE_RUN: payload_generator.get_payload_for_run_server,
 
     CseOperation.TEMPLATE_INSTALL: payload_generator.get_payload_for_install_template,  # noqa: E501
@@ -109,7 +110,6 @@ def record_user_action(cse_operation, status=OperationStatus.SUCCESS,
 
         if telemetry_settings['enable']:
             payload = get_payload_for_user_action(cse_operation, status, message)  # noqa: E501
-            print(json.dumps(payload))
             _send_data_to_telemetry_server(payload, telemetry_settings)
     except Exception as err:
         LOGGER.warning(f"Error in recording user action information:{str(err)}")  # noqa: E501
@@ -131,7 +131,6 @@ def record_user_action_details(cse_operation, cse_params,
 
         if telemetry_settings['enable']:
             payload = OPERATION_TO_PAYLOAD_GENERATOR[cse_operation](cse_params)
-            print(json.dumps(payload))
             _send_data_to_telemetry_server(payload, telemetry_settings)
     except Exception as err:
         LOGGER.warning(f"Error in recording CSE operation details :{str(err)}")  # noqa: E501

--- a/container_service_extension/telemetry/telemetry_handler.py
+++ b/container_service_extension/telemetry/telemetry_handler.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import functools
+import json
 
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.telemetry.constants import CseOperation
@@ -49,7 +50,10 @@ OPERATION_TO_PAYLOAD_GENERATOR = {
     CseOperation.OVDC_LIST: payload_generator.get_payload_for_ovdc_list,
 
     CseOperation.V35_CLUSTER_CONFIG: payload_generator.get_payload_for_v35_cluster_config,  # noqa: E501
-    CseOperation.V35_CLUSTER_APPLY: payload_generator.get_payload_for_v35_cluster_apply  # noqa: E501
+    CseOperation.V35_CLUSTER_APPLY: payload_generator.get_payload_for_v35_cluster_apply,  # noqa: E501
+    CseOperation.V35_CLUSTER_DELETE: payload_generator.get_payload_for_v35_cluster_delete,  # noqa: E501
+    CseOperation.V35_CLUSTER_UPGRADE_PLAN: payload_generator.get_payload_for_v35_cluster_upgrade_plan  # noqa: E501
+
 }
 
 
@@ -104,6 +108,7 @@ def record_user_action(cse_operation, status=OperationStatus.SUCCESS,
 
         if telemetry_settings['enable']:
             payload = get_payload_for_user_action(cse_operation, status, message)  # noqa: E501
+            print(json.dumps(payload))
             _send_data_to_telemetry_server(payload, telemetry_settings)
     except Exception as err:
         LOGGER.warning(f"Error in recording user action information:{str(err)}")  # noqa: E501
@@ -125,6 +130,7 @@ def record_user_action_details(cse_operation, cse_params,
 
         if telemetry_settings['enable']:
             payload = OPERATION_TO_PAYLOAD_GENERATOR[cse_operation](cse_params)
+            print(json.dumps(payload))
             _send_data_to_telemetry_server(payload, telemetry_settings)
     except Exception as err:
         LOGGER.warning(f"Error in recording CSE operation details :{str(err)}")  # noqa: E501

--- a/container_service_extension/telemetry/telemetry_handler.py
+++ b/container_service_extension/telemetry/telemetry_handler.py
@@ -4,7 +4,6 @@
 
 import functools
 
-
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.telemetry.constants import CseOperation
 from container_service_extension.telemetry.constants import OperationStatus
@@ -50,11 +49,14 @@ OPERATION_TO_PAYLOAD_GENERATOR = {
     CseOperation.OVDC_INFO: payload_generator.get_payload_for_ovdc_info,
     CseOperation.OVDC_LIST: payload_generator.get_payload_for_ovdc_list,
 
+    CseOperation.V35_CLUSTER_INFO: payload_generator.get_payload_for_v35_cluster_info,  # noqa: E501
+    CseOperation.V35_CLUSTER_LIST: payload_generator.get_payload_for_v35_cluster_list,  # noqa: E501
     CseOperation.V35_CLUSTER_CONFIG: payload_generator.get_payload_for_v35_cluster_config,  # noqa: E501
     CseOperation.V35_CLUSTER_APPLY: payload_generator.get_payload_for_v35_cluster_apply,  # noqa: E501
     CseOperation.V35_CLUSTER_DELETE: payload_generator.get_payload_for_v35_cluster_delete,  # noqa: E501
     CseOperation.V35_CLUSTER_UPGRADE_PLAN: payload_generator.get_payload_for_v35_cluster_upgrade_plan,  # noqa: E501
-    CseOperation.V35_CLUSTER_UPGRADE: payload_generator.get_payload_for_v35_cluster_upgrade  # noqa: E501
+    CseOperation.V35_CLUSTER_UPGRADE: payload_generator.get_payload_for_v35_cluster_upgrade,  # noqa: E501
+    CseOperation.V35_NODE_DELETE: payload_generator.get_payload_for_v35_node_delete  # noqa: E501
 
 }
 

--- a/container_service_extension/telemetry/telemetry_handler.py
+++ b/container_service_extension/telemetry/telemetry_handler.py
@@ -52,7 +52,8 @@ OPERATION_TO_PAYLOAD_GENERATOR = {
     CseOperation.V35_CLUSTER_CONFIG: payload_generator.get_payload_for_v35_cluster_config,  # noqa: E501
     CseOperation.V35_CLUSTER_APPLY: payload_generator.get_payload_for_v35_cluster_apply,  # noqa: E501
     CseOperation.V35_CLUSTER_DELETE: payload_generator.get_payload_for_v35_cluster_delete,  # noqa: E501
-    CseOperation.V35_CLUSTER_UPGRADE_PLAN: payload_generator.get_payload_for_v35_cluster_upgrade_plan  # noqa: E501
+    CseOperation.V35_CLUSTER_UPGRADE_PLAN: payload_generator.get_payload_for_v35_cluster_upgrade_plan,  # noqa: E501
+    CseOperation.V35_CLUSTER_UPGRADE: payload_generator.get_payload_for_v35_cluster_upgrade  # noqa: E501
 
 }
 


### PR DESCRIPTION
- Record telemetry data for defined entities
- Record telemetry data for CLI that uses server side DEF entity operations when CSE server is up and running.
- Tested manually using Super Collider Staging SQL workbench
- Tested with postman for telemetry on cluster list, info, node delete
- Tested for telemetry on api version 33/34 to make sure that they are recorded with existing VAC tables
   with collector id CSE.3_0. 
- Hide 'resize' subcommand from `vcd cse cluster` for api version 35.
- Few screen shots of recorded data in table format ( actions and details)

-----------
![image](https://user-images.githubusercontent.com/5530442/90096199-7d8a6780-dce7-11ea-9449-8cb9c7bcf089.png)
![image](https://user-images.githubusercontent.com/5530442/90096214-8844fc80-dce7-11ea-9c76-bbfd959bc505.png)
![image](https://user-images.githubusercontent.com/5530442/90096225-8f6c0a80-dce7-11ea-8ec6-b45229c993c8.png)
![image](https://user-images.githubusercontent.com/5530442/90096235-93982800-dce7-11ea-98fa-2629f57a5756.png)
![image](https://user-images.githubusercontent.com/5530442/90096242-998e0900-dce7-11ea-9f5b-10b5471b3086.png)
![image](https://user-images.githubusercontent.com/5530442/90096256-9f83ea00-dce7-11ea-8053-a0c561efa2da.png)

@Anirudh9794 @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/699)
<!-- Reviewable:end -->
