### PR TITLE
[PR] sample cluster configuration: nfs count default set to 0

### DIFF
--- a/container_service_extension/client/sample_generator.py
+++ b/container_service_extension/client/sample_generator.py
@@ -113,7 +113,7 @@ def _get_sample_cluster_configuration_by_k8_runtime(k8_runtime):
     )
 
     nfs = def_models.Nfs(
-        count=1,
+        count=0,
         sizing_class='Large_sizing_policy_name',
         storage_profile='Platinum_storage_profile_name'
     )


### PR DESCRIPTION
- update default nfs count to 0 for output of `vcd cse cluster apply --sample --native` 

![image](https://user-images.githubusercontent.com/5530442/95789122-cb90fc80-0c91-11eb-84cc-d104c5888a6c.png)

@Anirudh9794 @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/781)
<!-- Reviewable:end -->
