### PR TITLE
[VCDA-1772, VCDA-1734, fix snake case output] Raise exception if no rights are present, print only task href on console

### DIFF
--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -4,7 +4,7 @@
 from dataclasses import asdict
 import os
 
-from requests.exceptions import HTTPError
+import requests
 import yaml
 
 import container_service_extension.client.constants as cli_constants
@@ -73,7 +73,7 @@ class DefEntityClusterApi:
         try:
             clusters += self._tkgCluster.list_tkg_clusters(vdc=vdc, org=org)
         except tkg_rest.ApiException as e:
-            if e.status != 403:
+            if e.status != requests.codes.FORBIDDEN:
                 raise
             has_tkg_rights = False
         try:
@@ -90,8 +90,8 @@ class DefEntityClusterApi:
                     cli_constants.CLIOutputKey.OWNER.value: def_entity.owner.name  # noqa: E501
                 }
                 clusters.append(cluster)
-        except HTTPError as e:
-            if e.response.status_code != 403:
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code != requests.codes.FORBIDDEN:
                 raise
             has_native_rights = False
         if not (has_tkg_rights and has_native_rights):
@@ -141,7 +141,7 @@ class DefEntityClusterApi:
                 vdc=vdc,
                 org=org)
         except tkg_rest.ApiException as e:
-            if e.status != 403:
+            if e.status != requests.codes.FORBIDDEN:
                 raise
             has_tkg_rights = False
         if not (has_native_rights or has_tkg_rights):

--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -73,7 +73,7 @@ class DefEntityClusterApi:
         try:
             clusters += self._tkgCluster.list_tkg_clusters(vdc=vdc, org=org)
         except tkg_rest.ApiException as e:
-            if e.status != requests.codes.FORBIDDEN:
+            if e.status not in [requests.codes.FORBIDDEN, requests.codes.UNAUTHORIZED]:
                 raise
             has_tkg_rights = False
         try:
@@ -91,7 +91,7 @@ class DefEntityClusterApi:
                 }
                 clusters.append(cluster)
         except requests.exceptions.HTTPError as e:
-            if e.response.status_code != requests.codes.FORBIDDEN:
+            if e.response.status_code not in [requests.codes.FORBIDDEN, requests.codes.UNAUTHORIZED]:
                 raise
             has_native_rights = False
         if not (has_tkg_rights and has_native_rights):
@@ -141,7 +141,7 @@ class DefEntityClusterApi:
                 vdc=vdc,
                 org=org)
         except tkg_rest.ApiException as e:
-            if e.status != requests.codes.FORBIDDEN:
+            if e.status not in [requests.codes.FORBIDDEN, requests.codes.UNAUTHORIZED]:
                 raise
             has_tkg_rights = False
         if not (has_native_rights or has_tkg_rights):
@@ -152,12 +152,12 @@ class DefEntityClusterApi:
             # If org filter is not provided, ask the user to provide org
             # filter
             if not org:
-                # handles the case where there more than 1 TKG cluster with
-                # the same name
+                # handles the case where there is are TKG clusters and native
+                # clusters with the same name in different organizations
                 raise Exception(f"{msg} Please specify the org to use "
                                 "using --org flag.")
             # handles the case where there is a TKG cluster and a native
-            # native cluster with the same name
+            # native cluster with the same name in the same organization
             raise Exception(f"{msg} Please specify the k8-runtime to use using"
                             " --k8-runtime flag.")
         elif not native_def_entity_dict and len(tkg_def_entity_dicts) == 0:

--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -277,7 +277,7 @@ class DefEntityClusterApi:
         """
         cluster_def_entity, is_native_cluster = \
             self._get_tkg_native_clusters_by_name(cluster_name, org=org_name, vdc=ovdc_name)  # noqa: E501
-        if cluster_def_entity:
+        if is_native_cluster:
             cluster_def_entity['entity']['spec']['k8_distribution']['template_name'] = template_name  # noqa: E501
             cluster_def_entity['entity']['spec']['k8_distribution']['template_revision'] = template_revision  # noqa: E501
             return self._nativeCluster.upgrade_cluster_by_cluster_id(cluster_def_entity['id'], cluster_entity=cluster_def_entity)  # noqa: E501

--- a/container_service_extension/client/native_cluster_api.py
+++ b/container_service_extension/client/native_cluster_api.py
@@ -110,7 +110,7 @@ class NativeClusterApi:
             media_type='application/json',
             accept_type='application/json')
         cluster_entity = def_models.DefEntity(**response_processor.process_response(response))  # noqa: E501
-        return f"task_href: {cluster_entity.entity.status.task_href}"
+        return client_utils.construct_task_console_message(cluster_entity.entity.status.task_href)  # noqa: E501
 
     def get_cluster_config(self, cluster_name, org=None, vdc=None):
         """Get cluster config for the given cluster name.
@@ -217,7 +217,7 @@ class NativeClusterApi:
             media_type='application/json',
             accept_type='application/json')
         cluster_entity = def_models.DefEntity(**response_processor.process_response(response))  # noqa: E501
-        return f"task_href: {cluster_entity.entity.status.task_href}"
+        return client_utils.construct_task_console_message(cluster_entity.entity.status.task_href)  # noqa: E501
 
     def apply(self, cluster_config):
         """Apply the configuration either to create or update the cluster.
@@ -250,4 +250,4 @@ class NativeClusterApi:
                 media_type='application/json',
                 accept_type='application/json')
         cluster_entity = def_models.DefEntity(**response_processor.process_response(response))  # noqa: E501
-        return f"task_href: {cluster_entity.entity.status.task_href}"
+        return client_utils.construct_task_console_message(cluster_entity.entity.status.task_href)  # noqa: E501

--- a/container_service_extension/client/native_cluster_api.py
+++ b/container_service_extension/client/native_cluster_api.py
@@ -84,7 +84,7 @@ class NativeClusterApi:
         :param str cluster_name: native cluster name
         :param str org: name of the org
         :param str vdc: name of the vdc
-        :return: deleted cluster information
+        :return: string containing delete operation task href
         :rtype: str
         :raises ClusterNotFoundError
         """
@@ -99,7 +99,7 @@ class NativeClusterApi:
         """Delete the existing Kubernetes cluster by id.
 
         :param str cluster_id: native cluster entity id
-        :return: decoded response content
+        :return: string containing the task for delete operation
         :rtype: str
         """
         uri = f"{self._uri}/cluster/{cluster_id}"
@@ -109,7 +109,8 @@ class NativeClusterApi:
             self._client._session,
             media_type='application/json',
             accept_type='application/json')
-        return yaml.dump(response_processor.process_response(response))
+        cluster_entity = def_models.DefEntity(**response_processor.process_response(response))  # noqa: E501
+        return f"task_href: {cluster_entity.entity.status.task_href}"
 
     def get_cluster_config(self, cluster_name, org=None, vdc=None):
         """Get cluster config for the given cluster name.
@@ -187,8 +188,8 @@ class NativeClusterApi:
         should be upgraded to.
         :param org_name: name of the org
         :param ovdc_name: name of the vdc
-        :return: requests.models.Response response
-        :rtype: dict
+        :return: string containing upgrade cluster task href
+        :rtype: str
         """
         filters = client_utils.construct_filters(org=org_name, vdc=ovdc_name)
         entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
@@ -204,8 +205,8 @@ class NativeClusterApi:
 
         :param str cluster_id: unique id of the cluster
         :param dict cluster_entity: defined entity
-        :return: requests.models.Response response
-        :rtype: dict
+        :return: string containing upgrade cluster task href
+        :rtype: str
         """
         uri = f'{self._uri}/cluster/{cluster_id}/action/upgrade'
         response = self._client._do_request_prim(
@@ -215,13 +216,15 @@ class NativeClusterApi:
             contents=cluster_entity['entity'],
             media_type='application/json',
             accept_type='application/json')
-        return yaml.dump(response_processor.process_response(response)['entity']) # noqa: E501
+        cluster_entity = def_models.DefEntity(**response_processor.process_response(response))  # noqa: E501
+        return f"task_href: {cluster_entity.entity.status.task_href}"
 
     def apply(self, cluster_config):
         """Apply the configuration either to create or update the cluster.
 
         :param dict cluster_config: cluster configuration information
-        :return: str
+        :return: dictionary containing the apply operation task
+        :rtype: dict
         """
         uri = f"{self._uri}/clusters"
         entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
@@ -246,4 +249,5 @@ class NativeClusterApi:
                 contents=cluster_config,
                 media_type='application/json',
                 accept_type='application/json')
-        return yaml.dump(response_processor.process_response(response)['entity']) # noqa: E501
+        cluster_entity = def_models.DefEntity(**response_processor.process_response(response))  # noqa: E501
+        return f"task_href: {cluster_entity.entity.status.task_href}"

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -12,6 +12,7 @@ from container_service_extension.client.tkgclient.api_client import ApiClient
 from container_service_extension.client.tkgclient.configuration import Configuration  # noqa: E501
 from container_service_extension.client.tkgclient.models.tkg_cluster import TkgCluster  # noqa: E501
 import container_service_extension.client.tkgclient.rest as tkg_rest
+import container_service_extension.client.utils as client_utils
 from container_service_extension.def_.utils import DEF_TKG_ENTITY_TYPE_NSS
 from container_service_extension.def_.utils import DEF_TKG_ENTITY_TYPE_VERSION
 from container_service_extension.def_.utils import DEF_VMWARE_VENDOR
@@ -178,8 +179,7 @@ class TKGClusterApi:
                 raise cse_exceptions.CseDuplicateClusterError(msg)
             # Get the task href from the header
             headers = response[2]
-            output = f"task_href: {headers.get('Location')}"
-            return output
+            return client_utils.construct_task_console_message(headers.get('Location'))  # noqa: E501
         except tkg_rest.ApiException as e:
             server_message = json.loads(e.body).get('message') or e.reason
             msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{server_message}")  # noqa: E501
@@ -199,7 +199,7 @@ class TKGClusterApi:
             response = \
                 self._tkg_client_api.delete_tkg_cluster_with_http_info(tkg_cluster_id=cluster_id)  # noqa: E501
             headers = response[2]
-            return f"task_href: {headers.get('Location')}"
+            return client_utils.construct_task_console_message(headers.get('Location'))  # noqa: E501
         except tkg_rest.ApiException as e:
             msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{e.reason}")  # noqa: E501
             logger.CLIENT_LOGGER.error(msg)

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+import json
+
 import yaml
 
 import container_service_extension.client.constants as cli_constants
@@ -82,26 +84,29 @@ class TKGClusterApi:
             filter_string = ";".join([f"{f[0]}=={f[1]}" for f in filters])
         # tkg_def_entities in the following statement represents the
         # information associated with the defined entity
-        (entities, status, headers, tkg_def_entities) = \
+        response = \
             self._tkg_client_api.list_tkg_clusters(
                 f"{DEF_VMWARE_VENDOR}/{DEF_TKG_ENTITY_TYPE_NSS}/{DEF_TKG_ENTITY_TYPE_VERSION}",  # noqa: E501
                 _return_http_data_only=False,
+                _preload_content=False,
                 object_filter=filter_string)
+        def_entities = json.loads(response[0].data)['values']
         clusters = []
-        for i in range(len(entities)):
+        for def_entity in def_entities:
             # NOTE: tkg_def_entities will contain corresponding defined entity
             # details
-            entity: TkgCluster = entities[i]
-            entity_properties = tkg_def_entities[i]
-            logger.CLIENT_LOGGER.debug(f"TKG Defined entity list from server: {entity}")  # noqa: E501
+            entity = def_entity.get('entity', {})
+            metadata = entity.get('metadata', {})
+            spec = entity.get('spec', {})
+            logger.CLIENT_LOGGER.debug(f"TKG Defined entity list from server: {def_entity}")  # noqa: E501
             cluster = {
-                cli_constants.CLIOutputKey.CLUSTER_NAME.value: entity.metadata.name, # noqa: E501
-                cli_constants.CLIOutputKey.VDC.value: entity.metadata.virtual_data_center_name, # noqa: E501
-                cli_constants.CLIOutputKey.ORG.value: entity_properties['org']['name'], # noqa: E501
-                cli_constants.CLIOutputKey.K8S_RUNTIME.value: cli_constants.TKG_CLUSTER_RUNTIME, # noqa: E501
-                cli_constants.CLIOutputKey.K8S_VERSION.value: entity.spec.distribution.version, # noqa: E501
-                cli_constants.CLIOutputKey.STATUS.value: entity.status.phase if entity.status else 'N/A',  # noqa: E501
-                cli_constants.CLIOutputKey.OWNER.value: entity_properties['owner']['name'],  # noqa: E501
+                cli_constants.CLIOutputKey.CLUSTER_NAME.value: metadata.get('name', 'N/A'),  # noqa: E501
+                cli_constants.CLIOutputKey.VDC.value: metadata.get('virtualDataCenterName', 'N/A'),  # noqa: E501
+                cli_constants.CLIOutputKey.ORG.value: def_entity.get('org', {}).get('name', 'N/A'),  # noqa: E501
+                cli_constants.CLIOutputKey.K8S_RUNTIME.value: cli_constants.TKG_CLUSTER_RUNTIME,  # noqa: E501
+                cli_constants.CLIOutputKey.STATUS.value: entity.get('status', {}).get('phase', 'N/A'),  # noqa: E501
+                cli_constants.CLIOutputKey.K8S_VERSION.value: spec.get('distribution', {}).get('version', 'N/A'),  # noqa: E501
+                cli_constants.CLIOutputKey.OWNER.value: def_entity.get('owner', {}).get('name', 'N/A'),  # noqa: E501
             }
             clusters.append(cluster)
         return clusters
@@ -117,13 +122,12 @@ class TKGClusterApi:
         response = \
             self._tkg_client_api.list_tkg_clusters(
                 f"{DEF_VMWARE_VENDOR}/{DEF_TKG_ENTITY_TYPE_NSS}/{DEF_TKG_ENTITY_TYPE_VERSION}", # noqa: E501
+                _preload_content=False,
                 object_filter=filter_string)
-        entities = []
         tkg_def_entities = []
         if response:
-            entities = response[0]
-            tkg_def_entities = response[3]
-        return entities, tkg_def_entities
+            tkg_def_entities = json.loads(response[0].data)['values']
+        return tkg_def_entities
 
     def get_cluster_info(self, cluster_name, org=None, vdc=None):
         """Get cluster information of a TKG cluster API.
@@ -136,32 +140,33 @@ class TKGClusterApi:
         :rtype: str
         :raises ClusterNotFoundError
         """
-        tkg_entities, _ = self.get_tkg_clusters_by_name(cluster_name, vdc=vdc, org=org)  # noqa: E501
+        tkg_entities = self.get_tkg_clusters_by_name(cluster_name, vdc=vdc, org=org)  # noqa: E501
         if len(tkg_entities) == 0:
             msg = f"Cluster '{cluster_name}' not found."
             logger.CLIENT_LOGGER.error(msg)
             raise cse_exceptions.ClusterNotFoundError(msg)
-        cluster_dict = tkg_entities[0].to_dict()
+        cluster_entity = tkg_entities[0]['entity']
         logger.CLIENT_LOGGER.debug(
-            f"Received defined entity of cluster {cluster_name} : {cluster_dict}")  # noqa: E501
-        return yaml.dump(cluster_dict)
+            f"Received defined entity of cluster {cluster_name} : {cluster_entity}")  # noqa: E501
+        return yaml.dump(cluster_entity)
 
     def apply(self, cluster_config: dict):
         """Apply the configuration either to create or update the cluster.
 
         :param dict cluster_config: cluster configuration information
-        :return: str
+        :return: string containing the task href for the operation
+        :rtype: str
         """
         try:
             cluster_name = cluster_config.get('metadata', {}).get('name')
             vdc_name = cluster_config.get('metadata', {}).get('virtualDataCenterName')  # noqa: E501
-            tkg_entities, tkg_def_entities = self.get_tkg_clusters_by_name(cluster_name, vdc=vdc_name)  # noqa: E501
-            if len(tkg_entities) == 0:
-                response, status, headers, tkg_def_entities = \
+            tkg_def_entities = self.get_tkg_clusters_by_name(cluster_name, vdc=vdc_name)  # noqa: E501
+            if len(tkg_def_entities) == 0:
+                response = \
                     self._tkg_client_api.create_tkg_cluster_with_http_info(tkg_cluster=cluster_config)  # noqa: E501
-            elif len(tkg_entities) == 1:
+            elif len(tkg_def_entities) == 1:
                 cluster_id = tkg_def_entities[0]['id']
-                response, status, headers, tkg_def_entities = \
+                response = \
                     self._tkg_client_api.update_tkg_cluster_with_http_info(
                         tkg_cluster_id=cluster_id,
                         tkg_cluster=cluster_config)
@@ -171,14 +176,13 @@ class TKGClusterApi:
                       "Failed to apply the Spec."
                 logger.CLIENT_LOGGER.error(msg)
                 raise cse_exceptions.CseDuplicateClusterError(msg)
-            # Retrieve the created TKG cluster details
-            entity, tkg_def_entities = self.get_tkg_clusters_by_name(cluster_name)  # noqa: E501
-            output_dict = entity[0].to_dict()
             # Get the task href from the header
-            output_dict['task_href'] = headers.get('Location')
-            return yaml.dump(output_dict)
+            headers = response[2]
+            output = f"task_href: {headers.get('Location')}"
+            return output
         except tkg_rest.ApiException as e:
-            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{e.reason}")  # noqa: E501
+            server_message = json.loads(e.body).get('message') or e.reason
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{server_message}")  # noqa: E501
             logger.CLIENT_LOGGER.error(msg)
             raise Exception(msg)
         except Exception as e:
@@ -189,14 +193,13 @@ class TKGClusterApi:
         """Delete a cluster using the cluster id.
 
         :param str cluster_id:
-        :return: string representing the cluster entity.
+        :return: string containing the task href of delete cluster operation
         """
         try:
-            response, status, headers, tkg_def_entities = \
+            response = \
                 self._tkg_client_api.delete_tkg_cluster_with_http_info(tkg_cluster_id=cluster_id)  # noqa: E501
-            tkg_cluster_dict = self.get_tkg_cluster(cluster_id)
-            tkg_cluster_dict['task_href'] = headers.get('Location')
-            return yaml.dump(tkg_cluster_dict)
+            headers = response[2]
+            return f"task_href: {headers.get('Location')}"
         except tkg_rest.ApiException as e:
             msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{e.reason}")  # noqa: E501
             logger.CLIENT_LOGGER.error(msg)
@@ -211,16 +214,16 @@ class TKGClusterApi:
         :param str cluster_name: TKG cluster name
         :param str org: name of the org
         :param str vdc: name of the vdc
-        :return: deleted cluster information
+        :return: string containing delete cluster task href
         :rtype: str
         :raises ClusterNotFoundError, CseDuplicateClusterError
         """
         try:
-            entities, tkg_def_entities = \
+            tkg_def_entities = \
                 self.get_tkg_clusters_by_name(cluster_name, org=org, vdc=vdc)
-            if len(entities) == 1:
+            if len(tkg_def_entities) == 1:
                 return self.delete_cluster_by_id(tkg_def_entities[0]['id'])
-            elif len(entities) == 0:
+            elif len(tkg_def_entities) == 0:
                 raise cse_exceptions.ClusterNotFoundError(f"Cluster '{cluster_name}' not found.")  # noqa: E501
             else:
                 # More than 1 TKG cluster with the same name found.
@@ -229,7 +232,8 @@ class TKGClusterApi:
                 logger.CLIENT_LOGGER.error(msg)
                 raise cse_exceptions.CseDuplicateClusterError(msg)
         except tkg_rest.ApiException as e:
-            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{e.reason}")  # noqa: E501
+            server_message = json.loads(e.body).get('message') or e.reason
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{server_message}")  # noqa: E501
             logger.CLIENT_LOGGER.error(msg)
             raise Exception(msg)
         except Exception as e:
@@ -249,7 +253,7 @@ class TKGClusterApi:
             org_id = vcd_utils.extract_id(org_urn)
             self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.X_VMWARE_VCLOUD_TENANT_CONTEXT,  # noqa: E501
                                                 org_id)
-            response, status, headers, tkg_def_entities = \
+            response, status, headers = \
                 self._tkg_client_api.create_tkg_cluster_config_task(id=cluster_id)  # noqa: E501
 
             # Extract the task for creating the config from the Location header
@@ -261,7 +265,8 @@ class TKGClusterApi:
             config_task = self._client.get_resource(config_task_href)
             return {shared_constants.RESPONSE_MESSAGE_KEY: config_task.Result.ResultContent.text}  # noqa: E501
         except tkg_rest.ApiException as e:
-            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{e.reason}")  # noqa: E501
+            server_message = json.loads(e.body).get('message') or e.reason
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{server_message}")  # noqa: E501
             logger.CLIENT_LOGGER.error(msg)
             raise Exception(msg)
         except Exception as e:
@@ -276,13 +281,13 @@ class TKGClusterApi:
         :param str vdc: name of the vdc
         """
         try:
-            entities, tkg_def_entities = \
+            tkg_def_entities = \
                 self.get_tkg_clusters_by_name(cluster_name, org=org, vdc=vdc)
-            if len(entities) == 1:
+            if len(tkg_def_entities) == 1:
                 return self.get_cluster_config_by_id(
                     tkg_def_entities[0]['id'],
                     org_urn=tkg_def_entities[0]['org']['id'])
-            elif len(entities) == 0:
+            elif len(tkg_def_entities) == 0:
                 raise cse_exceptions.ClusterNotFoundError(f"Cluster '{cluster_name}' not found.")  # noqa: E501
             else:
                 # More than 1 TKG cluster with the same name found.
@@ -291,7 +296,8 @@ class TKGClusterApi:
                 logger.CLIENT_LOGGER.error(msg)
                 raise cse_exceptions.CseDuplicateClusterError(msg)
         except tkg_rest.ApiException as e:
-            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{e.reason}")  # noqa: E501
+            server_message = json.loads(e.body).get('message') or e.reason
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{server_message}")  # noqa: E501
             logger.CLIENT_LOGGER.error(msg)
             raise Exception(msg)
         except Exception as e:

--- a/container_service_extension/client/tkgclient/api_client.py
+++ b/container_service_extension/client/tkgclient/api_client.py
@@ -155,15 +155,11 @@ class ApiClient(object):
         self.last_response = response_data
 
         return_data = response_data
-        additional_data = None
         if _preload_content:
             # deserialize response data
             if response_type:
-                # additional_data represents the data related to TkgCluster
-                # entity
-                return_data, additional_data = self.deserialize(response_data,
-                                                                response_type,
-                                                                method)
+                return_data = self.deserialize(response_data, response_type,
+                                               method)
             else:
                 return_data = None
 
@@ -171,7 +167,7 @@ class ApiClient(object):
             return (return_data)
         else:
             return (return_data, response_data.status,
-                    response_data.getheaders(), additional_data)
+                    response_data.getheaders())
 
     def sanitize_for_serialization(self, obj):
         """Builds a JSON POST object.
@@ -223,7 +219,7 @@ class ApiClient(object):
             deserialized object, or string of class name.
         :param method: HTTP method used to get the response
 
-        :return: (deserialized object, additional entity properties)
+        :return: deserialized object
         """
         # handle file downloading
         # save response body into a tmp file and return the instance
@@ -235,20 +231,14 @@ class ApiClient(object):
             data = json.loads(response.data)
         except ValueError:
             data = response.data
-        additional_data = None
         if response_type == 'TkgCluster' and method == 'GET':
-            additional_data = data
             data = data['entity']
-            del additional_data['entity']
         elif response_type == 'list[TkgCluster]' and method == 'GET':
             def_entities = data['values']
-            additional_data = []
             data = []
             for def_entity in def_entities:
                 data.append(def_entity['entity'])
-                del def_entity['entity']
-                additional_data.append(def_entity)
-        return self.__deserialize(data, response_type), additional_data
+        return self.__deserialize(data, response_type)
 
     def __deserialize(self, data, klass):
         """Deserializes dict, list, str into an object.

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -134,3 +134,10 @@ def construct_filters(**kwargs):
     if kwargs.get('vdc'):
         filters[def_utils.ClusterEntityFilterKey.OVDC_NAME.value] = kwargs['vdc']  # noqa: E501
     return filters
+
+
+def construct_task_console_message(task_href: str) -> str:
+    msg = "Run the following command to track the status of the cluster:\n"
+    task_id = task_href.split('/')[-1]
+    msg += f"vcd task wait {task_id}"
+    return msg


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Fixes for the following included:
* Exception with message "User cannot access native or TKG clusters. Please contact administrator" raised when user doesnt have native or tkg rights (helps in cluster list and info)
* Console output for cluster write operations (upgrade, apply and delete) will print a task_href on the console instead of the whole cluster entity
* TKG cluster info output used to return snake case. The output from defined entities should be shown as is (which is in camel case)
   - There is no need for additional data parameter which was introduced to send in tkg defined entity details. Have removed it from the tkg client

Testing done:
TKG cluster:
* list, cluster info , delete and apply commands to see if the response is proper
Native cluster ( TODO )
* list, cluster info, delete, and apply commands and checked if the response is proper

* created user with no rights and saw if the appropriate error message is shown on the screen (TODO)

Screenshots:
list and info TKG cluster
<img width="844" alt="Screen Shot 2020-08-21 at 1 14 49 PM" src="https://user-images.githubusercontent.com/16699642/90930876-5b13e080-e3b0-11ea-86b3-8c6203823032.png">

delete TKG cluster
<img width="759" alt="Screen Shot 2020-08-21 at 1 17 20 PM" src="https://user-images.githubusercontent.com/16699642/90931029-a9c17a80-e3b0-11ea-80c2-22e6e52437f2.png">


@sahithi @sakthisunda @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/708)
<!-- Reviewable:end -->
