### PR TITLE
[VCDA-1908] Reorder CSE installation steps, to make `creation of extension` the last step

### DIFF
--- a/container_service_extension/telemetry/telemetry_utils.py
+++ b/container_service_extension/telemetry/telemetry_utils.py
@@ -95,7 +95,9 @@ def get_telemetry_instance_id(config_dict, logger_debug=NULL_LOGGER,
                 ext_version=MQTT_EXTENSION_VERSION,
                 ext_vendor=MQTT_EXTENSION_VENDOR)
             if not ext_info:
+                logger_debug.debug("Failed to retrieve telemetry instance id")
                 return None
+            logger_debug.debug("Retrieved telemetry instance id")
             return mqtt_ext_manager.get_extension_uuid(
                 ext_info[MQTTExtKey.EXT_URN_ID])
         else:
@@ -103,7 +105,7 @@ def get_telemetry_instance_id(config_dict, logger_debug=NULL_LOGGER,
             ext = APIExtension(client)
             cse_info = ext.get_extension_info(CSE_SERVICE_NAME,
                                               namespace=CSE_SERVICE_NAMESPACE)
-            logger_debug.info("Retrieved telemetry instance id")
+            logger_debug.debug("Retrieved telemetry instance id")
             return cse_info.get('id')
     except Exception as err:
         msg = f"Cannot retrieve telemetry instance id:{err}"


### PR DESCRIPTION
During CSE installation, the extension is registered before any of the other installation steps are preformed (viz. catalog creation, right registration, policy registration etc.). As a result of this if the installation fails midway, we won't be able to run `cse install` again, and to make matter worse since the `cse install`-ation process didn't complete, the next run of `cse upgrade` can fail due to lacking infra e.g. catalog.

To fix this issue, we are moving registration of CSE extension to be the last step during CSE installation, thereby guaranteeing that upgrade will be possible only when a valid CSE installation is in place.

Testing done:
Interrupted CSE install midway and verified that 
1. `cse install` can be triggered again and that it runs to completion.
2. `cse upgrade` can't be triggered in this particular case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/840)
<!-- Reviewable:end -->
