### PR TITLE
Add support for handling multiple Accept headers in incoming requests

### DIFF
--- a/container_service_extension/consumer.py
+++ b/container_service_extension/consumer.py
@@ -12,7 +12,6 @@ import pika
 import requests
 
 from container_service_extension.exceptions import CseRequestError
-from container_service_extension.exceptions import NotAcceptableRequestError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 import container_service_extension.request_processor as request_processor
 from container_service_extension.server_constants import EXCHANGE_TYPE
@@ -155,21 +154,6 @@ class MessageConsumer(object):
                          f"from {properties.app_id} "
                          f"({threading.currentThread().ident}): "
                          f"{json.dumps(body_json)}, props: {properties}")
-
-            response_format = None
-            accept_header = body_json['headers']['Accept'].lower()
-            accept_header = accept_header.split(';')[0]
-            tokens = accept_header.split('/')
-            if len(tokens) > 1:
-                if tokens[0] in ('*', 'application'):
-                    response_format = tokens[1]
-            if not response_format:
-                response_format = tokens[0]
-            response_format = response_format.replace('*+', '')
-
-            if not ('json' in response_format or '*' == response_format):
-                raise NotAcceptableRequestError(
-                    error_message="CSE can only serve response as json.")
 
             result = request_processor.process_request(body_json)
 

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -134,6 +134,7 @@ OPERATION_TO_HANDLER = {
 
 _OPERATION_KEY = 'operation'
 
+
 def _parse_accept_header(accept_header: str):
     """Parse accept headers and select one that fits CSE.
 
@@ -157,15 +158,24 @@ def _parse_accept_header(accept_header: str):
     selected_header = None
     for header in accept_headers:
         tokens = header.split(';')
+        if len(tokens) != 2:
+            continue
         application_fragment = tokens[0]
+        version_fragment = tokens[1]
+
+        tokens = version_fragment.split("=")
+        if len(tokens) == 2:
+            if tokens[0].lower() != 'version':
+                continue
+
         tokens = application_fragment.split('/')
+        response_format = tokens[0]
         if len(tokens) > 1:
             if tokens[0] in ('*', 'application'):
                 response_format = tokens[1]
-        if not response_format:
-            response_format = tokens[0]
         response_format = response_format.replace('*+', '')
-        if response_format in ('json' , '*'):
+
+        if response_format in ('json', '*'):
             selected_header = header
             break
 

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -165,7 +165,7 @@ def _parse_accept_header(accept_header: str):
 
         tokens = version_fragment.split("=")
         if len(tokens) == 2:
-            if tokens[0].lower() != 'version':
+            if tokens[0] != 'version':
                 continue
 
         tokens = application_fragment.split('/')


### PR DESCRIPTION
CSE currently expects only a single value in the Accept header. Multiple values result in a 406. This behavior is not in line with HTTP standard. This PR adds support in CSE to handle multiple values for Accept header and pick the one that is serviceable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/705)
<!-- Reviewable:end -->
