### PR TITLE
[VCDA-1848] Update sample config api version to 35.0

### DIFF
--- a/container_service_extension/sample_generator.py
+++ b/container_service_extension/sample_generator.py
@@ -134,6 +134,9 @@ SAMPLE_BROKER_CONFIG = {
 }
 
 TEMPLATE_RULE_NOTE = """# [Optional] Template rule section
+# Note : Template rules are only supported when CSE server is started with
+# vCD api v33.0 or v34.0.
+#
 # Rules can be defined to override template definitions as defined by remote
 # template cookbook.
 # Any rule defined in this section can match exactly one template.

--- a/container_service_extension/sample_generator.py
+++ b/container_service_extension/sample_generator.py
@@ -84,7 +84,7 @@ SAMPLE_VCD_CONFIG = {
         'port': 443,
         'username': 'administrator',
         'password': 'my_secret_password',
-        'api_version': '33.0',
+        'api_version': '35.0',
         'verify': True,
         'log': True
     }


### PR DESCRIPTION
Update sample config api version from 33.0 to 35.0.
Add note for template rule section support.

Testing Done:
Ran `cse sample` and confirmed sample api version is 35.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/762)
<!-- Reviewable:end -->
