### PR TITLE
Hiding ovdc list command in api v 33 and 34

### DIFF
--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -51,13 +51,13 @@ UNSUPPORTED_SUBCOMMANDS_BY_VERSION = {
         GroupKey.CLUSTER: ['apply', 'delete-nfs'],
         # TODO(metadata based enablement for < v35): Revisit after decision
         # to support metadata way of enabling for native clusters
-        GroupKey.OVDC: ['enable', 'disable', 'info']
+        GroupKey.OVDC: ['enable', 'disable', 'list', 'info']
     },
     vcd_client.ApiVersion.VERSION_34.value: {
         GroupKey.CLUSTER: ['apply', 'delete-nfs'],
         # TODO(metadata based enablement for < v35): Revisit after decision
         # to support metadata way of enabling for native clusters
-        GroupKey.OVDC: ['enable', 'disable', 'info']
+        GroupKey.OVDC: ['enable', 'disable', 'list', 'info']
     },
     vcd_client.ApiVersion.VERSION_35.value: {
         GroupKey.CLUSTER: ['create', 'resize'],


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* hiding `vcd cse ovdc list` command for vcd api version 33 and 34
![Screen Shot 2020-09-25 at 3 12 31 PM](https://user-images.githubusercontent.com/16699642/94320332-8a82b380-ff41-11ea-9ba2-599d7724b43a.png)

@rocknes @sahithi @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/756)
<!-- Reviewable:end -->
