### PR TITLE
[VCDA-1720] Add resource version to the request before update operation for TKG

### DIFF
--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -172,9 +172,10 @@ class TKGClusterApi:
             vdc_name = cluster_config.get('metadata', {}).get('virtualDataCenterName')  # noqa: E501
             response = None
             try:
-                _, tkg_def_entities = \
+                tkg_entity, tkg_def_entities = \
                     self.get_tkg_clusters_by_name(cluster_name, vdc=vdc_name)
                 cluster_id = tkg_def_entities[0].get('id')
+                cluster_config['metadata']['resourceVersion'] = tkg_entity[0].metadata.resource_version  # noqa: E501
                 response = \
                     self._tkg_client_api.update_tkg_cluster_with_http_info(
                         tkg_cluster_id=cluster_id,


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* Currently for all TKG cluster update operation, a new field `resourceVersion` should be added before `vcd cse cluster apply` is called. This PR removes the need for manually fetching the field and updating it.

* Testing done: Tested whether the update operation for TKG goes through successfully with different users.

@sakthisunda @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/730)
<!-- Reviewable:end -->
