### PR TITLE
[VCDA-1652] Transfer ownership of defined entity to cluster owner during cse upgrade

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -2160,9 +2160,36 @@ def _create_def_entity_for_existing_clusters(
 
         def_entity = def_models.DefEntity(entity=cluster_entity)
         entity_svc.create_entity(native_entity_type.id, entity=def_entity)
+
         def_entity = entity_svc.get_native_entity_by_name(cluster['name'])
         def_entity_id = def_entity.id
         def_entity.externalId = cluster['vapp_href']
+
+        # update ownership of the entity
+        try:
+            user = client.get_user_in_org(
+                user_name=cluster['owner_name'],
+                org_href=cluster['org_href'])
+            user_urn = user.get('id')
+            orgmember_urn = user_urn.replace(":user:", ":orgMember:")
+
+            org_href = cluster['org_href']
+            org_id = org_href.split("/")[-1]
+            org_urn = f"urn:vcloud:org:{org_id}"
+
+            def_entity.owner = def_models.Owner(
+                name=cluster['owner_name'],
+                id=orgmember_urn)
+            def_entity.org = def_models.Org(
+                name=cluster['org_name'],
+                id=org_urn)
+        except Exception as err:
+            INSTALL_LOGGER.debug(str(err))
+            msg = "Unable to determine current owner of cluster " \
+                  f"'{cluster['name']}'. Unable to process ownership."
+            msg_update_callback.info(msg)
+            INSTALL_LOGGER.info(msg)
+
         entity_svc.update_entity(def_entity_id, def_entity)
         entity_svc.resolve_entity(def_entity_id)
 


### PR DESCRIPTION
Currently sys admin creates the defined entities for existing k8s clusters during cse upgrade. This PR transfers the ownership of these newly created defined entities to the cluster owner.

Testing done:
Created cluster as org_admin
Ran cse upgrade
Verified that the defined entity created as part of cse upgrade process belongs to org_admin and not administrator (sys admin)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/710)
<!-- Reviewable:end -->
