### PR TITLE
Fix error messages and upgrade command for native

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -198,7 +198,8 @@ Examples
     required=False,
     metavar='CLUSTER_ID',
     help="ID of the cluster whose cluster config has to be obtained;"
-         "Supported only for CSE api version >= 35")
+         "Supported only for CSE api version >= 35."
+         "ID is given pecedence over cluster name.")
 def cluster_delete(ctx, name, vdc, org, k8_runtime=None, cluster_id=None):
     """Delete a Kubernetes cluster.
 
@@ -639,7 +640,8 @@ Examples
     required=False,
     metavar='CLUSTER_ID',
     help="ID of the cluster to which the configuration should be applied;"
-         "Supported only for CSE api version >=35")
+         "Supported only for CSE api version >=35."
+         "ID is given pecedence over cluster name.")
 def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, output, org, cluster_id):  # noqa: E501
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
@@ -921,7 +923,8 @@ Example
     required=False,
     metavar='CLUSTER_ID',
     help="ID of the cluster whose cluster config has to be obtained."
-         "Supported only for CSE api version >= 35")
+         "Supported only for CSE api version >= 35."
+         "ID is given pecedence over cluster name.")
 def cluster_config(ctx, name, vdc, org, k8_runtime=None, cluster_id=None):
     """Display cluster configuration.
 
@@ -1005,7 +1008,8 @@ Examples:
     required=False,
     metavar='CLUSTER_ID',
     help="ID of the cluster whose cluster config has to be obtained;"
-         "Supported only for CSE api version >=35")
+         "Supported only for CSE api version >=35. "
+         "ID is given pecedence over cluster name.")
 def cluster_info(ctx, name, org, vdc, k8_runtime=None, cluster_id=None):
     """Display info about a Kubernetes cluster.
 

--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -199,7 +199,7 @@ Examples
     metavar='CLUSTER_ID',
     help="ID of the cluster whose cluster config has to be obtained;"
          "Supported only for CSE api version >= 35."
-         "ID is given pecedence over cluster name.")
+         "ID gets precedence over cluster name.")
 def cluster_delete(ctx, name, vdc, org, k8_runtime=None, cluster_id=None):
     """Delete a Kubernetes cluster.
 
@@ -641,7 +641,7 @@ Examples
     metavar='CLUSTER_ID',
     help="ID of the cluster to which the configuration should be applied;"
          "Supported only for CSE api version >=35."
-         "ID is given pecedence over cluster name.")
+         "ID gets precedence over cluster name.")
 def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, output, org, cluster_id):  # noqa: E501
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
@@ -924,7 +924,7 @@ Example
     metavar='CLUSTER_ID',
     help="ID of the cluster whose cluster config has to be obtained."
          "Supported only for CSE api version >= 35."
-         "ID is given pecedence over cluster name.")
+         "ID gets precedence over cluster name.")
 def cluster_config(ctx, name, vdc, org, k8_runtime=None, cluster_id=None):
     """Display cluster configuration.
 
@@ -1009,7 +1009,7 @@ Examples:
     metavar='CLUSTER_ID',
     help="ID of the cluster whose cluster config has to be obtained;"
          "Supported only for CSE api version >=35. "
-         "ID is given pecedence over cluster name.")
+         "ID gets precedence over cluster name.")
 def cluster_info(ctx, name, org, vdc, k8_runtime=None, cluster_id=None):
     """Display info about a Kubernetes cluster.
 

--- a/container_service_extension/client/native_cluster_api.py
+++ b/container_service_extension/client/native_cluster_api.py
@@ -110,7 +110,7 @@ class NativeClusterApi:
             entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
             def_entity = entity_svc.get_native_entity_by_name(name=cluster_name, filters=filters)  # noqa: E501
             if not def_entity:
-                cse_exceptions.ClusterNotFoundError(f"Cluster '{cluster_name}' not found.")  # noqa: E501
+                raise cse_exceptions.ClusterNotFoundError(f"Cluster '{cluster_name}' not found.")  # noqa: E501
             cluster_id = def_entity.id
         return self.delete_cluster_by_id(cluster_id)
 
@@ -183,10 +183,10 @@ class NativeClusterApi:
             filters = client_utils.construct_filters(org=org, vdc=vdc)
             entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
             def_entity = entity_svc.get_native_entity_by_name(name=cluster_name, filters=filters)  # noqa: E501
-            cluster_id = def_entity.id
             if not def_entity:
                 raise cse_exceptions.ClusterNotFoundError(f"Cluster '{cluster_name}' not found.")  # noqa: E501
-        return self.get_cluster_config_by_id(def_entity.id)
+            cluster_id = def_entity.id
+        return self.get_cluster_config_by_id(cluster_id)
 
     def get_cluster_config_by_id(self, cluster_id, **kwargs):
         """Get the cluster config for given cluster id.
@@ -255,7 +255,7 @@ class NativeClusterApi:
         if current_entity:
             current_entity.entity.spec.k8_distribution.template_name = template_name  # noqa: E501
             current_entity.entity.spec.k8_distribution.template_revision = template_revision  # noqa: E501
-            return self.upgrade_cluster_by_cluster_id(current_entity.id, cluster_entity=asdict(current_entity))  # noqa: E501
+            return self.upgrade_cluster_by_cluster_id(current_entity.id, cluster_def_entity=asdict(current_entity))  # noqa: E501
         raise cse_exceptions.ClusterNotFoundError(f"Cluster '{cluster_name}' not found.")  # noqa: E501
 
     def upgrade_cluster_by_cluster_id(self, cluster_id, cluster_def_entity, **kwargs):  # noqa: E501

--- a/container_service_extension/client/tkg_cluster_api.py
+++ b/container_service_extension/client/tkg_cluster_api.py
@@ -354,10 +354,10 @@ class TKGClusterApi:
         :param str vdc: name of the vdc
         """
         raise NotImplementedError(
-            "Get Cluster upgrade-plan yet to be implemented for TKG clusters")
+            "Get Cluster upgrade-plan not supported for TKG clusters")
 
     def upgrade_cluster(self, cluster_name, template_name,
                         template_revision, **kwargs):
         """Upgrade TKG cluster to the given distribution."""
         raise NotImplementedError(
-            "Cluster upgrade yet to be implemented for TKG clusters")
+            "Cluster upgrade not supported for TKG clusters")


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* Fix incorrect error messages being shown
* Indicate that --id flag has more precedence than the cluster name
* Fix parameter for cluster upgrade in native_cluster_api.py

Testing done:
* Checked if correct error messages are shown in the CLI.
* Checked if cluster upgrade endpoint in cse server is being called with `--k8-runtime native` set.

@sakthisunda @sahithi @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/764)
<!-- Reviewable:end -->
