### PR TITLE
[VCDA-1822] Remove duplicate code on template list cli

### DIFF
--- a/container_service_extension/client/cse.py
+++ b/container_service_extension/client/cse.py
@@ -17,6 +17,7 @@ from container_service_extension.client.native_cluster_api import NativeClusterA
 from container_service_extension.client.ovdc import Ovdc
 import container_service_extension.client.sample_generator as client_sample_generator  # noqa: E501
 from container_service_extension.client.system import System
+from container_service_extension.client.template import Template
 import container_service_extension.client.utils as client_utils
 from container_service_extension.exceptions import CseResponseError
 from container_service_extension.exceptions import CseServerNotRunningError
@@ -82,8 +83,8 @@ def list_templates(ctx):
     try:
         client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
-        cluster = Cluster(client)
-        result = cluster.get_templates()
+        template = Template(client)
+        result = template.get_templates()
         CLIENT_LOGGER.debug(result)
         value_field_to_display_field = {
             'name': 'Name',

--- a/container_service_extension/client/def_entity_cluster_api.py
+++ b/container_service_extension/client/def_entity_cluster_api.py
@@ -10,7 +10,6 @@ import yaml
 
 import container_service_extension.client.constants as cli_constants
 from container_service_extension.client.native_cluster_api import NativeClusterApi  # noqa: E501
-import container_service_extension.client.response_processor as response_processor  # noqa: E501
 import container_service_extension.client.tkg_cluster_api as tkg_cli_api
 import container_service_extension.client.tkgclient.rest as tkg_rest
 import container_service_extension.client.utils as client_utils
@@ -21,7 +20,6 @@ from container_service_extension.def_.utils import DEF_NATIVE_ENTITY_TYPE_VERSIO
 import container_service_extension.exceptions as cse_exceptions
 import container_service_extension.logger as logger
 import container_service_extension.pyvcloud_utils as vcd_utils
-import container_service_extension.shared_constants as shared_constants
 
 DUPLICATE_CLUSTER_ERROR_MSG = "Duplicate clusters found. Please use --k8-runtime for the unique identification"  # noqa: E501
 
@@ -327,19 +325,3 @@ class DefEntityClusterApi:
             cluster_dict = asdict(cluster)
             return self._nativeCluster.upgrade_cluster_by_cluster_id(cluster.id, cluster_def_entity=cluster_dict)  # noqa: E501
         self._tkgCluster.upgrade_cluster(cluster_name, template_name, template_revision)  # noqa: E501
-
-    def get_templates(self):
-        """Get the template information that are supported by api version 35.
-
-        :return: decoded response content, if status code is 2xx.
-        :rtype: dict
-        :raises CseResponseError: if response http status code is not 2xx
-        """
-        method = shared_constants.RequestMethod.GET
-        uri = f"{self._client.get_api_uri()}/{shared_constants.CSE_URL_FRAGMENT}/{shared_constants.CSE_3_0_URL_FRAGMENT}/templates"  # noqa: E501
-        response = self._client._do_request_prim(
-            method,
-            uri,
-            self._client._session,
-            accept_type='application/json')
-        return response_processor.process_response(response)

--- a/container_service_extension/client/legacy_native_cluster_api.py
+++ b/container_service_extension/client/legacy_native_cluster_api.py
@@ -12,16 +12,6 @@ class LegacyNativeClusterApi:
         self.client = client
         self._uri = f"{self.client.get_api_uri()}/{shared_constants.CSE_URL_FRAGMENT}"  # noqa: E501
 
-    def get_templates(self):
-        method = shared_constants.RequestMethod.GET
-        uri = f"{self._uri}/templates"
-        response = self.client._do_request_prim(
-            method,
-            uri,
-            self.client._session,
-            accept_type='application/json')
-        return process_response(response)
-
     def list_clusters(self, vdc=None, org=None):
         method = shared_constants.RequestMethod.GET
         uri = f"{self._uri}/clusters"

--- a/container_service_extension/client/template.py
+++ b/container_service_extension/client/template.py
@@ -1,0 +1,23 @@
+# container-service-extension
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from container_service_extension.client.response_processor \
+    import process_response
+import container_service_extension.shared_constants as shared_constants
+
+
+class Template:
+    def __init__(self, client):
+        self.client = client
+        self._uri = f"{self.client.get_api_uri()}/{shared_constants.CSE_URL_FRAGMENT}"  # noqa: E501
+
+    def get_templates(self):
+        method = shared_constants.RequestMethod.GET
+        uri = f"{self._uri}/templates"
+        response = self.client._do_request_prim(
+            method,
+            uri,
+            self.client._session,
+            accept_type='application/json')
+        return process_response(response)

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -75,7 +75,7 @@ Not dependent on API version
 GET /cse/system
 PUT /cse/system
 
-GET /cse/template
+GET /cse/templates
 
 GET /pks/clusters?org={org name}&vdc={vdc name}
 POST /pks/clusters
@@ -116,7 +116,6 @@ OPERATION_TO_HANDLER = {
     CseOperation.V35_OVDC_LIST: v35_ovdc_handler.ovdc_list,
     CseOperation.V35_OVDC_INFO: v35_ovdc_handler.ovdc_info,
     CseOperation.V35_OVDC_UPDATE: v35_ovdc_handler.ovdc_update,
-    CseOperation.V35_TEMPLATE_LIST: template_handler.template_list,
 
     CseOperation.OVDC_UPDATE: ovdc_handler.ovdc_update,
     CseOperation.OVDC_INFO: ovdc_handler.ovdc_info,
@@ -464,9 +463,6 @@ def _get_v35_url_data(method: str, url: str, api_version: str):
     if operation_type == shared_constants.OperationType.OVDC:
         return _get_v35_ovdc_url_data(method, tokens)
 
-    if operation_type == shared_constants.OperationType.TEMPLATE:
-        return _get_v35_template_data(method, tokens)
-
     raise cse_exception.NotFoundRequestError()
 
 
@@ -560,23 +556,6 @@ def _get_v35_ovdc_url_data(method: str, tokens: list):
                 _OPERATION_KEY: CseOperation.V35_OVDC_INFO,
                 shared_constants.RequestKey.OVDC_ID: tokens[5]
             }
-        raise cse_exception.MethodNotAllowedRequestError()
-
-
-def _get_v35_template_data(method: str, tokens: list):
-    """Parse tokens from url and http method to get v35 template specific data.
-
-    Returns a dictionary with operation and url data.
-
-    :param shared_constants.RequestMethod method: http verb
-    :param str[] tokens: http url
-
-    :rtype: dict
-    """
-    num_tokens = len(tokens)
-    if num_tokens == 5:
-        if method == shared_constants.RequestMethod.GET:
-            return {_OPERATION_KEY: CseOperation.V35_TEMPLATE_LIST}
         raise cse_exception.MethodNotAllowedRequestError()
 
 


### PR DESCRIPTION
- Getting template list is same for all vCD versions   
- Remove duplicate endpoint that is not used by plugin UI
- Removed redundant logic of handling template list from client side cluster code
- Removed processing url and related template handling logic from request processor

- Tests done for `vcd cse template list`:
vcd.api_version: 34.0
vcd.api_version: 35.0

@Anirudh9794 @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/804)
<!-- Reviewable:end -->
