### PR TITLE
Filx for enabling cluster creation with system default policy

### DIFF
--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -448,7 +448,8 @@ class ComputePolicyManager:
                 break
             for cp in response_body['values']:
                 policy = {
-                    'name': self.get_policy_display_name(cp.get('name')),
+                    'display_name': self.get_policy_display_name(cp.get('name')),  # noqa: E501
+                    'name': cp.get('name'),
                     'href': self._get_policy_href(cp.get('id')),
                     'id': cp.get('id')
                 }

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -2013,11 +2013,11 @@ def _remove_old_cse_sizing_compute_policies(
             vdc_sizing_policies = cpm.list_vdc_sizing_policies_on_vdc(vdc_id)
             if vdc_sizing_policies:
                 for policy in vdc_sizing_policies:
-                    msg = f"Processing Policy : '{policy['name']}' on Org VDC : '{vdc_name}'" # noqa: E501
+                    msg = f"Processing Policy : '{policy['display_name']}' on Org VDC : '{vdc_name}'" # noqa: E501
                     msg_update_callback.info(msg)
                     INSTALL_LOGGER.info(msg)
 
-                    all_cse_policy_names.append(policy['name'])
+                    all_cse_policy_names.append(policy['display_name'])
                     task_data = cpm.remove_vdc_compute_policy_from_vdc(
                         ovdc_id=vdc_id,
                         compute_policy_href=policy['href'],
@@ -2025,7 +2025,7 @@ def _remove_old_cse_sizing_compute_policies(
                     fake_task_object = {'href': task_data['task_href']}
                     client.get_task_monitor().wait_for_status(fake_task_object) # noqa: E501
 
-                    msg = f"Removed Policy : '{policy['name']}' from Org VDC : '{vdc_name}'" # noqa: E501
+                    msg = f"Removed Policy : '{policy['display_name']}' from Org VDC : '{vdc_name}'" # noqa: E501
                     msg_update_callback.general(msg)
                     INSTALL_LOGGER.info(msg)
 

--- a/container_service_extension/def_/ovdc_service.py
+++ b/container_service_extension/def_/ovdc_service.py
@@ -153,7 +153,7 @@ def get_ovdc_k8s_runtime_details(sysadmin_client: vcd_client.Client,
     ovdc_name = ovdc.get_resource().get('name')
     policies = []
     for policy in cpm.list_vdc_placement_policies_on_vdc(ovdc_id):
-        policies.append(RUNTIME_INTERNAL_NAME_TO_DISPLAY_NAME_MAP[policy['name']])  # noqa: E501
+        policies.append(RUNTIME_INTERNAL_NAME_TO_DISPLAY_NAME_MAP[policy['display_name']])  # noqa: E501
     return def_models.Ovdc(ovdc_name=ovdc_name, ovdc_id=ovdc_id, k8s_runtime=policies) # noqa: E501
 
 
@@ -189,7 +189,7 @@ def _update_ovdc_using_placement_policy_async(operation_context: ctx.OperationCo
             operation_context.sysadmin_client, log_wire=log_wire)
         existing_policies = []
         for policy in cpm.list_vdc_placement_policies_on_vdc(ovdc_id):
-            existing_policies.append(policy['name'])
+            existing_policies.append(policy['display_name'])
 
         logger.SERVER_LOGGER.debug(policy_list)
         logger.SERVER_LOGGER.debug(existing_policies)

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -247,7 +247,12 @@ def ovdc_compute_policy_list(request_data,
         log_wire=utils.str_to_bool(config['service'].get('log_wire')))
     compute_policies = []
     for cp in cpm.list_compute_policies_on_vdc(request_data[RequestKey.OVDC_ID]): # noqa: E501
-        compute_policies.append(cp)
+        policy = {
+            'name': cp['display_name'],
+            'id': cp['id'],
+            'href': cp['href']
+        }
+        compute_policies.append(policy)
     return compute_policies
 
 
@@ -283,7 +288,7 @@ def ovdc_compute_policy_update(request_data,
         cp_id = None
         if cp_name == SYSTEM_DEFAULT_COMPUTE_POLICY_NAME:
             for _cp in cpm.list_compute_policies_on_vdc(ovdc_id):
-                if _cp['name'] == cp_name:
+                if _cp['display_name'] == cp_name:
                     cp_href = _cp['href']
                     cp_id = _cp['id']
         else:


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* Users could not associate system default sizing policy to sizing classes because filters used with the compute policies endpoint is not working for System default policy.
* Solution: iterate over all the sizing policies and avoid the name filter.

Testing done:
Created a cluster with system default sizing policy as sizing class

@rocknes @sahithi @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/717)
<!-- Reviewable:end -->
