### PR TITLE
[VCDA-1622] TKG cluster get config operation from CLI

### DIFF
--- a/container_service_extension/client/constants.py
+++ b/container_service_extension/client/constants.py
@@ -24,6 +24,11 @@ TKG_CLUSTER_RUNTIME = 'TkgCluster'
 # fails, a re-login is needed to reset the key in profiles.yaml
 CSE_SERVER_RUNNING = 'cse_server_running'
 
+TKG_RESPONSE_MESSAGES_BY_STATUS = {
+    403: "User doesn't have required rights to perform the operation",
+    500: "Unexpected error occurred"
+}
+
 
 @unique
 class CLIOutputKey(str, Enum):
@@ -39,7 +44,7 @@ class CLIOutputKey(str, Enum):
 
 
 @unique
-class TKGClusterEntityFilterKey(str, Enum):
+class TKGEntityFilterKey(str, Enum):
     """Keys to filter TKG cluster entities in CSE CLI.
 
     Below Keys are commonly used filters. An entity can be filtered by any of
@@ -49,3 +54,13 @@ class TKGClusterEntityFilterKey(str, Enum):
     CLUSTER_NAME = 'entity.metadata.name'
     VDC_NAME = 'entity.metadata.virtualDataCenterName'
     ORG_NAME = 'org.name'
+
+
+@unique
+class TKGRequestHeaderKey(str, Enum):
+    """Header keys for tkgCluster requests."""
+
+    AUTHORIZATION = 'Authorization'
+    X_VCLOUD_AUTHORIZATION = 'x-vcloud-authorization'
+    ACCEPT = 'Accept'
+    X_VMWARE_VCLOUD_TENANT_CONTEXT = "x-vmware-vcloud-tenant-context"

--- a/container_service_extension/client/constants.py
+++ b/container_service_extension/client/constants.py
@@ -24,7 +24,8 @@ TKG_CLUSTER_RUNTIME = 'TkgCluster'
 # fails, a re-login is needed to reset the key in profiles.yaml
 CSE_SERVER_RUNNING = 'cse_server_running'
 
-TKG_RESPONSE_MESSAGES_BY_STATUS = {
+
+TKG_RESPONSE_MESSAGES_BY_STATUS_CODE = {
     403: "User doesn't have required rights to perform the operation",
     500: "Unexpected error occurred"
 }

--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -284,3 +284,4 @@ class DefEntityClusterApi:
             self._client._session,
             accept_type='application/json')
         return response_processor.process_response(response)
+

--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -284,4 +284,3 @@ class DefEntityClusterApi:
             self._client._session,
             accept_type='application/json')
         return response_processor.process_response(response)
-

--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -181,8 +181,7 @@ class DefEntityClusterApi:
         elif native_def_entity:
             return self._nativeCluster.get_cluster_config_by_id(
                 native_def_entity.get('id'))
-        raise NotImplementedError(
-            "Get Cluster Config for TKG clusters not yet implemented")  # noqa: E501
+        return self._tkgCluster.get_cluster_config(cluster_name=cluster_name, org=org, vdc=vdc)  # noqa: E501
 
     def delete_cluster(self, cluster_name, org=None, vdc=None):
         """Delete DEF cluster by name.

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -16,6 +16,7 @@ from container_service_extension.def_.utils import DEF_VMWARE_VENDOR
 import container_service_extension.exceptions as cse_exceptions
 import container_service_extension.logger as logger
 import container_service_extension.pyvcloud_utils as vcd_utils
+import container_service_extension.shared_constants as shared_constants
 
 
 class TKGClusterApi:
@@ -30,15 +31,19 @@ class TKGClusterApi:
         self._tkg_client = ApiClient(configuration=tkg_config)
         jwt_token = self._client.get_access_token()
         if jwt_token:
-            self._tkg_client.set_default_header("Authorization", f"Bearer {jwt_token}")  # noqa: E501
+            self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.AUTHORIZATION,  # noqa: E501
+                                                f"Bearer {jwt_token}")
         else:
             legacy_token = self._client.get_xvcloud_authorization_token()
-            self._tkg_client.set_default_header("x-vcloud-authorization", legacy_token)  # noqa: E501
+            self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.X_VCLOUD_AUTHORIZATION,  # noqa: E501
+                                                legacy_token)
         api_version = self._client.get_api_version()
-        self._tkg_client.set_default_header("Accept", f"application/json;version={api_version}")  # noqa: E501
+        self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.ACCEPT,  # noqa: E501
+                                            f"application/json;version={api_version}")  # noqa: E501
         org_logged_in = vcd_utils.get_org(self._client)
         org_id = org_logged_in.href.split('/')[-1]
-        self._tkg_client.set_default_header("x-vmware-vcloud-tenant-context", org_id)  # noqa: E501
+        self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.X_VMWARE_VCLOUD_TENANT_CONTEXT,  # noqa: E501
+                                            org_id)
         self._tkg_client_api = TkgClusterApi(api_client=self._tkg_client)
 
     def get_tkg_cluster(self, cluster_id):
@@ -70,7 +75,7 @@ class TKGClusterApi:
             # filters.append((cli_constants.TKGClusterEntityFilterKey.ORG_NAME.value, org))  # noqa: E501
             pass
         if vdc:
-            filters.append((cli_constants.TKGClusterEntityFilterKey.VDC_NAME.value, vdc))  # noqa: E501
+            filters.append((cli_constants.TKGEntityFilterKey.VDC_NAME.value, vdc))  # noqa: E501
         filter_string = None
         if filters:
             filter_string = ";".join([f"{f[0]}=={f[1]}" for f in filters])
@@ -101,12 +106,12 @@ class TKGClusterApi:
         return clusters
 
     def get_tkg_clusters_by_name(self, name, vdc=None, org=None):
-        filters = [(cli_constants.TKGClusterEntityFilterKey.CLUSTER_NAME.value, name)]  # noqa: E501
+        filters = [(cli_constants.TKGEntityFilterKey.CLUSTER_NAME.value, name)]
         if org:
             # TODO(Org filed for TKG): Add filter once schema is updated
             pass
         if vdc:
-            filters.append((cli_constants.TKGClusterEntityFilterKey.VDC_NAME.value, vdc))  # noqa: E501
+            filters.append((cli_constants.TKGEntityFilterKey.VDC_NAME.value, vdc))  # noqa: E501
         filter_string = ";".join([f"{f[0]}=={f[1]}" for f in filters])
         response = \
             self._tkg_client_api.list_tkg_clusters(
@@ -172,7 +177,7 @@ class TKGClusterApi:
             output_dict['task_href'] = headers.get('Location')
             return yaml.dump(output_dict)
         except tkg_rest.ApiException as e:
-            msg = f"Error applying cluster spec: {e.reason}"
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS.get(e.status, f"{e.reason}")  # noqa: E501
             logger.CLIENT_LOGGER.error(msg)
             raise Exception(msg)
         except Exception as e:
@@ -192,7 +197,7 @@ class TKGClusterApi:
             tkg_cluster_dict['task_href'] = headers.get('Location')
             return yaml.dump(tkg_cluster_dict)
         except tkg_rest.ApiException as e:
-            msg = f"Error deleting cluster: {e.reason}"
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS.get(e.status, f"{e.reason}")  # noqa: E501
             logger.CLIENT_LOGGER.error(msg)
             raise Exception(msg)
         except Exception as e:
@@ -223,7 +228,71 @@ class TKGClusterApi:
                 logger.CLIENT_LOGGER.error(msg)
                 raise cse_exceptions.CseDuplicateClusterError(msg)
         except tkg_rest.ApiException as e:
-            msg = f"Error deleting cluster: {e.reason}"
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS.get(e.status, f"{e.reason}")  # noqa: E501
+            logger.CLIENT_LOGGER.error(msg)
+            raise Exception(msg)
+        except Exception as e:
+            logger.CLIENT_LOGGER.error(f"{e}")
+            raise
+
+    def get_cluster_config_by_id(self, cluster_id, org_urn):
+        """Get TKG cluster config by cluster id.
+
+        :param str cluster_id: ID of the cluster
+        :param str org_urn: URN of the org
+        :return the cluster config of the TKG cluster
+        :rtype: str
+        """
+        try:
+            # set org-id extracted from org-urn in the header
+            org_id = org_urn.split(':')[-1]
+            self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.X_VMWARE_VCLOUD_TENANT_CONTEXT,  # noqa: E501
+                                                org_id)
+
+            # TODO: Make the call using sysadmin context
+            response, status, headers, tkg_def_entities = \
+                self._tkg_client_api.create_tkg_cluster_config_task(id=cluster_id)  # noqa: E501
+
+            # Extract the task for creating the config from the Location header
+            config_task_href = headers.get('Location')
+            if not config_task_href:
+                raise Exception(f"Failed to fetch kube-config for TKG cluster {cluster_id}")  # noqa: E501
+            config_task = self._client.get_resource(config_task_href)
+            self._client.get_task_monitor().wait_for_success(config_task)
+            config_task = self._client.get_resource(config_task_href)
+            return {shared_constants.RESPONSE_MESSAGE_KEY: config_task.Result.ResultContent.text}  # noqa: E501
+        except tkg_rest.ApiException as e:
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS.get(e.status, f"{e.reason}")  # noqa: E501
+            logger.CLIENT_LOGGER.error(msg)
+            raise Exception(msg)
+        except Exception as e:
+            logger.CLIENT_LOGGER.error(f"{e}")
+            raise
+
+    def get_cluster_config(self, cluster_name, org=None, vdc=None):
+        """Get TKG cluster config by cluster name.
+
+        :param str cluster_name: name of the cluster
+        :param str org: name of the org
+        :param str vdc: name of the vdc
+        """
+        try:
+            entities, tkg_def_entities = \
+                self.get_tkg_clusters_by_name(cluster_name, org=org, vdc=vdc)
+            if len(entities) == 1:
+                return self.get_cluster_config_by_id(
+                    tkg_def_entities[0]['id'],
+                    org_urn=tkg_def_entities[0]['org']['id'])
+            elif len(entities) == 0:
+                raise cse_exceptions.ClusterNotFoundError(f"Cluster '{cluster_name}' not found.")  # noqa: E501
+            else:
+                # More than 1 TKG cluster with the same name found.
+                msg = f"Multiple clusters found with name {cluster_name}. " \
+                      "Failed to apply the Spec."
+                logger.CLIENT_LOGGER.error(msg)
+                raise cse_exceptions.CseDuplicateClusterError(msg)
+        except tkg_rest.ApiException as e:
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS.get(e.status, f"{e.reason}")  # noqa: E501
             logger.CLIENT_LOGGER.error(msg)
             raise Exception(msg)
         except Exception as e:

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -177,7 +177,7 @@ class TKGClusterApi:
             output_dict['task_href'] = headers.get('Location')
             return yaml.dump(output_dict)
         except tkg_rest.ApiException as e:
-            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS.get(e.status, f"{e.reason}")  # noqa: E501
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{e.reason}")  # noqa: E501
             logger.CLIENT_LOGGER.error(msg)
             raise Exception(msg)
         except Exception as e:
@@ -197,7 +197,7 @@ class TKGClusterApi:
             tkg_cluster_dict['task_href'] = headers.get('Location')
             return yaml.dump(tkg_cluster_dict)
         except tkg_rest.ApiException as e:
-            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS.get(e.status, f"{e.reason}")  # noqa: E501
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{e.reason}")  # noqa: E501
             logger.CLIENT_LOGGER.error(msg)
             raise Exception(msg)
         except Exception as e:
@@ -224,11 +224,11 @@ class TKGClusterApi:
             else:
                 # More than 1 TKG cluster with the same name found.
                 msg = f"Multiple clusters found with name {cluster_name}. " \
-                      "Failed to apply the Spec."
+                      "Failed to delete the TKG cluster."
                 logger.CLIENT_LOGGER.error(msg)
                 raise cse_exceptions.CseDuplicateClusterError(msg)
         except tkg_rest.ApiException as e:
-            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS.get(e.status, f"{e.reason}")  # noqa: E501
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{e.reason}")  # noqa: E501
             logger.CLIENT_LOGGER.error(msg)
             raise Exception(msg)
         except Exception as e:
@@ -260,7 +260,7 @@ class TKGClusterApi:
             config_task = self._client.get_resource(config_task_href)
             return {shared_constants.RESPONSE_MESSAGE_KEY: config_task.Result.ResultContent.text}  # noqa: E501
         except tkg_rest.ApiException as e:
-            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS.get(e.status, f"{e.reason}")  # noqa: E501
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{e.reason}")  # noqa: E501
             logger.CLIENT_LOGGER.error(msg)
             raise Exception(msg)
         except Exception as e:
@@ -286,11 +286,11 @@ class TKGClusterApi:
             else:
                 # More than 1 TKG cluster with the same name found.
                 msg = f"Multiple clusters found with name {cluster_name}. " \
-                      "Failed to apply the Spec."
+                      "Failed to fetch kube-config."
                 logger.CLIENT_LOGGER.error(msg)
                 raise cse_exceptions.CseDuplicateClusterError(msg)
         except tkg_rest.ApiException as e:
-            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS.get(e.status, f"{e.reason}")  # noqa: E501
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{e.reason}")  # noqa: E501
             logger.CLIENT_LOGGER.error(msg)
             raise Exception(msg)
         except Exception as e:

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -248,8 +248,6 @@ class TKGClusterApi:
             org_id = org_urn.split(':')[-1]
             self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.X_VMWARE_VCLOUD_TENANT_CONTEXT,  # noqa: E501
                                                 org_id)
-
-            # TODO: Make the call using sysadmin context
             response, status, headers, tkg_def_entities = \
                 self._tkg_client_api.create_tkg_cluster_config_task(id=cluster_id)  # noqa: E501
 

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -297,14 +297,3 @@ class TKGClusterApi:
             logger.CLIENT_LOGGER.error(f"{e}")
             raise
 
-    def get_cluster_config(self, cluster_name, vdc=None, org=None):
-        """Get kubernetes cluster config of the cluster.
-
-        :param str cluster_name: TKG cluster name
-        :param str org: name of the org
-        :param str vdc: name of the vdc
-        :return: Cluster kubeconfig information
-        :rtype: str
-        :raises ClusterNotFoundError, CseDuplicateClusterError
-        """
-        raise NotImplementedError()

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -42,6 +42,7 @@ class TKGClusterApi:
                                             f"application/json;version={api_version}")  # noqa: E501
         org_logged_in = vcd_utils.get_org(self._client)
         org_id = org_logged_in.href.split('/')[-1]
+        # TODO setting right tenant context for sysadmin users
         self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.X_VMWARE_VCLOUD_TENANT_CONTEXT,  # noqa: E501
                                             org_id)
         self._tkg_client_api = TkgClusterApi(api_client=self._tkg_client)
@@ -245,7 +246,7 @@ class TKGClusterApi:
         """
         try:
             # set org-id extracted from org-urn in the header
-            org_id = org_urn.split(':')[-1]
+            org_id = vcd_utils.extract_id(org_urn)
             self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.X_VMWARE_VCLOUD_TENANT_CONTEXT,  # noqa: E501
                                                 org_id)
             response, status, headers, tkg_def_entities = \
@@ -296,4 +297,3 @@ class TKGClusterApi:
         except Exception as e:
             logger.CLIENT_LOGGER.error(f"{e}")
             raise
-

--- a/container_service_extension/client/tkgclient/api/tkg_cluster_api.py
+++ b/container_service_extension/client/tkgclient/api/tkg_cluster_api.py
@@ -131,7 +131,19 @@ class TkgClusterApi(object):
             collection_formats=collection_formats)
 
     def create_tkg_cluster_config_task(self, id, **kwargs):
-        """Obtain VCD task to get TKG cluster config."""
+        """Obtain VCD task to get TKG cluster config.
+
+        Makes a call to /entities/{cluster_id}/behaviors/urn:vcloud:behavior-interface:createKubeConfig:vmware:k8s:1.0.0/invocations
+        which generates a task for creating the cluster kube-config. The task
+        is embedded in the 'Location' header of the response. Once the task
+        completes successfully, the kube-config can be found in GET /task/{id}
+        response, under Result.ResultContent tag.
+
+        Note: this method only returns the response to the behaviors endpoint
+        and doesn't handle waiting for task completion and returning the
+        kube-config.
+        :param str id: ID of the TKG cluster
+        """
         all_params = ['id']  # noqa: E501
         all_params.append('async_req')
         # all_params.append('_return_http_data_only')
@@ -168,10 +180,10 @@ class TkgClusterApi(object):
             body=body_params,
             post_params=form_params,
             files=local_var_files,
-            response_type=None,
+            response_type=None,  # Expected response has no content (204)
             auth_settings=auth_settings,
             async_req=params.get('async_req'),
-            _return_http_data_only=False,
+            _return_http_data_only=False,  # Task created present in the Location header  # noqa: E501
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)

--- a/container_service_extension/client/tkgclient/api/tkg_cluster_api.py
+++ b/container_service_extension/client/tkgclient/api/tkg_cluster_api.py
@@ -130,6 +130,52 @@ class TkgClusterApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
+    def create_tkg_cluster_config_task(self, id, **kwargs):
+        """Obtain VCD task to get TKG cluster config."""
+        all_params = ['id']  # noqa: E501
+        all_params.append('async_req')
+        # all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method create_tkg_cluster" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        if ('id' not in params or
+                params['id'] is None):
+            raise ValueError("Missing the required parameter `id` when calling `get_tkg_cluster`")  # noqa: E501
+        path_params = {}
+        query_params = []
+        header_params = {}
+        header_params['Content-Type'] = self.api_client.select_header_content_type(['application/json'])  # noqa: E501
+        form_params = []
+        local_var_files = {}
+        body_params = None
+        auth_settings = []
+        collection_formats = {}
+        return self.api_client.call_api(
+            f"entities/{id}/behaviors/urn:vcloud:behavior-interface:createKubeConfig:vmware:k8s:1.0.0/invocations",  # noqa: E501
+            'POST',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type=None,
+            auth_settings=auth_settings,
+            async_req=params.get('async_req'),
+            _return_http_data_only=False,
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def create_tkg_cluster(self, tkg_cluster, **kwargs):  # noqa: E501
         """Creates a new TKG cluster. This operation is asynchronous and returns a task that you can monitor to track the progress of the request.   # noqa: E501
 


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

 CLI changes to get TKG cluster config

* Added a method in TKG client for creating task for TKG kubeconfig
* Handle fetching the kubeconfig from the task in tkg_cluster_api.py

NOTE: only sys admin can create the task for creating th kubeconfig. So as of now, this changes only works for sysadmin user

Testing Done:
Fetch kubeconfig of a TKG cluster
![Screen Shot 2020-08-17 at 12 00 42 PM](https://user-images.githubusercontent.com/16699642/90437322-01957400-e087-11ea-84ae-9f139faacad0.png)

@sahithi @rocknes @sakthisunda @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/702)
<!-- Reviewable:end -->
