### PR TITLE
Allow upgrade from 3.0.x to 3.0.1

### DIFF
--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -1296,11 +1296,11 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
         # CSE version info in extension description is only applicable for
         # CSE 2.6.02b.dev and CSE 3.0.0+ versions.
         cse_2_6_any_patch = semantic_version.SimpleSpec('>=2.6.0,<2.7.0')
-        cse_3_0_0 = semantic_version.Version('3.0.0')
+        cse_3_0_any_previous_patch = semantic_version.SimpleSpec('>=3.0.0,<=3.0.1')  # noqa: E501
         allow_upgrade = \
             ext_cse_version == server_constants.UNKNOWN_CSE_VERSION or \
             cse_2_6_any_patch.match(ext_cse_version) or \
-            ext_cse_version == cse_3_0_0
+            cse_3_0_any_previous_patch.match(ext_cse_version)
 
         if not allow_upgrade:
             raise Exception(update_path_not_valid_msg)


### PR DESCRIPTION
Enabling the upgrade path from CSE 3.0.x to 3.0.1

Testing Done:
Ran cse upgrade on a CSE 3.0.1 installation (api v35.0) and the upgrade went through fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/811)
<!-- Reviewable:end -->
