### PR TITLE
[VCDA-1775] Add --org option for cluster apply to help sysadmin specify deployment org for TKG

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -622,7 +622,14 @@ def cluster_resize(ctx, cluster_name, node_count, network_name, org_name,
     default=None,
     metavar='OUTPUT_FILE_NAME',
     help="Filepath to write sample configuration file to; This flag should be used with -s")  # noqa: E501
-def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, output):  # noqa: E501
+@click.option(
+    '--org',
+    'org',
+    default=None,
+    required=False,
+    metavar='TKG_ORGANIZATION',
+    help="Organization to which the TKG cluster need to be deployed. Needed only for TKG clusters.")  # noqa: E501
+def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, output, org):  # noqa: E501
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
         console_message_printer = utils.ConsoleMessagePrinter()
@@ -684,7 +691,7 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, out
             cluster_config['metadata']['org_name'] = ctx.obj['profiles'].get('org_in_use')  # noqa: E501
 
         cluster = Cluster(client, k8_runtime=cluster_config.get('kind'))  # noqa: E501
-        result = cluster.apply(cluster_config)
+        result = cluster.apply(cluster_config, org=org)
         stdout(result, ctx)
         CLIENT_LOGGER.debug(result)
     except Exception as e:

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -627,8 +627,8 @@ def cluster_resize(ctx, cluster_name, node_count, network_name, org_name,
     'org',
     default=None,
     required=False,
-    metavar='TKG_ORGANIZATION',
-    help="Organization to which the TKG cluster need to be deployed. Needed only for TKG clusters.")  # noqa: E501
+    metavar='ORGANIZATION',
+    help="Organization on which the cluster configuration needs to be applied")
 def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, output, org):  # noqa: E501
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
@@ -672,26 +672,17 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, out
                 # Cannot run the command as cse cli is enabled only for native
                 raise CseServerNotRunningError()
             k8_runtime = shared_constants.ClusterEntityKind.TKG.value
-        metadata = cluster_config.get('metadata', {})
-        metadata_vdc_key = ''
-        if k8_runtime == shared_constants.ClusterEntityKind.NATIVE.value or \
-                k8_runtime == shared_constants.ClusterEntityKind.TKG_PLUS.value:  # noqa: E501
-            metadata_vdc_key = 'ovdc_name'
-        elif k8_runtime == shared_constants.ClusterEntityKind.TKG.value:
-            metadata_vdc_key = 'virtualDataCenterName'
-        if not metadata.get(metadata_vdc_key):
-            vdc = ctx.obj['profiles'].get('vdc_in_use')
-            if not vdc:
-                raise Exception("Virtual datacenter context is not set. "
-                                "Use either command 'vcd vdc use' or option "
-                                "'--vdc' to set the vdc context.")
-            metadata[metadata_vdc_key] = vdc
-        if k8_runtime != shared_constants.ClusterEntityKind.TKG.value and \
-                not cluster_config.get('metadata', {}).get('org_name'):
-            cluster_config['metadata']['org_name'] = ctx.obj['profiles'].get('org_in_use')  # noqa: E501
+        org_name = None
+        if k8_runtime == shared_constants.ClusterEntityKind.TKG.value:
+            from container_service_extension.utils import ConsoleMessagePrinter
+            cb = ConsoleMessagePrinter()
+            cb.general(f"val for org: {org}")
+            org_name = org
+            if not org:
+                org_name = ctx.obj['profiles'].get('org_in_use')
 
         cluster = Cluster(client, k8_runtime=cluster_config.get('kind'))  # noqa: E501
-        result = cluster.apply(cluster_config, org=org)
+        result = cluster.apply(cluster_config, org=org_name)
         stdout(result, ctx)
         CLIENT_LOGGER.debug(result)
     except Exception as e:

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -674,9 +674,6 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, out
             k8_runtime = shared_constants.ClusterEntityKind.TKG.value
         org_name = None
         if k8_runtime == shared_constants.ClusterEntityKind.TKG.value:
-            from container_service_extension.utils import ConsoleMessagePrinter
-            cb = ConsoleMessagePrinter()
-            cb.general(f"val for org: {org}")
             org_name = org
             if not org:
                 org_name = ctx.obj['profiles'].get('org_in_use')

--- a/container_service_extension/client/native_cluster_api.py
+++ b/container_service_extension/client/native_cluster_api.py
@@ -219,7 +219,7 @@ class NativeClusterApi:
         cluster_def_entity = def_models.DefEntity(**response_processor.process_response(response))  # noqa: E501
         return client_utils.construct_task_console_message(cluster_def_entity.entity.status.task_href)  # noqa: E501
 
-    def apply(self, cluster_config):
+    def apply(self, cluster_config, **kwargs):
         """Apply the configuration either to create or update the cluster.
 
         :param dict cluster_config: cluster configuration information

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -160,7 +160,7 @@ class TKGClusterApi:
             f"Received defined entity of cluster {cluster_name} : {cluster_entity_dict}")  # noqa: E501
         return yaml.dump(cluster_entity_dict)
 
-    def apply(self, cluster_config: dict):
+    def apply(self, cluster_config: dict, org=None, **kwargs):
         """Apply the configuration either to create or update the cluster.
 
         :param dict cluster_config: cluster configuration information
@@ -168,6 +168,12 @@ class TKGClusterApi:
         :rtype: str
         """
         try:
+            if self._client.is_sysadmin() and org:
+                org_logged_in = vcd_utils.get_org(self._client, org_name=org)
+                org_id = org_logged_in.href.split('/')[-1]
+                # TODO setting right tenant context for sysadmin users
+                self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.X_VMWARE_VCLOUD_TENANT_CONTEXT,  # noqa: E501
+                                                    org_id)
             cluster_name = cluster_config.get('metadata', {}).get('name')
             vdc_name = cluster_config.get('metadata', {}).get('virtualDataCenterName')  # noqa: E501
             response = None

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -25,6 +25,10 @@ import container_service_extension.shared_constants as shared_constants
 class TKGClusterApi:
     """Embedded Kubernetes into vSphere."""
 
+    # NOTE: When converting model objects from tkgclient/models to dictionary,
+    # please use utils.swagger_object_to_dict() function. This preserves camel
+    # case of the keys.
+
     def __init__(self, client):
         self._client = client
         tkg_config = Configuration()
@@ -168,7 +172,7 @@ class TKGClusterApi:
         :rtype: str
         """
         try:
-            if self._client.is_sysadmin() and org:
+            if org:
                 org_logged_in = vcd_utils.get_org(self._client, org_name=org)
                 org_id = org_logged_in.href.split('/')[-1]
                 # TODO setting right tenant context for sysadmin users


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* Sysadmins cannot deploy TKG clusters because they need to specify a non-system org context while deployment
* Introduce an --org flag to help sysadmins explicitly specify the deployment org, which is only useful for TKG cluster creation.
 
* Testing done:
 Created a TKG cluster as an administrator by specifying an org through the --org flag.

Screenshot:
<img width="762" alt="Screen Shot 2020-08-31 at 6 02 37 PM" src="https://user-images.githubusercontent.com/16699642/91783280-908cab00-ebb4-11ea-8be9-d0820976e810.png">

@sahithi @sakthisunda @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/722)
<!-- Reviewable:end -->
