### PR TITLE
Update task to error if defined enttiy update / create fails

### DIFF
--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -181,7 +181,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             org_resource = vcd_utils.get_org(self.context.client,
                                              org_name=def_entity.entity.metadata.org_name)  # noqa: E501
             org_context = org_resource.href.split('/')[-1]
-        msg = f"Creating cluster '{cluster_name}' ({def_entity.id}) " \
+        msg = f"Creating cluster '{cluster_name}' " \
               f"from template '{template_name}' (revision {template_revision})"
         self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
         def_entity.entity.status.task_href = self.task_resource.get('href')
@@ -192,10 +192,11 @@ class ClusterService(abstract_broker.AbstractBroker):
                 tenant_org_context=org_context)
             def_entity = self.entity_svc.get_native_entity_by_name(cluster_name)  # noqa: E501
         except Exception as err:
+            msg = f"Error creating the cluster '{cluster_name}'"
+            LOGGER.error(f"{msg}: {err}")
             self._update_task(vcd_client.TaskStatus.ERROR,
                               message=msg,
                               error_message=str(err))
-            LOGGER.error(str(err))
             raise
         self.context.is_async = True
         telemetry_handler.record_user_action_details(
@@ -744,7 +745,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         except Exception as err:
             msg = f"Unexpected error while resizing nodes for {cluster_name}" \
                   f" ({cluster_id})"
-            LOGGER.error(f"{msg}: {err}",
+            LOGGER.error(f"{msg}",
                          exc_info=True)
             self._fail_operation_and_resolve_entity(cluster_id,
                                                     DefEntityOperation.UPDATE)
@@ -917,7 +918,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             self._update_task(vcd_client.TaskStatus.SUCCESS, message=msg)
         except Exception as err:
             msg = f"Unexpected error while deleting cluster {cluster_name}"
-            LOGGER.error(f"{msg}: {err}",
+            LOGGER.error(f"{msg}",
                          exc_info=True)
             self._update_task(vcd_client.TaskStatus.ERROR,
                               message=msg,
@@ -1108,7 +1109,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         except Exception as err:
             msg = f"Unexpected error while upgrading cluster " \
                   f"'{cluster_name}'"
-            LOGGER.error(f"{msg}: {err}", exc_info=True)
+            LOGGER.error(f"{msg}", exc_info=True)
             self._fail_operation_and_resolve_entity(cluster_id,
                                                     DefEntityOperation.UPGRADE,
                                                     vapp)
@@ -1157,7 +1158,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         except Exception as err:
             msg = f"Unexpected error while deleting nodes for " \
                   f"{cluster_name} ({cluster_id})"
-            LOGGER.error(f"{msg}: {err}",
+            LOGGER.error(f"{msg}",
                          exc_info=True)
             self._fail_operation_and_resolve_entity(cluster_id,
                                                     DefEntityOperation.UPDATE)
@@ -1234,7 +1235,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
         except Exception as err:
             msg = f"Unexpected error while deleting nodes {nodes_to_del}"
-            LOGGER.error(f"{msg}: {err}",
+            LOGGER.error(f"{msg}",
                          exc_info=True)
             self._fail_operation_and_resolve_entity(cluster_id,
                                                     DefEntityOperation.UPDATE,
@@ -1273,8 +1274,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             self._sync_def_entity(cluster_id, def_entity)
             self.entity_svc.resolve_entity(cluster_id)
         except Exception as err:
-            msg = f"Failed to resolfe defined entity for cluster {cluster_id}"
-            LOGGER.error(f"{msg}: {err}", exc_info=True)
+            msg = f"Failed to resolve defined entity for cluster {cluster_id}"
+            LOGGER.error(f"{msg}", exc_info=True)
             self._update_task(vcd_client.TaskStatus.ERROR,
                               message=msg, error_message=str(err))
 

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -981,15 +981,18 @@ class VcdBroker(abstract_broker.AbstractBroker):
                 except Exception:
                     LOGGER.error(f"Failed to delete cluster '{cluster_name}'",
                                  exc_info=True)
-            LOGGER.error(f"Error creating cluster '{cluster_name}'",
-                         exc_info=True)
+            msg = f"Error creating cluster '{cluster_name}'"
+            LOGGER.error(msg, exc_info=True)
             self._update_task(vcd_client.TaskStatus.ERROR,
+                              message=msg,
                               error_message=str(err))
             # raising an exception here prints a stacktrace to server console
         except Exception as err:
-            LOGGER.error(f"Unknown error creating cluster '{cluster_name}'",
-                         exc_info=True)
+            msg = "Unknown error occured while creating " \
+                  f"cluster '{cluster_name}'"
+            LOGGER.error(msg, exc_info=True)
             self._update_task(vcd_client.TaskStatus.ERROR,
+                              message=msg,
                               error_message=str(err))
         finally:
             self.context.end()
@@ -1074,14 +1077,18 @@ class VcdBroker(abstract_broker.AbstractBroker):
                     LOGGER.error(f"Failed to delete nodes {err.node_names} "
                                  f"from cluster '{cluster_name}'",
                                  exc_info=True)
-            LOGGER.error(f"Error adding nodes to cluster '{cluster_name}'",
-                         exc_info=True)
+            msg = f"Error adding nodes to cluster '{cluster_name}' ({cluster_id})"  # noqa: E501
+            LOGGER.error(msg, exc_info=True)
             self._update_task(vcd_client.TaskStatus.ERROR,
+                              message=msg,
                               error_message=str(err))
             # raising an exception here prints a stacktrace to server console
         except Exception as err:
-            LOGGER.error(str(err), exc_info=True)
+            msg = "Unexpected error while adding nodes for " \
+                  f"cluster {cluster_name}"
+            LOGGER.error(msg, exc_info=True)
             self._update_task(vcd_client.TaskStatus.ERROR,
+                              message=msg,
                               error_message=str(err))
         finally:
             self.context.end()
@@ -1122,10 +1129,11 @@ class VcdBroker(abstract_broker.AbstractBroker):
             LOGGER.debug(msg)
             self._update_task(vcd_client.TaskStatus.SUCCESS, message=msg)
         except Exception as err:
-            LOGGER.error(f"Unexpected error while deleting nodes "
-                         f"{node_names_list}: {err}",
-                         exc_info=True)
+            msg = "Unexpected error while deleting nodes for " \
+                  f"cluster {cluster_name}. nodes: {node_names_list}"
+            LOGGER.error(msg, exc_info=True)
             self._update_task(vcd_client.TaskStatus.ERROR,
+                              message=msg,
                               error_message=str(err))
         finally:
             self.context.end()
@@ -1142,9 +1150,10 @@ class VcdBroker(abstract_broker.AbstractBroker):
             LOGGER.debug(msg)
             self._update_task(vcd_client.TaskStatus.SUCCESS, message=msg)
         except Exception as err:
-            LOGGER.error(f"Unexpected error while deleting cluster: {err}",
-                         exc_info=True)
+            msg = f"Unexpected error while deleting cluster {cluster_name}"
+            LOGGER.error(msg, exc_info=True)
             self._update_task(vcd_client.TaskStatus.ERROR,
+                              message=msg,
                               error_message=str(err))
         finally:
             self.context.end()
@@ -1296,10 +1305,11 @@ class VcdBroker(abstract_broker.AbstractBroker):
             LOGGER.debug(f"{msg} ({vapp_href})")
             self._update_task(vcd_client.TaskStatus.SUCCESS, message=msg)
         except Exception as err:
-            msg = f"Unexpected error while upgrading cluster " \
-                  f"'{cluster_name}': {err}"
+            msg = f"Unexpected error while upgrading cluster {cluster.get('name')}"  # noqa: E501
             LOGGER.error(msg, exc_info=True)
-            self._update_task(vcd_client.TaskStatus.ERROR, error_message=msg)
+            self._update_task(vcd_client.TaskStatus.ERROR,
+                              message=msg,
+                              error_message=str(err))
         finally:
             self.context.end()
 


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* When defined entity create/update fails in the sync portion of cluster operations, the task will be left in Running state forever
* Fix by adding exception handling to update tasks if defined entity create/ update fails

Testing done:
* create (with and without rights)
* resize (with and without rights)
* delete (with and without rights)
* upgrade (with and without rights)

@rocknes @sahithi @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/774)
<!-- Reviewable:end -->
