### PR TITLE
[VCDE-986]: Migrate to pika 1.1.0

### DIFF
--- a/container_service_extension/config_validator.py
+++ b/container_service_extension/config_validator.py
@@ -218,7 +218,6 @@ def _validate_amqp_config(amqp_dict, msg_update_callback=NullPrinter()):
                                            amqp_dict['port'],
                                            amqp_dict['vhost'],
                                            credentials,
-                                           ssl=amqp_dict['ssl'],
                                            connection_attempts=3,
                                            retry_delay=2,
                                            socket_timeout=5)

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -147,7 +147,6 @@ def _check_amqp_extension_installation(client, config, msg_update_callback,
                                         amqp['password'])
     parameters = pika.ConnectionParameters(amqp['host'], amqp['port'],
                                            amqp['vhost'], credentials,
-                                           ssl=amqp['ssl'],
                                            connection_attempts=3,
                                            retry_delay=2,
                                            socket_timeout=5)
@@ -381,7 +380,7 @@ def install_cse(config_file_name, config, skip_template_creation,
             # create amqp exchange if it doesn't exist
             amqp = config['amqp']
             _create_amqp_exchange(amqp['exchange'], amqp['host'], amqp['port'],
-                                  amqp['vhost'], amqp['ssl'], amqp['username'],
+                                  amqp['vhost'], amqp['username'],
                                   amqp['password'],
                                   msg_update_callback=msg_update_callback)
 
@@ -543,7 +542,7 @@ def _register_cse_as_mqtt_extension(client, target_vcd_api_version,
     INSTALL_LOGGER.info(mqtt_msg)
 
 
-def _create_amqp_exchange(exchange_name, host, port, vhost, use_ssl,
+def _create_amqp_exchange(exchange_name, host, port, vhost,
                           username, password,
                           msg_update_callback=utils.NullPrinter()):
     """Create the specified AMQP exchange if it does not exist.
@@ -554,7 +553,6 @@ def _create_amqp_exchange(exchange_name, host, port, vhost, use_ssl,
     :param str host: AMQP host name.
     :param str password: AMQP password.
     :param int port: AMQP port number.
-    :param bool use_ssl: Enable ssl.
     :param str username: AMQP username.
     :param str vhost: AMQP vhost.
     :param utils.ConsoleMessagePrinter msg_update_callback: Callback object.
@@ -566,7 +564,7 @@ def _create_amqp_exchange(exchange_name, host, port, vhost, use_ssl,
     INSTALL_LOGGER.info(msg)
     credentials = pika.PlainCredentials(username, password)
     parameters = pika.ConnectionParameters(host, port, vhost, credentials,
-                                           ssl=use_ssl, connection_attempts=3,
+                                           connection_attempts=3,
                                            retry_delay=2, socket_timeout=5)
     connection = None
     try:
@@ -1516,7 +1514,7 @@ def _legacy_upgrade_to_33_34(client, config, ext_vcd_api_version,
     # create amqp exchange if it doesn't exist
     amqp = config['amqp']
     _create_amqp_exchange(amqp['exchange'], amqp['host'], amqp['port'],
-                          amqp['vhost'], amqp['ssl'], amqp['username'],
+                          amqp['vhost'], amqp['username'],
                           amqp['password'],
                           msg_update_callback=msg_update_callback)
 
@@ -1684,7 +1682,6 @@ def _upgrade_to_35(client, config, ext_vcd_api_version,
             host=config['amqp']['host'],
             port=config['amqp']['port'],
             vhost=config['amqp']['vhost'],
-            use_ssl=config['amqp']['ssl'],
             username=config['amqp']['username'],
             password=config['amqp']['password'],
             msg_update_callback=msg_update_callback)

--- a/container_service_extension/consumer/amqp_consumer.py
+++ b/container_service_extension/consumer/amqp_consumer.py
@@ -21,20 +21,18 @@ class AMQPConsumer(object):
     def __init__(self,
                  host,
                  port,
-                 ssl,
                  vhost,
                  username,
                  password,
                  exchange,
                  routing_key,
                  num_processors):
-        self._connection = None
-        self._channel = None
+        self._connection: pika.connection.Connection = None
+        self._channel: pika.channel.Channel = None
         self._closing = False
-        self._consumer_tag = None
+        self._consumer_tag: str = None
         self.host = host
         self.port = port
-        self.ssl = ssl
         self.vhost = vhost
         self.username = username
         self.password = password
@@ -46,7 +44,7 @@ class AMQPConsumer(object):
         self._ctpe = ConsumerThreadPoolExecutor(self.num_processors)
         self._publish_lock = Lock()
 
-    def connect(self):
+    def connect(self) -> pika.connection.Connection:
         LOGGER.info(f"Connecting to {self.host}:{self.port}")
         credentials = pika.PlainCredentials(self.username, self.password)
         parameters = pika.ConnectionParameters(
@@ -54,12 +52,10 @@ class AMQPConsumer(object):
             self.port,
             self.vhost,
             credentials,
-            ssl=self.ssl,
             connection_attempts=3,
             retry_delay=2,
             socket_timeout=5)
-        return pika.SelectConnection(
-            parameters, self.on_connection_open, stop_ioloop_on_close=False)
+        return pika.SelectConnection(parameters, self.on_connection_open)
 
     def on_connection_open(self, unused_connection):
         LOGGER.debug("Connection opened")
@@ -70,14 +66,14 @@ class AMQPConsumer(object):
         LOGGER.debug("Adding connection close callback")
         self._connection.add_on_close_callback(self.on_connection_closed)
 
-    def on_connection_closed(self, connection, reply_code, reply_text):
+    def on_connection_closed(self, unused_connection, amqp_exception):
         self._channel = None
         if self._closing:
             self._connection.ioloop.stop()
         else:
             LOGGER.warning(f"Connection closed, reopening in 5 seconds: "
-                           f"({reply_code}) {reply_text}")
-            self._connection.add_timeout(5, self.reconnect)
+                           f"({str(amqp_exception)})")
+            self._connection.ioloop.call_later(5, self.reconnect)
 
     def reconnect(self):
         self._connection.ioloop.stop()
@@ -100,34 +96,39 @@ class AMQPConsumer(object):
         LOGGER.debug("Adding channel close callback")
         self._channel.add_on_close_callback(self.on_channel_closed)
 
-    def on_channel_closed(self, channel, reply_code, reply_text):
-        LOGGER.warning(f"Channel {channel} was closed: ({reply_code}) "
-                       f"{reply_text}")
-        self._connection.close()
+    def on_channel_closed(self, channel, amqp_exception):
+        LOGGER.warning(f"Closing channel ({channel}) due to exception: ({str(amqp_exception)})")
+        if self._channel.is_closed or self._channel.is_closing:
+            LOGGER.warning(f"Channel ({channel}) is already closed")
+            return
+        try:
+            self._connection.close()
+        except pika.exceptions.ConnectionWrongStateError as cwse:
+            LOGGER.warning(f"Connection is closed or closing: ({cwse})")
 
     def setup_exchange(self, exchange_name):
         LOGGER.debug(f"Declaring exchange {exchange_name}")
         self._channel.exchange_declare(
-            self.on_exchange_declareok,
-            exchange=exchange_name,
+            exchange_name,
             exchange_type=EXCHANGE_TYPE,
             passive=True,
             durable=True,
-            auto_delete=False)
+            auto_delete=False,
+            callback=self.on_exchange_declareok)
 
-    def on_exchange_declareok(self, unused_frame):
-        LOGGER.debug(f"Exchange declared: {unused_frame}")
+    def on_exchange_declareok(self, exchange_name):
+        LOGGER.debug(f"Exchange declared: ({exchange_name})")
         self.setup_queue(self.queue)
 
     def setup_queue(self, queue_name):
-        LOGGER.debug(f"Declaring queue {queue_name}")
-        self._channel.queue_declare(self.on_queue_declareok, queue_name)
+        LOGGER.debug(f"Declaring queue ({queue_name})")
+        self._channel.queue_declare(queue_name, callback=self.on_queue_declareok)
 
     def on_queue_declareok(self, method_frame):
-        LOGGER.debug(f"Binding {self.exchange} to {self.queue} with "
-                     f"{self.routing_key}")
-        self._channel.queue_bind(self.on_bindok, self.queue, self.exchange,
-                                 self.routing_key)
+        LOGGER.debug(f"Binding ({self.exchange}) to ({self.queue}) with "
+                     f"({self.routing_key})")
+        self._channel.queue_bind(self.queue, self.exchange,
+                                 routing_key=self.routing_key, callback=self.on_bindok)
 
     def on_bindok(self, unused_frame):
         LOGGER.debug("Queue bound")
@@ -136,8 +137,8 @@ class AMQPConsumer(object):
     def start_consuming(self):
         LOGGER.debug("Issuing consumer related RPC commands")
         self.add_on_cancel_callback()
-        self._consumer_tag = self._channel.basic_consume(
-            self.on_message, self.queue)
+        self._consumer_tag = self._channel.basic_consume(self.queue, self.on_message)
+        LOGGER.debug(f"Started consumer with tag ({self._consumer_tag})")
 
     def add_on_cancel_callback(self):
         LOGGER.debug("Adding consumer cancellation callback")
@@ -145,7 +146,7 @@ class AMQPConsumer(object):
 
     def on_consumer_cancelled(self, method_frame):
         LOGGER.debug(f"Consumer was cancelled remotely, shutting down: "
-                     f"{method_frame}")
+                     f"({method_frame})")
         if self._channel:
             self._channel.close()
 
@@ -199,12 +200,17 @@ class AMQPConsumer(object):
                 request_id=body_json['id'],
                 status_code=requests.codes.too_many_requests,
                 reply_body_str=constants.TOO_MANY_REQUESTS_BODY)
-            LOGGER.debug(f"reply: {constants.TOO_MANY_REQUESTS_BODY}")
+            LOGGER.debug(f"reply: ({constants.TOO_MANY_REQUESTS_BODY})")
             self.send_response(reply_msg, properties)
 
-    def on_message(self, unused_channel, basic_deliver, properties, body):
+    def on_message(
+        self,
+        channel: pika.channel.Channel,
+        basic_deliver: pika.spec.Basic.Deliver,
+        properties: pika.spec.BasicProperties,
+        body: bytes):
         # If consumer is closing, no longer adding messages to thread pool
-        if self._closing:
+        if channel.is_closed or channel.is_closing:
             return
 
         self.acknowledge_message(basic_deliver.delivery_tag)
@@ -216,12 +222,15 @@ class AMQPConsumer(object):
                                                                 basic_deliver))
 
     def acknowledge_message(self, delivery_tag):
-        LOGGER.debug(f"Acknowledging message {delivery_tag}")
-        self._channel.basic_ack(delivery_tag)
+        LOGGER.debug(f"Acknowledging message ({delivery_tag})")
+        self._channel.basic_ack(delivery_tag=delivery_tag)
 
     def stop_consuming(self):
         if self._channel:
-            LOGGER.info("Sending a Basic.Cancel RPC command to RabbitMQ")
+            if self._channel.is_closed or self._channel.is_closing:
+                LOGGER.info("Channel is already closed or is closing.")
+                return
+            LOGGER.info(f"Sending a Basic.Cancel RPC command to RabbitMQ for consumer ({self._consumer_tag})")
             self._channel.basic_cancel(self.on_cancelok, self._consumer_tag)
 
     def on_cancelok(self, unused_frame):
@@ -229,8 +238,14 @@ class AMQPConsumer(object):
         self.close_channel()
 
     def close_channel(self):
-        LOGGER.debug("Closing the channel")
-        self._channel.close()
+        LOGGER.debug(f"Closing channel ({self._channel})")
+        if self._channel.is_closed or self._channel.is_closing:
+            LOGGER.warning(f"Channel ({self._channel}) is already closed")
+            return
+        try:
+            self._channel.close()
+        except pika.exceptions.ConnectionWrongStateError as cwse:
+            LOGGER.warn("Trying to close channel with unexpected state: [{}]".format(cwse))
 
     def run(self):
         self._connection = self.connect()

--- a/container_service_extension/consumer/amqp_consumer.py
+++ b/container_service_extension/consumer/amqp_consumer.py
@@ -97,7 +97,9 @@ class AMQPConsumer(object):
         self._channel.add_on_close_callback(self.on_channel_closed)
 
     def on_channel_closed(self, channel, amqp_exception):
-        LOGGER.warning(f"Closing channel ({channel}) due to exception: ({str(amqp_exception)})")
+        LOGGER.warning(
+            f"Closing channel ({channel}) due to exception: "
+            f"({str(amqp_exception)})")
         if self._channel.is_closed or self._channel.is_closing:
             LOGGER.warning(f"Channel ({channel}) is already closed")
             return
@@ -122,13 +124,15 @@ class AMQPConsumer(object):
 
     def setup_queue(self, queue_name):
         LOGGER.debug(f"Declaring queue ({queue_name})")
-        self._channel.queue_declare(queue_name, callback=self.on_queue_declareok)
+        self._channel.queue_declare(
+            queue_name, callback=self.on_queue_declareok)
 
     def on_queue_declareok(self, method_frame):
         LOGGER.debug(f"Binding ({self.exchange}) to ({self.queue}) with "
                      f"({self.routing_key})")
         self._channel.queue_bind(self.queue, self.exchange,
-                                 routing_key=self.routing_key, callback=self.on_bindok)
+                                 routing_key=self.routing_key,
+                                 callback=self.on_bindok)
 
     def on_bindok(self, unused_frame):
         LOGGER.debug("Queue bound")
@@ -137,7 +141,8 @@ class AMQPConsumer(object):
     def start_consuming(self):
         LOGGER.debug("Issuing consumer related RPC commands")
         self.add_on_cancel_callback()
-        self._consumer_tag = self._channel.basic_consume(self.queue, self.on_message)
+        self._consumer_tag = self._channel.basic_consume(
+            self.queue, self.on_message)
         LOGGER.debug(f"Started consumer with tag ({self._consumer_tag})")
 
     def add_on_cancel_callback(self):
@@ -204,11 +209,11 @@ class AMQPConsumer(object):
             self.send_response(reply_msg, properties)
 
     def on_message(
-        self,
-        channel: pika.channel.Channel,
-        basic_deliver: pika.spec.Basic.Deliver,
-        properties: pika.spec.BasicProperties,
-        body: bytes):
+            self,
+            channel: pika.channel.Channel,
+            basic_deliver: pika.spec.Basic.Deliver,
+            properties: pika.spec.BasicProperties,
+            body: bytes):
         # If consumer is closing, no longer adding messages to thread pool
         if channel.is_closed or channel.is_closing:
             return
@@ -230,7 +235,9 @@ class AMQPConsumer(object):
             if self._channel.is_closed or self._channel.is_closing:
                 LOGGER.info("Channel is already closed or is closing.")
                 return
-            LOGGER.info(f"Sending a Basic.Cancel RPC command to RabbitMQ for consumer ({self._consumer_tag})")
+            LOGGER.info(
+                f"Sending a Basic.Cancel RPC command to RabbitMQ for consumer "
+                f"({self._consumer_tag})")
             self._channel.basic_cancel(self.on_cancelok, self._consumer_tag)
 
     def on_cancelok(self, unused_frame):
@@ -245,7 +252,8 @@ class AMQPConsumer(object):
         try:
             self._channel.close()
         except pika.exceptions.ConnectionWrongStateError as cwse:
-            LOGGER.warn("Trying to close channel with unexpected state: [{}]".format(cwse))
+            LOGGER.warn(
+                f"Trying to close channel with unexpected state: [{cwse}]")
 
     def run(self):
         self._connection = self.connect()

--- a/container_service_extension/consumer/consumer.py
+++ b/container_service_extension/consumer/consumer.py
@@ -39,7 +39,6 @@ class MessageConsumer:
             return AMQPConsumer(
                 host=amqp['host'],
                 port=amqp['port'],
-                ssl=amqp['ssl'],
                 vhost=amqp['vhost'],
                 username=amqp['username'],
                 password=amqp['password'],

--- a/container_service_extension/sample_generator.py
+++ b/container_service_extension/sample_generator.py
@@ -70,8 +70,6 @@ SAMPLE_AMQP_CONFIG = {
         'password': 'guest',
         'exchange': 'cse-ext',
         'routing_key': 'cse',
-        'ssl': False,
-        'ssl_accept_all': False,
         'vhost': '/'
     }
 }
@@ -179,8 +177,6 @@ COMMENTED_AMQP_SECTION = """\
 #  port: 5672
 #  prefix: vcd
 #  routing_key: cse
-#  ssl: false
-#  ssl_accept_all: false
 #  username: guest
 #  vhost: /
 """

--- a/docs/cse2_6/CSE_CONFIG.md
+++ b/docs/cse2_6/CSE_CONFIG.md
@@ -25,8 +25,6 @@ amqp:
   port: 5672
   prefix: vcd
   routing_key: cse
-  ssl: false
-  ssl_accept_all: false
   username: guest
   vhost: /
 

--- a/docs/cse2_6/CSE_CONFIG.md
+++ b/docs/cse2_6/CSE_CONFIG.md
@@ -25,6 +25,8 @@ amqp:
   port: 5672
   prefix: vcd
   routing_key: cse
+  ssl: false
+  ssl_accept_all: false
   username: guest
   vhost: /
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ humanfriendly >= 4.8, < 5.0
 paho-mqtt >=1.5.0, < 1.6.0
 
 # pika 0.13.1
-pika >= 0.11.2, < 1.0.0
+pika >= 1.0.0, < 2.0.0
 
 # pyvcloud 23.0.0
 pyvcloud >= 23.0.0, < 24.0.0


### PR DESCRIPTION
- Code works with pika==1.1.0. Changes are mainly limited to function signatures of callbacks.
- removed `ssl` and `ssl_accept_all` from the config
- Cleaned up a set of logging statements

This will not support ssl and there need to be more config parameters added to support it. I am not clear if the earlier version supported it. If it did, we can hold off this PR and merge it with SSL included. If it did not, we could take SSL support as a separate ticket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/847)
<!-- Reviewable:end -->
