### PR TITLE
[VCDA-1868] Server side changes to handle when TKG+ is swithced off

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -909,7 +909,7 @@ def _assign_placement_policies_to_existing_templates(client, config,
                 not is_tkg_plus_enabled:
             msg = "Found a TKG+ template." \
                   " However TKG+ is not enabled on CSE. " \
-                  "Please enable TKG+ for CSE and re-run " \
+                  "Please enable TKG+ for CSE via config file and re-run " \
                   "`cse upgrade` to process these vDC(s)."
             INSTALL_LOGGER.error(msg)
             raise cse_exception.CseUpgradeError(msg)
@@ -1099,7 +1099,7 @@ def _install_single_template(
             not is_tkg_plus_enabled:
         msg = "Found a TKG+ template." \
               " However TKG+ is not enabled on CSE. " \
-              "Please enable TKG+ for CSE and re-run " \
+              "Please enable TKG+ for CSE via config file and re-run " \
               "`cse upgrade` to process these vDC(s)."
         INSTALL_LOGGER.error(msg)
         msg_update_callback.error(msg)
@@ -2049,8 +2049,8 @@ def _assign_placement_policy_to_vdc_and_right_bundle_to_org(
         if not is_tkg_plus_enabled:
             msg += " However TKG+ is not enabled on CSE. vDC(s) hosting " \
                    "TKG+ clusters will not be processed. Please enable " \
-                   "TKG+ for CSE and re-run `cse upgrade` to process " \
-                   "these vDC(s)."
+                   "TKG+ for CSE via config file and re-run `cse upgrade` " \
+                   "to process these vDC(s)."
             INSTALL_LOGGER.error(msg)
             raise cse_exception.CseUpgradeError(msg)
         msg_update_callback.info(msg)
@@ -2222,7 +2222,7 @@ def _create_def_entity_for_existing_clusters(
                 not is_tkg_plus_enabled:
             msg = "Found a TKG+ cluster." \
                   " However TKG+ is not enabled on CSE. " \
-                  "Please enable TKG+ for CSE and re-run" \
+                  "Please enable TKG+ for CSE via config file and re-run" \
                   "`cse upgrade` to process these clusters"
             INSTALL_LOGGER.error(msg)
             raise cse_exception.CseUpgradeError(msg)

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -883,8 +883,12 @@ def _assign_placement_policies_to_existing_templates(client, config,
     catalog_name = config['broker']['catalog']
     org_name = config['broker']['org']
     all_templates = \
-        ltm.get_all_k8s_local_template_definition(client, catalog_name=catalog_name,  # noqa: E501
-                                                  org_name=org_name)
+        ltm.get_all_k8s_local_template_definition(
+            client,
+            catalog_name=catalog_name,  # noqa: E501
+            org_name=org_name,
+            is_tkg_plus_enabled=is_tkg_plus_enabled,
+            logger_debug=INSTALL_LOGGER)
     for template in all_templates:
         kind = template.get(server_constants.LocalTemplateKey.KIND)
         catalog_item_name = ltm.get_revisioned_template_name(

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -890,7 +890,6 @@ def _assign_placement_policies_to_existing_templates(client, config,
             client,
             catalog_name=catalog_name,  # noqa: E501
             org_name=org_name,
-            is_tkg_plus_enabled=is_tkg_plus_enabled,
             logger_debug=INSTALL_LOGGER)
     for template in all_templates:
         kind = template.get(server_constants.LocalTemplateKey.KIND)

--- a/container_service_extension/def_/ovdc_service.py
+++ b/container_service_extension/def_/ovdc_service.py
@@ -34,6 +34,9 @@ def update_ovdc(operation_context: ctx.OperationContext,
     :return: dictionary containing the task href for the update operation
     :rtype: dict
     """
+    # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
+    # Prevent enable/disable of OVDC for TKG+ k8s runtime by throwing an
+    # exception
     msg = "Updating OVDC placement policies"
     task = vcd_task.Task(operation_context.sysadmin_client)
     org = vcd_utils.get_org(operation_context.client)
@@ -64,7 +67,7 @@ def update_ovdc(operation_context: ctx.OperationContext,
     # current k8s runtimes.
     if ClusterEntityKind.TKG_PLUS.value in ovdc_spec.k8s_runtime and \
             not utils.is_tkg_plus_enabled():
-        msg = "TKG+ is not enabled in CSE server. Please enable TKG+ in the " \
+        msg = "TKG+ is not enabled on CSE server. Please enable TKG+ in the " \
               "server and try again."
         logger.SERVER_LOGGER.debug(msg)
         raise Exception(msg)
@@ -88,6 +91,8 @@ def get_ovdc(operation_context: ctx.OperationContext, ovdc_id: str) -> dict:
     :return: dictionary containing the ovdc information
     :rtype: dict
     """
+    # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
+    # Prevent showing information about TKG+ by skipping TKG+ from the result.
     cse_params = {
         RequestKey.OVDC_ID: ovdc_id
     }
@@ -114,6 +119,8 @@ def list_ovdc(operation_context: ctx.OperationContext) -> List[dict]:
     :return: list of dictionary containing details about the ovdc
     :rtype: List[dict]
     """
+    # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
+    # Prevent showing information about TKG+ by skipping TKG+ from the result.
     # Record telemetry
     telemetry_handler.record_user_action_details(cse_operation=CseOperation.OVDC_LIST, # noqa: E501
                                                  cse_params={})

--- a/container_service_extension/local_template_manager.py
+++ b/container_service_extension/local_template_manager.py
@@ -6,7 +6,6 @@ import ast
 import os
 import pathlib
 
-from pyvcloud.vcd.client import ApiVersion as vCDApiVersion
 from pyvcloud.vcd.client import MetadataDomain
 from pyvcloud.vcd.client import MetadataVisibility
 from pyvcloud.vcd.org import Org
@@ -15,7 +14,6 @@ from pyvcloud.vcd.utils import metadata_to_dict
 import container_service_extension.logger as logger
 from container_service_extension.pyvcloud_utils import get_org
 from container_service_extension.server_constants import LocalTemplateKey
-import container_service_extension.shared_constants as shared_constants
 
 LOCAL_SCRIPTS_DIR = '.cse_scripts'
 
@@ -90,19 +88,6 @@ def get_all_k8s_local_template_definition(client, catalog_name, org=None,
             msg = f"Catalog item '{item_name}' missing " \
                   f"{num_missing_metadata_keys} metadata: " \
                   f"{missing_metadata_keys}" # noqa: F841
-            logger_debug.debug(msg)
-            continue
-
-        api_version = float(client.get_api_version())
-        if api_version >= float(vCDApiVersion.VERSION_35.value) and \
-                metadata_dict[LocalTemplateKey.KIND] == \
-                shared_constants.ClusterEntityKind.TKG_PLUS.value and \
-                not is_tkg_plus_enabled:
-            # TKG+ is not enabled in CSE config. Skip the template and log the
-            # relevant information.
-            msg = "Skipping loading template " \
-                  f"'{metadata_dict[LocalTemplateKey.NAME]}' as " \
-                  "TKG+ is not enabled"
             logger_debug.debug(msg)
             continue
 

--- a/container_service_extension/local_template_manager.py
+++ b/container_service_extension/local_template_manager.py
@@ -44,7 +44,6 @@ def get_script_filepath(template_name, revision, script_file_name):
 
 def get_all_k8s_local_template_definition(client, catalog_name, org=None,
                                           org_name=None,
-                                          is_tkg_plus_enabled=False,
                                           logger_debug=logger.NULL_LOGGER):
     """Fetch all CSE k8s templates in a catalog.
 

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -938,8 +938,8 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                     config_dict['broker']['default_template_name']
                 default_template_revision = \
                     str(config_dict['broker']['default_template_revision'])
+                api_version = float(client.get_api_version())
                 for definition in local_template_definitions:
-                    api_version = float(client.get_api_version())
                     if api_version >= float(vcd_client.ApiVersion.VERSION_35.value) and \
                             definition[LocalTemplateKey.KIND] == ClusterEntityKind.TKG_PLUS.value and \
                             not is_tkg_plus_enabled:  # noqa: E501

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -921,7 +921,9 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                     ltm.get_all_k8s_local_template_definition(
                         client=client,
                         catalog_name=catalog_name,
-                        org_name=org_name)
+                        org_name=org_name,
+                        is_tkg_plus_enabled=utils.is_tkg_plus_enabled(config_dict),  # noqa: E501
+                        logger_debug=SERVER_CLI_LOGGER)
 
                 default_template_name = \
                     config_dict['broker']['default_template_name']

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -932,7 +932,6 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                         client=client,
                         catalog_name=catalog_name,
                         org_name=org_name,
-                        is_tkg_plus_enabled=is_tkg_plus_enabled,  # noqa: E501
                         logger_debug=SERVER_CLI_LOGGER)
 
                 default_template_name = \

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -549,6 +549,10 @@ def install(ctx, config_file_path, pks_config_file_path,
             skip_config_decryption, skip_template_creation,
             retain_temp_vapp, ssh_key_file):
     """Install CSE on vCloud Director."""
+    # NOTE: For CSE 3.0, if `enable_tkg_plus` in config file is set to false
+    # and if `cse install` is invoked without skipping template creation,
+    # an Exception will be thrown if TKG+ template is present in the
+    # remote_template_cookbook.
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
     console_message_printer = ConsoleMessagePrinter()
     check_python_version(console_message_printer)
@@ -802,6 +806,10 @@ def upgrade(ctx, config_file_path, skip_config_decryption,
       CSE template repository to adhere to CSE 3.0 template requirements.
     - Update existing CSE k8s cluster's to match CSE 3.0 k8s clusters.
     """
+    # NOTE: For CSE 3.0, if `enable_tkg_plus` in the config is set to false,
+    # an exception is throwin if
+    # 1. If there is an existing TKG+ template
+    # 2. If remote template cookbook contains a TKG+ template.
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
     console_message_printer = ConsoleMessagePrinter()
     check_python_version(console_message_printer)
@@ -918,7 +926,7 @@ def list_template(ctx, config_file_path, skip_config_decryption,
 
                 org_name = config_dict['broker']['org']
                 catalog_name = config_dict['broker']['catalog']
-                is_tkg_plus_enabled=utils.is_tkg_plus_enabled(config_dict)
+                is_tkg_plus_enabled = utils.is_tkg_plus_enabled(config_dict)
                 local_template_definitions = \
                     ltm.get_all_k8s_local_template_definition(
                         client=client,
@@ -936,9 +944,9 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                     if api_version >= float(vcd_client.ApiVersion.VERSION_35.value) and \
                             definition[LocalTemplateKey.KIND] == ClusterEntityKind.TKG_PLUS.value and \
                             not is_tkg_plus_enabled:  # noqa: E501
-                        # TKG+ is not enabled in CSE config. Skip the template and log the
-                        # relevant information.
-                        msg = "Skipping loading template " \
+                        # TKG+ is not enabled on CSE config. Skip the template
+                        # and log the relevant information.
+                        msg = "Skipping loading template data for " \
                               f"'{definition[LocalTemplateKey.NAME]}' as " \
                               "TKG+ is not enabled"
                         SERVER_CLI_LOGGER.debug(msg)
@@ -1095,6 +1103,8 @@ def install_cse_template(ctx, template_name, template_revision,
     Use '*' for TEMPLATE_NAME and TEMPLATE_REVISION to install
     all listed templates.
     """
+    # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
+    # Throw an error if TKG+ template creation is issued.
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
     console_message_printer = ConsoleMessagePrinter()
     check_python_version(console_message_printer)

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -478,6 +478,9 @@ class Service(object, metaclass=Singleton):
 
     def _load_template_definition_from_catalog(self,
                                                msg_update_callback=utils.NullPrinter()): # noqa: E501
+        # NOTE: If `enable_tkg_plus` in the config file is set to false,
+        # CSE server will skip loading the TKG+ template this will prevent
+        # users from performing TKG+ related operations.
         msg = "Loading k8s template definition from catalog"
         logger.SERVER_LOGGER.info(msg)
         msg_update_callback.general_no_color(msg)
@@ -530,9 +533,9 @@ class Service(object, metaclass=Singleton):
                         template[server_constants.LocalTemplateKey.KIND] == \
                         shared_constants.ClusterEntityKind.TKG_PLUS.value and \
                         not is_tkg_plus_enabled:
-                    # TKG+ is not enabled in CSE config. Skip the template and log the
-                    # relevant information.
-                    msg = "Skipping loading template " \
+                    # TKG+ is not enabled on CSE config. Skip the template and
+                    # log the relevant information.
+                    msg = "Skipping loading template data for " \
                           f"'{template[server_constants.LocalTemplateKey.NAME]}' as " \
                           "TKG+ is not enabled"  # noqa: E501
                     logger.SERVER_LOGGER.debug(msg)

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -121,6 +121,32 @@ class ServerState(Enum):
     STOPPED = 'Stopped'
 
 
+# NOTE: CSE 3.0 behavior when `enable_tkg_plus` is set to true in the config:
+# cse install/upgrade will:
+# 1. create appropriate TKG+ policy
+# 2. Tag new/old templates with the corresponding policy
+# 3. publish TKG+ policy to OVDC
+# cse template install will:
+# 1. tag the newly created template with TKG+ policy
+# 2. If the policy is not found error will be raised
+# cse run will
+# 1. read all templates from catalog including the ones that have 'kind' set
+#   to TKG+
+# ovdc handler will:
+# 1. allow enabling/disabling ovdcs for TKG+
+#
+# If `enable_tkg_plus` flag is set to false in the config:
+# cse install/upgrade will:
+# 1. not create TKG+ policy
+# 2. raise error if a TKG+ template is specified in the templates.yaml
+# 3. raise error if a TKG+ cluster is encountered
+# cse template install will
+# 1. raise error if TKG+ template is given as an input
+# cse run will
+# 1. Skip reading all TKG+ templates
+# OVDC handler will
+# 1. reject all TKG+ related OVDC updates
+# 2. Skip showing TKG+ in the output for list and get
 class Service(object, metaclass=Singleton):
     def __init__(self, config_file, pks_config_file=None,
                  should_check_config=True,

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -538,6 +538,7 @@ class Service(object, metaclass=Singleton):
                           f"'{template[server_constants.LocalTemplateKey.NAME]}' as " \
                           "TKG+ is not enabled"  # noqa: E501
                     logger.SERVER_LOGGER.debug(msg)
+                    k8_templates.remove(template)
                     continue
                 if str(template[server_constants.LocalTemplateKey.REVISION]) == default_template_revision and \
                         template[server_constants.LocalTemplateKey.NAME] == default_template_name: # noqa: E501

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -510,7 +510,6 @@ class Service(object, metaclass=Singleton):
             catalog_name = self.config['broker']['catalog']
             k8_templates = ltm.get_all_k8s_local_template_definition(
                 client=client, catalog_name=catalog_name, org_name=org_name,
-                is_tkg_plus_enabled=is_tkg_plus_enabled,
                 logger_debug=logger.SERVER_LOGGER)
 
             if not k8_templates:

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -505,7 +505,9 @@ class Service(object, metaclass=Singleton):
             org_name = self.config['broker']['org']
             catalog_name = self.config['broker']['catalog']
             k8_templates = ltm.get_all_k8s_local_template_definition(
-                client=client, catalog_name=catalog_name, org_name=org_name)
+                client=client, catalog_name=catalog_name, org_name=org_name,
+                is_tkg_plus_enabled=utils.is_tkg_plus_enabled(self.config),
+                logger_debug=logger.SERVER_LOGGER)
 
             if not k8_templates:
                 msg = "No valid K8 templates were found in catalog " \


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* Some of the TKG+ operations can still be performed if the server is first installed with `enable_tkg_plus` option set to true and later disabled.
* Disable TKG+ operations from CSE server if TKG+ is not enabled in CSE server.

If TKG+ is not enabled
* Prevent loading of TKG+ template.
* Prevent TKG+ ovdc updates.
* Skip TKG+ in the output for OVDC list

Testing done:
* checked if ovdc list doesn't give TKG+ if there is already an OVDC enabled with TKG+ ( tkg+ disabled)
* checked if TKG+ templates are not being loaded during runtime (tkg+ disabled)
* checked if OVDC update operations throw exception if TKG+ policies are updated (tkg+ disabled)
* checked if the above operations work fine when the flag is switched back to `true`

@rocknes @sahithi @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/765)
<!-- Reviewable:end -->
