### PR TITLE
[VCDA-1793] Create defined entities in specific org when sysadmin creates a cluster

### DIFF
--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -100,7 +100,7 @@ class DefEntityClusterApi:
                 logger.CLIENT_LOGGER.debug(f"No rights present to fetch native clusters: {e}")
                 
                 has_native_rights = False
-        if not (has_tkg_rights and has_native_rights):
+        if not (has_tkg_rights or has_native_rights):
             raise Exception("Logged in user doesn't have Native cluster rights"
                             " or TKG rights. Please contact administrator.")
         return clusters

--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -66,7 +66,10 @@ class DefEntityClusterApi:
             clusters += self._tkgCluster.list_tkg_clusters(vdc=vdc, org=org)
         except tkg_rest.ApiException as e:
             if e.status not in [requests.codes.FORBIDDEN, requests.codes.UNAUTHORIZED]:  # noqa: E501
-                raise
+                logger.CLIENT_LOGGER.error(f"Failed to fetch TKG clusters: {e}")
+                #TODO for debug: VCD is raising 404 at this point hence uncommenting
+                # raise
+            logger.CLIENT_LOGGER.debug(f"No rights present to fetch TKG clusters: {e}")
             has_tkg_rights = False
         if not client_utils.is_cli_for_tkg_only():
             filters = client_utils.construct_filters(org=org, vdc=vdc)
@@ -92,7 +95,10 @@ class DefEntityClusterApi:
                     clusters.append(cluster)
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code not in [requests.codes.FORBIDDEN, requests.codes.UNAUTHORIZED]:  # noqa: E501
+                    logger.CLIENT_LOGGER.error(f"Failed to fetch native clusters: {e}")
                     raise
+                logger.CLIENT_LOGGER.debug(f"No rights present to fetch native clusters: {e}")
+                
                 has_native_rights = False
         if not (has_tkg_rights and has_native_rights):
             raise Exception("Logged in user doesn't have Native cluster rights"

--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -66,10 +66,9 @@ class DefEntityClusterApi:
             clusters += self._tkgCluster.list_tkg_clusters(vdc=vdc, org=org)
         except tkg_rest.ApiException as e:
             if e.status not in [requests.codes.FORBIDDEN, requests.codes.UNAUTHORIZED]:  # noqa: E501
-                logger.CLIENT_LOGGER.error(f"Failed to fetch TKG clusters: {e}")
-                #TODO for debug: VCD is raising 404 at this point hence uncommenting
-                # raise
-            logger.CLIENT_LOGGER.debug(f"No rights present to fetch TKG clusters: {e}")
+                logger.CLIENT_LOGGER.error(f"Failed to fetch TKG clusters: {e}")  # noqa: E501
+                raise
+            logger.CLIENT_LOGGER.debug(f"No rights present to fetch TKG clusters: {e}") # noqa: E501
             has_tkg_rights = False
         if not client_utils.is_cli_for_tkg_only():
             filters = client_utils.construct_filters(org=org, vdc=vdc)
@@ -95,10 +94,9 @@ class DefEntityClusterApi:
                     clusters.append(cluster)
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code not in [requests.codes.FORBIDDEN, requests.codes.UNAUTHORIZED]:  # noqa: E501
-                    logger.CLIENT_LOGGER.error(f"Failed to fetch native clusters: {e}")
+                    logger.CLIENT_LOGGER.error(f"Failed to fetch native clusters: {str(e)}")  # noqa: E501
                     raise
-                logger.CLIENT_LOGGER.debug(f"No rights present to fetch native clusters: {e}")
-                
+                logger.CLIENT_LOGGER.debug(f"No rights present to fetch native clusters: {str(e)}")  # noqa: E501
                 has_native_rights = False
         if not (has_tkg_rights or has_native_rights):
             raise Exception("Logged in user doesn't have Native cluster rights"

--- a/container_service_extension/cloudapi/cloudapi_client.py
+++ b/container_service_extension/cloudapi/cloudapi_client.py
@@ -51,16 +51,14 @@ class CloudApiClient(object):
         if self._last_response:
             return self._last_response.headers
 
-    def set_header(self, key: str, value: str):
-        self._headers[key] = value
-
     def do_request(self,
                    method,
                    cloudapi_version=None,
                    resource_url_relative_path=None,
                    resource_url_absolute_path=None,
                    payload=None,
-                   content_type=None):
+                   content_type=None,
+                   additional_headers=None):
         """Make a request to cloudpai server.
 
         :param shared_constants.RequestMethod method: One of the HTTP verb
@@ -75,6 +73,8 @@ class CloudApiClient(object):
         :param str resource_url_absolute_path: absolute path for a resource,
             e.g. https://<vcd fqdn>/transfer/{id}/{file name}
         :param dict payload: JSON payload for the REST call.
+        :param str content_type: content type of the body of the request
+        :param dict additional_headers: request specific headers
 
         :return: body of the response text (JSON) in form of a dictionary.
 
@@ -93,6 +93,8 @@ class CloudApiClient(object):
 
         self.LOGGER_WIRE.debug(f"Request uri : {(method.value).upper()} {url}")
         headers = deepcopy(self._headers)
+        if additional_headers:
+            headers.update(additional_headers)
         if content_type and 'json' not in content_type:
             headers['Content-type'] = content_type
             response = requests.request(

--- a/container_service_extension/cloudapi/cloudapi_client.py
+++ b/container_service_extension/cloudapi/cloudapi_client.py
@@ -51,6 +51,9 @@ class CloudApiClient(object):
         if self._last_response:
             return self._last_response.headers
 
+    def set_header(self, key: str, value: str):
+        self._headers[key] = value
+
     def do_request(self,
                    method,
                    cloudapi_version=None,

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -2158,8 +2158,11 @@ def _create_def_entity_for_existing_clusters(
                 cluster_name=cluster['name']),
             api_version="")
 
+        org_resource = vcd_utils.get_org(self._client, org_name=org)
+        org_id = org_resource.href.split('/')[-1]
         def_entity = def_models.DefEntity(entity=cluster_entity)
-        entity_svc.create_entity(native_entity_type.id, entity=def_entity)
+        entity_svc.create_entity(native_entity_type.id, entity=def_entity,
+                                 tenant_org_context=org_id)
 
         def_entity = entity_svc.get_native_entity_by_name(cluster['name'])
         def_entity_id = def_entity.id

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -2158,7 +2158,7 @@ def _create_def_entity_for_existing_clusters(
                 cluster_name=cluster['name']),
             api_version="")
 
-        org_resource = vcd_utils.get_org(self._client, org_name=org)
+        org_resource = vcd_utils.get_org(client, org_name=cluster['org_name'])
         org_id = org_resource.href.split('/')[-1]
         def_entity = def_models.DefEntity(entity=cluster_entity)
         entity_svc.create_entity(native_entity_type.id, entity=def_entity,

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -184,8 +184,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             org_context = org_resource.href.split('/')[-1]
         self.entity_svc. \
             create_entity(def_utils.get_registered_def_entity_type().id,
-                          entity=def_entity,
-                          tenant_org_context=org_context)
+                        entity=def_entity,
+                        tenant_org_context=org_context)
         self.context.is_async = True
         def_entity = self.entity_svc.get_native_entity_by_name(cluster_name)
         telemetry_handler.record_user_action_details(

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -177,9 +177,15 @@ class ClusterService(abstract_broker.AbstractBroker):
                                         template[LocalTemplateKey.CNI_VERSION])
         def_entity.entity.status.docker_version = template[LocalTemplateKey.DOCKER_VERSION] # noqa: E501
         def_entity.entity.status.os = template[LocalTemplateKey.OS]
+        # No need to set org context for non sysadmin users
+        org_context = None
+        if self.context.client.is_sysadmin():
+            org_resource = vcd_utils.get_org(self.context.client, org_name=def_entity.entity.metadata.org_name)
+            org_context = org_resource.href.split('/')[-1]
         self.entity_svc. \
             create_entity(def_utils.get_registered_def_entity_type().id,
-                          entity=def_entity)
+                          entity=def_entity,
+                          tenant_org_context=org_context)
         self.context.is_async = True
         def_entity = self.entity_svc.get_native_entity_by_name(cluster_name)
         telemetry_handler.record_user_action_details(

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -180,12 +180,13 @@ class ClusterService(abstract_broker.AbstractBroker):
         # No need to set org context for non sysadmin users
         org_context = None
         if self.context.client.is_sysadmin():
-            org_resource = vcd_utils.get_org(self.context.client, org_name=def_entity.entity.metadata.org_name)
+            org_resource = vcd_utils.get_org(self.context.client,
+                                             org_name=def_entity.entity.metadata.org_name)  # noqa: E501
             org_context = org_resource.href.split('/')[-1]
         self.entity_svc. \
             create_entity(def_utils.get_registered_def_entity_type().id,
-                        entity=def_entity,
-                        tenant_org_context=org_context)
+                          entity=def_entity,
+                          tenant_org_context=org_context)
         self.context.is_async = True
         def_entity = self.entity_svc.get_native_entity_by_name(cluster_name)
         telemetry_handler.record_user_action_details(

--- a/container_service_extension/def_/entity_service.py
+++ b/container_service_extension/def_/entity_service.py
@@ -70,15 +70,16 @@ class DefEntityService():
         :param DefEntity entity: Defined entity instance
         :return: None
         """
+        additional_headers = {}
         if tenant_org_context:
-            self._cloudapi_client.set_header(key='x-vmware-vcloud-tenant-context',  # noqa: E501
-                                             value=tenant_org_context)
+            additional_headers['x-vmware-vcloud-tenant-context'] = tenant_org_context
         self._cloudapi_client.do_request(
             method=RequestMethod.POST,
             cloudapi_version=CLOUDAPI_VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}/"
                                        f"{entity_type_id}",
-            payload=asdict(entity))
+            payload=asdict(entity),
+            additional_headers=additional_headers)
 
     @handle_entity_service_exception
     def list_entities_by_entity_type(self, vendor: str, nss: str, version: str,

--- a/container_service_extension/def_/entity_service.py
+++ b/container_service_extension/def_/entity_service.py
@@ -72,7 +72,7 @@ class DefEntityService():
         """
         additional_headers = {}
         if tenant_org_context:
-            additional_headers['x-vmware-vcloud-tenant-context'] = tenant_org_context
+            additional_headers['x-vmware-vcloud-tenant-context'] = tenant_org_context  # noqa: E501
         self._cloudapi_client.do_request(
             method=RequestMethod.POST,
             cloudapi_version=CLOUDAPI_VERSION_1_0_0,

--- a/container_service_extension/def_/entity_service.py
+++ b/container_service_extension/def_/entity_service.py
@@ -62,13 +62,17 @@ class DefEntityService():
         self._cloudapi_client = cloudapi_client
 
     @handle_entity_service_exception
-    def create_entity(self, entity_type_id: str, entity: DefEntity) -> None:
+    def create_entity(self, entity_type_id: str, entity: DefEntity,
+                      tenant_org_context: str = None) -> None:
         """Create defined entity instance of an entity type.
 
         :param str entity_type_id: ID of the DefEntityType
         :param DefEntity entity: Defined entity instance
         :return: None
         """
+        if tenant_org_context:
+            self._cloudapi_client.set_header(key='x-vmware-vcloud-tenant-context',  # noqa: E501
+                                             value=tenant_org_context)
         self._cloudapi_client.do_request(
             method=RequestMethod.POST,
             cloudapi_version=CLOUDAPI_VERSION_1_0_0,


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

Currently, defined entities for clusters which are created by system administrators are created in system org. This PR makes changes so that the defined entities are created in specific orgs instead of system org.

Testing done:
1. Verified that if cluster is created by system administrator, its corresponding defined entity doesn't get created in system org.
2. Tested if clusters are upgraded, its corresponding entities are not created in system org,

@rocknes @sahithi @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/738)
<!-- Reviewable:end -->
