### PR TITLE
Changes for showing proper error message for TKG cluster upgrade and …

### DIFF
--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -103,10 +103,16 @@ UNSUPPORTED_SUBCOMMAND_OPTIONS_BY_VERSION = {
     }
 }
 
-UNSUPPORTED_SUBCOMMANDS_WITH_SERVER_NOT_RUNNING_BY_VERSION = {
+UNSUPPORTED_COMMANDS_WITH_SERVER_NOT_RUNNING_BY_VERSION = {
     vcd_client.ApiVersion.VERSION_35.value: [GroupKey.VERSION, GroupKey.OVDC,
                                              GroupKey.SYSTEM, GroupKey.TEMPLATE,  # noqa: E501
                                              GroupKey.PKS]
+}
+
+UNSUPPORTED_SUBCOMMANDS_WITH_SERVER_NOT_RUNNING_BY_VERSION = {
+    vcd_client.ApiVersion.VERSION_35.value: {
+        GroupKey.CLUSTER: ['upgrade', 'upgrade-plan']
+    }
 }
 
 
@@ -137,7 +143,9 @@ class GroupCommandFilter(click.Group):
             version = client.get_api_version()
 
             # Skipping some commands when CSE server is not running
-            if cmd_name in UNSUPPORTED_SUBCOMMANDS_WITH_SERVER_NOT_RUNNING_BY_VERSION.get(version, []) and client_utils.is_cli_for_tkg_only():  # noqa: E501
+            if client_utils.is_cli_for_tkg_only() and \
+                cmd_name in [*UNSUPPORTED_COMMANDS_WITH_SERVER_NOT_RUNNING_BY_VERSION.get(version, []),  # noqa: E501
+                             *UNSUPPORTED_SUBCOMMANDS_WITH_SERVER_NOT_RUNNING_BY_VERSION.get(version, {}).get(self.name, [])]:  # noqa: E501
                 return None
 
             # Skip the command if not supported

--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -251,8 +251,7 @@ class DefEntityClusterApi:
             self._get_tkg_native_clusters_by_name(cluster_name, org=org, vdc=vdc)  # noqa: E501
         if is_native_cluster:
             return self._nativeCluster.get_upgrade_plan_by_cluster_id(cluster.id)  # noqa: E501
-        raise NotImplementedError(
-            "Get Cluster upgrade-plan for TKG clusters not yet implemented")  # noqa: E501
+        self._tkgCluster.get_upgrade_plan(cluster_name, vdc=vdc, org=org)
 
     def upgrade_cluster(self, cluster_name, template_name,
                         template_revision, org_name=None, ovdc_name=None):
@@ -275,8 +274,7 @@ class DefEntityClusterApi:
             cluster.entity.spec.k8_distribution.template_revision = template_revision  # noqa: E501
             cluster_dict = asdict(cluster)
             return self._nativeCluster.upgrade_cluster_by_cluster_id(cluster.id, cluster_def_entity=cluster_dict)  # noqa: E501
-        raise NotImplementedError(
-            "Cluster upgrade for TKG clusters not yet implemented")  # noqa: E501
+        self._tkgCluster.upgrade_cluster(cluster_name)
 
     def get_templates(self):
         """Get the template information that are supported by api version 35.

--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -274,7 +274,7 @@ class DefEntityClusterApi:
             cluster.entity.spec.k8_distribution.template_revision = template_revision  # noqa: E501
             cluster_dict = asdict(cluster)
             return self._nativeCluster.upgrade_cluster_by_cluster_id(cluster.id, cluster_def_entity=cluster_dict)  # noqa: E501
-        self._tkgCluster.upgrade_cluster(cluster_name)
+        self._tkgCluster.upgrade_cluster(cluster_name, template_name, template_revision)  # noqa: E501
 
     def get_templates(self):
         """Get the template information that are supported by api version 35.

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -298,7 +298,8 @@ class TKGClusterApi:
         raise NotImplementedError(
             "Get Cluster upgrade-plan yet to be implemented for TKG clusters")
 
-    def upgrade_cluster(self, cluster_name, **kwargs):
+    def upgrade_cluster(self, cluster_name, template_name,
+                        template_revision, **kwargs):
         """Upgrade TKG cluster to the given distribution."""
         raise NotImplementedError(
             "Cluster upgrade yet to be implemented for TKG clusters")

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -287,3 +287,18 @@ class TKGClusterApi:
         except Exception as e:
             logger.CLIENT_LOGGER.error(f"{e}")
             raise
+
+    def get_upgrade_plan(self, cluster_name, vdc=None, org=None):
+        """List of clusters the TKG cluster can upgrade to.
+
+        :param str cluster_name: name of the cluster
+        :param str org: name of the org
+        :param str vdc: name of the vdc
+        """
+        raise NotImplementedError(
+            "Get Cluster upgrade-plan yet to be implemented for TKG clusters")
+
+    def upgrade_cluster(self, cluster_name, **kwargs):
+        """Upgrade TKG cluster to the given distribution."""
+        raise NotImplementedError(
+            "Cluster upgrade yet to be implemented for TKG clusters")


### PR DESCRIPTION
…upgrade-plan

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* cluster upgrade nad cluster upgrade-plan are not yet implemented and proper error message should be shown to the user if it is executed.

![Screen Shot 2020-08-26 at 3 30 57 PM](https://user-images.githubusercontent.com/16699642/91363417-736d6c00-e7b1-11ea-91ba-3a2eccba422a.png)

Testing done:
* executed cluster upgrade-plan and upgrade commands on tkg cluster and checked if right error messages are shown.

@sahithi @sakthisunda @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/716)
<!-- Reviewable:end -->
