### PR TITLE
Fix regression related to cse install/upgrade/run

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -2105,9 +2105,9 @@ def _create_def_entity_for_existing_clusters(
 
         if policy_name == shared_constants.NATIVE_CLUSTER_RUNTIME_INTERNAL_NAME:  # noqa: E501
             # TODO combine to a single constant
-            kind = def_utils.ClusterEntityKind.NATIVE.value
+            kind = shared_constants.ClusterEntityKind.NATIVE.value
         elif policy_name == shared_constants.TKG_PLUS_CLUSTER_RUNTIME_INTERNAL_NAME:  # noqa: E501
-            kind = def_utils.ClusterEntityKind.TKG_PLUS.value
+            kind = shared_constants.ClusterEntityKind.TKG_PLUS.value
 
         worker_nodes = []
         for item in cluster['nodes']:

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -440,7 +440,7 @@ class Service(object, metaclass=Singleton):
                     pass
             self.config['placement_policy_hrefs'] = placement_policy_name_to_href  # noqa: E501
         except Exception as e:
-            msg = f"Failed to load placement policies to server runtime configtion: {str(e)}" # noqa: E501
+            msg = f"Failed to load placement policies to server runtime configuration: {str(e)}" # noqa: E501
             msg_update_callback.error(msg)
             logger.SERVER_LOGGER.error(msg)
             raise

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -434,12 +434,15 @@ class Service(object, metaclass=Singleton):
                                                               log_wire=self.config['service'].get('log_wire')) # noqa: E501
             for runtime_policy in shared_constants.CLUSTER_RUNTIME_PLACEMENT_POLICIES:  # noqa: E501
                 k8_runtime = shared_constants.RUNTIME_INTERNAL_NAME_TO_DISPLAY_NAME_MAP[runtime_policy]  # noqa: E501
-                placement_policy_name_to_href[k8_runtime] = cpm.get_vdc_compute_policy(runtime_policy, is_placement_policy=True)['href']  # noqa: E501
+                try:
+                    placement_policy_name_to_href[k8_runtime] = cpm.get_vdc_compute_policy(runtime_policy, is_placement_policy=True)['href']  # noqa: E501
+                except EntityNotFoundException:
+                    pass
             self.config['placement_policy_hrefs'] = placement_policy_name_to_href  # noqa: E501
         except Exception as e:
-            msg = f"Failed to load placement policies to server runtime configt: {str(e)}" # noqa: E501
-            msg_update_callback.error(e)
-            logger.SERVER_LOGGER.error(e)
+            msg = f"Failed to load placement policies to server runtime configtion: {str(e)}" # noqa: E501
+            msg_update_callback.error(msg)
+            logger.SERVER_LOGGER.error(msg)
             raise
 
     def _load_template_definition_from_catalog(self,


### PR DESCRIPTION
Few of the previous PRs has caused regressions in cse install/upgrade/run functionallity. This PR fixes those issues.
1. Wrong constant used during CSE install/upgrade to create/read placement policies
2. During CSE server startup, missing TKG PLUS placement policy is not handled.

Testing done:
With the fixes, cse install/upgrade/run works correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/713)
<!-- Reviewable:end -->
