### PR TITLE
[VCDA-1919] Add ACL to the System Org while registering the defined entity schema

### DIFF
--- a/container_service_extension/cloudapi/constants.py
+++ b/container_service_extension/cloudapi/constants.py
@@ -25,3 +25,4 @@ class CloudApiResource(str, Enum):
     ENTITIES = 'entities'
     ENTITY_RESOLVE = 'resolve'
     RIGHT_BUNDLES = 'rightsBundles'
+    ACL = 'accessControls'

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -658,6 +658,7 @@ def _register_cse_as_amqp_extension(client, routing_key, exchange,
 def _update_user_role_with_right_bundle(right_bundle_name,
                                         client: Client,
                                         msg_update_callback=utils.NullPrinter(), # noqa: E501
+                                        logger_debug=NULL_LOGGER,
                                         log_wire=False):
     """Add defined entity rights to user's role.
 
@@ -681,7 +682,7 @@ def _update_user_role_with_right_bundle(right_bundle_name,
     logger_wire = SERVER_CLOUDAPI_WIRE_LOGGER if log_wire else NULL_LOGGER
     cloudapi_client = \
         vcd_utils.get_cloudapi_client_from_vcd_client(client=client,
-                                                      logger_debug=INSTALL_LOGGER, # noqa: E501
+                                                      logger_debug=logger_debug, # noqa: E501
                                                       logger_wire=logger_wire) # noqa: E501
 
     # Determine role name for the user
@@ -724,8 +725,8 @@ def _update_user_role_with_right_bundle(right_bundle_name,
 
     msg = "Updated user-role: " + str(role_name) + " with Rights-bundle: " + \
         str(right_bundle_name)
-    msg_update_callback.info(msg)
-    INSTALL_LOGGER.info(msg)
+    msg_update_callback.general(msg)
+    logger_debug.info(msg)
 
     return True
 
@@ -794,7 +795,18 @@ def _register_def_schema(client: Client,
         except cse_exception.DefSchemaServiceError:
             # TODO handle this part only if the entity type was not found
             native_entity_type = schema_svc.create_entity_type(native_entity_type)  # noqa: E501
-            msg = "Successfully registered defined entity type"
+            msg = "Successfully registered defined entity type\n"
+
+            entity_svc = def_entity_svc.DefEntityService(cloudapi_client)
+            entity_svc.create_acl_for_entity(
+                native_entity_type.get_id(),
+                grant_type=server_constants.AclGrantType.MembershipACLGrant,
+                access_level_id=server_constants.AclAccessLevelId.AccessLevelReadWrite, # noqa: E501
+                member_id=server_constants.AclMemberId.SystemOrgId)
+            msg += "Successfully added ReadWrite ACL for native defined entity"
+
+        msg_update_callback.general(msg)
+        INSTALL_LOGGER.info(msg)
 
         # Update user's role with right bundle associated with native defined
         # entity
@@ -802,6 +814,7 @@ def _register_def_schema(client: Client,
                 def_utils.DEF_NATIVE_ENTITY_TYPE_RIGHT_BUNDLE,
                 client=client,
                 msg_update_callback=msg_update_callback,
+                logger_debug=INSTALL_LOGGER,
                 log_wire=log_wire)):
             # Given that Rights for the current user have been updated, CSE
             # should logout the user and login again.
@@ -812,9 +825,6 @@ def _register_def_schema(client: Client,
                                                 server_constants.SYSTEM_ORG_NAME, # noqa: E501
                                                 config['vcd']['password'])
             client.set_credentials(credentials)
-
-        msg_update_callback.general(msg)
-        INSTALL_LOGGER.info(msg)
     except cse_exception.DefNotSupportedException:
         msg = "Skipping defined entity type and defined entity interface" \
               " registration"

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -803,7 +803,7 @@ def _register_def_schema(client: Client,
                 grant_type=server_constants.AclGrantType.MembershipACLGrant,
                 access_level_id=server_constants.AclAccessLevelId.AccessLevelReadWrite, # noqa: E501
                 member_id=server_constants.AclMemberId.SystemOrgId)
-            msg += "Successfully added ReadWrite ACL for native defined entity"
+            msg += "Successfully added ReadWrite ACL for native defined entity to System Org" # noqa: E501
 
         msg_update_callback.general(msg)
         INSTALL_LOGGER.info(msg)

--- a/container_service_extension/def_/entity_service.py
+++ b/container_service_extension/def_/entity_service.py
@@ -183,6 +183,35 @@ class DefEntityService():
         return DefEntity(**response_body)
 
     @handle_entity_service_exception
+    def create_acl_for_entity(self,
+                              id: str,
+                              grant_type: str,
+                              access_level_id: str,
+                              member_id: str):
+        """Create ACL Rule for the Entity.
+
+        :param str id: Id of the Entity
+        :param str grant_type: if acl grant is based on memberships or
+        entitlements
+        :param str access_level_id: level of access which the
+        subject will be granted.
+        param str member_id: member id, this access control grant applies to
+        """
+        acl_details = {}
+        acl_details['grantType'] = grant_type
+        acl_details['accessLevelId'] = access_level_id
+        acl_details['memberId'] = member_id
+
+        self._cloudapi_client.do_request(
+            method=RequestMethod.POST,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
+            resource_url_relative_path=f"{CloudApiResource.ENTITIES}/"
+                                       f"{id}/"
+                                       f"{CloudApiResource.ACL}/",
+            payload=acl_details)
+        return
+
+    @handle_entity_service_exception
     def get_native_entity_by_name(self, name: str, filters: dict = {}) -> DefEntity:  # noqa: E501
         """Get Native cluster defined entity by its name.
 

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -306,11 +306,28 @@ class ExtensionType(str, Enum):
     NONE = 'None'
 
 
+@unique
+class AclGrantType(str, Enum):
+    MembershipACLGrant = "MembershipAccessControlGrant"
+
+
+@unique
+class AclAccessLevelId(str, Enum):
+    AccessLevelReadWrite = "urn:vcloud:accessLevel:ReadWrite"
+
+
+@unique
+class AclMemberId(str, Enum):
+    SystemOrgId = "urn:vcloud:org:a93c9db9-7471-3192-8d09-a8f7eeda85f9"
+
+
 # CSE Service Role Name
 CSE_SERVICE_ROLE_NAME = 'CSE Service Role'
 CSE_SERVICE_ROLE_DESC = "CSE Service Role has all the rights necessary for \
         CSE to operate"
 CSE_SERVICE_ROLE_RIGHTS = [
+    "Access Control List: View",
+    "Access Control List: Manage",
     "AMQP Settings: View",
     "Catalog: Add vApp from My Cloud",
     "Catalog: Create / Delete a Catalog",


### PR DESCRIPTION


During CSE install/upgrade operation, if we endup creating a Native
defined Entity, we also need to publish access to this defined entity to
other users in System Org. In order to get this done, we need to setup an ACL
entry allowing other users to access the native defined entity.

This patch takes care of above functionality.

Signed-off-by: Chintan Shah <schintan@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/823)
<!-- Reviewable:end -->
