### PR TITLE
[VCDA-1787] Add --id option for cluster commands

### DIFF
--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -71,22 +71,22 @@ UNSUPPORTED_SUBCOMMAND_OPTIONS_BY_VERSION = {
     vcd_client.ApiVersion.VERSION_33.value: {
         GroupKey.CLUSTER: {
             CommandNameKey.CREATE: ['sizing_class'],
-            CommandNameKey.DELETE: ['k8_runtime'],
-            CommandNameKey.INFO: ['k8_runtime'],
+            CommandNameKey.DELETE: ['k8_runtime', 'cluster_id'],
+            CommandNameKey.INFO: ['k8_runtime', 'cluster_id'],
             CommandNameKey.UPGRADE: ['k8_runtime'],
             CommandNameKey.UPGRADE_PLAN: ['k8_runtime'],
-            CommandNameKey.CONFIG: ['k8_runtime']
+            CommandNameKey.CONFIG: ['k8_runtime', 'cluster_id']
         },
     },
 
     vcd_client.ApiVersion.VERSION_34.value: {
         GroupKey.CLUSTER: {
             CommandNameKey.CREATE: ['sizing_class'],
-            CommandNameKey.DELETE: ['k8_runtime'],
-            CommandNameKey.INFO: ['k8_runtime'],
+            CommandNameKey.DELETE: ['k8_runtime', 'cluster_id'],
+            CommandNameKey.INFO: ['k8_runtime', 'cluster_id'],
             CommandNameKey.UPGRADE: ['k8_runtime'],
             CommandNameKey.UPGRADE_PLAN: ['k8_runtime'],
-            CommandNameKey.CONFIG: ['k8_runtime']
+            CommandNameKey.CONFIG: ['k8_runtime', 'cluster_id']
         }
     },
 

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -199,7 +199,7 @@ Examples
     required=False,
     metavar='CLUSTER_ID',
     help="ID of the cluster whose cluster config has to be obtained;"
-         "Supported only for vcd api version >= 35")
+         "Supported only for CSE api version >= 35")
 def cluster_delete(ctx, name, vdc, org, k8_runtime, cluster_id):
     """Delete a Kubernetes cluster.
 
@@ -209,14 +209,17 @@ Example
         Delete cluster 'mycluster' without prompting.
         '--vdc' option can be used for faster command execution.
 \b
-
-    """
+    vcd cse cluster delete --id urn:vcloud:entity:cse:nativeCluster:1.0.0:0632c7c7-a613-427c-b4fc-9f1247da5561
+        Delete cluster with cluster ID 'urn:vcloud:entity:cse:nativeCluster:1.0.0:0632c7c7-a613-427c-b4fc-9f1247da5561'.
+        (--id option is suported only applicable for api version >= 35)
+    """  # noqa: E501
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
         client_utils.cse_restore_session(ctx)
         if not (cluster_id or name):
             # --id is not required when working with api version 33 and 34
-            raise Exception("Please specify cluster name or cluster id using --id flag if available")  # noqa: E501
+            raise Exception("Please specify cluster name (or) cluster Id. "
+                            "Note that '--id' flag is applicable for API versions >= 35 only.")  # noqa: E501
 
         client = ctx.obj['client']
         if client_utils.is_cli_for_tkg_only():
@@ -228,10 +231,8 @@ Example
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org is None:
             org = ctx.obj['profiles'].get('org_in_use')
-        if not cluster_id:
-            result = cluster.delete_cluster(name, org, vdc)
-        else:
-            result = cluster.delete_cluster_by_id(cluster_id)
+        result = cluster.delete_cluster(name, cluster_id=cluster_id,
+                                        org=org, vdc=vdc)
         if len(result) == 0:
             click.secho(f"Delete cluster operation has been initiated on "
                         f"{name}, please check the status using"
@@ -639,7 +640,7 @@ Examples
     required=False,
     metavar='CLUSTER_ID',
     help="ID of the cluster to which the configuration should be applied;"
-         "Supported only for vcd api version >=35")
+         "Supported only for CSE api version >=35")
 def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, output, org, cluster_id):  # noqa: E501
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
@@ -912,7 +913,8 @@ Example
     default=None,
     required=False,
     metavar='K8-RUNTIME',
-    help='Restrict cluster search to cluster kind; Supported only for vcd api version >= 35')
+    help='Restrict cluster search to cluster kind;'
+         'Supported only for vcd api version >= 35')
 @click.option(
     '--id',
     'cluster_id',
@@ -920,7 +922,7 @@ Example
     required=False,
     metavar='CLUSTER_ID',
     help="ID of the cluster whose cluster config has to be obtained."
-          "Supported only for vcd api version >= 35")
+         "Supported only for CSE api version >= 35")
 def cluster_config(ctx, name, vdc, org, k8_runtime, cluster_id):
     """Display cluster configuration.
 
@@ -933,12 +935,16 @@ Examples:
     (Supported only for vcd api version >= 35)
 
     To write to a file: `vcd cse cluster config mycluster > ~/.kube/my_config`
-    """
+\b
+    vcd cse cluster config --id urn:vcloud:entity:cse:nativeCluster:1.0.0:0632c7c7-a613-427c-b4fc-9f1247da5561
+    (--id option is supported only for vcd api version >= 35)
+    """  # noqa: E501
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
         if not (cluster_id or name):
             # --id is not required when working with api version 33 and 34
-            raise Exception("Please specify cluster name or cluster id using --id flag if available")  # noqa: E501
+            raise Exception("Please specify cluster name (or) cluster Id. "
+                            "Note that '--id' flag is applicable for API versions >= 35 only.")  # noqa: E501
         client_utils.cse_restore_session(ctx)
         if client_utils.is_cli_for_tkg_only():
             if k8_runtime in [shared_constants.ClusterEntityKind.NATIVE.value,
@@ -950,14 +956,10 @@ Examples:
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org is None:
             org = ctx.obj['profiles'].get('org_in_use')
-        if cluster_id:
-            cluster_config = \
-                cluster.get_cluster_config_by_id(cluster_id, org=org) \
-                .get(shared_constants.RESPONSE_MESSAGE_KEY)
-        else:
-            cluster_config = \
-                cluster.get_cluster_config(name, vdc=vdc, org=org) \
-                .get(shared_constants.RESPONSE_MESSAGE_KEY)
+        cluster_config = \
+            cluster.get_cluster_config(name, cluster_id=cluster_id,
+                                       vdc=vdc, org=org) \
+            .get(shared_constants.RESPONSE_MESSAGE_KEY)  # noqa: E501
         if os.name == 'nt':
             cluster_config = str.replace(cluster_config, '\n', '\r\n')
 
@@ -995,7 +997,8 @@ Examples:
     default=None,
     required=False,
     metavar='K8-RUNTIME',
-    help='Restrict cluster search to cluster kind; Supported only for vcd api version >=35')
+    help='Restrict cluster search to cluster kind;'
+         'Supported only for vcd api version >=35')
 @click.option(
     '--id',
     'cluster_id',
@@ -1003,7 +1006,7 @@ Examples:
     required=False,
     metavar='CLUSTER_ID',
     help="ID of the cluster whose cluster config has to be obtained;"
-         "Supported only for vcd api version >=35")
+         "Supported only for CSE api version >=35")
 def cluster_info(ctx, name, org, vdc, k8_runtime, cluster_id):
     """Display info about a Kubernetes cluster.
 
@@ -1012,12 +1015,18 @@ Example
     vcd cse cluster info mycluster
         Display detailed information about cluster 'mycluster'.
         '--vdc' option can be used for faster command execution.
-    """
+\b
+    vcd cse cluster info --id urn:vcloud:entity:cse:nativeCluster:1.0.0:0632c7c7-a613-427c-b4fc-9f1247da5561
+        Display cluster information about cluster with
+        ID 'urn:vcloud:entity:cse:nativeCluster:1.0.0:0632c7c7-a613-427c-b4fc-9f1247da5561'
+        (--id option is supported only for api version >= 35)
+    """  # noqa: E501
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
         if not (cluster_id or name):
             # --id is not required when working with api version 33 and 34
-            raise Exception("Please specify cluster name or cluster id using --id flag if available")  # noqa: E501
+            raise Exception("Please specify cluster name (or) cluster Id. "
+                            "Note that '--id' flag is applicable for API versions >= 35 only.")  # noqa: E501
         client_utils.cse_restore_session(ctx)
         if client_utils.is_cli_for_tkg_only():
             if k8_runtime in [shared_constants.ClusterEntityKind.NATIVE.value,
@@ -1029,10 +1038,8 @@ Example
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org is None:
             org = ctx.obj['profiles'].get('org_in_use')
-        if cluster_id:
-            result = cluster.get_cluster_info_by_id(cluster_id, org=org)
-        else:
-            result = cluster.get_cluster_info(name, org=org, vdc=vdc)
+        result = cluster.get_cluster_info(name, cluster_id=cluster_id,
+                                          org=org, vdc=vdc)
         stdout(result, ctx)
         CLIENT_LOGGER.debug(result)
     except Exception as e:

--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -183,7 +183,8 @@ class DefEntityClusterApi:
 
         return cluster, additional_entity_properties, is_native_cluster
 
-    def get_cluster_info(self, cluster_name, org=None, vdc=None, **kwargs):
+    def get_cluster_info(self, cluster_name, cluster_id=None,
+                         org=None, vdc=None, **kwargs):
         """Get cluster information using DEF API.
 
         :param str cluster_name: name of the cluster
@@ -197,6 +198,8 @@ class DefEntityClusterApi:
         """
         # TODO(Display Owner information): Owner information needs to be
         # displayed
+        if cluster_id:
+            return self.get_cluster_info_by_id(cluster_id, org=org)
         cluster, _, is_native_cluster = \
             self._get_tkg_native_clusters_by_name(cluster_name,
                                                   org=org, vdc=vdc)
@@ -221,7 +224,8 @@ class DefEntityClusterApi:
             return self._nativeCluster.get_cluster_info_by_id(cluster_id=cluster_id)  # noqa: E501
         return self._tkgCluster.get_cluster_info_by_id(cluster_id, org=org)  # noqa: E501
 
-    def get_cluster_config(self, cluster_name, org=None, vdc=None):
+    def get_cluster_config(self, cluster_name, cluster_id=None,
+                           org=None, vdc=None):
         """Get cluster config.
 
         :param str cluster_name: name of the cluster
@@ -232,6 +236,8 @@ class DefEntityClusterApi:
         :rtype: str
         :raises ClusterNotFoundError, CseDuplicateClusterError
         """
+        if cluster_id:
+            return self.get_cluster_config_by_id(cluster_id, org=org)
         cluster, entity_properties, is_native_cluster = \
             self._get_tkg_native_clusters_by_name(cluster_name,
                                                   org=org, vdc=vdc)
@@ -250,7 +256,8 @@ class DefEntityClusterApi:
             return self._nativeCluster.get_cluster_config_by_id(cluster_id)
         return self._tkgCluster.get_cluster_config_by_id(cluster_id, org=org)
 
-    def delete_cluster(self, cluster_name, org=None, vdc=None):
+    def delete_cluster(self, cluster_name, cluster_id=None,
+                       org=None, vdc=None):
         """Delete DEF cluster by name.
 
         :param str cluster_name: name of the cluster
@@ -260,6 +267,8 @@ class DefEntityClusterApi:
         :rtype: str
         :raises ClusterNotFoundError, CseDuplicateClusterError
         """
+        if cluster_id:
+            return self.delete_cluster_by_id(cluster_id)
         cluster, entity_properties, is_native_cluster = \
             self._get_tkg_native_clusters_by_name(cluster_name,
                                                   org=org, vdc=vdc)

--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -209,6 +209,18 @@ class DefEntityClusterApi:
             f"Received defined entity of cluster {cluster_name} : {cluster_info}")  # noqa: E501
         return yaml.dump(cluster_info)
 
+    def get_cluster_info_by_id(self, cluster_id, org=None):
+        """Obtain cluster information using cluster ID.
+
+        :param str cluster_id
+        :return: yaml representation of the cluster information
+        :rtype: str
+        """
+        entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
+        if entity_svc.is_native_entity(cluster_id):
+            return self._nativeCluster.get_cluster_info_by_id(cluster_id=cluster_id)  # noqa: E501
+        return self._tkgCluster.get_cluster_info_by_id(cluster_id, org=org)  # noqa: E501
+
     def get_cluster_config(self, cluster_name, org=None, vdc=None):
         """Get cluster config.
 
@@ -227,6 +239,17 @@ class DefEntityClusterApi:
             return self._nativeCluster.get_cluster_config_by_id(cluster.id)
         return self._tkgCluster.get_cluster_config_by_id(cluster_id=entity_properties.get('id'))  # noqa: E501
 
+    def get_cluster_config_by_id(self, cluster_id, org=None):
+        """Fetch kube config of the cluster using cluster ID.
+
+        :param str cluster_id:
+        :param str org:
+        """
+        entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
+        if entity_svc.is_native_entity(cluster_id):
+            return self._nativeCluster.get_cluster_config_by_id(cluster_id)
+        return self._tkgCluster.get_cluster_config_by_id(cluster_id, org=org)
+
     def delete_cluster(self, cluster_name, org=None, vdc=None):
         """Delete DEF cluster by name.
 
@@ -243,6 +266,19 @@ class DefEntityClusterApi:
         if is_native_cluster:
             return self._nativeCluster.delete_cluster_by_id(cluster.id)
         return self._tkgCluster.delete_cluster_by_id(cluster_id=entity_properties.get('id'))  # noqa: E501
+
+    def delete_cluster_by_id(self, cluster_id, org=None):
+        """Delete cluster using cluster id.
+
+        :param str cluster_id: id of the cluster to be deleted
+        :return: deleted cluster information
+        :rtype: str
+        :raises: ClusterNotFoundError
+        """
+        entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
+        if entity_svc.is_native_entity(cluster_id):
+            return self._nativeCluster.delete_cluster_by_id(cluster_id)
+        return self._tkgCluster.delete_cluster_by_id(cluster_id, org=org)
 
     def get_upgrade_plan(self, cluster_name, org=None, vdc=None):
         """Get the upgrade plan for the given cluster name.

--- a/container_service_extension/client/legacy_native_cluster_api.py
+++ b/container_service_extension/client/legacy_native_cluster_api.py
@@ -50,7 +50,7 @@ class LegacyNativeClusterApi:
             clusters.append(cluster)
         return clusters
 
-    def get_cluster_info(self, name, org=None, vdc=None):
+    def get_cluster_info(self, name, org=None, vdc=None, **kwargs):
         method = shared_constants.RequestMethod.GET
         uri = f'{self._uri}/cluster/{name}'
         response = self.client._do_request_prim(
@@ -203,7 +203,7 @@ class LegacyNativeClusterApi:
             accept_type='application/json')
         return process_response(response)
 
-    def delete_cluster(self, cluster_name, org=None, vdc=None):
+    def delete_cluster(self, cluster_name, org=None, vdc=None, **kwargs):
         method = shared_constants.RequestMethod.DELETE
         uri = f"{self._uri}/cluster/{cluster_name}"
         response = self.client._do_request_prim(

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -47,12 +47,20 @@ class TKGClusterApi:
         api_version = self._client.get_api_version()
         self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.ACCEPT,  # noqa: E501
                                             f"application/json;version={api_version}")  # noqa: E501
-        org_logged_in = vcd_utils.get_org(self._client)
-        org_id = org_logged_in.href.split('/')[-1]
-        # TODO setting right tenant context for sysadmin users
-        self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.X_VMWARE_VCLOUD_TENANT_CONTEXT,  # noqa: E501
-                                            org_id)
         self._tkg_client_api = TkgClusterApi(api_client=self._tkg_client)
+
+    def set_tenant_org_context(self, org_name=None):
+        """Set tenant org context if not set in the client.
+
+        :param str org_name: Name of the org. If not set, makes use of
+            the logged in org name
+        """
+        if cli_constants.TKGRequestHeaderKey.X_VMWARE_VCLOUD_TENANT_CONTEXT not in self._tkg_client.default_headers:  # noqa: E501
+            logger.CLIENT_LOGGER.debug(f"Setting client org context with org name {org_name}")  # noqa: E501
+            org_resource = vcd_utils.get_org(self._client, org_name=org_name)
+            org_id = org_resource.href.split('/')[-1]
+            self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.X_VMWARE_VCLOUD_TENANT_CONTEXT,  # noqa: E501
+                                                org_id)
 
     def get_tkg_cluster(self, cluster_id):
         """Sample method to use tkg_client.
@@ -65,9 +73,16 @@ class TKGClusterApi:
         """
         # Returns tuple of response_data, response_status, response_headers,
         #   tkg_def_entities
-        response = self._tkg_client_api.get_tkg_cluster(cluster_id)
-        cluster: TkgCluster = response[0]
-        return cluster.to_dict()
+        try:
+            response = self._tkg_client_api.get_tkg_cluster(
+                cluster_id,
+                _return_http_data_only=False)
+            cluster: TkgCluster = response[0]
+            cluster_def_entity = response[3]
+            return cluster, cluster_def_entity
+        except Exception as e:
+            logger.CLIENT_LOGGER.debug(e)
+            raise
 
     def list_tkg_clusters(self, vdc=None, org=None):
         """List all the TKG clusters.
@@ -78,11 +93,7 @@ class TKGClusterApi:
         :rtype: List[dict]
         """
         filters = []
-        if org:
-            org_resource = vcd_utils.get_org(self._client, org_name=org)
-            org_id = org_resource.href.split('/')[-1]
-            self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.X_VMWARE_VCLOUD_TENANT_CONTEXT,  # noqa: E501
-                                                org_id)
+        self.set_tenant_org_context(org_name=org)
         if vdc:
             filters.append((cli_constants.TKGEntityFilterKey.VDC_NAME.value, vdc))  # noqa: E501
         filter_string = None
@@ -116,11 +127,7 @@ class TKGClusterApi:
 
     def get_tkg_clusters_by_name(self, name, vdc=None, org=None):
         filters = [(cli_constants.TKGEntityFilterKey.CLUSTER_NAME.value, name)]
-        if org:
-            org_resource = vcd_utils.get_org(self._client, org_name=org)
-            org_id = org_resource.href.split('/')[-1]
-            self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.X_VMWARE_VCLOUD_TENANT_CONTEXT,  # noqa: E501
-                                                org_id)
+        self.set_tenant_org_context(org_name=org)
         if vdc:
             filters.append((cli_constants.TKGEntityFilterKey.VDC_NAME.value, vdc))  # noqa: E501
         filter_string = ";".join([f"{f[0]}=={f[1]}" for f in filters])
@@ -157,14 +164,45 @@ class TKGClusterApi:
         :rtype: str
         :raises ClusterNotFoundError
         """
-        tkg_entities, _ = \
-            self.get_tkg_clusters_by_name(cluster_name, vdc=vdc, org=org)
-        cluster_entity_dict = client_utils.swagger_object_to_dict(tkg_entities[0])  # noqa: E501
-        logger.CLIENT_LOGGER.debug(
-            f"Received defined entity of cluster {cluster_name} : {cluster_entity_dict}")  # noqa: E501
-        return yaml.dump(cluster_entity_dict)
+        try:
+            tkg_entities, _ = \
+                self.get_tkg_clusters_by_name(cluster_name, vdc=vdc, org=org)
+            cluster_entity_dict = client_utils.swagger_object_to_dict(tkg_entities[0])  # noqa: E501
+            logger.CLIENT_LOGGER.debug(
+                f"Received defined entity of cluster {cluster_name} : {cluster_entity_dict}")  # noqa: E501
+            return yaml.dump(cluster_entity_dict)
+        except tkg_rest.ApiException as e:
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{e.reason}")  # noqa: E501
+            logger.CLIENT_LOGGER.error(msg)
+            raise Exception(msg)
+        except Exception as e:
+            logger.CLIENT_LOGGER.error(f"Error deleting cluster: {e}")
+            raise
 
-    def apply(self, cluster_config: dict, org=None, **kwargs):
+    def get_cluster_info_by_id(self, cluster_id, org=None, **kwargs):
+        """Get TKG cluster information using cluster ID.
+
+        :param str cluster_id:
+        :param str org:
+        :return: cluster information in yaml format
+        :rtype: string
+        """
+        try:
+            self.set_tenant_org_context(org_name=org)
+            tkg_entity, _ = self.get_tkg_cluster(cluster_id)
+            cluster_info = client_utils.swagger_object_to_dict(tkg_entity)
+            logger.CLIENT_LOGGER.debug(f"Retrieved TKG entitty for ID {cluster_id}: {cluster_info}")  # noqa: E501
+            return yaml.dump(cluster_info)
+        except tkg_rest.ApiException as e:
+            logger.CLIENT_LOGGER.debug(e)
+            msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{e.reason}")  # noqa: E501
+            logger.CLIENT_LOGGER.error(msg)
+            raise Exception(msg)
+        except Exception as e:
+            logger.CLIENT_LOGGER.error(f"Error getting TKG cluster information: {e}")  # noqa: E501
+            raise
+
+    def apply(self, cluster_config: dict, cluster_id=None, org=None, **kwargs):
         """Apply the configuration either to create or update the cluster.
 
         :param dict cluster_config: cluster configuration information
@@ -172,20 +210,20 @@ class TKGClusterApi:
         :rtype: str
         """
         try:
-            if org:
-                org_logged_in = vcd_utils.get_org(self._client, org_name=org)
-                org_id = org_logged_in.href.split('/')[-1]
-                # TODO setting right tenant context for sysadmin users
-                self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.X_VMWARE_VCLOUD_TENANT_CONTEXT,  # noqa: E501
-                                                    org_id)
+            self.set_tenant_org_context(org_name=org)
             cluster_name = cluster_config.get('metadata', {}).get('name')
             vdc_name = cluster_config.get('metadata', {}).get('virtualDataCenterName')  # noqa: E501
             response = None
             try:
-                tkg_entity, tkg_def_entities = \
-                    self.get_tkg_clusters_by_name(cluster_name, vdc=vdc_name)
-                cluster_id = tkg_def_entities[0].get('id')
-                cluster_config['metadata']['resourceVersion'] = tkg_entity[0].metadata.resource_version  # noqa: E501
+                if cluster_id:
+                    tkg_entity, tkg_def_entity = self.get_tkg_cluster(cluster_id)  # noqa: E501
+                else:
+                    tkg_entities, tkg_def_entities = \
+                        self.get_tkg_clusters_by_name(cluster_name, vdc=vdc_name)  # noqa: E501
+                    tkg_entity = tkg_entities[0]
+                    tkg_def_entity = tkg_def_entities[0]
+                cluster_id = tkg_def_entity.get('id')
+                cluster_config['metadata']['resourceVersion'] = tkg_entity.metadata.resource_version  # noqa: E501
                 response = \
                     self._tkg_client_api.update_tkg_cluster_with_http_info(
                         tkg_cluster_id=cluster_id,
@@ -205,15 +243,14 @@ class TKGClusterApi:
             logger.CLIENT_LOGGER.error(f"Error while applying cluster spec: {e}")  # noqa: E501
             raise
 
-    def delete_cluster_by_id(self, cluster_id):
+    def delete_cluster_by_id(self, cluster_id, org=None, **kwargs):
         """Delete a cluster using the cluster id.
 
         :param str cluster_id:
         :return: string containing the task href of delete cluster operation
         """
-        # Assumes that the caller of the function has
-        # already set the org context
         try:
+            self.set_tenant_org_context(org_name=org)
             response = \
                 self._tkg_client_api.delete_tkg_cluster_with_http_info(tkg_cluster_id=cluster_id)  # noqa: E501
             headers = response[2]
@@ -249,7 +286,7 @@ class TKGClusterApi:
             logger.CLIENT_LOGGER.error(f"{e}")
             raise
 
-    def get_cluster_config_by_id(self, cluster_id):
+    def get_cluster_config_by_id(self, cluster_id, org=None, **kwargs):
         """Get TKG cluster config by cluster id.
 
         :param str cluster_id: ID of the cluster
@@ -257,9 +294,8 @@ class TKGClusterApi:
         :return the cluster config of the TKG cluster
         :rtype: str
         """
-        # Assumes that the caller of the function has
-        # already set the org context
         try:
+            self.set_tenant_org_context(org_name=org)
             response = self._tkg_client_api.create_tkg_cluster_config_task(id=cluster_id)  # noqa: E501
             # Extract the task for creating the config from the Location header
             headers = response[2]
@@ -289,7 +325,8 @@ class TKGClusterApi:
         try:
             _, tkg_def_entities = \
                 self.get_tkg_clusters_by_name(cluster_name, org=org, vdc=vdc)
-            return self.get_cluster_config_by_id(tkg_def_entities[0]['id'])
+            return self.get_cluster_config_by_id(tkg_def_entities[0]['id'],
+                                                 org=org)
         except tkg_rest.ApiException as e:
             server_message = json.loads(e.body).get('message') or e.reason
             msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{server_message}")  # noqa: E501

--- a/container_service_extension/def_/entity_service.py
+++ b/container_service_extension/def_/entity_service.py
@@ -252,3 +252,12 @@ class DefEntityService():
             nss=keys_map[def_utils.DefKey.ENTITY_TYPE_NSS],
             version=keys_map[def_utils.DefKey.ENTITY_TYPE_VERSION])
         return schema_svc.get_entity_type(entity_type_id)
+
+    def is_native_entity(self, entity_id: str):
+        """."""
+        response_body = self._cloudapi_client.do_request(
+            method=RequestMethod.GET,
+            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            resource_url_relative_path=f"{CloudApiResource.ENTITIES}/"
+                                       f"{entity_id}")
+        return def_utils.DEF_NATIVE_ENTITY_TYPE_NSS in response_body['entityType']  # noqa: E501


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* Commands affected:
  * cluster apply
  * cluster delete
  * cluster config
  * cluster info

* Testing done: Checked if the above commands with and without id are working fine
* Screenshot:
<img width="861" alt="Screen Shot 2020-09-15 at 10 50 54 PM" src="https://user-images.githubusercontent.com/16699642/93297382-047aa600-f7a6-11ea-9578-b1bcca7da884.png">
<img width="861" alt="Screen Shot 2020-09-15 at 10 58 28 PM" src="https://user-images.githubusercontent.com/16699642/93297866-0133ea00-f7a7-11ea-9028-8e08c3da38ad.png">


@sahithi @sakthisunda @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/749)
<!-- Reviewable:end -->
