### PR TITLE
[VCDA-1950] Fix missing value telemetry recording ovdc enable/disable (v35)

### DIFF
--- a/container_service_extension/client/policy_based_ovdc.py
+++ b/container_service_extension/client/policy_based_ovdc.py
@@ -57,6 +57,7 @@ class PolicyBasedOvdc:
                 runtimes.remove(k)
         updated_ovdc = def_models.Ovdc(
             k8s_runtime=runtimes,
+            org_name=org_name,
             remove_cp_from_vms_on_disable=remove_cp_from_vms_on_disable)
         return self._ovdc_api.update_ovdc(ovdc_id, updated_ovdc)
 

--- a/container_service_extension/def_/models.py
+++ b/container_service_extension/def_/models.py
@@ -297,4 +297,5 @@ class Ovdc:
     k8s_runtime: List[str]
     ovdc_name: str = None
     ovdc_id: str = None
+    org_name: str = None
     remove_cp_from_vms_on_disable: bool = False

--- a/container_service_extension/def_/ovdc_service.py
+++ b/container_service_extension/def_/ovdc_service.py
@@ -78,6 +78,7 @@ def update_ovdc(operation_context: ctx.OperationContext,
                                               policy_list=policy_list, # noqa:E501
                                               ovdc_id=ovdc_id,
                                               vdc=vdc,
+                                              org_name=ovdc_spec.org_name,
                                               remove_cp_from_vms_on_disable=ovdc_spec.remove_cp_from_vms_on_disable) # noqa:E501
     return {'task_href': task_href}
 
@@ -196,6 +197,7 @@ def _update_ovdc_using_placement_policy_async(operation_context: ctx.OperationCo
                                               policy_list,
                                               ovdc_id,
                                               vdc,
+                                              org_name,
                                               remove_cp_from_vms_on_disable=False):  # noqa: E501
     """Enable ovdc using placement policies.
 
@@ -207,6 +209,7 @@ def _update_ovdc_using_placement_policy_async(operation_context: ctx.OperationCo
         the ovdc
     :param str ovdc_id:
     :param pyvcloud.vcd.vdc.VDC vdc: VDC object
+    :param str org_name: name of the organization that vdc provides resource
     :param bool remove_cp_from_vms_on_disable: Set to true if placement
         policies need to be removed from the vms before removing from the VDC.
     """
@@ -235,6 +238,7 @@ def _update_ovdc_using_placement_policy_async(operation_context: ctx.OperationCo
             cse_params = {
                 RequestKey.K8S_PROVIDER: k8s_runtimes_added,
                 RequestKey.OVDC_ID: ovdc_id,
+                RequestKey.ORG_NAME: org_name
             }
             telemetry_handler.record_user_action_details(cse_operation=CseOperation.OVDC_ENABLE, # noqa: E501
                                                          cse_params=cse_params)
@@ -246,6 +250,7 @@ def _update_ovdc_using_placement_policy_async(operation_context: ctx.OperationCo
             cse_params = {
                 RequestKey.K8S_PROVIDER: k8s_runtimes_deleted,
                 RequestKey.OVDC_ID: ovdc_id,
+                RequestKey.ORG_NAME: org_name,
                 RequestKey.REMOVE_COMPUTE_POLICY_FROM_VMS: remove_cp_from_vms_on_disable # noqa: E501
             }
             telemetry_handler.record_user_action_details(cse_operation=CseOperation.OVDC_DISABLE, # noqa: E501

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -7,7 +7,7 @@ from enum import unique
 
 # End point of Vmware telemetry staging server
 # TODO() : This URL should reflect production server during release
-VAC_URL = "https://vcsa.vmware.com/ph/api/hyper/send"
+VAC_URL = "https://vcsa.vmware.com/ph-stg/api/hyper/send/"
 
 # Value of collector id that is required as part of HTTP request
 # to post sample data to telemetry server


### PR DESCRIPTION
- Restore recording `was_org_specified ` column in ovdc enable/disable for v35 
- Since org_name is not passed to the backend, it always record a 'false' value for `was_org_specified ` in table : `cse_ovdc_enable` and `cse_ovdc_disable` . This fix passes `org_name` to the back end telemetry payload constuction.
- Tested with VAC(telemetry) staging database
****cse_ovdc_enable****
![image](https://user-images.githubusercontent.com/5530442/100948509-d8291880-34bc-11eb-90f3-9be5c5affc07.png)
****cse_ovdc_disable****
![image](https://user-images.githubusercontent.com/5530442/100948546-ec6d1580-34bc-11eb-8971-75a39c5decfd.png)

@Anirudh9794 @rocknes @ltimothy7 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/844)
<!-- Reviewable:end -->
