### PR TITLE
[VCDA-1831] Fixed broken vcd cse pks ovdc disable command

### DIFF
--- a/container_service_extension/client/pks.py
+++ b/container_service_extension/client/pks.py
@@ -12,7 +12,6 @@ from container_service_extension.client.pks_cluster import PksCluster
 from container_service_extension.client.pks_ovdc import PksOvdc
 import container_service_extension.client.utils as client_utils
 from container_service_extension.logger import CLIENT_LOGGER
-from container_service_extension.server_constants import K8sProvider
 from container_service_extension.shared_constants import RESPONSE_MESSAGE_KEY
 
 

--- a/container_service_extension/client/pks.py
+++ b/container_service_extension/client/pks.py
@@ -493,7 +493,6 @@ def ovdc_disable(ctx, ovdc_name, org_name):
                 org_name = ctx.obj['profiles'].get('org_in_use')
             result = ovdc.update_ovdc(enable=False,
                                       ovdc_name=ovdc_name,
-                                      k8s_provider=K8sProvider.PKS,
                                       org_name=org_name)
             stdout(result, ctx)
             CLIENT_LOGGER.debug(result)


### PR DESCRIPTION

- Fixed broken `vcd cse pks ovdc disable` 
- k8_provider is not required as it is taken care by the ovdc_disable() handler.
---- Before fix
<img width="976" alt="Screen Shot 2020-09-15 at 2 11 26 PM" src="https://user-images.githubusercontent.com/5530442/93272510-7df4a300-f76a-11ea-97ab-c25dbf4fc9a8.png">
---- After fix
<img width="892" alt="Screen Shot 2020-09-15 at 3 42 05 PM" src="https://user-images.githubusercontent.com/5530442/93272519-83ea8400-f76a-11ea-84ee-2b1633ba2e34.png">

@Anirudh9794 @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/748)
<!-- Reviewable:end -->
