### PR TITLE
Fix failing CToT against vCD 10.2

### DIFF
--- a/container_service_extension/sample_generator.py
+++ b/container_service_extension/sample_generator.py
@@ -129,7 +129,7 @@ SAMPLE_BROKER_CONFIG = {
         'storage_profile': '*',
         'default_template_name': 'my_template',
         'default_template_revision': 0,
-        'remote_template_cookbook_url': 'https://raw.githubusercontent.com/vmware/container-service-extension-templates/upgrades/template.yaml', # noqa: E501
+        'remote_template_cookbook_url': 'http://raw.githubusercontent.com/vmware/container-service-extension-templates/upgrades/template.yaml', # noqa: E501
     }
 }
 

--- a/container_service_extension/system_test_framework/environment.py
+++ b/container_service_extension/system_test_framework/environment.py
@@ -203,11 +203,11 @@ def create_user(username, password, role):
     # no assert here because if the user exists, the exit code will be 2
 
     # user can already exist but be disabled
-    cmd = f"user update {username} --enable"
-    result = CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
-    assert result.exit_code == 0,\
-        testutils.format_command_info('vcd', cmd, result.exit_code,
-                                      result.output)
+    # cmd = f"user update {username} --enable"
+    # result = CLI_RUNNER.invoke(vcd, cmd.split(), catch_exceptions=False)
+    # assert result.exit_code == 0,\
+    #    testutils.format_command_info('vcd', cmd, result.exit_code,
+    #                                  result.output)
 
 
 def delete_catalog_item(item_name):

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -66,6 +66,6 @@ broker:
                                         #   Should have outbound access to the public internet
                                         #   CSE appliance doesn't need to be connected to this network
   org: '???'                            # vCD org that contains the shared catalog where the master templates will be stored
-  remote_template_cookbook_url: https://raw.githubusercontent.com/vmware/container-service-extension-templates/upgrades/template.yaml
+  remote_template_cookbook_url: http://raw.githubusercontent.com/vmware/container-service-extension-templates/upgrades/template.yaml
   storage_profile: '*'                  # name of the storage profile to use when creating the temporary vApp used to build the template
   vdc: '???'                            # VDC within @org that will be used during the install process to build the template


### PR DESCRIPTION
Enabling an user via PUT /api/admin/user/{id} causes their vm quota to be set as 0. This is a bug in vCD. Until the vCD bug is fixed, CSE system test will avoid enabling the user as a separate step.This change should fix the failing system tests against vCD 10.2