### PR TITLE
Modify the template list endpoint to return entire template definition

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -81,8 +81,18 @@ def list_templates(ctx):
         client = ctx.obj['client']
         cluster = Cluster(client)
         result = cluster.get_templates()
-        stdout(result, ctx, sort_headers=False)
         CLIENT_LOGGER.debug(result)
+
+        fields_to_display = [
+            'name', 'revision', 'is_default', 'catalog', 'catalog_item',
+            'description']
+        all_templates = []
+        for template in result:
+            filtered_template_record = {}
+            for field in fields_to_display:
+                filtered_template_record[field] = template.get(field, '')
+            all_templates.append(filtered_template_record)
+        stdout(all_templates, ctx, sort_headers=False)
     except Exception as e:
         stderr(e, ctx)
         CLIENT_LOGGER.error(str(e))

--- a/container_service_extension/request_handlers/template_handler.py
+++ b/container_service_extension/request_handlers/template_handler.py
@@ -16,20 +16,29 @@ def template_list(request_data, op_ctx):
     """
     config = utils.get_server_runtime_config()
     templates = []
+    default_template_name = config['broker']['default_template_name']
+    default_template_revision = str(config['broker']['default_template_revision'])  # noqa: E501
+
     for t in config['broker']['templates']:
         template_name = t[LocalTemplateKey.NAME]
         template_revision = str(t[LocalTemplateKey.REVISION])
-        default_template_name = config['broker']['default_template_name']
-        default_template_revision = str(config['broker']['default_template_revision'])  # noqa: E501
         is_default = (template_name, template_revision) == (default_template_name, default_template_revision)  # noqa: E501
 
         templates.append({
-            'name': template_name,
-            'revision': template_revision,
-            'is_default': 'Yes' if is_default else 'No',
             'catalog': config['broker']['catalog'],
             'catalog_item': t[LocalTemplateKey.CATALOG_ITEM_NAME],
-            'description': t[LocalTemplateKey.DESCRIPTION].replace("\\n", ", ")
+            'cni': t[LocalTemplateKey.CNI],
+            'cni_version': t[LocalTemplateKey.CNI_VERSION],
+            'deprecated': t[LocalTemplateKey.DEPRECATED],
+            'description': t[LocalTemplateKey.DESCRIPTION].replace("\\n", ", "),  # noqa: E501
+            'docker_version': t[LocalTemplateKey.DOCKER_VERSION],
+            'is_default': 'Yes' if is_default else 'No',
+            'kind': t[LocalTemplateKey.KIND],
+            'kubernetes': t[LocalTemplateKey.KUBERNETES],
+            'kubernetes_version': t[LocalTemplateKey.KUBERNETES_VERSION],
+            'name': template_name,
+            'os': t[LocalTemplateKey.OS],
+            'revision': template_revision
         })
 
     return sorted(templates, key=lambda i: (i['name'], i['revision']), reverse=True)  # noqa: E501


### PR DESCRIPTION
Currently template list endpoint only returns a handful of fields to describe a template. This info is not enough for UI plugin. This PR improves the template list endpoint to return complete template definition.

Testing done:
Ran vcd cse template list to make sure regression hasn't been introduced
Made GET /api/cse/3.0/templates call using POSTman to verify that template definitions are now complete

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/707)
<!-- Reviewable:end -->
