### PR TITLE
[VCDA-1897] sample generator with  MQTT section

### DIFF
--- a/container_service_extension/sample_generator.py
+++ b/container_service_extension/sample_generator.py
@@ -137,9 +137,6 @@ SAMPLE_BROKER_CONFIG = {
 }
 
 TEMPLATE_RULE_NOTE = """# [Optional] Template rule section
-# Note : Template rules are only supported when CSE server is started with
-# vCD api v33.0 or v34.0.
-#
 # Rules can be defined to override template definitions as defined by remote
 # template cookbook.
 # Any rule defined in this section can match exactly one template.
@@ -172,7 +169,7 @@ TEMPLATE_RULE_NOTE = """# [Optional] Template rule section
 """  # noqa: E501
 
 COMMENTED_AMQP_SECTION = """\
-# Only one of the amqp of mqtt sections should be present.
+# Only one of the amqp or mqtt sections should be present.
 
 #amqp:
 #  exchange: cse-ext
@@ -343,7 +340,7 @@ def generate_sample_config(output=None, generate_pks_config=False,
                                         default_flow_style=False) + '\n'
         sample_config += yaml.safe_dump(SAMPLE_BROKER_CONFIG,
                                         default_flow_style=False) + '\n'
-        if api_version < MQTT_MIN_API_VERSION:
+        if api_version < 35.0:
             sample_config += TEMPLATE_RULE_NOTE + '\n'
     else:
         sample_config = yaml.safe_dump(

--- a/container_service_extension/sample_generator.py
+++ b/container_service_extension/sample_generator.py
@@ -317,7 +317,8 @@ def generate_sample_config(output=None, generate_pks_config=False,
 
     :rtype: dict
     """
-    if str(api_version) not in SUPPORTED_VCD_API_VERSIONS:
+    api_version_str = str(api_version)
+    if api_version_str not in SUPPORTED_VCD_API_VERSIONS:
         raise Exception(f'vCD API version {api_version} is not supported. '
                         f'Please pick one of the following API versions: '
                         f'{SUPPORTED_VCD_API_VERSIONS}')
@@ -332,7 +333,7 @@ def generate_sample_config(output=None, generate_pks_config=False,
                                            default_flow_style=False) + '\n'
 
         api_version_vcd_config = dict(SAMPLE_VCD_CONFIG)
-        api_version_vcd_config['vcd']['api_version'] = str(api_version)
+        api_version_vcd_config['vcd']['api_version'] = api_version_str
         sample_config += yaml.safe_dump(api_version_vcd_config,
                                         default_flow_style=False) + '\n'
         sample_config += yaml.safe_dump(SAMPLE_VCS_CONFIG,

--- a/container_service_extension/sample_generator.py
+++ b/container_service_extension/sample_generator.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+from pyvcloud.vcd.client import ApiVersion
 import yaml
 
 from container_service_extension.server_constants import MQTT_MIN_API_VERSION
@@ -87,7 +88,7 @@ SAMPLE_VCD_CONFIG = {
         'port': 443,
         'username': 'administrator',
         'password': 'my_secret_password',
-        'api_version': '35.0',
+        'api_version': ApiVersion.VERSION_35.value,
         'verify': True,
         'log': True
     }
@@ -340,7 +341,7 @@ def generate_sample_config(output=None, generate_pks_config=False,
                                         default_flow_style=False) + '\n'
         sample_config += yaml.safe_dump(SAMPLE_BROKER_CONFIG,
                                         default_flow_style=False) + '\n'
-        if api_version < 35.0:
+        if api_version < float(ApiVersion.VERSION_35.value):
             sample_config += TEMPLATE_RULE_NOTE + '\n'
     else:
         sample_config = yaml.safe_dump(

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -325,7 +325,17 @@ def version(ctx):
     '--pks-config',
     is_flag=True,
     help='Generate only sample PKS config')
-def sample(ctx, output, pks_config):
+@click.option(
+    '-v',
+    '--api-version',
+    'api_version',
+    required=False,
+    default='35.0',
+    show_default=True,
+    metavar='API_VERSION',
+    help='Specify vCD API version: (33.0, 34.0, 35.0). '
+         'Note: Not needed if only generating PKS config.')
+def sample(ctx, output, pks_config, api_version):
     """Display sample CSE config file contents."""
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
     console_message_printer = ConsoleMessagePrinter()
@@ -333,8 +343,22 @@ def sample(ctx, output, pks_config):
     # check, because we want to suppress the version check messages from being
     # printed onto console, and pollute the sample config.
     check_python_version()
-    sample_config = generate_sample_config(output=output,
-                                           generate_pks_config=pks_config)
+
+    try:
+        api_version = float(api_version)
+    except ValueError as err:
+        console_message_printer.error(str(err))
+        SERVER_CLI_LOGGER.error(str(err))
+        sys.exit(1)
+
+    try:
+        sample_config = generate_sample_config(output=output,
+                                               generate_pks_config=pks_config,
+                                               api_version=api_version)
+    except Exception as err:
+        console_message_printer.error(str(err))
+        SERVER_CLI_LOGGER.error(str(err))
+        sys.exit(1)
 
     console_message_printer.general_no_color(sample_config)
     SERVER_CLI_LOGGER.debug(sample_config)

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -39,6 +39,7 @@ from container_service_extension.remote_template_manager import RemoteTemplateMa
 from container_service_extension.sample_generator import generate_sample_config
 from container_service_extension.server_constants import LocalTemplateKey
 from container_service_extension.server_constants import RemoteTemplateKey
+from container_service_extension.server_constants import SUPPORTED_VCD_API_VERSIONS  # noqa: E501
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
 import container_service_extension.service as cse_service
 from container_service_extension.shared_constants import ClusterEntityKind
@@ -330,11 +331,11 @@ def version(ctx):
     '--api-version',
     'api_version',
     required=False,
-    default='35.0',
+    default=vcd_client.ApiVersion.VERSION_35.value,
     show_default=True,
     metavar='API_VERSION',
-    help='Specify vCD API version: (33.0, 34.0, 35.0). '
-         'Note: Not needed if only generating PKS config.')
+    help=f'vCD API version: {SUPPORTED_VCD_API_VERSIONS}. '
+         f'Not needed if only generating PKS config.')
 def sample(ctx, output, pks_config, api_version):
     """Display sample CSE config file contents."""
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
@@ -346,12 +347,6 @@ def sample(ctx, output, pks_config, api_version):
 
     try:
         api_version = float(api_version)
-    except ValueError as err:
-        console_message_printer.error(str(err))
-        SERVER_CLI_LOGGER.error(str(err))
-        sys.exit(1)
-
-    try:
         sample_config = generate_sample_config(output=output,
                                                generate_pks_config=pks_config,
                                                api_version=api_version)


### PR DESCRIPTION
Signed-off-by: ltimothy <ltimothy@vmware.com>

To help us process your pull request efficiently, please include: 

- (Required) Short description of changes in the PR topic line
Added MQTT section for sample generator.

- (Required) Detailed description of changes include tests and
  documentation.  If the pull request contains multiple commits with 
  detailed messages, refer to those instead
The cse sample command now supports a version flag. For vcd API versions 33 and 34, the config file is unchanged. For version 35, there is a new MQTT section with the AMQP section commented out and a commend specifying that only one of the message protocol sections should be used.

I have checked the output sample configurations for api versions 33, 34, and 35 and the help string for `cse sample`.


- (Optional) Names of reviewers using @ sign + name
@rocknes @sakthisunda @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/810)
<!-- Reviewable:end -->
