### PR TITLE
[PR] Get cluster configuration only on resolved DEF entity

### DIFF
--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -92,6 +92,10 @@ class ClusterService(abstract_broker.AbstractBroker):
         :rtype: dict
         """
         curr_entity = self.entity_svc.get_entity(cluster_id)
+        if curr_entity.state != def_utils.DEF_RESOLVED_STATE:
+            raise e.CseServerError(
+                f"Cluster {curr_entity.name} with id {cluster_id} is not in a "
+                f"valid state for this operation. Please contact the administrator")  # noqa: E501
 
         telemetry_handler.record_user_action_details(
             cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_CONFIG,


### PR DESCRIPTION
- Prevent runtime error(s) on getting cluster config when the respective DEF entity is not in Resolved state
- This fix checks if the entity is resolved before getting the configuration else throw custom error
- Verified manually when cluster creation in progress, cluster not in resolved state.

------- Before fix---------
![image](https://user-images.githubusercontent.com/5530442/94970821-5ae02800-04ba-11eb-9371-953322ac01be.png)
------------------------------After fix-------------------
 
![image](https://user-images.githubusercontent.com/5530442/94970944-a1ce1d80-04ba-11eb-8182-f43238904196.png)

@Anirudh9794 @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/769)
<!-- Reviewable:end -->
