### PR TITLE
[VCDA-1955] Update and resolve entity with correct status before syncing def entity

### DIFF
--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1277,8 +1277,9 @@ class ClusterService(abstract_broker.AbstractBroker):
             # and fail the operation.
             def_entity.entity.status.phase = \
                 str(DefEntityPhase(op, DefEntityOperationStatus.FAILED))
-            self._sync_def_entity(cluster_id, def_entity)
+            self.entity_svc.update_entity(cluster_id, def_entity)
             self.entity_svc.resolve_entity(cluster_id)
+            self._sync_def_entity(cluster_id, def_entity)
         except Exception as err:
             msg = f"Failed to resolve defined entity for cluster {cluster_id}"
             LOGGER.error(f"{msg}", exc_info=True)


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* If sync defined entity fails, the cluster defined entity will be stuck in a busy state forever

Solution:
* Update defined entity with failed status before syncing with vapp

Testing done:
* cluster create
* cluster delete
* cluster resize

@rocknes @sakthisunda @ChintanShahVMware @arunmk @ltimothy7 @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/845)
<!-- Reviewable:end -->
