### PR TITLE
[VCDA-1858] Encode value for query filter expressions

### DIFF
--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -93,8 +93,8 @@ class TKGClusterApi:
         :return: list of TKG cluster information.
         :rtype: List[dict]
         """
-        filters = {}
         self.set_tenant_org_context(org_name=org)
+        filters = {}
         if vdc:
             filters[cli_constants.TKGEntityFilterKey.VDC_NAME.value] = vdc
         filter_string = utils.construct_filter_string(filters)

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -20,6 +20,7 @@ import container_service_extension.exceptions as cse_exceptions
 import container_service_extension.logger as logger
 import container_service_extension.pyvcloud_utils as vcd_utils
 import container_service_extension.shared_constants as shared_constants
+import container_service_extension.utils as utils
 
 
 class TKGClusterApi:
@@ -92,13 +93,11 @@ class TKGClusterApi:
         :return: list of TKG cluster information.
         :rtype: List[dict]
         """
-        filters = []
+        filters = {}
         self.set_tenant_org_context(org_name=org)
         if vdc:
-            filters.append((cli_constants.TKGEntityFilterKey.VDC_NAME.value, vdc))  # noqa: E501
-        filter_string = None
-        if filters:
-            filter_string = ";".join([f"{f[0]}=={f[1]}" for f in filters])
+            filters[cli_constants.TKGEntityFilterKey.VDC_NAME.value] = vdc
+        filter_string = utils.construct_filter_string(filters)
         # tkg_def_entities in the following statement represents the
         # information associated with the defined entity
         (entities, status, headers, tkg_def_entities) = \
@@ -126,11 +125,11 @@ class TKGClusterApi:
         return clusters
 
     def get_tkg_clusters_by_name(self, name, vdc=None, org=None):
-        filters = [(cli_constants.TKGEntityFilterKey.CLUSTER_NAME.value, name)]
         self.set_tenant_org_context(org_name=org)
+        filters = {cli_constants.TKGEntityFilterKey.CLUSTER_NAME.value: name}
         if vdc:
-            filters.append((cli_constants.TKGEntityFilterKey.VDC_NAME.value, vdc))  # noqa: E501
-        filter_string = ";".join([f"{f[0]}=={f[1]}" for f in filters])
+            filters[cli_constants.TKGEntityFilterKey.VDC_NAME.value] = vdc
+        filter_string = utils.construct_filter_string(filters)
         response = \
             self._tkg_client_api.list_tkg_clusters(
                 f"{DEF_VMWARE_VENDOR}/{DEF_TKG_ENTITY_TYPE_NSS}/{DEF_TKG_ENTITY_TYPE_VERSION}", # noqa: E501

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -80,9 +80,7 @@ class ComputePolicyManager:
         :rtype: Generator[Dict, None, None]
         """
         self._raise_error_if_not_supported()
-        filter_string = None
-        if filters:
-            filter_string = ";".join([f"{key}=={value}" for (key, value) in filters.items()]) # noqa: E501
+        filter_string = utils.construct_filter_string(filters)
         cloudapiResource = cloudapi_constants.CloudApiResource
         page_num = 0
         while True:
@@ -120,9 +118,7 @@ class ComputePolicyManager:
         :rtype: Generator[Dict, None, None]
         """
         self._raise_error_if_not_supported()
-        filter_string = None
-        if filters:
-            filter_string = ";".join([f"{key}=={value}" for (key, value) in filters.items()]) # noqa: E501
+        filter_string = utils.construct_filter_string(filters)
         cloudapiResource = cloudapi_constants.CloudApiResource
         page_num = 0
         while True:
@@ -429,9 +425,7 @@ class ComputePolicyManager:
         self._raise_error_if_not_supported()
         vdc_urn = self._generate_vdc_urn_from_id(vdc_id=vdc_id)
         relative_path = f"vdcs/{vdc_urn}/computePolicies"
-        filter_string = ""
-        if filters:
-            filter_string = ";".join([f"{key}=={value}" for (key, value) in filters.items()]) # noqa: E501
+        filter_string = utils.construct_filter_string(filters)
         page_num = 0
         while True:
             page_num += 1

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -1394,14 +1394,6 @@ def _legacy_upgrade_to_33_34(client, config, ext_vcd_api_version,
                           amqp['password'],
                           msg_update_callback=msg_update_callback)
 
-    # update cse api extension
-    _update_cse_amqp_extension(
-        client=client,
-        routing_key=amqp['routing_key'],
-        exchange=amqp['exchange'],
-        target_vcd_api_version=config['vcd']['api_version'],
-        msg_update_callback=msg_update_callback)
-
     if skip_template_creation:
         msg = "Skipping creation of templates."
         msg_update_callback.info(msg)
@@ -1427,6 +1419,14 @@ def _legacy_upgrade_to_33_34(client, config, ext_vcd_api_version,
         client=client,
         cse_clusters=clusters,
         new_admin_password=admin_password,
+        msg_update_callback=msg_update_callback)
+
+    # update cse api extension
+    _update_cse_amqp_extension(
+        client=client,
+        routing_key=amqp['routing_key'],
+        exchange=amqp['exchange'],
+        target_vcd_api_version=config['vcd']['api_version'],
         msg_update_callback=msg_update_callback)
 
 

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -7,6 +7,7 @@ import string
 import threading
 import time
 from typing import List
+import urllib
 
 import pkg_resources
 import pyvcloud.vcd.client as vcd_client
@@ -1494,16 +1495,16 @@ def _is_valid_cluster_name(name):
 
 
 def _cluster_exists(client, cluster_name, org_name=None, ovdc_name=None):
-    query_filter = f'name=={cluster_name}'
+    query_filter = f'name=={urllib.parse.quote(cluster_name)}'
     if ovdc_name is not None:
-        query_filter += f";vdcName=={ovdc_name}"
-    resource_type = 'vApp'
+        query_filter += f";vdcName=={urllib.parse.quote(ovdc_name)}"
+    resource_type = vcd_client.ResourceType.VAPP.value
     if client.is_sysadmin():
-        resource_type = 'adminVApp'
+        resource_type = vcd_client.ResourceType.ADMIN_VAPP.value
         if org_name is not None and org_name.lower() != SYSTEM_ORG_NAME.lower(): # noqa: E501
             org_resource = client.get_org_by_name(org_name)
             org = vcd_org.Org(client, resource=org_resource)
-            query_filter += f";org=={org.resource.get('id')}"
+            query_filter += f";org=={urllib.parse.quote(org.resource.get('id'))}"  # noqa: E501
 
     q = client.get_typed_query(
         resource_type,

--- a/container_service_extension/def_/entity_service.py
+++ b/container_service_extension/def_/entity_service.py
@@ -20,6 +20,7 @@ import container_service_extension.exceptions as cse_exception
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.minor_error_codes import MinorErrorCode
 from container_service_extension.shared_constants import RequestMethod
+import container_service_extension.utils as utils
 
 
 def handle_entity_service_exception(func):
@@ -102,10 +103,7 @@ class DefEntityService():
         :return: List of entities of that entity type
         :rtype: Generator[DefEntity, None, None]
         """
-        filter_string = None
-        if filters:
-            filter_string = ";".join(
-                [f"{k}=={v}" for (k, v) in filters.items()])  # noqa: E501
+        filter_string = utils.construct_filter_string(filters)
         page_num = 0
         while True:
             page_num += 1

--- a/container_service_extension/pyvcloud_utils.py
+++ b/container_service_extension/pyvcloud_utils.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import pathlib
+import urllib
 
 import pyvcloud.vcd.client as vcd_client
 from pyvcloud.vcd.exceptions import EntityNotFoundException
@@ -234,7 +235,7 @@ def get_pvdc_id_from_pvdc_name(name, vc_name_in_vcd):
         query = client.get_typed_query(
             vcd_client.ResourceType.PROVIDER_VDC.value,
             query_result_format=vcd_client.QueryResultFormat.RECORDS,
-            qfilter=f'vcName=={vc_name_in_vcd}',
+            qfilter=f'vcName=={urllib.parse.quote(vc_name_in_vcd)}',
             equality_filter=('name', name))
         for pvdc_record in list(query.execute()):
             href = pvdc_record.get('href')

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 import copy
+import urllib
 
 import pyvcloud.vcd.client as vcd_client
 import pyvcloud.vcd.exceptions as vcd_e
@@ -185,10 +186,12 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
                 pks_server = ''
                 if k8s_provider == K8sProvider.PKS:
                     # vc name for vdc can only be found using typed query
+                    qfilter = f"name=={urllib.parse.quote(ovdc_name)};" \
+                              f"orgName=={urllib.parse.quote(org_name)}"
                     q = op_ctx.client.get_typed_query(
                         vcd_client.ResourceType.ADMIN_ORG_VDC.value,
                         query_result_format=vcd_client.QueryResultFormat.RECORDS, # noqa: E501
-                        qfilter=f"name=={ovdc_name};orgName=={org_name}")
+                        qfilter=qfilter)
                 # should only ever be one element in the generator
                     ovdc_records = list(q.execute())
                     if len(ovdc_records) == 0:

--- a/container_service_extension/right_bundle_manager.py
+++ b/container_service_extension/right_bundle_manager.py
@@ -11,6 +11,7 @@ from container_service_extension.logger import NULL_LOGGER
 from container_service_extension.logger import SERVER_CLOUDAPI_WIRE_LOGGER
 import container_service_extension.pyvcloud_utils as vcd_utils
 from container_service_extension.shared_constants import RequestMethod
+import container_service_extension.utils as utils
 
 CSE_NATIVE_RIGHT_BUNDLE_NAME = \
     f'{def_utils.DEF_CSE_VENDOR}:{def_utils.DEF_NATIVE_ENTITY_TYPE_NSS} Entitlement'  # noqa: E501
@@ -29,7 +30,11 @@ class RightBundleManager():
             logger_wire=self.logger_wire)
 
     def get_right_bundle_by_name(self, right_bundle_name):
-        query_string = f"filter=name=={right_bundle_name}"
+        filters = {'name': right_bundle_name}
+        filter_string = utils.construct_filter_string(filters)
+        query_string = ""
+        if filter_string:
+            query_string = f"filter={filter_string}"
         response_body = self.cloudapi_client.do_request(
             method=RequestMethod.GET,
             cloudapi_version=CLOUDAPI_VERSION_1_0_0,

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -444,5 +444,10 @@ def escape_query_filter_expression_value(value):
 def construct_filter_string(filters: dict):
     filter_string = ""
     if filters:
-        filter_string = ";".join([f"{key}=={urllib.parse.quote(escape_query_filter_expression_value(value))}" for (key, value) in filters.items()]) # noqa: E501
+        filter_expressions = []
+        for (key, value) in filters.items():
+            if key and value:
+                filter_exp = f"{key}=={urllib.parse.quote(escape_query_filter_expression_value(value))}"  # noqa: E501
+                filter_expressions.append(filter_exp)
+        filter_string = ";".join(filter_expressions)
     return filter_string

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -10,6 +10,7 @@ import platform
 import stat
 import sys
 import threading
+import urllib
 
 import click
 import pkg_resources
@@ -429,3 +430,19 @@ def flatten_dictionary(input_dict, parent_key='', separator='.'):
         else:
             flattened_dict.update({key_prefix: val})
     return flattened_dict
+
+
+def escape_query_filter_expression_value(value):
+    value_str = str(value)
+    value_str = value_str.replace('(', "\\(")
+    value_str = value_str.replace(')', "\\)")
+    value_str = value_str.replace(';', "\\;")
+    value_str = value_str.replace(',', "\\,")
+    return value_str
+
+
+def construct_filter_string(filters: dict):
+    filter_string = ""
+    if filters:
+        filter_string = ";".join([f"{key}=={urllib.parse.quote(escape_query_filter_expression_value(value))}" for (key, value) in filters.items()]) # noqa: E501
+    return filter_string

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -7,6 +7,7 @@ import random
 import re
 import string
 import time
+import urllib
 import uuid
 
 import pkg_resources
@@ -1537,18 +1538,18 @@ def get_all_clusters(client, cluster_name=None, cluster_id=None,
     """
     query_filter = f'metadata:{ClusterMetadataKey.CLUSTER_ID}==STRING:*'
     if cluster_id is not None:
-        query_filter = f'metadata:{ClusterMetadataKey.CLUSTER_ID}==STRING:{cluster_id}' # noqa: E501
+        query_filter = f'metadata:{ClusterMetadataKey.CLUSTER_ID}==STRING:{urllib.parse.quote(cluster_id)}' # noqa: E501
     if cluster_name is not None:
-        query_filter += f';name=={cluster_name}'
+        query_filter += f';name=={urllib.parse.quote(cluster_name)}'
     if ovdc_name is not None:
-        query_filter += f";vdcName=={ovdc_name}"
-    resource_type = 'vApp'
+        query_filter += f";vdcName=={urllib.parse.quote(ovdc_name)}"
+    resource_type = vcd_client.ResourceType.VAPP.value
     if client.is_sysadmin():
-        resource_type = 'adminVApp'
+        resource_type = vcd_client.ResourceType.ADMIN_VAPP.value
         if org_name is not None and org_name.lower() != SYSTEM_ORG_NAME.lower(): # noqa: E501
             org_resource = client.get_org_by_name(org_name)
             org = vcd_org.Org(client, resource=org_resource)
-            query_filter += f";org=={org.resource.get('id')}"
+            query_filter += f";org=={urllib.parse.quote(org.resource.get('id'))}"
 
     # 2 queries are required because each query can only return 8 metadata
     q = client.get_typed_query(

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -1549,7 +1549,7 @@ def get_all_clusters(client, cluster_name=None, cluster_id=None,
         if org_name is not None and org_name.lower() != SYSTEM_ORG_NAME.lower(): # noqa: E501
             org_resource = client.get_org_by_name(org_name)
             org = vcd_org.Org(client, resource=org_resource)
-            query_filter += f";org=={urllib.parse.quote(org.resource.get('id'))}"
+            query_filter += f";org=={urllib.parse.quote(org.resource.get('id'))}" # noqa: E501
 
     # 2 queries are required because each query can only return 8 metadata
     q = client.get_typed_query(

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pika >= 0.11.2, < 1.0.0
 
 # pyvcloud 22.0.1
 # pyvcloud >= 22.0.1, < 23.0.0
-pyvcloud == 22.0.2.dev31
+pyvcloud == 22.0.2.dev32
 
 # pyvmomi 6.7.3
 pyvmomi >= 6.7.0 , < 7.0.0


### PR DESCRIPTION
CSE uses get_typed_query method of pyvcloud's client, however right now CSE is not url encoding the values of the query filter values. This PR fixes the gap in query filter usage in CSE.
Additionally all cloudapi calls that leverage queries have been updated to follow the same scheme.

Testing done:
Ran CSE commands including server side cli commands against vCD 10.0, 10.1 and 10.2 to make sure that no regression has been introduced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/763)
<!-- Reviewable:end -->
