### PR TITLE
Add information about deprecation of templates

### DIFF
--- a/docs/cse2_6/TEMPLATE_ANNOUNCEMENTS.md
+++ b/docs/cse2_6/TEMPLATE_ANNOUNCEMENTS.md
@@ -16,9 +16,10 @@ All templates currently available:
 | **ubuntu-16.04_k8-1.18_weave-2.6.5** | 1        | Ubuntu-16.04      | 1.18.6      | 2.6.5     | Docker-ce 19.03.12      |
 | ubuntu-16.04_k8-1.17_weave-2.6.0     | **2**    | Ubuntu 16.04      | 1.17.9      | 2.6.0     | Docker-ce 19.03.5       |
 | ubuntu-16.04_k8-1.16_weave-2.6.0     | **2**    | Ubuntu 16.04      | 1.16.13     | 2.6.0     | Docker-ce 18.09.7       |
-| ubuntu-16.04_k8-1.15_weave-2.5.2     | **4**    | Ubuntu 16.04      | 1.15.12     | 2.5.2     | Docker-ce 18.09.7       |
+| ubuntu-16.04_k8-1.15_weave-2.5.2 *     | **4**    | Ubuntu 16.04      | 1.15.12     | 2.5.2     | Docker-ce 18.09.7       |
 | photon-v2_k8-1.14_weave-2.5.2        | **3**    | Photon OS 2.0     | 1.14.10      | 2.5.2    | Docker-ce 18.06.2-6     |
 
+Templates marked with '*' are deprecated and will be removed in future update.
 
 ## March 09, 2020
 

--- a/docs/cse3_0/TEMPLATE_ANNOUNCEMENTS.md
+++ b/docs/cse3_0/TEMPLATE_ANNOUNCEMENTS.md
@@ -15,9 +15,10 @@ All templates currently available:
 | **ubuntu-16.04_k8-1.18_weave-2.6.5** | 1        | Ubuntu-16.04      | 1.18.6      | 2.6.5     | Docker-ce 19.03.12      |
 | ubuntu-16.04_k8-1.17_weave-2.6.0     | **2**    | Ubuntu 16.04      | 1.17.9      | 2.6.0     | Docker-ce 19.03.5       |
 | ubuntu-16.04_k8-1.16_weave-2.6.0     | **2**    | Ubuntu 16.04      | 1.16.13     | 2.6.0     | Docker-ce 18.09.7       |
-| ubuntu-16.04_k8-1.15_weave-2.5.2     | **4**    | Ubuntu 16.04      | 1.15.12     | 2.5.2     | Docker-ce 18.09.7       |
+| ubuntu-16.04_k8-1.15_weave-2.5.2 *     | **4**    | Ubuntu 16.04      | 1.15.12     | 2.5.2     | Docker-ce 18.09.7       |
 | photon-v2_k8-1.14_weave-2.5.2        | **3**    | Photon OS 2.0     | 1.14.10      | 2.5.2    | Docker-ce 18.06.2-6     |
 
+Templates marked with '*' are deprecated and will be removed in future update.
 
 ## March 09, 2020
 


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* Add information in the doc that template ubuntu-16.04_k8-1.15_weave-2.5.2 will be deprecated in future update
![Screen Shot 2020-10-14 at 10 26 22 AM](https://user-images.githubusercontent.com/16699642/96025662-4bda6d80-0e0a-11eb-8855-4433e12a8ed1.png)


@sahithi @rocknes @sakthisunda @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/790)
<!-- Reviewable:end -->
