### PR TITLE
[PR] Fixed Broken server system tests

### DIFF
--- a/system_tests/test_cse_client.py
+++ b/system_tests/test_cse_client.py
@@ -294,16 +294,16 @@ def delete_test_clusters():
     Teardown tasks (only if config key 'teardown_clusters'=True):
     - Delete test cluster vApp
     """
-    env.delete_vapp(env.SYS_ADMIN_TEST_CLUSTER_NAME)
-    env.delete_vapp(env.ORG_ADMIN_TEST_CLUSTER_NAME)
-    env.delete_vapp(env.VAPP_AUTHOR_TEST_CLUSTER_NAME)
+    env.delete_vapp(env.SYS_ADMIN_TEST_CLUSTER_NAME, vdc_href=env.TEST_VDC_HREF)  # noqa
+    env.delete_vapp(env.ORG_ADMIN_TEST_CLUSTER_NAME, vdc_href=env.TEST_VDC_HREF)  # noqa
+    env.delete_vapp(env.VAPP_AUTHOR_TEST_CLUSTER_NAME, vdc_href=env.TEST_VDC_HREF)  # noqa
 
     yield
 
     if env.TEARDOWN_CLUSTERS:
-        env.delete_vapp(env.SYS_ADMIN_TEST_CLUSTER_NAME)
-        env.delete_vapp(env.ORG_ADMIN_TEST_CLUSTER_NAME)
-        env.delete_vapp(env.VAPP_AUTHOR_TEST_CLUSTER_NAME)
+        env.delete_vapp(env.SYS_ADMIN_TEST_CLUSTER_NAME, vdc_href=env.TEST_VDC_HREF)  # noqa
+        env.delete_vapp(env.ORG_ADMIN_TEST_CLUSTER_NAME, vdc_href=env.TEST_VDC_HREF)  # noqa
+        env.delete_vapp(env.VAPP_AUTHOR_TEST_CLUSTER_NAME, vdc_href=env.TEST_VDC_HREF)  # noqa
 
 
 def test_0010_vcd_cse_version():
@@ -341,7 +341,8 @@ def test_0030_vcd_cse_cluster_create_rollback(config, vcd_org_admin,
                                       result.output)
     # TODO: Make cluster rollback delete call blocking
     time.sleep(env.WAIT_INTERVAL * 2)  # wait for vApp to be deleted
-    assert not env.vapp_exists(env.SYS_ADMIN_TEST_CLUSTER_NAME), \
+    assert not env.vapp_exists(
+        env.SYS_ADMIN_TEST_CLUSTER_NAME, vdc_href=env.TEST_VDC_HREF), \
         "Cluster exists when it should not."
 
     cmd += " --disable-rollback"
@@ -349,7 +350,8 @@ def test_0030_vcd_cse_cluster_create_rollback(config, vcd_org_admin,
     assert result.exit_code == 0,\
         testutils.format_command_info('vcd', cmd, result.exit_code,
                                       result.output)
-    assert env.vapp_exists(env.SYS_ADMIN_TEST_CLUSTER_NAME), \
+    assert env.vapp_exists(env.SYS_ADMIN_TEST_CLUSTER_NAME,
+                           vdc_href=env.TEST_VDC_HREF), \
         "Cluster does not exist when it should."
 
 
@@ -407,7 +409,8 @@ def test_0050_vcd_cse_system_toggle(config, test_runner_username,
 
     execute_commands(cmd_list)
 
-    assert not env.vapp_exists(env.SYS_ADMIN_TEST_CLUSTER_NAME), \
+    assert not env.vapp_exists(env.SYS_ADMIN_TEST_CLUSTER_NAME,
+                               vdc_href=env.TEST_VDC_HREF), \
         "Cluster exists when it should not."
 
 
@@ -448,7 +451,8 @@ def test_0070_vcd_cse_cluster_create(config, test_runner_username):
     execute_commands(cmd_list)
 
     assert env.vapp_exists(
-        env.USERNAME_TO_CLUSTER_NAME[test_runner_username]),\
+        env.USERNAME_TO_CLUSTER_NAME[test_runner_username],
+        vdc_href=env.TEST_VDC_HREF), \
         f"Cluster {env.USERNAME_TO_CLUSTER_NAME[test_runner_username]} " \
         f"should exist"
     print(f"Successfully created cluster {env.USERNAME_TO_CLUSTER_NAME[test_runner_username]} "  # noqa
@@ -742,7 +746,7 @@ def test_0130_vcd_cse_cluster_delete(config):
     execute_commands(cmd_list)
 
     for cluster_name in env.USERNAME_TO_CLUSTER_NAME.values():
-        assert not env.vapp_exists(cluster_name), \
+        assert not env.vapp_exists(cluster_name, vdc_href=env.TEST_VDC_HREF), \
             f"Cluster {cluster_name} exists when it should not"
     print("Successfully deleted clusters.")
 

--- a/system_tests/test_cse_server.py
+++ b/system_tests/test_cse_server.py
@@ -71,7 +71,7 @@ def _remove_cse_artifacts():
             template['name'], template['revision'])
         env.delete_catalog_item(catalog_item_name)
         temp_vapp_name = testutils.get_temp_vapp_name(template['name'])
-        env.delete_vapp(temp_vapp_name)
+        env.delete_vapp(temp_vapp_name, vdc_href=env.VDC_HREF)
     env.delete_catalog()
     env.unregister_cse()
 
@@ -292,7 +292,7 @@ def test_0080_install_skip_template_creation(config,
 
         # check that temp vapp does not exists
         temp_vapp_name = testutils.get_temp_vapp_name(template_config['name'])
-        assert not env.vapp_exists(temp_vapp_name), \
+        assert not env.vapp_exists(temp_vapp_name, vdc_href=env.VDC_HREF), \
             'vApp exists when it should not.'
 
 


### PR DESCRIPTION
- Fixed broken catalog and vapp urls for server tests (Caused by [VCDA-1906] system-tests-in-test-org-context).  
- Make separate org and vdc href each for server and client tests
- Client tests use test org and vdc href
- Server tests use broker's org and href that hosts the catalog
- Server tests passed
- Client tests passed 
---------------
 
![image](https://user-images.githubusercontent.com/5530442/99611889-52d83b00-29c9-11eb-805b-e640f6805f78.png)

![image](https://user-images.githubusercontent.com/5530442/99611951-726f6380-29c9-11eb-9b04-fbf27e12094d.png)

     
@Anirudh9794 @rocknes @andrew-ni 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/838)
<!-- Reviewable:end -->
