### PR TITLE
[VCDA-1696] Upgrade cloudapi endpoints and refactor compute policy manager

### DIFF
--- a/container_service_extension/cloudapi/constants.py
+++ b/container_service_extension/cloudapi/constants.py
@@ -9,6 +9,11 @@ CLOUDAPI_URN_PREFIX = 'urn:vcloud'
 CSE_COMPUTE_POLICY_PREFIX = 'cse----'
 
 
+class CloudApiVersion(str, Enum):
+    VERSION_1_0_0 = '1.0.0'
+    VERSION_2_0_0 = '2.0.0'
+
+
 class CloudApiResource(str, Enum):
     """Keys that are used to get the cloudapi resource names."""
 

--- a/container_service_extension/cloudapi/constants.py
+++ b/container_service_extension/cloudapi/constants.py
@@ -6,7 +6,6 @@ from enum import Enum
 
 CLOUDAPI_VERSION_1_0_0 = '1.0.0'
 CLOUDAPI_URN_PREFIX = 'urn:vcloud'
-CSE_COMPUTE_POLICY_PREFIX = 'cse----'
 
 
 class CloudApiVersion(str, Enum):

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -243,7 +243,7 @@ class ComputePolicyManager:
             f"{policy_info['id']}"
         return self._cloudapi_client.do_request(
             method=RequestMethod.DELETE,
-            cloudapi_version=cloudapi_constants.CloudApiVersion.VERSION_1_0_0,
+            cloudapi_version=self._cloudapi_version,
             resource_url_relative_path=resource_url_relative_path)
 
     def add_vdc_compute_policy(self, policy_name,

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -43,8 +43,6 @@ class ComputePolicyManager:
         self._cloudapi_client = None
         self._session = self._sysadmin_client.get_vcloud_session()
         self._is_operation_supported = True
-        self._cloudapi_version = \
-            cloudapi_constants.CloudApiVersion.VERSION_2_0_0
 
         try:
             wire_logger = logger.NULL_LOGGER
@@ -54,6 +52,8 @@ class ComputePolicyManager:
                 vcd_utils.get_cloudapi_client_from_vcd_client(self._sysadmin_client, # noqa: E501
                                                               logger.SERVER_LOGGER, # noqa: E501
                                                               wire_logger)
+            self._cloudapi_version = \
+                cloudapi_constants.CloudApiVersion.VERSION_2_0_0
             if float(self._cloudapi_client.get_api_version()) < \
                     GLOBAL_PVDC_COMPUTE_POLICY_MIN_VERSION:
                 self._cloudapi_version = \
@@ -337,7 +337,7 @@ class ComputePolicyManager:
 
             updated_policy = self._cloudapi_client.do_request(
                 method=RequestMethod.PUT,
-                cloudapi_version=cloudapi_constants.CloudApiVersion.VERSION_1_0_0,  # noqa: E501
+                cloudapi_version=self._cloudapi_version,
                 resource_url_relative_path=resource_url_relative_path,
                 payload=payload)
 

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -264,7 +264,8 @@ class ComputePolicyManager:
         policy_info = {}
         resource = cloudapi_constants.CloudApiResource
         policy_info['name'] = policy_name
-        if self._cloudapi_version == cloudapi_constants.CloudApiVersion.VERSION_2_0_0:
+        if self._cloudapi_version == \
+                cloudapi_constants.CloudApiVersion.VERSION_2_0_0:
             policy_info['policyType'] = VDC_POLICY_TYPE_VM
         if description:
             policy_info['description'] = description
@@ -325,7 +326,8 @@ class ComputePolicyManager:
         if new_policy_info.get('name'):
             payload = {}
             payload['name'] = new_policy_info['name']
-            if self._cloudapi_version == cloudapi_constants.CloudApiVersion.VERSION_2_0_0:
+            if self._cloudapi_version == \
+                    cloudapi_constants.CloudApiVersion.VERSION_2_0_0:
                 payload['policyType'] = VDC_POLICY_TYPE_VM
             if 'description' in new_policy_info:
                 payload['description'] = new_policy_info['description']
@@ -927,24 +929,28 @@ def get_cse_policy_display_name(policy_name):
     :rtype: str
     """
     if policy_name and \
-        policy_name.startswith(CSE_COMPUTE_POLICY_PREFIX): # noqa: E501
-        return policy_name.replace(CSE_COMPUTE_POLICY_PREFIX, '', 1) # noqa: E501
+            policy_name.startswith(CSE_COMPUTE_POLICY_PREFIX):
+        return policy_name.replace(CSE_COMPUTE_POLICY_PREFIX, '', 1)
     return policy_name
 
+
 def get_cse_policy_name(policy_name):
-    """Adds a prefix to the compute policy name."""
+    """Add a prefix to the compute policy name."""
     return f"{CSE_COMPUTE_POLICY_PREFIX}{policy_name}"
+
 
 def get_cse_pvdc_compute_policy(cpm: ComputePolicyManager,
                                 unprefixed_policy_name: str):
     policy_name = get_cse_policy_name(unprefixed_policy_name)
     return cpm.get_pvdc_compute_policy(policy_name)
 
+
 def add_cse_pvdc_compute_policy(cpm: ComputePolicyManager,
                                 unprefixed_policy_name: str,
                                 policy_description: str):
     policy_name = get_cse_policy_name(unprefixed_policy_name)
     return cpm.add_pvdc_compute_policy(policy_name, policy_description)
+
 
 def add_cse_vdc_compute_policy(cpm: ComputePolicyManager,
                                unprefixed_policy_name: str,
@@ -955,11 +961,13 @@ def add_cse_vdc_compute_policy(cpm: ComputePolicyManager,
                                       description=policy_description,
                                       pvdc_compute_policy_id=pvdc_compute_policy_id)  # noqa: E501
 
+
 def get_cse_vdc_compute_policy(cpm: ComputePolicyManager,
                                unprefixed_policy_name: str,
                                is_placement_policy: bool = False):
     policy_name = get_cse_policy_name(unprefixed_policy_name)
     return cpm.get_vdc_compute_policy(policy_name, is_placement_policy=is_placement_policy)  # noqa: E501
+
 
 def delete_cse_vdc_compute_policy(cpm: ComputePolicyManager,
                                   unprefixed_policy_name: str,
@@ -967,15 +975,16 @@ def delete_cse_vdc_compute_policy(cpm: ComputePolicyManager,
     policy_name = get_cse_policy_name(unprefixed_policy_name)
     return cpm.delete_vdc_compute_policy(policy_name, is_placement_policy=is_placement_policy)  # noqa: E501
 
+
 def list_cse_sizing_policies_on_vdc(cpm: ComputePolicyManager, vdc_id: str):
     cse_policy_name_filter = \
         {'name': f'{cloudapi_constants.CSE_COMPUTE_POLICY_PREFIX}*'}
     return cpm.list_vdc_sizing_policies_on_vdc(vdc_id,
                                                filters=cse_policy_name_filter)
 
+
 def list_cse_placement_policies_on_vdc(cpm: ComputePolicyManager, vdc_id: str):
     cse_policy_name_filter = \
         {'name': f'{cloudapi_constants.CSE_COMPUTE_POLICY_PREFIX}*'}
     return cpm.list_vdc_placement_policies_on_vdc(vdc_id,
                                                   filters=cse_policy_name_filter)  # noqa: E501
-

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -104,7 +104,6 @@ class ComputePolicyManager:
             if len(response_body['values']) == 0:
                 break
             for policy in response_body['values']:
-                cp_name = policy['name']
                 yield policy
 
     def get_all_vdc_compute_policies(self, filters=None):
@@ -139,7 +138,6 @@ class ComputePolicyManager:
             if len(response_body['values']) == 0:
                 break
             for policy in response_body['values']:
-                cp_name = policy['name']
                 yield policy
 
     def get_pvdc_compute_policy(self, policy_name):
@@ -948,9 +946,9 @@ def add_cse_pvdc_compute_policy(cpm: ComputePolicyManager,
                                 unprefixed_policy_name: str,
                                 policy_description: str):
     policy_name = get_cse_policy_name(unprefixed_policy_name)
-    created_policy = cpm.add_pvdc_compute_policy(policy_name, policy_description)
+    created_policy = cpm.add_pvdc_compute_policy(policy_name, policy_description)  # noqa: E501
     created_policy['display_name'] = \
-            get_cse_policy_display_name(pvdc_policy['name'])
+        get_cse_policy_display_name(created_policy['name'])
     return created_policy
 
 
@@ -964,7 +962,7 @@ def add_cse_vdc_compute_policy(cpm: ComputePolicyManager,
         description=policy_description,
         pvdc_compute_policy_id=pvdc_compute_policy_id)
     created_policy['display_name'] = \
-            get_cse_policy_display_name(created_policy['name'])
+        get_cse_policy_display_name(created_policy['name'])
     return created_policy
 
 
@@ -987,8 +985,7 @@ def delete_cse_vdc_compute_policy(cpm: ComputePolicyManager,
 def list_cse_sizing_policies_on_vdc(cpm: ComputePolicyManager, vdc_id: str):
     cse_policy_name_filter = \
         {'name': f'{CSE_COMPUTE_POLICY_PREFIX}*'}
-    policy_list = list(cpm.list_vdc_sizing_policies_on_vdc(vdc_id,
-                                               filters=cse_policy_name_filter))
+    policy_list = list(cpm.list_vdc_sizing_policies_on_vdc(vdc_id, filters=cse_policy_name_filter))  # noqa: E501
     for policy in policy_list:
         policy['display_name'] = get_cse_policy_display_name(policy['name'])
     return policy_list
@@ -997,8 +994,7 @@ def list_cse_sizing_policies_on_vdc(cpm: ComputePolicyManager, vdc_id: str):
 def list_cse_placement_policies_on_vdc(cpm: ComputePolicyManager, vdc_id: str):
     cse_policy_name_filter = \
         {'name': f'{CSE_COMPUTE_POLICY_PREFIX}*'}
-    policy_list = list(cpm.list_vdc_placement_policies_on_vdc(vdc_id,
-                                                  filters=cse_policy_name_filter))  # noqa: E501
+    policy_list = list(cpm.list_vdc_placement_policies_on_vdc(vdc_id, filters=cse_policy_name_filter))  # noqa: E501
     for policy in policy_list:
         policy['display_name'] = get_cse_policy_display_name(policy['name'])
     return policy_list

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -978,13 +978,13 @@ def delete_cse_vdc_compute_policy(cpm: ComputePolicyManager,
 
 def list_cse_sizing_policies_on_vdc(cpm: ComputePolicyManager, vdc_id: str):
     cse_policy_name_filter = \
-        {'name': f'{cloudapi_constants.CSE_COMPUTE_POLICY_PREFIX}*'}
+        {'name': f'{CSE_COMPUTE_POLICY_PREFIX}*'}
     return cpm.list_vdc_sizing_policies_on_vdc(vdc_id,
                                                filters=cse_policy_name_filter)
 
 
 def list_cse_placement_policies_on_vdc(cpm: ComputePolicyManager, vdc_id: str):
     cse_policy_name_filter = \
-        {'name': f'{cloudapi_constants.CSE_COMPUTE_POLICY_PREFIX}*'}
+        {'name': f'{CSE_COMPUTE_POLICY_PREFIX}*'}
     return cpm.list_vdc_placement_policies_on_vdc(vdc_id,
                                                   filters=cse_policy_name_filter)  # noqa: E501

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -816,8 +816,10 @@ def _setup_placement_policies(client,
     pvdc_compute_policy = None
     try:
         try:
-            pvdc_compute_policy = cpm.get_pvdc_compute_policy(
-                server_constants.CSE_GLOBAL_PVDC_COMPUTE_POLICY_NAME)
+            pvdc_compute_policy = \
+                compute_policy_manager.get_cse_pvdc_compute_policy(
+                    cpm,
+                    server_constants.CSE_GLOBAL_PVDC_COMPUTE_POLICY_NAME)
             msg = "Skipping creation of global PVDC compute policy. Policy already exists" # noqa: E501
             msg_update_callback.general(msg)
             INSTALL_LOGGER.info(msg)
@@ -825,25 +827,32 @@ def _setup_placement_policies(client,
             msg = "Creating global PVDC compute policy"
             msg_update_callback.general(msg)
             INSTALL_LOGGER.info(msg)
-            pvdc_compute_policy = cpm.add_pvdc_compute_policy(
-                server_constants.CSE_GLOBAL_PVDC_COMPUTE_POLICY_NAME,
-                server_constants.CSE_GLOBAL_PVDC_COMPUTE_POLICY_DESCRIPTION)
+            pvdc_compute_policy = \
+                compute_policy_manager.add_cse_pvdc_compute_policy(
+                    cpm,
+                    server_constants.CSE_GLOBAL_PVDC_COMPUTE_POLICY_NAME,
+                    server_constants.CSE_GLOBAL_PVDC_COMPUTE_POLICY_DESCRIPTION)  # noqa: E501
 
-        for policy in policy_list:
+        for policy_name in policy_list:
             if not is_tkg_plus_enabled and \
-                    policy == shared_constants.TKG_PLUS_CLUSTER_RUNTIME_INTERNAL_NAME:  # noqa: E501
+                    policy_name == shared_constants.TKG_PLUS_CLUSTER_RUNTIME_INTERNAL_NAME:  # noqa: E501
                 continue
             try:
-                cpm.get_vdc_compute_policy(policy, is_placement_policy=True)
-                msg = f"Skipping creation of VDC placement policy '{policy}'. Policy already exists" # noqa: E501
+                compute_policy_manager.get_cse_vdc_compute_policy(
+                    cpm,
+                    policy_name,
+                    is_placement_policy=True)
+                msg = f"Skipping creation of VDC placement policy '{policy_name}'. Policy already exists" # noqa: E501
                 msg_update_callback.general(msg)
                 INSTALL_LOGGER.info(msg)
             except EntityNotFoundException:
-                msg = f"Creating placement policy '{policy}'"
+                msg = f"Creating placement policy '{policy_name}'"
                 msg_update_callback.general(msg)
                 INSTALL_LOGGER.info(msg)
-                cpm.add_vdc_compute_policy(
-                    policy, pvdc_compute_policy_id=pvdc_compute_policy['id'])
+                compute_policy_manager.add_cse_vdc_compute_policy(
+                    cpm,
+                    policy_name,
+                    pvdc_compute_policy_id=pvdc_compute_policy['id'])
     except cse_exception.GlobalPvdcComputePolicyNotSupported:
         msg = "Global PVDC compute policies are not supported." \
               "Skipping creation of placement policy."
@@ -2015,8 +2024,9 @@ def _assign_placement_policy_to_vdc_and_right_bundle_to_org(
         msg = f"Found {len(native_ovdcs)} vDC(s) hosting NATIVE CSE custers."
         msg_update_callback.info(msg)
         INSTALL_LOGGER.info(msg)
-        native_policy = cpm.get_vdc_compute_policy(
-            policy_name=shared_constants.NATIVE_CLUSTER_RUNTIME_INTERNAL_NAME,
+        native_policy = compute_policy_manager.get_cse_vdc_compute_policy(
+            cpm,
+            shared_constants.NATIVE_CLUSTER_RUNTIME_INTERNAL_NAME,
             is_placement_policy=True)
         for vdc_id in native_ovdcs:
             cpm.add_compute_policy_to_vdc(
@@ -2041,9 +2051,11 @@ def _assign_placement_policy_to_vdc_and_right_bundle_to_org(
         INSTALL_LOGGER.info(msg)
 
         if is_tkg_plus_enabled:
-            tkg_plus_policy = cpm.get_vdc_compute_policy(
-                policy_name=shared_constants.TKG_PLUS_CLUSTER_RUNTIME_INTERNAL_NAME,  # noqa: E501
-                is_placement_policy=True)
+            tkg_plus_policy = \
+                compute_policy_manager.get_cse_vdc_compute_policy(
+                    cpm,
+                    shared_constants.TKG_PLUS_CLUSTER_RUNTIME_INTERNAL_NAME,
+                    is_placement_policy=True)
             for vdc_id in tkg_plus_ovdcs:
                 cpm.add_compute_policy_to_vdc(
                     vdc_id=vdc_id,
@@ -2107,7 +2119,7 @@ def _remove_old_cse_sizing_compute_policies(
 
             vdc = vcd_utils.get_vdc(client, vdc_name=vdc_name, org_name=org_name) # noqa: E501
             vdc_id = pyvcloud_vcd_utils.extract_id(vdc.get_resource().get('id')) # noqa: E501
-            vdc_sizing_policies = cpm.list_vdc_sizing_policies_on_vdc(vdc_id)
+            vdc_sizing_policies = compute_policy_manager.list_cse_sizing_policies_on_vdc(cpm, vdc_id)  # noqa: E501
             if vdc_sizing_policies:
                 for policy in vdc_sizing_policies:
                     msg = f"Processing Policy : '{policy['display_name']}' on Org VDC : '{vdc_name}'" # noqa: E501
@@ -2140,7 +2152,8 @@ def _remove_old_cse_sizing_compute_policies(
             msg_update_callback.info(msg)
             INSTALL_LOGGER.info(msg)
 
-            cpm.delete_vdc_compute_policy(policy_name=policy_name)
+            compute_policy_manager.delete_cse_vdc_compute_policy(cpm,
+                                                                 policy_name)
 
             msg = f"Deleted  Policy : '{policy_name}'"
             msg_update_callback.general(msg)

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1377,7 +1377,7 @@ def _get_nodes_details(sysadmin_client, vapp):
                                                         'VmSizingPolicy'):
                 policy_name = vm.ComputePolicy.VmSizingPolicy.get('name')
                 sizing_class = compute_policy_manager.\
-                    ComputePolicyManager.get_policy_display_name(policy_name)
+                    get_cse_policy_display_name(policy_name)
             if vm_name.startswith(NodeType.CONTROL_PLANE):
                 control_plane = def_models.Node(name=vm_name, ip=ip,
                                                 sizing_class=sizing_class)

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1632,6 +1632,7 @@ def _add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
                     msg = f"No sizing policy with the name {sizing_class_name} exists on the VDC"  # noqa: E501
                     LOGGER.error(msg)
                     raise Exception(msg)
+                LOGGER.debug(f"Found sizing policy with name {sizing_class_name} on the VDC {vdc_resource.get('name')}")  # noqa: E501
 
             cust_script = None
             if ssh_key is not None:

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1620,10 +1620,7 @@ def _add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
             sizing_class_href = None
             if sizing_class_name:
                 vdc_resource = vdc.get_resource()
-                filters = {
-                    'isSizingOnly': True,
-                }
-                for policy in cpm.list_compute_policies_on_vdc(vdc_resource.get('id'), filters=filters):  # noqa: E501
+                for policy in cpm.list_vdc_sizing_policies_on_vdc(vdc_resource.get('id')):  # noqa: E501
                     if policy['name'] == sizing_class_name:
                         if not sizing_class_href:
                             sizing_class_href = policy['href']

--- a/container_service_extension/def_/entity_service.py
+++ b/container_service_extension/def_/entity_service.py
@@ -11,8 +11,8 @@ from requests.exceptions import HTTPError
 
 
 from container_service_extension.cloudapi.cloudapi_client import CloudApiClient
-from container_service_extension.cloudapi.constants import CloudApiVersion
 from container_service_extension.cloudapi.constants import CloudApiResource
+from container_service_extension.cloudapi.constants import CloudApiVersion
 from container_service_extension.def_.models import DefEntity, DefEntityType
 import container_service_extension.def_.schema_service as def_schema_svc
 import container_service_extension.def_.utils as def_utils

--- a/container_service_extension/def_/entity_service.py
+++ b/container_service_extension/def_/entity_service.py
@@ -11,7 +11,7 @@ from requests.exceptions import HTTPError
 
 
 from container_service_extension.cloudapi.cloudapi_client import CloudApiClient
-from container_service_extension.cloudapi.constants import CLOUDAPI_VERSION_1_0_0  # noqa: E501
+from container_service_extension.cloudapi.constants import CloudApiVersion
 from container_service_extension.cloudapi.constants import CloudApiResource
 from container_service_extension.def_.models import DefEntity, DefEntityType
 import container_service_extension.def_.schema_service as def_schema_svc
@@ -79,7 +79,7 @@ class DefEntityService():
             additional_headers['x-vmware-vcloud-tenant-context'] = tenant_org_context  # noqa: E501
         self._cloudapi_client.do_request(
             method=RequestMethod.POST,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}/"
                                        f"{entity_type_id}",
             payload=asdict(entity),
@@ -112,7 +112,7 @@ class DefEntityService():
                 query_string = f"filter={filter_string}&{query_string}"
             response_body = self._cloudapi_client.do_request(
                 method=RequestMethod.GET,
-                cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+                cloudapi_version=CloudApiVersion.VERSION_1_0_0,
                 resource_url_relative_path=f"{CloudApiResource.ENTITIES}/"
                                            f"{CloudApiResource.ENTITY_TYPES_TOKEN}/"  # noqa: E501
                                            f"{vendor}/{nss}/{version}?{query_string}")  # noqa: E501
@@ -141,7 +141,7 @@ class DefEntityService():
             page_num += 1
             response_body = self._cloudapi_client.do_request(
                 method=RequestMethod.GET,
-                cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+                cloudapi_version=CloudApiVersion.VERSION_1_0_0,
                 resource_url_relative_path=f"{CloudApiResource.ENTITIES}/"
                                            f"{CloudApiResource.INTERFACES}/{vendor}/{nss}/{version}?"  # noqa: E501
                                            f"page={page_num}")
@@ -161,7 +161,7 @@ class DefEntityService():
         """
         response_body = self._cloudapi_client.do_request(
             method=RequestMethod.PUT,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITIES}/"
                                        f"{entity_id}",
             payload=asdict(entity))
@@ -177,7 +177,7 @@ class DefEntityService():
         """
         response_body = self._cloudapi_client.do_request(
             method=RequestMethod.GET,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITIES}/"
                                        f"{entity_id}")
         return DefEntity(**response_body)
@@ -208,7 +208,7 @@ class DefEntityService():
         """
         self._cloudapi_client.do_request(
             method=RequestMethod.DELETE,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITIES}/"
                                        f"{entity_id}")
 
@@ -224,7 +224,7 @@ class DefEntityService():
         """
         response_body = self._cloudapi_client.do_request(
             method=RequestMethod.POST,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITIES}/"
                                        f"{entity_id}/{CloudApiResource.ENTITY_RESOLVE}")  # noqa: E501
         msg = response_body[def_utils.DEF_ERROR_MESSAGE_KEY]
@@ -258,7 +258,7 @@ class DefEntityService():
         """."""
         response_body = self._cloudapi_client.do_request(
             method=RequestMethod.GET,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITIES}/"
                                        f"{entity_id}")
         return def_utils.DEF_NATIVE_ENTITY_TYPE_NSS in response_body['entityType']  # noqa: E501

--- a/container_service_extension/def_/ovdc_service.py
+++ b/container_service_extension/def_/ovdc_service.py
@@ -322,7 +322,7 @@ def _update_ovdc_using_placement_policy_async(operation_context: ctx.OperationCo
         logger.SERVER_LOGGER.error(err)
         task.update(status=vcd_client.TaskStatus.ERROR.value,
                     namespace='vcloud.cse',
-                    operation='',
+                    operation='Failed to update OVDC',
                     operation_name=operation_name,
                     details=f'Failed with error: {err}',
                     progress=None,

--- a/container_service_extension/def_/schema_service.py
+++ b/container_service_extension/def_/schema_service.py
@@ -9,7 +9,7 @@ import json
 from requests.exceptions import HTTPError
 
 from container_service_extension.cloudapi.cloudapi_client import CloudApiClient
-from container_service_extension.cloudapi.constants import CLOUDAPI_VERSION_1_0_0 # noqa: E501
+from container_service_extension.cloudapi.constants import CloudApiVersion
 from container_service_extension.cloudapi.constants import CloudApiResource
 import container_service_extension.def_.models as def_models
 from container_service_extension.def_.utils import raise_error_if_def_not_supported # noqa: E501
@@ -69,7 +69,7 @@ class DefSchemaService():
             page_num += 1
             response_body = self._cloudapi_client.do_request(
                 method=cse_shared_constants.RequestMethod.GET,
-                cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+                cloudapi_version=CloudApiVersion.VERSION_1_0_0,
                 resource_url_relative_path=f"{CloudApiResource.INTERFACES}?"
                 f"page={page_num}")
             if len(response_body['values']) > 0:
@@ -88,7 +88,7 @@ class DefSchemaService():
         """
         response_body = self._cloudapi_client.do_request(
             method=cse_shared_constants.RequestMethod.GET,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.INTERFACES}/{id}")
         return def_models.DefInterface(**response_body)
 
@@ -104,7 +104,7 @@ class DefSchemaService():
             raise ValueError("Cloud API Client should be sysadmin.")
         response_body = self._cloudapi_client.do_request(
             method=cse_shared_constants.RequestMethod.POST,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.INTERFACES}",
             payload=asdict(interface))
         return def_models.DefInterface(**response_body)
@@ -123,7 +123,7 @@ class DefSchemaService():
             raise ValueError("Cloud API Client should be sysadmin.")
         response_body = self._cloudapi_client.do_request(
             method=cse_shared_constants.RequestMethod.PUT,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.INTERFACES}/"
             f"{interface.id}",
             payload=asdict(interface))
@@ -140,7 +140,7 @@ class DefSchemaService():
             raise ValueError("Cloud API Client should be sysadmin.")
         return self._cloudapi_client.do_request(
             method=cse_shared_constants.RequestMethod.DELETE,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.INTERFACES}/{id}")
 
     @handle_schema_service_exception
@@ -155,7 +155,7 @@ class DefSchemaService():
             raise ValueError("Cloud API Client should be sysadmin.")
         response_body = self._cloudapi_client.do_request(
             method=cse_shared_constants.RequestMethod.POST,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}",
             payload=asdict(entity_type))
         return def_models.DefEntityType(**response_body)
@@ -170,7 +170,7 @@ class DefSchemaService():
         """
         response_body = self._cloudapi_client.do_request(
             method=cse_shared_constants.RequestMethod.GET,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}/{id}")
         return def_models.DefEntityType(**response_body)
 
@@ -186,7 +186,7 @@ class DefSchemaService():
             page_num += 1
             response_body = self._cloudapi_client.do_request(
                 method=cse_shared_constants.RequestMethod.GET,
-                cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+                cloudapi_version=CloudApiVersion.VERSION_1_0_0,
                 resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}?"
                 f"page={page_num}")
             if len(response_body['values']) > 0:
@@ -210,7 +210,7 @@ class DefSchemaService():
             raise ValueError("Cloud API Client should be sysadmin.")
         response_body = self._cloudapi_client.do_request(
             method=cse_shared_constants.RequestMethod.PUT,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}/"
             f"{entity_type.id}",
             payload=asdict(entity_type))
@@ -227,5 +227,5 @@ class DefSchemaService():
             raise ValueError("Cloud API Client should be sysadmin.")
         self._cloudapi_client.do_request(
             method=cse_shared_constants.RequestMethod.DELETE,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}/{id}")

--- a/container_service_extension/def_/schema_service.py
+++ b/container_service_extension/def_/schema_service.py
@@ -9,8 +9,8 @@ import json
 from requests.exceptions import HTTPError
 
 from container_service_extension.cloudapi.cloudapi_client import CloudApiClient
-from container_service_extension.cloudapi.constants import CloudApiVersion
 from container_service_extension.cloudapi.constants import CloudApiResource
+from container_service_extension.cloudapi.constants import CloudApiVersion
 import container_service_extension.def_.models as def_models
 from container_service_extension.def_.utils import raise_error_if_def_not_supported # noqa: E501
 import container_service_extension.exceptions as cse_exceptions

--- a/container_service_extension/mqtt_extension_manager.py
+++ b/container_service_extension/mqtt_extension_manager.py
@@ -354,7 +354,7 @@ class MQTTExtensionManager:
         }
         response_body = self._cloudapi_client.do_request(
             method=RequestMethod.POST,
-            cloudapi_version=cloudapi_constants.CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=cloudapi_constants.CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=constants.TOKEN_PATH,
             payload=payload)
         token_info = {
@@ -377,7 +377,7 @@ class MQTTExtensionManager:
         token_ids = []
         response_body = self._cloudapi_client.do_request(
             method=RequestMethod.GET,
-            cloudapi_version=cloudapi_constants.CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=cloudapi_constants.CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=constants.TOKEN_PATH)
         ext_combine_name = f"{ext_vendor}/{ext_name}/{ext_version}"
         for token_info in response_body['values']:
@@ -394,7 +394,7 @@ class MQTTExtensionManager:
         """
         self._cloudapi_client.do_request(
             method=RequestMethod.DELETE,
-            cloudapi_version=cloudapi_constants.CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=cloudapi_constants.CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{constants.TOKEN_PATH}/"
                                        f"{token_id}")
 
@@ -422,7 +422,7 @@ class MQTTExtensionManager:
         try:
             self._cloudapi_client.do_request(
                 method=RequestMethod.GET,
-                cloudapi_version=cloudapi_constants.CLOUDAPI_VERSION_1_0_0,
+                cloudapi_version=cloudapi_constants.CloudApiVersion.VERSION_1_0_0,  # noqa: E501
                 resource_url_relative_path=f"{constants.TOKEN_PATH}/"
                                            f"{token_id}")
         except requests.exceptions.HTTPError:

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -291,12 +291,12 @@ def ovdc_compute_policy_update(request_data,
         cp_id = None
         if cp_name == SYSTEM_DEFAULT_COMPUTE_POLICY_NAME:
             for _cp in cpm.list_compute_policies_on_vdc(ovdc_id):
-                if _cp['display_name'] == cp_name:
+                if _cp['name'] == cp_name:
                     cp_href = _cp['href']
                     cp_id = _cp['id']
         else:
             try:
-                _cp = cpm.get_vdc_compute_policy(cp_name)
+                _cp = cpm.get_vdc_compute_policy(utils.get_cse_policy_name(cp_name))  # noqa: E501
                 cp_href = _cp['href']
                 cp_id = _cp['id']
             except vcd_e.EntityNotFoundException:

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -296,7 +296,7 @@ def ovdc_compute_policy_update(request_data,
                     cp_id = _cp['id']
         else:
             try:
-                _cp = cpm.get_vdc_compute_policy(utils.get_cse_policy_name(cp_name))  # noqa: E501
+                _cp = compute_policy_manager.get_cse_vdc_compute_policy(cpm, cp_name)  # noqa: E501
                 cp_href = _cp['href']
                 cp_id = _cp['id']
             except vcd_e.EntityNotFoundException:

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -251,6 +251,7 @@ def ovdc_compute_policy_list(request_data,
     compute_policies = []
     for cp in \
             compute_policy_manager.list_cse_sizing_policies_on_vdc(
+                cpm,
                 request_data[RequestKey.OVDC_ID]):
         policy = {
             'name': cp['display_name'],

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -249,7 +249,9 @@ def ovdc_compute_policy_list(request_data,
         op_ctx.sysadmin_client,
         log_wire=utils.str_to_bool(config['service'].get('log_wire')))
     compute_policies = []
-    for cp in cpm.list_compute_policies_on_vdc(request_data[RequestKey.OVDC_ID]): # noqa: E501
+    for cp in \
+            compute_policy_manager.list_cse_sizing_policies_on_vdc(
+                request_data[RequestKey.OVDC_ID]):
         policy = {
             'name': cp['display_name'],
             'id': cp['id'],

--- a/container_service_extension/right_bundle_manager.py
+++ b/container_service_extension/right_bundle_manager.py
@@ -4,8 +4,8 @@
 
 import pyvcloud.vcd.client as vcd_client
 
-from container_service_extension.cloudapi.constants import CloudApiVersion
 from container_service_extension.cloudapi.constants import CloudApiResource
+from container_service_extension.cloudapi.constants import CloudApiVersion
 import container_service_extension.def_.utils as def_utils
 from container_service_extension.logger import NULL_LOGGER
 from container_service_extension.logger import SERVER_CLOUDAPI_WIRE_LOGGER

--- a/container_service_extension/right_bundle_manager.py
+++ b/container_service_extension/right_bundle_manager.py
@@ -4,7 +4,7 @@
 
 import pyvcloud.vcd.client as vcd_client
 
-from container_service_extension.cloudapi.constants import CLOUDAPI_VERSION_1_0_0  # noqa: E501
+from container_service_extension.cloudapi.constants import CloudApiVersion
 from container_service_extension.cloudapi.constants import CloudApiResource
 import container_service_extension.def_.utils as def_utils
 from container_service_extension.logger import NULL_LOGGER
@@ -37,7 +37,7 @@ class RightBundleManager():
             query_string = f"filter={filter_string}"
         response_body = self.cloudapi_client.do_request(
             method=RequestMethod.GET,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.RIGHT_BUNDLES}?{query_string}")  # noqa: E501
         right_bundles = response_body['values']
         if right_bundles and len(right_bundles) > 0:
@@ -51,6 +51,6 @@ class RightBundleManager():
             {"values": [{"id": self.cloudapi_client.get_org_urn_from_id(org_id)} for org_id in org_ids]}  # noqa: E501
         return self.cloudapi_client.do_request(
             method=RequestMethod.PUT,
-            cloudapi_version=CLOUDAPI_VERSION_1_0_0,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=relative_url,
             payload=payload)

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -526,7 +526,11 @@ class Service(object, metaclass=Singleton):
             for runtime_policy in shared_constants.CLUSTER_RUNTIME_PLACEMENT_POLICIES:  # noqa: E501
                 k8_runtime = shared_constants.RUNTIME_INTERNAL_NAME_TO_DISPLAY_NAME_MAP[runtime_policy]  # noqa: E501
                 try:
-                    placement_policy_name_to_href[k8_runtime] = cpm.get_vdc_compute_policy(runtime_policy, is_placement_policy=True)['href']  # noqa: E501
+                    placement_policy_name_to_href[k8_runtime] = \
+                        compute_policy_manager.get_cse_vdc_compute_policy(
+                            cpm,
+                            runtime_policy,
+                            is_placement_policy=True)['href']
                 except EntityNotFoundException:
                     pass
             self.config['placement_policy_hrefs'] = placement_policy_name_to_href  # noqa: E501
@@ -674,14 +678,19 @@ class Service(object, metaclass=Singleton):
                 # if policy name is not empty, stamp it on the template
                 if policy_name:
                     try:
-                        policy = cpm.get_vdc_compute_policy(policy_name=policy_name) # noqa: E501
+                        policy = \
+                            compute_policy_manager.get_cse_vdc_compute_policy(
+                                cpm, policy_name) # noqa: E501
                     except EntityNotFoundException:
                         # create the policy if it does not exist
                         msg = f"Creating missing compute policy " \
                               f"'{policy_name}'."
                         msg_update_callback.info(msg)
                         logger.SERVER_LOGGER.debug(msg)
-                        policy = cpm.add_vdc_compute_policy(policy_name=policy_name) # noqa: E501
+                        policy = \
+                            compute_policy_manager.add_cse_vdc_compute_policy(
+                                cpm,
+                                policy_name)
 
                     msg = f"Assigning compute policy '{policy_name}' to " \
                           f"template '{catalog_item_name}'."

--- a/container_service_extension/template_builder.py
+++ b/container_service_extension/template_builder.py
@@ -41,8 +41,10 @@ def assign_placement_policy_to_template(client, cse_placement_policy,
     cpm = compute_policy_manager.ComputePolicyManager(client,
                                                       log_wire=log_wire)
     try:
-        policy = cpm.get_vdc_compute_policy(cse_placement_policy,
-                                            is_placement_policy=True)
+        policy = compute_policy_manager.get_cse_vdc_compute_policy(
+            cpm,
+            cse_placement_policy,
+            is_placement_policy=True)
         task = cpm.assign_vdc_placement_policy_to_vapp_template_vms(
             policy['href'],
             org_name,


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* Refactor compute policy manager to use cloudapi version 2.0.0
* separate out cse prefixing form compute policy manager

Testing done:
* Checked paths which were affected by the change:
- `cse run`
- `cse template install`
- `cse upgrade`
- `cse install` (TODO for api version < 35)
- `vcd cse ovdc list`
- `vcd cse ovdc enable/disable`
- `vcd cse ovdc compute-policy list` (TODO)
- `vcd cse ovdc compute-policy add/remove` (TODO)

@rocknes @sahithi @ltimothy7 @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/801)
<!-- Reviewable:end -->
