### PR TITLE
Move to VAC production for telemetry

### DIFF
--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1580,8 +1580,6 @@ def _add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
                     msg = f"No sizing policy with the name {sizing_class_name} exists on the VDC"  # noqa: E501
                     LOGGER.error(msg)
                     raise Exception(msg)
-            if storage_profile:
-                storage_profile = vdc.get_storage_profile(storage_profile)
 
             cust_script = None
             if ssh_key is not None:

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -897,7 +897,10 @@ def list_template(ctx, config_file_path, skip_config_decryption,
             logger_debug=SERVER_CLI_LOGGER)
 
         # Record telemetry details
-        cse_params = {PayloadKey.DISPLAY_OPTION: display_option}
+        cse_params = {
+            PayloadKey.DISPLAY_OPTION: display_option,
+            PayloadKey.WAS_DECRYPTION_SKIPPED: bool(skip_config_decryption)
+        }
         record_user_action_details(cse_operation=CseOperation.TEMPLATE_LIST,
                                    cse_params=cse_params,
                                    telemetry_settings=config_dict['service']['telemetry'])  # noqa: E501

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -7,7 +7,7 @@ from enum import unique
 
 # End point of Vmware telemetry staging server
 # TODO() : This URL should reflect production server during release
-VAC_URL = "https://vcsa.vmware.com/ph-stg/api/hyper/send/"
+VAC_URL = "https://vcsa.vmware.com/ph/api/hyper/send"
 
 # Value of collector id that is required as part of HTTP request
 # to post sample data to telemetry server

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -84,7 +84,6 @@ def get_payload_for_install_server(params):
         PayloadKey.WAS_DECRYPTION_SKIPPED: bool(params.get(PayloadKey.WAS_DECRYPTION_SKIPPED)),  # noqa: E501
         PayloadKey.WAS_PKS_CONFIG_FILE_PROVIDED: bool(params.get(PayloadKey.WAS_PKS_CONFIG_FILE_PROVIDED)),  # noqa: E501
         PayloadKey.WERE_TEMPLATES_SKIPPED: bool(params.get(PayloadKey.WERE_TEMPLATES_SKIPPED)),  # noqa: E501
-        PayloadKey.WERE_TEMPLATES_FORCE_UPDATED: bool(params.get(PayloadKey.WERE_TEMPLATES_FORCE_UPDATED)),  # noqa: E501
         PayloadKey.WAS_TEMP_VAPP_RETAINED: bool(params.get(PayloadKey.WAS_TEMP_VAPP_RETAINED)),  # noqa: E501
         PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(params.get(PayloadKey.WAS_SSH_KEY_SPECIFIED))  # noqa: E501
     }


### PR DESCRIPTION
Update VAC url in CSE to use prod instead of staging.
Fix few bugs related to telemetry.

Testing done:
Ran all workflows at api v35.0 and made sure that telemetry data is ingesting in the prod tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/757)
<!-- Reviewable:end -->
