### PR TITLE
[VCDA-1619] - Fix system tests, Add support for specifying selective templates to r…

### DIFF
--- a/container_service_extension/system_test_framework/environment.py
+++ b/container_service_extension/system_test_framework/environment.py
@@ -150,7 +150,21 @@ def init_environment(config_filepath=BASE_CONFIG_FILEPATH):
         TEARDOWN_INSTALLATION = test_config.get('teardown_installation', True)
         TEARDOWN_CLUSTERS = test_config.get('teardown_clusters', True)
         TEST_ALL_TEMPLATES = test_config.get('test_all_templates', False)
-
+        if not TEST_ALL_TEMPLATES:
+            specified_templates_str = test_config.get('test_templates', "")
+            specified_templates = specified_templates_str.split(",")
+            specified_templates_def = []
+            for template in specified_templates:
+                tokens = template.split(":")
+                # ToDo: log missing/bad specified templates
+                if len(tokens) == 2:
+                    template_name = tokens[0]
+                    template_revision = tokens[1]
+                    for template_def in TEMPLATE_DEFINITIONS:
+                        if (template_name, int(template_revision)) == (template_def['name'], int(template_def['revision'])):  # noqa: E501
+                            specified_templates_def.append(template_def)
+                            break
+            TEMPLATE_DEFINITIONS = specified_templates_def
 
 def cleanup_environment():
     if CLIENT is not None:

--- a/container_service_extension/system_test_framework/environment.py
+++ b/container_service_extension/system_test_framework/environment.py
@@ -166,6 +166,7 @@ def init_environment(config_filepath=BASE_CONFIG_FILEPATH):
                             break
             TEMPLATE_DEFINITIONS = specified_templates_def
 
+
 def cleanup_environment():
     if CLIENT is not None:
         CLIENT.logout()

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -11,11 +11,11 @@ test:
                                                            #   if false, do not delete test cluster on test failure.
                                                            #   if this key is omitted, defaults to true.
                                                            # Successful client tests will not leave clusters up.
-  test_all_templates: false                                # Affects test_cse_client.py.
+  test_all_templates: true                                 # Affects test_cse_client.py.
                                                            #   if true, tests cluster deployment on all templates found.
                                                            #   if false, tests cluster deployment only for first template found.
                                                            #   if this key is omitted, defaults to false.
-  test_templates: "ubuntu-16.04_k8-1.18_weave-2.6.5:1"     # Tests will only create these templates if test_all_templates is set to false
+  test_templates: "???"                                    # Tests will only create these templates if test_all_templates is set to false
                                                            #   format -> "template_1_name:template_1_revision,template_2_name:template_2_revision"
   upgrade_template_repo_url: '???'                         #
   network: '???'                                           # org network within @vdc that will be used during testing

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -2,25 +2,27 @@
 # Fill in fields marked with '???'
 
 test:
-  teardown_installation: true       # Affects test_cse_server.py.
-                                    #   if true, delete all installation entities (even on test failure).
-                                    #   if false, do not delete installation entities (even on test success).
-                                    #   if this key is omitted, defaults to true.
-  teardown_clusters: true           # Affects test_cse_client.py.
-                                    #   if true, delete test cluster (env.TEST_CLUSTER_NAME) on test failure.
-                                    #   if false, do not delete test cluster on test failure.
-                                    #   if this key is omitted, defaults to true.
-                                    # Successful client tests will not leave clusters up.
-  test_all_templates: false         # Affects test_cse_client.py.
-                                    #   if true, tests cluster deployment on all templates found.
-                                    #   if false, tests cluster deployment only for first template found.
-                                    #   if this key is omitted, defaults to false.
-  upgrade_template_repo_url: '???'  #
-  network: '???'                    # org network within @vdc that will be used during testing
-                                    #   Should have outbound access to the public internet
-  org: '???'                        # vCD org where all the test will be run
-  storage_profile: '???'            # name of the storage profile to use while creating clusters on this org vdc
-  vdc: '???'                        # Org VDC powering the org
+  teardown_installation: true                              # Affects test_cse_server.py.
+                                                           #   if true, delete all installation entities (even on test failure).
+                                                           #   if false, do not delete installation entities (even on test success).
+                                                           #   if this key is omitted, defaults to true.
+  teardown_clusters: true                                  # Affects test_cse_client.py.
+                                                           #   if true, delete test cluster (env.TEST_CLUSTER_NAME) on test failure.
+                                                           #   if false, do not delete test cluster on test failure.
+                                                           #   if this key is omitted, defaults to true.
+                                                           # Successful client tests will not leave clusters up.
+  test_all_templates: false                                # Affects test_cse_client.py.
+                                                           #   if true, tests cluster deployment on all templates found.
+                                                           #   if false, tests cluster deployment only for first template found.
+                                                           #   if this key is omitted, defaults to false.
+  test_templates: "ubuntu-16.04_k8-1.18_weave-2.6.5:1"     # Tests will only create these templates if test_all_templates is set to false
+                                                           #   format -> "template_1_name:template_1_revision,template_2_name:template_2_revision"
+  upgrade_template_repo_url: '???'                         #
+  network: '???'                                           # org network within @vdc that will be used during testing
+                                                           #   Should have outbound access to the public internet
+  org: '???'                                               # vCD org where all the test will be run
+  storage_profile: '???'                                   # name of the storage profile to use while creating clusters on this org vdc
+  vdc: '???'                                               # Org VDC powering the org
 
 amqp:
   exchange: test-exchange # cse exclusive exchange used by amqp server
@@ -35,7 +37,7 @@ amqp:
   vhost: /
 
 vcd:
-  api_version: '35.0'
+  api_version: '33.0'
   host: '???'
   log: true
   password: '???'

--- a/system_tests/test_cse_server.py
+++ b/system_tests/test_cse_server.py
@@ -296,6 +296,8 @@ def test_0080_install_skip_template_creation(config,
             'vApp exists when it should not.'
 
 
+@pytest.mark.skipif(not env.TEST_ALL_TEMPLATES,
+                    reason="Configuration specifies 'test_all_templates' as False")  # noqa: E501
 def test_0090_install_all_templates(config, unregister_cse_before_test):
     """Test install.
 
@@ -315,8 +317,6 @@ def test_0090_install_all_templates(config, unregister_cse_before_test):
     expected: cse registered, catalog exists, source ovas exist,
         temp vapps exist, k8s templates exist.
     """
-    if not env.TEST_ALL_TEMPLATES:
-        return
     cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
           f"{env.SSH_KEY_FILEPATH} --retain-temp-vapp --skip-config-decryption"
     result = env.CLI_RUNNER.invoke(cli, cmd.split(),
@@ -352,6 +352,8 @@ def test_0090_install_all_templates(config, unregister_cse_before_test):
             assert False, 'vApp does not exist when it should.'
 
 
+@pytest.mark.skipif(env.TEST_ALL_TEMPLATES,
+                    reason="Configuration specifies 'test_all_templates' as True")  # noqa: E501
 def test_0100_install_select_templates(config, unregister_cse_before_test):
     """Tests template installation.
 
@@ -365,9 +367,6 @@ def test_0100_install_select_templates(config, unregister_cse_before_test):
     expected: cse registered, source ovas exist, k8s templates exist and
         temp vapps exist.
     """
-    if env.TEST_ALL_TEMPLATES:
-        return
-
     cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
           f"{env.SSH_KEY_FILEPATH} --skip-template-creation " \
           f"--skip-config-decryption"

--- a/system_tests/test_cse_server.py
+++ b/system_tests/test_cse_server.py
@@ -291,16 +291,16 @@ def test_0080_install_skip_template_creation(config,
             'k8s templates exist when they should not.'
 
         # check that temp vapp does not exists
-        temp_vapp_name = testutils.get_temp_vapp_name(template_config['name'])  # noqa: E501
+        temp_vapp_name = testutils.get_temp_vapp_name(template_config['name'])
         assert not env.vapp_exists(temp_vapp_name), \
             'vApp exists when it should not.'
 
 
-def test_0090_install_retain_temp_vapp(config, unregister_cse_before_test):
+def test_0090_install_all_templates(config, unregister_cse_before_test):
     """Test install.
 
-    Installation options: '--template', '--ssh-key',
-        '--retain-temp-vapp', '--skip-config-decryption'.
+    Installation options: '--ssh-key', '--retain-temp-vapp',
+        '--skip-config-decryption'.
 
     Tests that installation:
     - downloads/uploads ova file,
@@ -369,7 +369,7 @@ def test_0100_install_select_templates(config, unregister_cse_before_test):
         return
 
     cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
-          f"{env.SSH_KEY_FILEPATH} --skip-template-creation --force-update " \
+          f"{env.SSH_KEY_FILEPATH} --skip-template-creation " \
           f"--skip-config-decryption"
     result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
     assert result.exit_code == 0,\
@@ -403,11 +403,14 @@ def test_0100_install_select_templates(config, unregister_cse_before_test):
         assert env.catalog_item_exists(catalog_item_name), \
             'k8s template does not exist when it should.'
 
-        # check that temp vapp does not exists
+        # check that temp vapp exists
         temp_vapp_name = testutils.get_temp_vapp_name(
             template_config['name'])
-        assert not env.vapp_exists(temp_vapp_name), \
-            'vApp exists when it should not.'
+        try:
+            vdc.reload()
+            vdc.get_vapp(temp_vapp_name)
+        except EntityNotFoundException:
+            assert False, 'vApp does not exist when it should.'
 
 
 def test_0110_cse_check_valid_installation(config):

--- a/system_tests/test_cse_server.py
+++ b/system_tests/test_cse_server.py
@@ -380,6 +380,7 @@ def test_0100_install_select_templates(config, unregister_cse_before_test):
     env.check_cse_registration(config['amqp']['routing_key'],
                                config['amqp']['exchange'])
 
+    vdc = VDC(env.CLIENT, href=env.VDC_HREF)
     for template_config in env.TEMPLATE_DEFINITIONS:
         # install the template
         cmd = f"template install {template_config['name']} " \

--- a/system_tests/test_cse_server.py
+++ b/system_tests/test_cse_server.py
@@ -248,52 +248,52 @@ def test_0070_check_invalid_installation(config):
     except Exception:
         pass
 
-# TODO() This will be fixed once upgrade command is implemented
-# def test_0080_install_skip_template_creation(config,
-#                                              unregister_cse_before_test):
-#     """Test install.
-#
-#     Installation options: '--ssh-key', '--skip-create-templates',
-#     '--skip-config-decryption'
-#
-#     Tests that installation:
-#     - registers CSE, without installing the templates
-#
-#     command: cse install --config cse_test_config.yaml
-#         --ssh-key ~/.ssh/id_rsa.pub --skip-config-decryption
-#         --skip-create-templates
-#     required files: ~/.ssh/id_rsa.pub, cse_test_config.yaml,
-#     expected: cse registered, catalog exists, source ovas do not exist,
-#         temp vapps do not exist, k8s templates do not exist.
-#     """
-#     cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
-#           f"{env.SSH_KEY_FILEPATH} --skip-template-creation " \
-#           f"--skip-config-decryption"
-#     result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
-#     assert result.exit_code == 0,\
-#         testutils.format_command_info('cse', cmd, result.exit_code,
-#                                       result.output)
-#
-#     # check that cse was registered correctly
-#     env.check_cse_registration(config['amqp']['routing_key'],
-#                                config['amqp']['exchange'])
-#
-#     for template_config in env.TEMPLATE_DEFINITIONS:
-#         # check that source ova file does not exist in catalog
-#         assert not env.catalog_item_exists(
-#             template_config['source_ova_name']), \
-#             'Source ova file exists when it should not.'
-#
-#         # check that k8s templates does not exist
-#         catalog_item_name = ltm.get_revisioned_template_name(
-#             template_config['name'], template_config['revision'])
-#         assert not env.catalog_item_exists(catalog_item_name), \
-#             'k8s templates exist when they should not.'
-#
-#         # check that temp vapp does not exists
-#         temp_vapp_name = testutils.get_temp_vapp_name(template_config['name'])  # noqa: E501
-#         assert not env.vapp_exists(temp_vapp_name), \
-#             'vApp exists when it should not.'
+
+def test_0080_install_skip_template_creation(config,
+                                             unregister_cse_before_test):
+    """Test install.
+
+    Installation options: '--ssh-key', '--skip-template-creation',
+    '--skip-config-decryption'
+
+    Tests that installation:
+    - registers CSE, without installing the templates
+
+    command: cse install --config cse_test_config.yaml
+        --ssh-key ~/.ssh/id_rsa.pub --skip-config-decryption
+        --skip-create-templates
+    required files: ~/.ssh/id_rsa.pub, cse_test_config.yaml,
+    expected: cse registered, catalog exists, source ovas do not exist,
+        temp vapps do not exist, k8s templates do not exist.
+    """
+    cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
+          f"{env.SSH_KEY_FILEPATH} --skip-template-creation " \
+          f"--skip-config-decryption"
+    result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0,\
+        testutils.format_command_info('cse', cmd, result.exit_code,
+                                      result.output)
+
+    # check that cse was registered correctly
+    env.check_cse_registration(config['amqp']['routing_key'],
+                               config['amqp']['exchange'])
+
+    for template_config in env.TEMPLATE_DEFINITIONS:
+        # check that source ova file does not exist in catalog
+        assert not env.catalog_item_exists(
+            template_config['source_ova_name']), \
+            'Source ova file exists when it should not.'
+
+        # check that k8s templates does not exist
+        catalog_item_name = ltm.get_revisioned_template_name(
+            template_config['name'], template_config['revision'])
+        assert not env.catalog_item_exists(catalog_item_name), \
+            'k8s templates exist when they should not.'
+
+        # check that temp vapp does not exists
+        temp_vapp_name = testutils.get_temp_vapp_name(template_config['name'])  # noqa: E501
+        assert not env.vapp_exists(temp_vapp_name), \
+            'vApp exists when it should not.'
 
 
 def test_0090_install_retain_temp_vapp(config, unregister_cse_before_test):
@@ -315,6 +315,8 @@ def test_0090_install_retain_temp_vapp(config, unregister_cse_before_test):
     expected: cse registered, catalog exists, source ovas exist,
         temp vapps exist, k8s templates exist.
     """
+    if not env.TEST_ALL_TEMPLATES:
+        return
     cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
           f"{env.SSH_KEY_FILEPATH} --retain-temp-vapp --skip-config-decryption"
     result = env.CLI_RUNNER.invoke(cli, cmd.split(),
@@ -349,50 +351,63 @@ def test_0090_install_retain_temp_vapp(config, unregister_cse_before_test):
         except EntityNotFoundException:
             assert False, 'vApp does not exist when it should.'
 
-# TODO() This will be fixed once upgrade command is implemented
-# def test_0100_install_force_update(config, unregister_cse_before_test):
-#     """Tests installation option: '--force-update'.
-#
-#     Tests that installation:
-#     - creates all templates correctly,
-#     - customizes temp vapps correctly.
-#
-#     command: cse install --config cse_test_config.yaml
-#         --ssh-key ~/.ssh/id_rsa.pub --force-update --skip-config-decryption
-#     required files: cse_test_config.yaml, ~/.ssh/id_rsa.pub,
-#         ubuntu/photon init/cust scripts
-#     expected: cse registered, source ovas exist, k8s templates exist and
-#         temp vapps don't exist.
-#     """
-#     cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
-#           f"{env.SSH_KEY_FILEPATH} --force-update --skip-config-decryption"
-#     result = env.CLI_RUNNER.invoke(
-#         cli, cmd.split(), catch_exceptions=False)
-#     assert result.exit_code == 0,\
-#         testutils.format_command_info('cse', cmd, result.exit_code,
-#                                       result.output)
-#
-#     # check that cse was registered correctly
-#     env.check_cse_registration(config['amqp']['routing_key'],
-#                                config['amqp']['exchange'])
-#
-#     for template_config in env.TEMPLATE_DEFINITIONS:
-#         # check that source ova file exists in catalog
-#         assert env.catalog_item_exists(
-#             template_config['source_ova_name']), \
-#             'Source ova file does not exists when it should.'
-#
-#         # check that k8s templates exist
-#         catalog_item_name = ltm.get_revisioned_template_name(
-#             template_config['name'], template_config['revision'])
-#         assert env.catalog_item_exists(catalog_item_name), \
-#             'k8s template does not exist when it should.'
-#
-#         # check that temp vapp does not exists
-#         temp_vapp_name = testutils.get_temp_vapp_name(
-#             template_config['name'])
-#         assert not env.vapp_exists(temp_vapp_name), \
-#             'vApp exists when it should not.'
+
+def test_0100_install_select_templates(config, unregister_cse_before_test):
+    """Tests template installation.
+
+    Tests that selected template installation is done correctly
+
+    command: cse template install template_name template_revision
+        --config cse_test_config.yaml --ssh-key ~/.ssh/id_rsa.pub
+        --skip-config-decryption --retain-temp-vapp
+    required files: cse_test_config.yaml, ~/.ssh/id_rsa.pub,
+        ubuntu/photon init/cust scripts
+    expected: cse registered, source ovas exist, k8s templates exist and
+        temp vapps exist.
+    """
+    if env.TEST_ALL_TEMPLATES:
+        return
+
+    cmd = f"install --config {env.ACTIVE_CONFIG_FILEPATH} --ssh-key " \
+          f"{env.SSH_KEY_FILEPATH} --skip-template-creation --force-update " \
+          f"--skip-config-decryption"
+    result = env.CLI_RUNNER.invoke(cli, cmd.split(), catch_exceptions=False)
+    assert result.exit_code == 0,\
+        testutils.format_command_info('cse', cmd, result.exit_code,
+                                      result.output)
+
+    # check that cse was registered correctly
+    env.check_cse_registration(config['amqp']['routing_key'],
+                               config['amqp']['exchange'])
+
+    for template_config in env.TEMPLATE_DEFINITIONS:
+        # install the template
+        cmd = f"template install {template_config['name']} " \
+              f"{template_config['revision']} " \
+              f"--config {env.ACTIVE_CONFIG_FILEPATH} " \
+              f"--ssh-key {env.SSH_KEY_FILEPATH} " \
+              f"--skip-config-decryption --force --retain-temp-vapp"
+        result = env.CLI_RUNNER.invoke(
+            cli, cmd.split(), catch_exceptions=False)
+        assert result.exit_code == 0,\
+            testutils.format_command_info('cse', cmd, result.exit_code,
+                                          result.output)
+        # check that source ova file exists in catalog
+        assert env.catalog_item_exists(
+            template_config['source_ova_name']), \
+            'Source ova file does not exists when it should.'
+
+        # check that k8s templates exist
+        catalog_item_name = ltm.get_revisioned_template_name(
+            template_config['name'], template_config['revision'])
+        assert env.catalog_item_exists(catalog_item_name), \
+            'k8s template does not exist when it should.'
+
+        # check that temp vapp does not exists
+        temp_vapp_name = testutils.get_temp_vapp_name(
+            template_config['name'])
+        assert not env.vapp_exists(temp_vapp_name), \
+            'vApp exists when it should not.'
 
 
 def test_0110_cse_check_valid_installation(config):


### PR DESCRIPTION
Update system tests to account for changes in `cse install` in CSE 3.0 viz. the command will fail in brown field deployments.
Add capability in the framework to work with a subset of K8s templates specified by test runner.

Testing Done:
Ran both server and client test with just 1 template specified in the config file. All tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/805)
<!-- Reviewable:end -->
