### PR TITLE
[VCDA-1849] CSE upgrade to tag templates with placement policy when template creation is skipped

### DIFF
--- a/container_service_extension/cloudapi/cloudapi_client.py
+++ b/container_service_extension/cloudapi/cloudapi_client.py
@@ -51,6 +51,9 @@ class CloudApiClient(object):
         if self._last_response:
             return self._last_response.headers
 
+    def get_org_urn_from_id(self, org_id):
+        return f"urn:vcloud:org:{org_id}"
+
     def do_request(self,
                    method,
                    cloudapi_version=None,

--- a/container_service_extension/cloudapi/constants.py
+++ b/container_service_extension/cloudapi/constants.py
@@ -20,3 +20,4 @@ class CloudApiResource(str, Enum):
     ENTITY_TYPES_TOKEN = 'types'
     ENTITIES = 'entities'
     ENTITY_RESOLVE = 'resolve'
+    RIGHT_BUNDLES = 'rightsBundles'

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -2328,13 +2328,16 @@ def _print_users_in_need_of_def_rights(
             org_user_dict[cluster['org_name']] = []
         org_user_dict[cluster['org_name']].append(cluster['owner_name'])
 
-    msg = "The following users own CSE k8s clusters and will require `cse:nativeCluster Entitlement` rights to access them in CSE 3.0"  # noqa: E501
-    msg_update_callback.info(msg)
-    INSTALL_LOGGER.info(msg)
-
+    msg = "The following users own CSE k8s clusters and will require " \
+          "`cse:nativeCluster Entitlement` right bundle " \
+          "to access them in CSE 3.0"
+    org_users_msg = ""
     for org_name, user_list in org_user_dict.items():
-        msg = f"Org : {org_name} -> Users : {', '.join(set(user_list))}"
-        msg_update_callback.general(msg)
+        org_users_msg += f"\nOrg : {org_name} -> Users : {', '.join(set(user_list))}"  # noqa: E501
+
+    if org_users_msg:
+        msg = msg + org_users_msg
+        msg_update_callback.info(msg)
         INSTALL_LOGGER.info(msg)
 
 

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -884,14 +884,6 @@ def _assign_placement_policies_to_existing_templates(client, config,
                                                   org_name=org_name)
     for template in all_templates:
         kind = template.get(server_constants.LocalTemplateKey.KIND)
-        if kind == shared_constants.ClusterEntityKind.TKG_PLUS:
-            msg = "Found a TKG+ template." \
-                  " However TKG PLUS is not enabled in CSE. vDC(s) hosting " \
-                  "Please enable TKG PLUS for CSE and re-run " \
-                  "`cse upgrade` to process these vDC(s)."
-            INSTALL_LOGGER.error(msg)
-            msg_update_callback.error(msg)
-            raise cse_exception.CseUpgradeError(msg)
         catalog_item_name = ltm.get_revisioned_template_name(
             template[server_constants.RemoteTemplateKey.NAME],
             template[server_constants.RemoteTemplateKey.REVISION])
@@ -904,6 +896,14 @@ def _assign_placement_policies_to_existing_templates(client, config,
             INSTALL_LOGGER.debug(msg)
             msg_update_callback.general(msg)
             continue
+        if kind == shared_constants.ClusterEntityKind.TKG_PLUS:
+            msg = "Found a TKG+ template." \
+                  " However TKG PLUS is not enabled in CSE. vDC(s) hosting " \
+                  "Please enable TKG PLUS for CSE and re-run " \
+                  "`cse upgrade` to process these vDC(s)."
+            INSTALL_LOGGER.error(msg)
+            msg_update_callback.error(msg)
+            raise cse_exception.CseUpgradeError(msg)
         placement_policy_name = \
             shared_constants.RUNTIME_DISPLAY_NAME_TO_INTERNAL_NAME_MAP[kind]  # noqa: E501
         template_builder.assign_placement_policy_to_template(

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1662,7 +1662,7 @@ def _add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
             # TODO: get details of the exception to determine cause of failure,
             # e.g. not enough resources available.
             node_list = [entry.get('target_vm_name') for entry in specs]
-            if hasattr(err, 'vcd_error') and \
+            if hasattr(err, 'vcd_error') and err.vcd_error and \
                     "throwPolicyNotAvailableException" in err.vcd_error.get('stackTrace', ''):  # noqa: E501
                 raise e.NodeCreationError(node_list,
                                           f"OVDC not enabled for {template[LocalTemplateKey.KIND]}")  # noqa: E501

--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -33,6 +33,10 @@ class CseServerError(Exception):
     """Base class for cse server side exceptions."""
 
 
+class CseUpgradeError(Exception):
+    """Base class for cse server upgrade exception."""
+
+
 class CseServerNotRunningError(CseServerError):
     """Raised when CLI makes requests to CSE server when it is not available."""  # noqa: E501
 

--- a/container_service_extension/right_bundle_manager.py
+++ b/container_service_extension/right_bundle_manager.py
@@ -6,12 +6,14 @@ import pyvcloud.vcd.client as vcd_client
 
 from container_service_extension.cloudapi.constants import CLOUDAPI_VERSION_1_0_0  # noqa: E501
 from container_service_extension.cloudapi.constants import CloudApiResource
+import container_service_extension.def_.utils as def_utils
 from container_service_extension.logger import NULL_LOGGER
 from container_service_extension.logger import SERVER_CLOUDAPI_WIRE_LOGGER
 import container_service_extension.pyvcloud_utils as vcd_utils
 from container_service_extension.shared_constants import RequestMethod
 
-CSE_NATIVE_RIGHT_BUNDLE_NAME = 'cse:nativeCluster Entitlement'
+CSE_NATIVE_RIGHT_BUNDLE_NAME = \
+    f'{def_utils.DEF_CSE_VENDOR}:{def_utils.DEF_NATIVE_ENTITY_TYPE_NSS} Entitlement'  # noqa: E501
 
 
 class RightBundleManager():

--- a/container_service_extension/right_bundle_manager.py
+++ b/container_service_extension/right_bundle_manager.py
@@ -1,0 +1,49 @@
+# container-service-extension
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Claus
+
+import pyvcloud.vcd.client as vcd_client
+
+from container_service_extension.cloudapi.constants import CLOUDAPI_VERSION_1_0_0  # noqa: E501
+from container_service_extension.cloudapi.constants import CloudApiResource
+from container_service_extension.logger import NULL_LOGGER
+from container_service_extension.logger import SERVER_CLOUDAPI_WIRE_LOGGER
+import container_service_extension.pyvcloud_utils as vcd_utils
+from container_service_extension.shared_constants import RequestMethod
+
+CSE_NATIVE_RIGHT_BUNDLE_NAME = 'cse:nativeCluster Entitlement'
+
+
+class RightBundleManager():
+    def __init__(self, sysadmin_client: vcd_client.Client,
+                 log_wire=False, logger_debug=NULL_LOGGER):
+        vcd_utils.raise_error_if_not_sysadmin(sysadmin_client)
+        self.logger_wire = SERVER_CLOUDAPI_WIRE_LOGGER \
+            if log_wire else NULL_LOGGER
+        self.logger_debug = logger_debug
+        self.cloudapi_client = vcd_utils.get_cloudapi_client_from_vcd_client(
+            sysadmin_client,
+            logger_debug=self.logger_debug,
+            logger_wire=self.logger_wire)
+
+    def get_right_bundle_by_name(self, right_bundle_name):
+        query_string = f"filter=name=={right_bundle_name}"
+        response_body = self.cloudapi_client.do_request(
+            method=RequestMethod.GET,
+            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            resource_url_relative_path=f"{CloudApiResource.RIGHT_BUNDLES}?{query_string}")  # noqa: E501
+        right_bundles = response_body['values']
+        if right_bundles and len(right_bundles) > 0:
+            return right_bundles[0]
+
+    def publish_cse_right_bundle_to_tenants(self, right_bundle_id,
+                                            org_ids):
+        relative_url = \
+            f"{CloudApiResource.RIGHT_BUNDLES}/{right_bundle_id}/tenants"
+        payload = \
+            {"values": [{"id": self.cloudapi_client.get_org_urn_from_id(org_id)} for org_id in org_ids]}  # noqa: E501
+        return self.cloudapi_client.do_request(
+            method=RequestMethod.PUT,
+            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            resource_url_relative_path=relative_url,
+            payload=payload)

--- a/container_service_extension/template_builder.py
+++ b/container_service_extension/template_builder.py
@@ -58,11 +58,6 @@ def assign_placement_policy_to_template(client, cse_placement_policy,
                   f" placement policy {cse_placement_policy}."
         msg_update_callback.info(msg)
         logger.info(msg)
-    except EntityNotFoundException as err:
-        msg = f"Placement policy {cse_placement_policy} not found: {err}"
-        msg_update_callback.error(msg)
-        logger.error(msg)
-        raise
     except Exception as err:
         msg = f"Failed to tag template {catalog_item_name} with " \
               f"placement policy {cse_placement_policy}. Error: {err}"

--- a/container_service_extension/template_builder.py
+++ b/container_service_extension/template_builder.py
@@ -35,7 +35,7 @@ TEMP_VAPP_FENCE_MODE = FenceMode.BRIDGED.value
 def assign_placement_policy_to_template(client, cse_placement_policy,
                                         catalog_name, catalog_item_name,
                                         org_name, logger=NULL_LOGGER,
-                                        log_wire=False,msg_update_callback=NullPrinter()): # noqa: E501
+                                        log_wire=False, msg_update_callback=NullPrinter()): # noqa: E501
 
     policy = None
     cpm = compute_policy_manager.ComputePolicyManager(client,
@@ -51,22 +51,25 @@ def assign_placement_policy_to_template(client, cse_placement_policy,
         if task is not None:
             client.get_task_monitor().wait_for_success(task)
             msg = "Successfully tagged template " \
-                    f"{catalog_item_name} with placement policy " \
-                    f"{cse_placement_policy}."
+                  f"{catalog_item_name} with placement policy " \
+                  f"{cse_placement_policy}."
         else:
             msg = f"{catalog_item_name} already tagged with" \
-                    f" placement policy {cse_placement_policy}."
+                  f" placement policy {cse_placement_policy}."
         msg_update_callback.info(msg)
         logger.info(msg)
-    except EntityNotFoundException:
-        msg = f"Placement policy {cse_placement_policy} not found"
+    except EntityNotFoundException as err:
+        msg = f"Placement policy {cse_placement_policy} not found: {err}"
         msg_update_callback.error(msg)
         logger.error(msg)
+        raise
     except Exception as err:
         msg = f"Failed to tag template {catalog_item_name} with " \
-                f"placement policy {cse_placement_policy}. Error: {err}"
+              f"placement policy {cse_placement_policy}. Error: {err}"
         msg_update_callback.error(msg)
         logger.error(msg)
+        raise
+
 
 class TemplateBuilder():
     """Builder calls for K8 templates."""

--- a/container_service_extension/template_builder.py
+++ b/container_service_extension/template_builder.py
@@ -32,6 +32,42 @@ TEMP_VAPP_NETWORK_ADAPTER_TYPE = NetworkAdapterType.VMXNET3.value
 TEMP_VAPP_FENCE_MODE = FenceMode.BRIDGED.value
 
 
+def assign_placement_policy_to_template(client, cse_placement_policy,
+                                        catalog_name, catalog_item_name,
+                                        org_name, logger=NULL_LOGGER,
+                                        log_wire=False,msg_update_callback=NullPrinter()): # noqa: E501
+
+    policy = None
+    cpm = compute_policy_manager.ComputePolicyManager(client,
+                                                      log_wire=log_wire)
+    try:
+        policy = cpm.get_vdc_compute_policy(cse_placement_policy,
+                                            is_placement_policy=True)
+        task = cpm.assign_vdc_placement_policy_to_vapp_template_vms(
+            policy['href'],
+            org_name,
+            catalog_name,
+            catalog_item_name)
+        if task is not None:
+            client.get_task_monitor().wait_for_success(task)
+            msg = "Successfully tagged template " \
+                    f"{catalog_item_name} with placement policy " \
+                    f"{cse_placement_policy}."
+        else:
+            msg = f"{catalog_item_name} already tagged with" \
+                    f" placement policy {cse_placement_policy}."
+        msg_update_callback.info(msg)
+        logger.info(msg)
+    except EntityNotFoundException:
+        msg = f"Placement policy {cse_placement_policy} not found"
+        msg_update_callback.error(msg)
+        logger.error(msg)
+    except Exception as err:
+        msg = f"Failed to tag template {catalog_item_name} with " \
+                f"placement policy {cse_placement_policy}. Error: {err}"
+        msg_update_callback.error(msg)
+        logger.error(msg)
+
 class TemplateBuilder():
     """Builder calls for K8 templates."""
 
@@ -389,36 +425,15 @@ class TemplateBuilder():
             self.msg_update_callback.info(msg)
             self.logger.debug(msg)
             return
-        policy = None
-        cpm = compute_policy_manager.ComputePolicyManager(self.client,
-                                                          log_wire=self.log_wire) # noqa: E501
-        try:
-            policy = cpm.get_vdc_compute_policy(self.cse_placement_policy,
-                                                is_placement_policy=True)
-            task = cpm.assign_vdc_placement_policy_to_vapp_template_vms(
-                policy['href'],
-                self.org_name,
-                self.catalog_name,
-                self.catalog_item_name)
-            if task is not None:
-                self.client.get_task_monitor().wait_for_success(task)
-                msg = "Successfully tagged template " \
-                      f"{self.catalog_item_name} with placement policy " \
-                      f"{self.cse_placement_policy}."
-            else:
-                msg = f"{self.catalog_item_name} already tagged with" \
-                      f" placement policy {self.cse_placement_policy}."
-            self.msg_update_callback.info(msg)
-            self.logger.info(msg)
-        except EntityNotFoundException:
-            msg = f"Placement policy {self.cse_placement_policy} not found"
-            self.msg_update_callback.error(msg)
-            self.logger.error(msg)
-        except Exception as err:
-            msg = f"Failed to tag template {self.catalog_item_name} with " \
-                  f"placement policy {self.cse_placement_policy}. Error: {err}"
-            self.msg_update_callback.error(msg)
-            self.logger.error(msg)
+        assign_placement_policy_to_template(
+            self.client,
+            self.cse_placement_policy,
+            self.catalog_name,
+            self.catalog_item_name,
+            self.org_name,
+            logger=self.logger,
+            log_wire=self.log_wire,
+            msg_update_callback=self.msg_update_callback)
 
     def build(self, force_recreate=False, retain_temp_vapp=False):
         """Create a K8 template.


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

* If `cse upgrade`is done with templates created with new metadata already present, CSE will contain templates which can be deployed even without enabling an OVDC. To prevent this, if the user skips template installation, tag the already existing templates with relevant placement policies.

* Testing done:
- created templates with current upgrades branch and ran cse upgrade with skip template creation option. Checked if the templates are being tagged with proper placement policies
- created a template after the upgrade to see if the newly created template is properly tagged with placement policies.

@rocknes @sahithi @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/761)
<!-- Reviewable:end -->
