### PR TITLE
[VCDA-1794] Order-of-output-columns-fixed

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -86,12 +86,12 @@ def list_templates(ctx):
         result = cluster.get_templates()
         CLIENT_LOGGER.debug(result)
         display_field_to_value_field = {
-            'name': 'name',
-            'revision': 'revision',
-            'is_default': 'is_default',
-            'catalog': 'catalog',
-            'catalog_item': 'catalog_item',
-            'description': 'description'
+            'Name': 'name',
+            'Revision': 'revision',
+            'Default': 'is_default',
+            'Catalog': 'catalog',
+            'Catalog Item': 'catalog_item',
+            'Description': 'description'
         }
         filtered_result = client_utils.filter_result_set(result, display_field_to_value_field)  # noqa: E501
         stdout(filtered_result, ctx, sort_headers=False)
@@ -1219,10 +1219,10 @@ def list_nodes(ctx, name, org, vdc):
                             "native clusters.")
         all_nodes = cluster_info['master_nodes'] + cluster_info['nodes']
         display_field_to_value_field = {
-            'name': 'name',
-            'ipAddress': 'ipAddress',
-            'numberOfCpus': 'numberOfCpus',
-            'memoryMB': 'memoryMB'
+            'Name': 'name',
+            'IP Address': 'ipAddress',
+            'Number of CPUs': 'numberOfCpus',
+            'Memory MB': 'memoryMB'
         }
         filtered_nodes = client_utils.filter_result_set(all_nodes, display_field_to_value_field)  # noqa: E501
         stdout(filtered_nodes, ctx, show_id=True, sort_headers=False)

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -85,15 +85,15 @@ def list_templates(ctx):
         cluster = Cluster(client)
         result = cluster.get_templates()
         CLIENT_LOGGER.debug(result)
-        display_field_to_value_field = {
-            'Name': 'name',
-            'Revision': 'revision',
-            'Default': 'is_default',
-            'Catalog': 'catalog',
-            'Catalog Item': 'catalog_item',
-            'Description': 'description'
+        value_field_to_display_field = {
+            'name': 'Name',
+            'revision': 'Revision',
+            'is_default': 'Default',
+            'catalog': 'Catalog',
+            'catalog_item': 'Catalog Item',
+            'description': 'Description'
         }
-        filtered_result = client_utils.filter_result_set(result, display_field_to_value_field)  # noqa: E501
+        filtered_result = client_utils.filter_columns(result, value_field_to_display_field)  # noqa: E501
         stdout(filtered_result, ctx, sort_headers=False)
     except Exception as e:
         stderr(e, ctx)
@@ -1041,8 +1041,18 @@ def node_info(ctx, cluster_name, node_name, org_name, vdc):
             org_name = ctx.obj['profiles'].get('org_in_use')
         node_info = cluster.get_node_info(cluster_name, node_name,
                                           org_name, vdc)
-        stdout(node_info, ctx, show_id=True)
-        CLIENT_LOGGER.debug(node_info)
+        value_field_to_display_field = {
+            'name': 'Name',
+            'node_type': 'Node Type',
+            'ipAddress': 'IP Address',
+            'numberOfCpus': 'Number of CPUs',
+            'memoryMB': 'Memory MB',
+            'status': 'Status'
+        }
+        filtered_node_info = client_utils.filter_columns(
+            node_info, value_field_to_display_field)
+        stdout(filtered_node_info, ctx, sort_headers=False)
+        CLIENT_LOGGER.debug(filtered_node_info)
     except Exception as e:
         stderr(e, ctx)
         CLIENT_LOGGER.error(str(e))
@@ -1218,13 +1228,13 @@ def list_nodes(ctx, name, org, vdc):
             raise Exception("'node list' operation is not supported by non "
                             "native clusters.")
         all_nodes = cluster_info['master_nodes'] + cluster_info['nodes']
-        display_field_to_value_field = {
-            'Name': 'name',
-            'IP Address': 'ipAddress',
-            'Number of CPUs': 'numberOfCpus',
-            'Memory MB': 'memoryMB'
+        value_field_to_display_field = {
+            'name': 'Name',
+            'ipAddress': 'IP Address',
+            'numberOfCpus': 'Number of CPUs',
+            'memoryMB': 'Memory MB'
         }
-        filtered_nodes = client_utils.filter_result_set(all_nodes, display_field_to_value_field)  # noqa: E501
+        filtered_nodes = client_utils.filter_columns(all_nodes, value_field_to_display_field)  # noqa: E501
         stdout(filtered_nodes, ctx, show_id=True, sort_headers=False)
         CLIENT_LOGGER.debug(all_nodes)
     except Exception as e:

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -85,17 +85,16 @@ def list_templates(ctx):
         cluster = Cluster(client)
         result = cluster.get_templates()
         CLIENT_LOGGER.debug(result)
-
-        fields_to_display = [
-            'name', 'revision', 'is_default', 'catalog', 'catalog_item',
-            'description']
-        all_templates = []
-        for template in result:
-            filtered_template_record = {}
-            for field in fields_to_display:
-                filtered_template_record[field] = template.get(field, '')
-            all_templates.append(filtered_template_record)
-        stdout(all_templates, ctx, sort_headers=False)
+        display_field_to_value_field = {
+            'name': 'name',
+            'revision': 'revision',
+            'is_default': 'is_default',
+            'catalog': 'catalog',
+            'catalog_item': 'catalog_item',
+            'description': 'description'
+        }
+        filtered_result = client_utils.filter_result_set(result, display_field_to_value_field)  # noqa: E501
+        stdout(filtered_result, ctx, sort_headers=False)
     except Exception as e:
         stderr(e, ctx)
         CLIENT_LOGGER.error(str(e))
@@ -1219,7 +1218,14 @@ def list_nodes(ctx, name, org, vdc):
             raise Exception("'node list' operation is not supported by non "
                             "native clusters.")
         all_nodes = cluster_info['master_nodes'] + cluster_info['nodes']
-        stdout(all_nodes, ctx, show_id=True)
+        display_field_to_value_field = {
+            'name': 'name',
+            'ipAddress': 'ipAddress',
+            'numberOfCpus': 'numberOfCpus',
+            'memoryMB': 'memoryMB'
+        }
+        filtered_nodes = client_utils.filter_result_set(all_nodes, display_field_to_value_field)  # noqa: E501
+        stdout(filtered_nodes, ctx, show_id=True, sort_headers=False)
         CLIENT_LOGGER.debug(all_nodes)
     except Exception as e:
         stderr(e, ctx)

--- a/container_service_extension/client/ovdc_policy.py
+++ b/container_service_extension/client/ovdc_policy.py
@@ -29,9 +29,9 @@ class PolicyBasedOvdc:
             accept_type='application/json')
         result = process_response(response)
         display_field_to_value_field = {
-            'ovdc_name': 'ovdc_name',
-            'ovdc_id': 'ovdc_id',
-            'k8s_runtime': 'k8s_runtime'
+            'Name': 'ovdc_name',
+            'ID': 'ovdc_id',
+            'K8s Runtime': 'k8s_runtime'
         }
         return client_utils.filter_result_set(result, display_field_to_value_field)  # noqa: E501
 

--- a/container_service_extension/client/ovdc_policy.py
+++ b/container_service_extension/client/ovdc_policy.py
@@ -28,12 +28,12 @@ class PolicyBasedOvdc:
             self.client._session,
             accept_type='application/json')
         result = process_response(response)
-        display_field_to_value_field = {
-            'Name': 'ovdc_name',
-            'ID': 'ovdc_id',
-            'K8s Runtime': 'k8s_runtime'
+        value_field_to_display_field = {
+            'ovdc_name': 'Name',
+            'ovdc_id': 'ID',
+            'k8s_runtime': 'K8s Runtime'
         }
-        return client_utils.filter_result_set(result, display_field_to_value_field)  # noqa: E501
+        return client_utils.filter_columns(result, value_field_to_display_field)  # noqa: E501
 
     def update_ovdc(self, ovdc_name, k8s_runtime, enable=True, org_name=None,
                     remove_cp_from_vms_on_disable=False):

--- a/container_service_extension/client/ovdc_policy.py
+++ b/container_service_extension/client/ovdc_policy.py
@@ -8,6 +8,7 @@ import pyvcloud.vcd.exceptions as vcd_exceptions
 
 from container_service_extension.client.response_processor import \
     process_response
+import container_service_extension.client.utils as client_utils
 import container_service_extension.def_.models as def_models
 from container_service_extension.pyvcloud_utils import get_vdc
 import container_service_extension.shared_constants as shared_constants
@@ -26,7 +27,13 @@ class PolicyBasedOvdc:
             uri,
             self.client._session,
             accept_type='application/json')
-        return process_response(response)
+        result = process_response(response)
+        display_field_to_value_field = {
+            'ovdc_name': 'ovdc_name',
+            'ovdc_id': 'ovdc_id',
+            'k8s_runtime': 'k8s_runtime'
+        }
+        return client_utils.filter_result_set(result, display_field_to_value_field)  # noqa: E501
 
     def update_ovdc(self, ovdc_name, k8s_runtime, enable=True, org_name=None,
                     remove_cp_from_vms_on_disable=False):

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -169,3 +169,24 @@ def swagger_object_to_dict(obj):
             result[o_map[attr]] = value
 
     return result
+
+
+def filter_result_set(result_set, display_field_to_value_field):
+    """Extract selected fields from each list item in result_set.
+
+    :param list(dict) result_set: row of records
+    :param dict display_field_to_value_field: display field name -> value field
+    name in result set
+    :return: filtered list of records from result_set
+    :rtype: list(dict)
+    """
+    if isinstance(result_set, list):
+        filtered_result = []
+        for result_record in result_set:
+            filtered_record = {}
+            for display_field, value_field in display_field_to_value_field.items():  # noqa: E501
+                filtered_record[display_field] = result_record.get(value_field, '')  # noqa: E501
+            filtered_result.append(filtered_record)
+        return filtered_result
+    else:
+        return result_set

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -171,22 +171,27 @@ def swagger_object_to_dict(obj):
     return result
 
 
-def filter_result_set(result_set, display_field_to_value_field):
-    """Extract selected fields from each list item in result_set.
+def filter_columns(result, value_field_to_display_field):
+    """Extract selected fields from each list item in result.
 
-    :param list(dict) result_set: row of records
-    :param dict display_field_to_value_field: display field name -> value field
-    name in result set
-    :return: filtered list of records from result_set
-    :rtype: list(dict)
+    :param list(dict) or dict result: row of records
+    :param dict value_field_to_display_field: mapping of value field to
+    respective display name in result set. Extract selected fields from result
+    based on value fields from this dictionary.
+    :return: filtered list or dict of record(s) from result
+    :rtype: list(dict) or dict
     """
-    if isinstance(result_set, list):
+    if isinstance(result, list):
         filtered_result = []
-        for result_record in result_set:
+        for result_record in result:
             filtered_record = {}
-            for display_field, value_field in display_field_to_value_field.items():  # noqa: E501
+            for value_field, display_field in value_field_to_display_field.items():  # noqa: E501
                 filtered_record[display_field] = result_record.get(value_field, '')  # noqa: E501
             filtered_result.append(filtered_record)
         return filtered_result
-    else:
-        return result_set
+    elif isinstance(result, dict):
+        filtered_result = {
+            display_field: result.get(value_field, '')
+            for value_field, display_field in value_field_to_display_field.items()  # noqa: E501
+        }
+        return filtered_result


### PR DESCRIPTION

-  Fixed order of output columns on CLI tabular results wherever it is not handled
-  Fixed ovdc list and node list having wrong column formats. 
----------
![image](https://user-images.githubusercontent.com/5530442/93108588-d727de00-f667-11ea-989d-aed08d6625a5.png)
---------------
Node list before fix:
![image](https://user-images.githubusercontent.com/5530442/93111848-0fc9b680-f66c-11ea-8ac6-8a1cf848eeae.png)

Node list after fix:
![image](https://user-images.githubusercontent.com/5530442/93108664-ef97f880-f667-11ea-8fa2-e78ba1c2b5bd.png)

@Anirudh9794 @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/745)
<!-- Reviewable:end -->
