### PR TITLE
[VCDA-1811] Change tkgCluster to TanzuKubernetesCluster in CLI output

### DIFF
--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -102,7 +102,7 @@ class TKGClusterApi:
                 cli_constants.CLIOutputKey.CLUSTER_NAME.value: entity.metadata.name, # noqa: E501
                 cli_constants.CLIOutputKey.VDC.value: entity.metadata.virtual_data_center_name, # noqa: E501
                 cli_constants.CLIOutputKey.ORG.value: entity_properties['org']['name'], # noqa: E501
-                cli_constants.CLIOutputKey.K8S_RUNTIME.value: cli_constants.TKG_CLUSTER_RUNTIME, # noqa: E501
+                cli_constants.CLIOutputKey.K8S_RUNTIME.value: shared_constants.ClusterEntityKind.TKG.value, # noqa: E501
                 cli_constants.CLIOutputKey.K8S_VERSION.value: entity.spec.distribution.version, # noqa: E501
                 cli_constants.CLIOutputKey.STATUS.value: entity.status.phase if entity.status else 'N/A',  # noqa: E501
                 cli_constants.CLIOutputKey.OWNER.value: entity_properties['owner']['name'],  # noqa: E501


### PR DESCRIPTION

-  Change `tkgCluster` to `TanzuKubernetesCluster` in CLI output`vcd cse cluster list`
--------
![image](https://user-images.githubusercontent.com/5530442/92524376-dbbb4500-f1d6-11ea-8fea-ebb3491776b8.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/736)
<!-- Reviewable:end -->
