### PR TITLE
Enable pks ovdc commands for v35

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -1327,7 +1327,7 @@ def list_ovdcs(ctx):
         client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
         ovdc = Ovdc(client)
-        result = ovdc.list_ovdc_for_k8s()
+        result = ovdc.list_ovdc()
         stdout(result, ctx, sort_headers=False)
         CLIENT_LOGGER.debug(result)
     except Exception as e:
@@ -1380,7 +1380,7 @@ def ovdc_enable(ctx, ovdc_name, org_name, enable_native, enable_tkg_plus=None):
             ovdc = Ovdc(client)
             if org_name is None:
                 org_name = ctx.obj['profiles'].get('org_in_use')
-            result = ovdc.update_ovdc_for_k8s(
+            result = ovdc.update_ovdc(
                 enable=True,
                 ovdc_name=ovdc_name,
                 org_name=org_name,
@@ -1451,11 +1451,11 @@ def ovdc_disable(ctx, ovdc_name, org_name,
             ovdc = Ovdc(client)
             if org_name is None:
                 org_name = ctx.obj['profiles'].get('org_in_use')
-            result = ovdc.update_ovdc_for_k8s(enable=False,
-                                              ovdc_name=ovdc_name,
-                                              org_name=org_name,
-                                              k8s_runtime=k8_runtime,
-                                              remove_cp_from_vms_on_disable=remove_cp_from_vms_on_disable) # noqa: E501
+            result = ovdc.update_ovdc(enable=False,
+                                      ovdc_name=ovdc_name,
+                                      org_name=org_name,
+                                      k8s_runtime=k8_runtime,
+                                      remove_cp_from_vms_on_disable=remove_cp_from_vms_on_disable) # noqa: E501
             stdout(result, ctx)
             CLIENT_LOGGER.debug(result)
         else:
@@ -1490,7 +1490,7 @@ def ovdc_info(ctx, ovdc_name, org_name):
             ovdc = Ovdc(client)
             if org_name is None:
                 org_name = ctx.obj['profiles'].get('org_in_use')
-            result = ovdc.info_ovdc_for_k8s(ovdc_name, org_name)
+            result = ovdc.info_ovdc(ovdc_name, org_name)
             stdout(yaml.dump(result), ctx)
             CLIENT_LOGGER.debug(result)
         else:

--- a/container_service_extension/client/legacy_ovdc.py
+++ b/container_service_extension/client/legacy_ovdc.py
@@ -8,7 +8,6 @@ import pyvcloud.vcd.exceptions as vcd_exceptions
 from container_service_extension.client.response_processor import \
     process_response
 from container_service_extension.pyvcloud_utils import get_vdc
-import container_service_extension.server_constants as server_constants
 import container_service_extension.shared_constants as shared_constants
 
 
@@ -17,7 +16,7 @@ class LegacyOvdc:
         self.client = client
         self._uri = f"{self.client.get_api_uri()}/{shared_constants.CSE_URL_FRAGMENT}"  # noqa: E501
 
-    def list_ovdc_for_k8s(self, list_pks_plans=False):
+    def list_ovdc(self, list_pks_plans=False):
         method = shared_constants.RequestMethod.GET
         uri = f'{self._uri}/ovdcs'
         response = self.client._do_request_prim(
@@ -31,62 +30,12 @@ class LegacyOvdc:
 
     # TODO(metadata based enablement for < v35): Revisit after decision
     # to support metadata way of enabling for native clusters
-    def update_ovdc_for_k8s(self, ovdc_name, k8s_provider, **kwargs):
+    def update_ovdc(self, ovdc_name, k8s_provider, **kwargs):
         """Enable/Disable ovdc for native workflow."""
         msg = "Operation not supported; Under implementation"
         raise vcd_exceptions.OperationNotSupportedException(msg)
 
-    def update_ovdc_for_pks(self,
-                            enable,
-                            ovdc_name,
-                            org_name=None,
-                            k8s_provider=None,
-                            pks_plan=None,
-                            pks_cluster_domain=None):
-        """Enable/Disable ovdc for k8s for the given container provider.
-
-        :param bool enable: If set to True will enable the vdc for the
-            paricular k8s_provider else if set to False, K8 support on
-            the vdc will be disabled.
-        :param str ovdc_name: Name of org VDC to update
-        :param str org_name: Name of org that @ovdc_name belongs to
-        :param str k8s_provider: Name of the container provider
-        :param str pks_plan: PKS plan
-        :param str pks_cluster_domain: Suffix of the domain name, which will be
-         used to construct FQDN of the clusters.
-
-        :rtype: dict
-        """
-        method = shared_constants.RequestMethod.PUT
-        ovdc = get_vdc(self.client, vdc_name=ovdc_name, org_name=org_name,
-                       is_admin_operation=True)
-        ovdc_id = utils.extract_id(ovdc.get_resource().get('id'))
-        uri = f'{self._uri}/ovdc/{ovdc_id}'
-
-        if not enable:
-            k8s_provider = server_constants.K8sProvider.NONE
-            pks_plan = None
-            pks_cluster_domain = None
-
-        data = {
-            shared_constants.RequestKey.OVDC_ID: ovdc_id,
-            shared_constants.RequestKey.OVDC_NAME: ovdc_name,
-            shared_constants.RequestKey.ORG_NAME: org_name,
-            shared_constants.RequestKey.K8S_PROVIDER: k8s_provider,
-            shared_constants.RequestKey.PKS_PLAN_NAME: pks_plan,
-            shared_constants.RequestKey.PKS_CLUSTER_DOMAIN: pks_cluster_domain
-        }
-
-        response = self.client._do_request_prim(
-            method,
-            uri,
-            self.client._session,
-            contents=data,
-            media_type='application/json',
-            accept_type='application/json')
-        return process_response(response)
-
-    def info_ovdc_for_k8s(self, ovdc_name, org_name):
+    def info_ovdc(self, ovdc_name, org_name):
         """Disable ovdc for k8s for the given container provider.
 
         :param str ovdc_name: Name of the org VDC to be enabled

--- a/container_service_extension/client/ovdc_policy.py
+++ b/container_service_extension/client/ovdc_policy.py
@@ -82,25 +82,15 @@ class PolicyBasedOvdc:
         return process_response(resp)
 
     def info_ovdc(self, ovdc_name, org_name):
-        """Disable ovdc for k8s for the given container provider.
+        """Disable ovdc for given kubernetes runtime.
 
         :param str ovdc_name: Name of the org VDC to be enabled
         :param str org_name: Name of org that @ovdc_name belongs to
 
         :rtype: dict
         """
-        method = shared_constants.RequestMethod.GET
-        ovdc = get_vdc(self.client, vdc_name=ovdc_name, org_name=org_name,
-                       is_admin_operation=True)
-        ovdc_id = utils.extract_id(ovdc.get_resource().get('id'))
-        uri = f'{self._uri}/ovdc/{ovdc_id}'
-
-        response = self.client._do_request_prim(
-            method,
-            uri,
-            self.client._session,
-            accept_type='application/json')
-        return process_response(response)
+        raise NotImplementedError("OVDC info functionality is not supported "
+                                  "for the installed CSE version.")
 
     # TODO(compute-policy for v35): Revisit after decision on api v35 support
     def update_ovdc_compute_policies(self, ovdc_name, org_name,

--- a/container_service_extension/client/ovdc_policy.py
+++ b/container_service_extension/client/ovdc_policy.py
@@ -18,7 +18,7 @@ class PolicyBasedOvdc:
         self.client = client
         self._uri = f"{self.client.get_api_uri()}/{shared_constants.CSE_URL_FRAGMENT}/{shared_constants.CSE_3_0_URL_FRAGMENT}"  # noqa: E501
 
-    def list_ovdc_for_k8s(self):
+    def list_ovdc(self):
         method = shared_constants.RequestMethod.GET
         uri = f'{self._uri}/ovdcs'
         response = self.client._do_request_prim(
@@ -28,12 +28,8 @@ class PolicyBasedOvdc:
             accept_type='application/json')
         return process_response(response)
 
-    def update_ovdc_for_k8s(self,
-                            ovdc_name,
-                            k8s_runtime,
-                            enable=True,
-                            org_name=None,
-                            remove_cp_from_vms_on_disable=False):
+    def update_ovdc(self, ovdc_name, k8s_runtime, enable=True, org_name=None,
+                    remove_cp_from_vms_on_disable=False):
         """Enable/Disable ovdc for k8s for the given k8s provider.
 
         :param str ovdc_name: Name of org VDC to update
@@ -85,7 +81,7 @@ class PolicyBasedOvdc:
             accept_type='application/json')
         return process_response(resp)
 
-    def info_ovdc_for_k8s(self, ovdc_name, org_name):
+    def info_ovdc(self, ovdc_name, org_name):
         """Disable ovdc for k8s for the given container provider.
 
         :param str ovdc_name: Name of the org VDC to be enabled

--- a/container_service_extension/client/pks.py
+++ b/container_service_extension/client/pks.py
@@ -455,7 +455,6 @@ def ovdc_enable(ctx, ovdc_name, pks_plan,
                 enable=True,
                 ovdc_name=ovdc_name,
                 org_name=org_name,
-                k8s_provider=K8sProvider.PKS,
                 pks_plan=pks_plan,
                 pks_cluster_domain=pks_cluster_domain)
             stdout(result, ctx)

--- a/container_service_extension/client/pks.py
+++ b/container_service_extension/client/pks.py
@@ -8,8 +8,8 @@ import click
 from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
 
-from container_service_extension.client.pks_ovdc import PksOvdc
 from container_service_extension.client.pks_cluster import PksCluster
+from container_service_extension.client.pks_ovdc import PksOvdc
 import container_service_extension.client.utils as client_utils
 from container_service_extension.logger import CLIENT_LOGGER
 from container_service_extension.server_constants import K8sProvider
@@ -406,7 +406,7 @@ def list_ovdcs(ctx, list_pks_plans):
         client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
         ovdc = PksOvdc(client)
-        result = ovdc.list_ovdc_for_k8s(list_pks_plans=list_pks_plans)
+        result = ovdc.list_ovdc(list_pks_plans=list_pks_plans)
         stdout(result, ctx, sort_headers=False)
         CLIENT_LOGGER.debug(result)
     except Exception as e:
@@ -451,7 +451,7 @@ def ovdc_enable(ctx, ovdc_name, pks_plan,
             ovdc = PksOvdc(client)
             if org_name is None:
                 org_name = ctx.obj['profiles'].get('org_in_use')
-            result = ovdc.update_ovdc_for_pks(
+            result = ovdc.update_ovdc(
                 enable=True,
                 ovdc_name=ovdc_name,
                 org_name=org_name,
@@ -492,10 +492,10 @@ def ovdc_disable(ctx, ovdc_name, org_name):
             ovdc = PksOvdc(client)
             if org_name is None:
                 org_name = ctx.obj['profiles'].get('org_in_use')
-            result = ovdc.update_ovdc_for_pks(enable=False,
-                                              ovdc_name=ovdc_name,
-                                              k8s_provider=K8sProvider.PKS,
-                                              org_name=org_name)
+            result = ovdc.update_ovdc(enable=False,
+                                      ovdc_name=ovdc_name,
+                                      k8s_provider=K8sProvider.PKS,
+                                      org_name=org_name)
             stdout(result, ctx)
             CLIENT_LOGGER.debug(result)
         else:
@@ -530,7 +530,7 @@ def ovdc_info(ctx, ovdc_name, org_name):
             ovdc = PksOvdc(client)
             if org_name is None:
                 org_name = ctx.obj['profiles'].get('org_in_use')
-            result = ovdc.info_ovdc_for_k8s(ovdc_name, org_name)
+            result = ovdc.info_ovdc(ovdc_name, org_name)
             stdout(result, ctx)
             CLIENT_LOGGER.debug(result)
         else:

--- a/container_service_extension/client/pks.py
+++ b/container_service_extension/client/pks.py
@@ -8,7 +8,7 @@ import click
 from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
 
-from container_service_extension.client.legacy_ovdc import LegacyOvdc
+from container_service_extension.client.pks_ovdc import PksOvdc
 from container_service_extension.client.pks_cluster import PksCluster
 import container_service_extension.client.utils as client_utils
 from container_service_extension.logger import CLIENT_LOGGER
@@ -405,7 +405,7 @@ def list_ovdcs(ctx, list_pks_plans):
     try:
         client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
-        ovdc = LegacyOvdc(client)
+        ovdc = PksOvdc(client)
         result = ovdc.list_ovdc_for_k8s(list_pks_plans=list_pks_plans)
         stdout(result, ctx, sort_headers=False)
         CLIENT_LOGGER.debug(result)
@@ -448,7 +448,7 @@ def ovdc_enable(ctx, ovdc_name, pks_plan,
         client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
         if client.is_sysadmin():
-            ovdc = LegacyOvdc(client)
+            ovdc = PksOvdc(client)
             if org_name is None:
                 org_name = ctx.obj['profiles'].get('org_in_use')
             result = ovdc.update_ovdc_for_pks(
@@ -489,7 +489,7 @@ def ovdc_disable(ctx, ovdc_name, org_name):
         client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
         if client.is_sysadmin():
-            ovdc = LegacyOvdc(client)
+            ovdc = PksOvdc(client)
             if org_name is None:
                 org_name = ctx.obj['profiles'].get('org_in_use')
             result = ovdc.update_ovdc_for_pks(enable=False,
@@ -527,7 +527,7 @@ def ovdc_info(ctx, ovdc_name, org_name):
         client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
         if client.is_sysadmin():
-            ovdc = LegacyOvdc(client)
+            ovdc = PksOvdc(client)
             if org_name is None:
                 org_name = ctx.obj['profiles'].get('org_in_use')
             result = ovdc.info_ovdc_for_k8s(ovdc_name, org_name)

--- a/container_service_extension/client/pks_ovdc.py
+++ b/container_service_extension/client/pks_ovdc.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from pyvcloud.vcd import utils
-import pyvcloud.vcd.exceptions as vcd_exceptions
 
 from container_service_extension.client.response_processor import \
     process_response
@@ -17,7 +16,7 @@ class PksOvdc:
         self.client = client
         self._uri = f"{self.client.get_api_uri()}/{shared_constants.PKS_URL_FRAGMENT}"  # noqa: E501
 
-    def list_ovdc_for_k8s(self, list_pks_plans=False):
+    def list_ovdc(self, list_pks_plans=False):
         method = shared_constants.RequestMethod.GET
         uri = f'{self._uri}/ovdcs'
         response = self.client._do_request_prim(
@@ -29,20 +28,8 @@ class PksOvdc:
                 shared_constants.RequestKey.LIST_PKS_PLANS: list_pks_plans})
         return process_response(response)
 
-    # TODO(metadata based enablement for < v35): Revisit after decision
-    # to support metadata way of enabling for native clusters
-    def update_ovdc_for_k8s(self, ovdc_name, k8s_provider, **kwargs):
-        """Enable/Disable ovdc for native workflow."""
-        msg = "Operation not supported; Under implementation"
-        raise vcd_exceptions.OperationNotSupportedException(msg)
-
-    def update_ovdc_for_pks(self,
-                            enable,
-                            ovdc_name,
-                            org_name=None,
-                            k8s_provider=None,
-                            pks_plan=None,
-                            pks_cluster_domain=None):
+    def update_ovdc(self, enable, ovdc_name, org_name=None, k8s_provider=None,
+                    pks_plan=None, pks_cluster_domain=None):
         """Enable/Disable ovdc for k8s for the given container provider.
 
         :param bool enable: If set to True will enable the vdc for the
@@ -86,7 +73,7 @@ class PksOvdc:
             accept_type='application/json')
         return process_response(response)
 
-    def info_ovdc_for_k8s(self, ovdc_name, org_name):
+    def info_ovdc(self, ovdc_name, org_name):
         """Disable ovdc for k8s for the given container provider.
 
         :param str ovdc_name: Name of the org VDC to be enabled
@@ -99,61 +86,6 @@ class PksOvdc:
                        is_admin_operation=True)
         ovdc_id = utils.extract_id(ovdc.get_resource().get('id'))
         uri = f'{self._uri}/ovdc/{ovdc_id}'
-
-        response = self.client._do_request_prim(
-            method,
-            uri,
-            self.client._session,
-            accept_type='application/json')
-        return process_response(response)
-
-    def update_ovdc_compute_policies(self, ovdc_name, org_name,
-                                     compute_policy_name, action,
-                                     remove_compute_policy_from_vms):
-        """Update an ovdc's compute policies.
-
-        :param str ovdc_name: Name of org VDC to update
-        :param str org_name: Name of org that @ovdc_name belongs to
-        :param str compute_policy_name: Name of compute policy to add or remove
-        :param ComputePolicyAction action:
-
-        :rtype: dict
-        """
-        method = shared_constants.RequestMethod.PUT
-        ovdc = get_vdc(self.client, vdc_name=ovdc_name, org_name=org_name,
-                       is_admin_operation=True)
-        ovdc_id = utils.extract_id(ovdc.get_resource().get('id'))
-        uri = f'{self._uri}/ovdc/{ovdc_id}/compute-policies'
-
-        data = {
-            shared_constants.RequestKey.OVDC_ID: ovdc_id, # also exists in url
-            shared_constants.RequestKey.COMPUTE_POLICY_NAME: compute_policy_name,  # noqa: E501
-            shared_constants.RequestKey.COMPUTE_POLICY_ACTION: action,
-            shared_constants.RequestKey.REMOVE_COMPUTE_POLICY_FROM_VMS: remove_compute_policy_from_vms  # noqa: E501
-        }
-
-        response = self.client._do_request_prim(
-            method,
-            uri,
-            self.client._session,
-            contents=data,
-            media_type='application/json',
-            accept_type='application/json')
-        return process_response(response)
-
-    def list_ovdc_compute_policies(self, ovdc_name, org_name):
-        """List an ovdc's compute policies.
-
-        :param str ovdc_name: Name of org VDC to update
-        :param str org_name: Name of org that @ovdc_name belongs to
-
-        :rtype: dict
-        """
-        method = shared_constants.RequestMethod.GET
-        ovdc = get_vdc(self.client, vdc_name=ovdc_name, org_name=org_name,
-                       is_admin_operation=True)
-        ovdc_id = utils.extract_id(ovdc.get_resource().get('id'))
-        uri = f'{self._uri}/ovdc/{ovdc_id}/compute-policies'
 
         response = self.client._do_request_prim(
             method,

--- a/container_service_extension/client/pks_ovdc.py
+++ b/container_service_extension/client/pks_ovdc.py
@@ -1,0 +1,163 @@
+# container-service-extension
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from pyvcloud.vcd import utils
+import pyvcloud.vcd.exceptions as vcd_exceptions
+
+from container_service_extension.client.response_processor import \
+    process_response
+from container_service_extension.pyvcloud_utils import get_vdc
+import container_service_extension.server_constants as server_constants
+import container_service_extension.shared_constants as shared_constants
+
+
+class PksOvdc:
+    def __init__(self, client):
+        self.client = client
+        self._uri = f"{self.client.get_api_uri()}/{shared_constants.PKS_URL_FRAGMENT}"  # noqa: E501
+
+    def list_ovdc_for_k8s(self, list_pks_plans=False):
+        method = shared_constants.RequestMethod.GET
+        uri = f'{self._uri}/ovdcs'
+        response = self.client._do_request_prim(
+            method,
+            uri,
+            self.client._session,
+            accept_type='application/json',
+            params={
+                shared_constants.RequestKey.LIST_PKS_PLANS: list_pks_plans})
+        return process_response(response)
+
+    # TODO(metadata based enablement for < v35): Revisit after decision
+    # to support metadata way of enabling for native clusters
+    def update_ovdc_for_k8s(self, ovdc_name, k8s_provider, **kwargs):
+        """Enable/Disable ovdc for native workflow."""
+        msg = "Operation not supported; Under implementation"
+        raise vcd_exceptions.OperationNotSupportedException(msg)
+
+    def update_ovdc_for_pks(self,
+                            enable,
+                            ovdc_name,
+                            org_name=None,
+                            k8s_provider=None,
+                            pks_plan=None,
+                            pks_cluster_domain=None):
+        """Enable/Disable ovdc for k8s for the given container provider.
+
+        :param bool enable: If set to True will enable the vdc for the
+            paricular k8s_provider else if set to False, K8 support on
+            the vdc will be disabled.
+        :param str ovdc_name: Name of org VDC to update
+        :param str org_name: Name of org that @ovdc_name belongs to
+        :param str k8s_provider: Name of the container provider
+        :param str pks_plan: PKS plan
+        :param str pks_cluster_domain: Suffix of the domain name, which will be
+         used to construct FQDN of the clusters.
+
+        :rtype: dict
+        """
+        method = shared_constants.RequestMethod.PUT
+        ovdc = get_vdc(self.client, vdc_name=ovdc_name, org_name=org_name,
+                       is_admin_operation=True)
+        ovdc_id = utils.extract_id(ovdc.get_resource().get('id'))
+        uri = f'{self._uri}/ovdc/{ovdc_id}'
+
+        if not enable:
+            k8s_provider = server_constants.K8sProvider.NONE
+            pks_plan = None
+            pks_cluster_domain = None
+
+        data = {
+            shared_constants.RequestKey.OVDC_ID: ovdc_id,
+            shared_constants.RequestKey.OVDC_NAME: ovdc_name,
+            shared_constants.RequestKey.ORG_NAME: org_name,
+            shared_constants.RequestKey.K8S_PROVIDER: k8s_provider,
+            shared_constants.RequestKey.PKS_PLAN_NAME: pks_plan,
+            shared_constants.RequestKey.PKS_CLUSTER_DOMAIN: pks_cluster_domain
+        }
+
+        response = self.client._do_request_prim(
+            method,
+            uri,
+            self.client._session,
+            contents=data,
+            media_type='application/json',
+            accept_type='application/json')
+        return process_response(response)
+
+    def info_ovdc_for_k8s(self, ovdc_name, org_name):
+        """Disable ovdc for k8s for the given container provider.
+
+        :param str ovdc_name: Name of the org VDC to be enabled
+        :param str org_name: Name of org that @ovdc_name belongs to
+
+        :rtype: dict
+        """
+        method = shared_constants.RequestMethod.GET
+        ovdc = get_vdc(self.client, vdc_name=ovdc_name, org_name=org_name,
+                       is_admin_operation=True)
+        ovdc_id = utils.extract_id(ovdc.get_resource().get('id'))
+        uri = f'{self._uri}/ovdc/{ovdc_id}'
+
+        response = self.client._do_request_prim(
+            method,
+            uri,
+            self.client._session,
+            accept_type='application/json')
+        return process_response(response)
+
+    def update_ovdc_compute_policies(self, ovdc_name, org_name,
+                                     compute_policy_name, action,
+                                     remove_compute_policy_from_vms):
+        """Update an ovdc's compute policies.
+
+        :param str ovdc_name: Name of org VDC to update
+        :param str org_name: Name of org that @ovdc_name belongs to
+        :param str compute_policy_name: Name of compute policy to add or remove
+        :param ComputePolicyAction action:
+
+        :rtype: dict
+        """
+        method = shared_constants.RequestMethod.PUT
+        ovdc = get_vdc(self.client, vdc_name=ovdc_name, org_name=org_name,
+                       is_admin_operation=True)
+        ovdc_id = utils.extract_id(ovdc.get_resource().get('id'))
+        uri = f'{self._uri}/ovdc/{ovdc_id}/compute-policies'
+
+        data = {
+            shared_constants.RequestKey.OVDC_ID: ovdc_id, # also exists in url
+            shared_constants.RequestKey.COMPUTE_POLICY_NAME: compute_policy_name,  # noqa: E501
+            shared_constants.RequestKey.COMPUTE_POLICY_ACTION: action,
+            shared_constants.RequestKey.REMOVE_COMPUTE_POLICY_FROM_VMS: remove_compute_policy_from_vms  # noqa: E501
+        }
+
+        response = self.client._do_request_prim(
+            method,
+            uri,
+            self.client._session,
+            contents=data,
+            media_type='application/json',
+            accept_type='application/json')
+        return process_response(response)
+
+    def list_ovdc_compute_policies(self, ovdc_name, org_name):
+        """List an ovdc's compute policies.
+
+        :param str ovdc_name: Name of org VDC to update
+        :param str org_name: Name of org that @ovdc_name belongs to
+
+        :rtype: dict
+        """
+        method = shared_constants.RequestMethod.GET
+        ovdc = get_vdc(self.client, vdc_name=ovdc_name, org_name=org_name,
+                       is_admin_operation=True)
+        ovdc_id = utils.extract_id(ovdc.get_resource().get('id'))
+        uri = f'{self._uri}/ovdc/{ovdc_id}/compute-policies'
+
+        response = self.client._do_request_prim(
+            method,
+            uri,
+            self.client._session,
+            accept_type='application/json')
+        return process_response(response)

--- a/container_service_extension/client/pks_ovdc.py
+++ b/container_service_extension/client/pks_ovdc.py
@@ -28,7 +28,7 @@ class PksOvdc:
                 shared_constants.RequestKey.LIST_PKS_PLANS: list_pks_plans})
         return process_response(response)
 
-    def update_ovdc(self, enable, ovdc_name, org_name=None, k8s_provider=None,
+    def update_ovdc(self, enable, ovdc_name, org_name=None,
                     pks_plan=None, pks_cluster_domain=None):
         """Enable/Disable ovdc for k8s for the given container provider.
 
@@ -37,7 +37,6 @@ class PksOvdc:
             the vdc will be disabled.
         :param str ovdc_name: Name of org VDC to update
         :param str org_name: Name of org that @ovdc_name belongs to
-        :param str k8s_provider: Name of the container provider
         :param str pks_plan: PKS plan
         :param str pks_cluster_domain: Suffix of the domain name, which will be
          used to construct FQDN of the clusters.
@@ -50,6 +49,7 @@ class PksOvdc:
         ovdc_id = utils.extract_id(ovdc.get_resource().get('id'))
         uri = f'{self._uri}/ovdc/{ovdc_id}'
 
+        k8s_provider = server_constants.K8sProvider.PKS
         if not enable:
             k8s_provider = server_constants.K8sProvider.NONE
             pks_plan = None

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -83,6 +83,9 @@ GET /pks/cluster/{cluster name}?org={org name}&vdc={vdc name}
 PUT /pks/cluster/{cluster name}?org={org name}&vdc={vdc name}
 DELETE /pks/cluster/{cluster name}?org={org name}&vdc={vdc name}
 GET /pks/cluster/{cluster name}/config?org={org name}&vdc={vdc name}
+GET /pks/ovdcs
+GET /pks/ovdc/{ovdc_id}
+PUT /pks/ovdc/{ovdc_id}
 """  # noqa: E501
 
 OPERATION_TO_HANDLER = {
@@ -411,6 +414,23 @@ def _get_pks_url_data(method: str, url: str):
                         _OPERATION_KEY: CseOperation.PKS_CLUSTER_CONFIG,
                         shared_constants.RequestKey.CLUSTER_NAME: tokens[4]
                     }
+            raise cse_exception.MethodNotAllowedRequestError()
+    elif operation_type == shared_constants.OperationType.OVDC:
+        if num_tokens == 4:
+            if method == shared_constants.RequestMethod.GET:
+                return {_OPERATION_KEY: CseOperation.OVDC_LIST}
+            raise cse_exception.MethodNotAllowedRequestError()
+        if num_tokens == 5:
+            if method == shared_constants.RequestMethod.GET:
+                return {
+                    _OPERATION_KEY: CseOperation.OVDC_INFO,
+                    shared_constants.RequestKey.OVDC_ID: tokens[4]
+                }
+            if method == shared_constants.RequestMethod.PUT:
+                return {
+                    _OPERATION_KEY: CseOperation.OVDC_UPDATE,
+                    shared_constants.RequestKey.OVDC_ID: tokens[4]
+                }
             raise cse_exception.MethodNotAllowedRequestError()
 
     raise cse_exception.NotFoundRequestError()


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* Currently, with api version 35, legacy ovdc commands wont work because the request will be rejected by the server. The legacy ovdc enablement is required for enabling PKS in the ovdc.

* updated CLI and Server code so that pks commands can enable and disable the ovdc

* Testing done: Executed pks ovdc commands and checked if the server is working fine with pks/ovdc API calls from postman

<img width="658" alt="Screen Shot 2020-08-27 at 3 02 39 PM" src="https://user-images.githubusercontent.com/16699642/91499582-86963f80-e876-11ea-9d75-ee7f436fb4d7.png">


@rocknes @sahithi @sakthisunda @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/719)
<!-- Reviewable:end -->
