### PR TITLE
[VCDA 1950] Add source to telemetry

### DIFF
--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -37,6 +37,7 @@ from container_service_extension.server_constants import SYSTEM_ORG_NAME
 from container_service_extension.shared_constants import DefEntityOperation
 from container_service_extension.shared_constants import DefEntityOperationStatus  # noqa: E501
 from container_service_extension.shared_constants import DefEntityPhase
+from container_service_extension.shared_constants import RequestKey
 import container_service_extension.telemetry.constants as telemetry_constants
 import container_service_extension.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
 import container_service_extension.utils as utils
@@ -74,11 +75,14 @@ class ClusterService(abstract_broker.AbstractBroker):
         )
         return self._sync_def_entity(cluster_id)
 
-    def list_clusters(self, filters: dict = {}) -> List[def_models.DefEntity]:
+    def list_clusters(self, filters: dict = {}, **kwargs) -> List[def_models.DefEntity]:  # noqa: E501
         """List corresponding defined entities of all native clusters."""
         telemetry_handler.record_user_action_details(
             cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_LIST,
-            cse_params={telemetry_constants.PayloadKey.FILTER_KEYS: ','.join(filters.keys())}  # noqa: E501
+            cse_params={
+                telemetry_constants.PayloadKey.FILTER_KEYS: ','.join(filters.keys()),  # noqa: E501
+                telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: kwargs.get(RequestKey.USER_AGENT)  # noqa: E501
+            }  # noqa: E501
         )
         ent_type: def_models.DefEntityType = def_utils.get_registered_def_entity_type()  # noqa: E501
         return self.entity_svc.list_entities_by_entity_type(

--- a/container_service_extension/def_/ovdc_service.py
+++ b/container_service_extension/def_/ovdc_service.py
@@ -24,7 +24,7 @@ import container_service_extension.utils as utils
 
 
 def update_ovdc(operation_context: ctx.OperationContext,
-                ovdc_id: str, ovdc_spec: def_models.Ovdc) -> dict: # noqa: 501
+                ovdc_id: str, ovdc_spec: def_models.Ovdc, **kwargs) -> dict:  # noqa: 501
     """Update ovdc with the updated k8s runtimes list.
 
     :param ctx.OperationContext operation_context: context for the request
@@ -79,11 +79,12 @@ def update_ovdc(operation_context: ctx.OperationContext,
                                               ovdc_id=ovdc_id,
                                               vdc=vdc,
                                               org_name=ovdc_spec.org_name,
-                                              remove_cp_from_vms_on_disable=ovdc_spec.remove_cp_from_vms_on_disable) # noqa:E501
+                                              remove_cp_from_vms_on_disable=ovdc_spec.remove_cp_from_vms_on_disable,  # noqa:E501
+                                              **kwargs)
     return {'task_href': task_href}
 
 
-def get_ovdc(operation_context: ctx.OperationContext, ovdc_id: str) -> dict:
+def get_ovdc(operation_context: ctx.OperationContext, ovdc_id: str, **kwargs) -> dict:  # noqa:E501
     """Get ovdc info for a particular ovdc.
 
     :param ctx.OperationContext operation_context: context for the request
@@ -94,7 +95,8 @@ def get_ovdc(operation_context: ctx.OperationContext, ovdc_id: str) -> dict:
     # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
     # Prevent showing information about TKG+ by skipping TKG+ from the result.
     cse_params = {
-        RequestKey.OVDC_ID: ovdc_id
+        RequestKey.OVDC_ID: ovdc_id,
+        RequestKey.USER_AGENT: kwargs.get(RequestKey.USER_AGENT)
     }
     telemetry_handler.record_user_action_details(cse_operation=CseOperation.OVDC_INFO, # noqa: E501
                                                  cse_params=cse_params)
@@ -121,10 +123,6 @@ def list_ovdc(operation_context: ctx.OperationContext) -> List[dict]:
     """
     # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
     # Prevent showing information about TKG+ by skipping TKG+ from the result.
-    # Record telemetry
-    telemetry_handler.record_user_action_details(cse_operation=CseOperation.OVDC_LIST, # noqa: E501
-                                                 cse_params={})
-
     ovdcs = []
     org_vdcs = vcd_utils.get_all_ovdcs(operation_context.client)
     for ovdc in org_vdcs:
@@ -198,7 +196,8 @@ def _update_ovdc_using_placement_policy_async(operation_context: ctx.OperationCo
                                               ovdc_id,
                                               vdc,
                                               org_name,
-                                              remove_cp_from_vms_on_disable=False):  # noqa: E501
+                                              remove_cp_from_vms_on_disable=False,  # noqa: E501
+                                              **kwargs):
     """Enable ovdc using placement policies.
 
     :param ctx.OperationContext operation_context: operation context object
@@ -238,7 +237,8 @@ def _update_ovdc_using_placement_policy_async(operation_context: ctx.OperationCo
             cse_params = {
                 RequestKey.K8S_PROVIDER: k8s_runtimes_added,
                 RequestKey.OVDC_ID: ovdc_id,
-                RequestKey.ORG_NAME: org_name
+                RequestKey.ORG_NAME: org_name,
+                RequestKey.USER_AGENT: kwargs.get(RequestKey.USER_AGENT)
             }
             telemetry_handler.record_user_action_details(cse_operation=CseOperation.OVDC_ENABLE, # noqa: E501
                                                          cse_params=cse_params)
@@ -251,7 +251,8 @@ def _update_ovdc_using_placement_policy_async(operation_context: ctx.OperationCo
                 RequestKey.K8S_PROVIDER: k8s_runtimes_deleted,
                 RequestKey.OVDC_ID: ovdc_id,
                 RequestKey.ORG_NAME: org_name,
-                RequestKey.REMOVE_COMPUTE_POLICY_FROM_VMS: remove_cp_from_vms_on_disable # noqa: E501
+                RequestKey.REMOVE_COMPUTE_POLICY_FROM_VMS: remove_cp_from_vms_on_disable,  # noqa: E501
+                RequestKey.USER_AGENT: kwargs.get(RequestKey.USER_AGENT)
             }
             telemetry_handler.record_user_action_details(cse_operation=CseOperation.OVDC_DISABLE, # noqa: E501
                                                          cse_params=cse_params)

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -138,7 +138,10 @@ def cluster_list(data: dict, op_ctx: ctx.OperationContext):
     """
     svc = cluster_svc.ClusterService(op_ctx)
     return [asdict(def_entity) for def_entity in
-            svc.list_clusters(data.get(RequestKey.V35_QUERY, {}))]
+            svc.list_clusters(
+                data.get(RequestKey.V35_QUERY, {}),
+                **{RequestKey.USER_AGENT: data.get(RequestKey.USER_AGENT)})
+            ]
 
 
 @request_utils.v35_api_exception_handler

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -26,7 +26,7 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     """
     svc = cluster_svc.ClusterService(op_ctx)
     cluster_entity_spec = def_models.ClusterEntity(**data[RequestKey.V35_SPEC])
-    return asdict(svc.create_cluster(cluster_entity_spec))
+    return asdict(svc.create_cluster(cluster_entity_spec, **{RequestKey.USER_AGENT: data.get(RequestKey.USER_AGENT)}))  # noqa: E501
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY)  # noqa: E501
@@ -47,7 +47,7 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
         asdict(cluster_entity_spec.spec), asdict(curr_entity.entity.spec),
         exclude_fields=[FlattenedClusterSpecKey.WORKERS_COUNT.value,
                         FlattenedClusterSpecKey.NFS_COUNT.value])
-    return asdict(svc.resize_cluster(cluster_id, cluster_entity_spec))
+    return asdict(svc.resize_cluster(cluster_id, cluster_entity_spec, **{RequestKey.USER_AGENT: data.get(RequestKey.USER_AGENT)}))  # noqa: E501
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_DELETE)  # noqa: E501
@@ -64,7 +64,7 @@ def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
     """
     svc = cluster_svc.ClusterService(op_ctx)
     cluster_id = data[RequestKey.CLUSTER_ID]
-    return asdict(svc.delete_cluster(cluster_id))
+    return asdict(svc.delete_cluster(cluster_id, **{RequestKey.USER_AGENT: data.get(RequestKey.USER_AGENT)}))  # noqa: E501
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_INFO)  # noqa: E501
@@ -81,7 +81,7 @@ def cluster_info(data: dict, op_ctx: ctx.OperationContext):
     """
     svc = cluster_svc.ClusterService(op_ctx)
     cluster_id = data[RequestKey.CLUSTER_ID]
-    return asdict(svc.get_cluster_info(cluster_id))
+    return asdict(svc.get_cluster_info(cluster_id, **{RequestKey.USER_AGENT: data.get(RequestKey.USER_AGENT)}))  # noqa: E501
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_CONFIG)  # noqa: E501
@@ -95,7 +95,7 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     """
     svc = cluster_svc.ClusterService(op_ctx)
     cluster_id = data[RequestKey.CLUSTER_ID]
-    return svc.get_cluster_config(cluster_id)
+    return svc.get_cluster_config(cluster_id, **{RequestKey.USER_AGENT: data.get(RequestKey.USER_AGENT)})  # noqa: E501)
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE_PLAN)  # noqa: E501
@@ -106,7 +106,7 @@ def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     :return: List[Tuple(str, str)]
     """
     svc = cluster_svc.ClusterService(op_ctx)
-    return svc.get_cluster_upgrade_plan(data[RequestKey.CLUSTER_ID])
+    return svc.get_cluster_upgrade_plan(data[RequestKey.CLUSTER_ID], **{RequestKey.USER_AGENT: data.get(RequestKey.USER_AGENT)})  # noqa: E501
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE)  # noqa: E501
@@ -126,7 +126,7 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
         asdict(cluster_entity_spec.spec), asdict(curr_entity.entity.spec),
         exclude_fields=[FlattenedClusterSpecKey.TEMPLATE_NAME.value,
                         FlattenedClusterSpecKey.TEMPLATE_REVISION.value])
-    return asdict(svc.upgrade_cluster(cluster_id, cluster_entity_spec))
+    return asdict(svc.upgrade_cluster(cluster_id, cluster_entity_spec, **{RequestKey.USER_AGENT: data.get(RequestKey.USER_AGENT)}))  # noqa: E501
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_LIST)  # noqa: E501
@@ -181,7 +181,8 @@ def nfs_node_delete(data, op_ctx: ctx.OperationContext):
         cse_operation=telemetry_constants.CseOperation.V35_NODE_DELETE,
         cse_params={
             telemetry_constants.PayloadKey.CLUSTER_ID: cluster_id,
-            telemetry_constants.PayloadKey.NODE_NAME: node_name
+            telemetry_constants.PayloadKey.NODE_NAME: node_name,
+            telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: data.get(RequestKey.USER_AGENT)  # noqa: E501
         }
     )
 

--- a/container_service_extension/request_handlers/v35/ovdc_handler.py
+++ b/container_service_extension/request_handlers/v35/ovdc_handler.py
@@ -7,7 +7,7 @@ import container_service_extension.operation_context as ctx
 import container_service_extension.request_handlers.request_utils as request_utils  # noqa: E501
 from container_service_extension.shared_constants import RequestKey
 from container_service_extension.telemetry.constants import CseOperation
-from container_service_extension.telemetry.telemetry_handler import record_user_action_telemetry  # noqa: E501
+import container_service_extension.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
 
 
 @request_utils.v35_api_exception_handler
@@ -24,10 +24,11 @@ def ovdc_update(data, operation_context: ctx.OperationContext):
     ovdc_spec = def_models.Ovdc(**data[RequestKey.V35_SPEC])
     return ovdc_service.update_ovdc(operation_context,
                                     ovdc_id=data[RequestKey.OVDC_ID],
-                                    ovdc_spec=ovdc_spec)
+                                    ovdc_spec=ovdc_spec,
+                                    **{RequestKey.USER_AGENT: data.get(RequestKey.USER_AGENT)})  # noqa: E501
 
 
-@record_user_action_telemetry(cse_operation=CseOperation.OVDC_INFO)
+@telemetry_handler.record_user_action_telemetry(cse_operation=CseOperation.OVDC_INFO)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def ovdc_info(data, operation_context: ctx.OperationContext):
     """Request handler for ovdc info operation.
@@ -37,14 +38,20 @@ def ovdc_info(data, operation_context: ctx.OperationContext):
     :return: Dictionary with org VDC k8s provider metadata.
     """
     ovdc_id = data[RequestKey.OVDC_ID]
-    return ovdc_service.get_ovdc(operation_context, ovdc_id)
+    return ovdc_service.get_ovdc(operation_context,
+                                 ovdc_id,
+                                 **{RequestKey.USER_AGENT: data.get(RequestKey.USER_AGENT)})  # noqa: E501
 
 
-@record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
+@telemetry_handler.record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def ovdc_list(data, operation_context: ctx.OperationContext):
     """Request handler for ovdc list operation.
 
     :return: List of dictionaries with org VDC k8s runtimes.
     """
+    telemetry_handler.record_user_action_details(
+        cse_operation=CseOperation.OVDC_LIST,
+        cse_params={RequestKey.USER_AGENT: data.get(RequestKey.USER_AGENT)}
+    )
     return ovdc_service.list_ovdc(operation_context)

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -285,6 +285,7 @@ def process_request(message):
         LOGGER.debug(f"query parameters: {query_params}")
     # update request spec with operation specific data in the url
     request_data.update(url_data)
+    request_data.update({shared_constants.RequestKey.USER_AGENT: message['headers'].get('User-Agent')})  # noqa: E501
     # remove None values from request payload
     data = {k: v for k, v in request_data.items() if v is not None}
     # extract out the authorization token

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -130,6 +130,9 @@ class RequestKey(str, Enum):
     # keys that are only used internally at server side
     PKS_EXT_HOST = 'pks_ext_host'
 
+    # user agent
+    USER_AGENT = 'User-Agent'
+
 
 @unique
 class DefEntityOperation(str, Enum):

--- a/container_service_extension/telemetry/constants.py
+++ b/container_service_extension/telemetry/constants.py
@@ -125,6 +125,8 @@ class PayloadKey(str, Enum):
     NUMBER_OF_NFS_NODES = 'number_of_nfs_nodes'
     OS = 'os'
     SOURCE_CSE_VERSION = 'source_cse_version'
+    SOURCE_DESCRIPTION = 'source_description'
+    SOURCE_ID = 'source_id'
     SOURCE_VCD_API_VERSION = 'source_vcd_api_version'
     STATUS = 'status'
     TARGET = 'target',
@@ -164,3 +166,24 @@ class PayloadValue(str, Enum):
 @unique
 class PayloadTable(str, Enum):
     USER_ACTIONS = 'CSE_USER_ACTIONS'
+
+
+@unique
+class SourceMap(str, Enum):
+    VCD_CLI = 'python'
+    CURL = 'curl'
+    EDGE = 'edg'
+    CHROME = 'chrome'
+    SAFARI = 'safari'
+    TERRAFORM = 'terraform'
+    POSTMAN = 'postman'
+    UNKNOWN = 'unknown'
+
+    @staticmethod
+    def get_source_id(user_agent: str):
+        if user_agent is None:
+            return SourceMap.UNKNOWN.name
+        for source_entry in SourceMap:
+            if source_entry.value in user_agent.lower():
+                return source_entry.name
+        return SourceMap.UNKNOWN.name

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -504,11 +504,13 @@ def get_payload_for_v35_cluster_info(params):
     """
     return {
         PayloadKey.TYPE: CseOperation.V35_CLUSTER_INFO.telemetry_table,
-        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(params.get(PayloadKey.CLUSTER_ID)))  # noqa: E501
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(params.get(PayloadKey.CLUSTER_ID))),  # noqa: E501
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
     }
 
 
-def get_payload_for_v35_cluster_config(def_entity: DefEntity):
+def get_payload_for_v35_cluster_config(def_entity: DefEntity, **kwargs):
     """Construct telemetry payload of v35 cluster config.
 
     :param DefEntity def_entity: defined entity instance
@@ -522,11 +524,13 @@ def get_payload_for_v35_cluster_config(def_entity: DefEntity):
         PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
         PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
         PayloadKey.TEMPLATE_NAME: def_entity.entity.spec.k8_distribution.template_name,  # noqa: E501
-        PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision  # noqa: E501
+        PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision,  # noqa: E501
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(kwargs.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: kwargs.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
     }
 
 
-def get_payload_for_v35_cluster_apply(def_entity: DefEntity):
+def get_payload_for_v35_cluster_apply(def_entity: DefEntity, **kwargs):
     """Construct telemetry payload of v35 cluster apply.
 
     :param DefEntity def_entity: defined entity instance
@@ -545,11 +549,13 @@ def get_payload_for_v35_cluster_apply(def_entity: DefEntity):
         PayloadKey.NUMBER_OF_WORKER_NODES: def_entity.entity.spec.workers.count,  # noqa: E501
         PayloadKey.NUMBER_OF_NFS_NODES: def_entity.entity.spec.nfs.count,  # noqa: E501
         PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(def_entity.entity.spec.settings.ssh_key),  # noqa: E501
-        PayloadKey.WAS_ROLLBACK_ENABLED: bool(def_entity.entity.spec.settings.rollback_on_failure)  # noqa: E501
+        PayloadKey.WAS_ROLLBACK_ENABLED: bool(def_entity.entity.spec.settings.rollback_on_failure),  # noqa: E501
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(kwargs.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: kwargs.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
     }
 
 
-def get_payload_for_v35_cluster_delete(def_entity: DefEntity):
+def get_payload_for_v35_cluster_delete(def_entity: DefEntity, **kwargs):
     """Construct telemetry payload of v35 cluster delete.
 
     :param DefEntity def_entity: defined entity instance
@@ -561,11 +567,13 @@ def get_payload_for_v35_cluster_delete(def_entity: DefEntity):
     return {
         PayloadKey.TYPE: CseOperation.V35_CLUSTER_DELETE.telemetry_table,
         PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
-        PayloadKey.CLUSTER_KIND: def_entity.entity.kind
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(kwargs.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: kwargs.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
     }
 
 
-def get_payload_for_v35_cluster_upgrade_plan(def_entity: DefEntity):
+def get_payload_for_v35_cluster_upgrade_plan(def_entity: DefEntity, **kwargs):
     """Construct telemetry payload of v35 cluster upgrade plan.
 
     :param DefEntity def_entity: defined entity instance
@@ -577,11 +585,13 @@ def get_payload_for_v35_cluster_upgrade_plan(def_entity: DefEntity):
     return {
         PayloadKey.TYPE: CseOperation.V35_CLUSTER_UPGRADE_PLAN.telemetry_table,
         PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
-        PayloadKey.CLUSTER_KIND: def_entity.entity.kind
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(kwargs.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: kwargs.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
     }
 
 
-def get_payload_for_v35_cluster_upgrade(def_entity: DefEntity):
+def get_payload_for_v35_cluster_upgrade(def_entity: DefEntity, **kwargs):
     """Construct telemetry payload of v35 cluster upgrade.
 
     :param DefEntity def_entity: defined entity instance
@@ -595,7 +605,9 @@ def get_payload_for_v35_cluster_upgrade(def_entity: DefEntity):
         PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
         PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
         PayloadKey.TEMPLATE_NAME: def_entity.entity.spec.k8_distribution.template_name,  # noqa: E501
-        PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision  # noqa: E501
+        PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision,  # noqa: E501
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(kwargs.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: kwargs.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
     }
 
 
@@ -611,5 +623,7 @@ def get_payload_for_v35_node_delete(params):
     return {
         PayloadKey.TYPE: CseOperation.V35_NODE_DELETE.telemetry_table,
         PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(params.get(PayloadKey.CLUSTER_ID))),  # noqa: E501
-        PayloadKey.NODE_NAME: params.get(PayloadKey.NODE_NAME)
+        PayloadKey.NODE_NAME: params.get(PayloadKey.NODE_NAME),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
     }

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -424,7 +424,9 @@ def get_payload_for_ovdc_disable(params):
     """
     return {
         PayloadKey.TYPE: CseOperation.OVDC_DISABLE.telemetry_table,
-        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
     }
 
 
@@ -442,7 +444,9 @@ def get_payload_for_ovdc_enable(params):
         PayloadKey.K8S_PROVIDER: params.get(RequestKey.K8S_PROVIDER),
         PayloadKey.WAS_PKS_PLAN_SPECIFIED: bool(params.get(RequestKey.PKS_PLAN_NAME)),  # noqa: E501
         PayloadKey.WAS_PKS_CLUSTER_DOMAIN_SPECIFIED: bool(params.get(RequestKey.PKS_CLUSTER_DOMAIN)),  # noqa: E501
-        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
     }
 
 
@@ -457,7 +461,9 @@ def get_payload_for_ovdc_info(params):
     """
     return {
         PayloadKey.TYPE: CseOperation.OVDC_INFO.telemetry_table,
-        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))  # noqa: E501
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),  # noqa: E501
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
     }
 
 
@@ -472,7 +478,9 @@ def get_payload_for_ovdc_list(params):
     """
     return {
         PayloadKey.TYPE: CseOperation.OVDC_LIST.telemetry_table,
-        PayloadKey.WAS_PKS_PLAN_SPECIFIED: bool(params.get(RequestKey.LIST_PKS_PLANS))  # noqa: E501
+        PayloadKey.WAS_PKS_PLAN_SPECIFIED: bool(params.get(RequestKey.LIST_PKS_PLANS)),  # noqa: E501
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
     }
 
 

--- a/container_service_extension/telemetry/payload_generator.py
+++ b/container_service_extension/telemetry/payload_generator.py
@@ -10,6 +10,7 @@ from container_service_extension.telemetry.constants import CseOperation
 from container_service_extension.telemetry.constants import PayloadKey
 from container_service_extension.telemetry.constants import PayloadTable
 from container_service_extension.telemetry.constants import PayloadValue
+from container_service_extension.telemetry.constants import SourceMap
 from container_service_extension.telemetry.telemetry_utils import uuid_hash
 
 
@@ -178,7 +179,9 @@ def get_payload_for_cluster_config(params):
         PayloadKey.TEMPLATE_NAME: params.get(RequestKey.TEMPLATE_NAME),
         PayloadKey.TEMPLATE_REVISION: params.get(RequestKey.TEMPLATE_REVISION),
         PayloadKey.WAS_OVDC_SPECIFIED: bool(params.get(RequestKey.OVDC_NAME)),
-        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
     }
 
 
@@ -208,7 +211,9 @@ def get_payload_for_create_cluster(params):
         PayloadKey.ADDED_NFS_NODE: params.get(RequestKey.ENABLE_NFS),
         PayloadKey.WAS_ROLLBACK_ENABLED: bool(params.get(RequestKey.ROLLBACK)),
         PayloadKey.WAS_OVDC_SPECIFIED: bool(params.get(RequestKey.OVDC_NAME)),
-        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
     }
 
 
@@ -225,7 +230,9 @@ def get_payload_for_cluster_delete(params):
         PayloadKey.TYPE: CseOperation.CLUSTER_DELETE.telemetry_table,
         PayloadKey.CLUSTER_ID: uuid_hash(params.get(PayloadKey.CLUSTER_ID)),
         PayloadKey.WAS_OVDC_SPECIFIED: bool(params.get(RequestKey.OVDC_NAME)),
-        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
     }
 
 
@@ -242,7 +249,9 @@ def get_payload_for_cluster_info(params):
         PayloadKey.TYPE: CseOperation.CLUSTER_INFO.telemetry_table,
         PayloadKey.CLUSTER_ID: uuid_hash(params.get(PayloadKey.CLUSTER_ID)),
         PayloadKey.WAS_OVDC_SPECIFIED: bool(params.get(RequestKey.OVDC_NAME)),
-        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
     }
 
 
@@ -258,7 +267,9 @@ def get_payload_for_list_clusters(params):
     return {
         PayloadKey.TYPE: CseOperation.CLUSTER_LIST.telemetry_table,
         PayloadKey.WAS_OVDC_SPECIFIED: bool(params.get(RequestKey.OVDC_NAME)),
-        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
     }
 
 
@@ -282,6 +293,9 @@ def get_payload_for_cluster_resize(params):
         PayloadKey.WAS_ROLLBACK_ENABLED: bool(params.get(RequestKey.ROLLBACK)),
         PayloadKey.WAS_OVDC_SPECIFIED: bool(params.get(RequestKey.OVDC_NAME)),
         PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
+
     }
 
 
@@ -300,7 +314,9 @@ def get_payload_for_cluster_upgrade(params):
         PayloadKey.TEMPLATE_NAME: params.get(RequestKey.TEMPLATE_NAME),
         PayloadKey.TEMPLATE_REVISION: params.get(RequestKey.TEMPLATE_REVISION),
         PayloadKey.WAS_OVDC_SPECIFIED: bool(params.get(RequestKey.OVDC_NAME)),
-        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
     }
 
 
@@ -317,7 +333,9 @@ def get_payload_for_cluster_upgrade_plan(params):
         PayloadKey.TYPE: CseOperation.CLUSTER_UPGRADE_PLAN.telemetry_table,
         PayloadKey.CLUSTER_ID: uuid_hash(params.get(PayloadKey.CLUSTER_ID)),
         PayloadKey.WAS_OVDC_SPECIFIED: bool(params.get(RequestKey.OVDC_NAME)),
-        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
     }
 
 
@@ -349,7 +367,9 @@ def get_payload_for_node_create(params):
         PayloadKey.WAS_NFS_ENABLED: bool(params.get(RequestKey.ENABLE_NFS)),
         PayloadKey.WAS_ROLLBACK_ENABLED: bool(params.get(RequestKey.ROLLBACK)),
         PayloadKey.WAS_OVDC_SPECIFIED: bool(params.get(RequestKey.OVDC_NAME)),
-        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
     }
 
 
@@ -367,7 +387,9 @@ def get_payload_for_node_delete(params):
         PayloadKey.CLUSTER_ID: uuid_hash(params.get(PayloadKey.CLUSTER_ID)),
         PayloadKey.NODE_NAME: params.get(RequestKey.NODE_NAME),
         PayloadKey.WAS_OVDC_SPECIFIED: bool(params.get(RequestKey.OVDC_NAME)),
-        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
     }
 
 
@@ -385,7 +407,9 @@ def get_payload_for_node_info(params):
         PayloadKey.CLUSTER_ID: uuid_hash(params.get(PayloadKey.CLUSTER_ID)),
         PayloadKey.NODE_NAME: params.get(RequestKey.NODE_NAME),
         PayloadKey.WAS_OVDC_SPECIFIED: bool(params.get(RequestKey.OVDC_NAME)),
-        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME))
+        PayloadKey.WAS_ORG_SPECIFIED: bool(params.get(RequestKey.ORG_NAME)),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(RequestKey.USER_AGENT)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(RequestKey.USER_AGENT)
     }
 
 
@@ -463,7 +487,9 @@ def get_payload_for_v35_cluster_list(params):
     """
     return {
         PayloadKey.TYPE: CseOperation.V35_CLUSTER_LIST.telemetry_table,
-        PayloadKey.FILTER_KEYS: params.get(PayloadKey.FILTER_KEYS)
+        PayloadKey.FILTER_KEYS: params.get(PayloadKey.FILTER_KEYS),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
     }
 
 

--- a/container_service_extension/telemetry/telemetry_handler.py
+++ b/container_service_extension/telemetry/telemetry_handler.py
@@ -123,7 +123,7 @@ def record_user_action(cse_operation, status=OperationStatus.SUCCESS,
 
 
 def record_user_action_details(cse_operation, cse_params,
-                               telemetry_settings=None):
+                               telemetry_settings=None, **kwargs):
     """Record CSE user operation details in telemetry server.
 
     No exception should be leaked. Catch all exceptions and log them.
@@ -137,7 +137,7 @@ def record_user_action_details(cse_operation, cse_params,
             telemetry_settings = get_server_runtime_config()['service']['telemetry']  # noqa: E501
 
         if telemetry_settings['enable']:
-            payload = OPERATION_TO_PAYLOAD_GENERATOR[cse_operation](cse_params)
+            payload = OPERATION_TO_PAYLOAD_GENERATOR[cse_operation](cse_params, **kwargs)  # noqa: E501
             _send_data_to_telemetry_server(payload, telemetry_settings)
     except Exception as err:
         LOGGER.warning(f"Error in recording CSE operation details :{str(err)}")  # noqa: E501


### PR DESCRIPTION
-  Add source of CSE server request to telemetry tables 
-  CSE telemetry to record the type of client that make HTTP Requests to CSE server
-  Added two new columns to telemetry table: source_id and source_description
-  Testing done by running CLI thru `vcd cli, postman, curl
-  Tested all native cluster commands 
-  Tested all defined entity cluster commands 
- **TODO - Adding source to PKS telemetry tables (Testbed build is failing)**


--------
cse_v35_cluster_list 
![image](https://user-images.githubusercontent.com/5530442/101711493-81858680-3a48-11eb-92c0-06359545f6b7.png)

cse_v35_cluster_info
![image](https://user-images.githubusercontent.com/5530442/101711674-eb9e2b80-3a48-11eb-8b21-b3f769bfbf84.png)

cse_v35_cluster_apply
![image](https://user-images.githubusercontent.com/5530442/101711879-49cb0e80-3a49-11eb-95b5-d667b5d9b409.png)

cse_ovdc_enable
![image](https://user-images.githubusercontent.com/5530442/101712060-9a426c00-3a49-11eb-88de-a17e8b79c774.png)

cse_ovdc_list
![image](https://user-images.githubusercontent.com/5530442/101847137-5f9f0900-3b07-11eb-9ae5-3a05bd51e8eb.png)


@Anirudh9794 @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/849)
<!-- Reviewable:end -->
