### PR TITLE
[VCDA-1909] Add logic in AMQP consumer to reject redelivered messages

### DIFF
--- a/container_service_extension/consumer/amqp_consumer.py
+++ b/container_service_extension/consumer/amqp_consumer.py
@@ -5,7 +5,6 @@
 import json
 import sys
 from threading import Lock
-import time
 
 from lru import LRU
 import pika
@@ -249,7 +248,7 @@ class AMQPConsumer(object):
         else:
             LRU_LOCK.acquire()
             try:
-                REQUESTS_BEING_PROCESSED[req_id] = time.time()
+                REQUESTS_BEING_PROCESSED[req_id] = True
             finally:
                 LRU_LOCK.release()
             self._ctpe.submit(lambda: self.process_amqp_message(

--- a/container_service_extension/consumer/amqp_consumer.py
+++ b/container_service_extension/consumer/amqp_consumer.py
@@ -189,7 +189,12 @@ class AMQPConsumer(object):
                 reply_body_str=reply_body_str)
 
             self.send_response(reply_msg, properties)
-            LOGGER.debug(f"AMQP reply: {reply_msg}")
+            LOGGER.debug(f"Sucessfully sent reply: {reply_msg} to AMQP.")
+            if req_id in REQUESTS_BEING_PROCESSSED:
+                del REQUESTS_BEING_PROCESSSED[req_id]
+        else:
+            LOGGER.debug(f"Unable to reply to message {delivery_tag}")
+            self.reject_message(basic_deliver.delivery_tag)
 
     def send_response(self, reply_msg, properties):
         reply_properties = pika.BasicProperties(
@@ -228,7 +233,7 @@ class AMQPConsumer(object):
             request_msg=body, fsencoding=self.fsencoding)
         global REQUESTS_BEING_PROCESSSED
         if req_id not in REQUESTS_BEING_PROCESSSED:
-            REQUESTS_BEING_PROCESSSED[req_id] = time.time()
+            REQUESTS_BEING_PROCESSSED.set(req_id, time.time())
             self.acknowledge_message(basic_deliver.delivery_tag)
         else:
             self.reject_message(basic_deliver.delivery_tag)

--- a/container_service_extension/consumer/amqp_consumer.py
+++ b/container_service_extension/consumer/amqp_consumer.py
@@ -5,7 +5,9 @@
 import json
 import sys
 from threading import Lock
+import time
 
+from lru import LRU
 import pika
 import requests
 
@@ -15,6 +17,10 @@ from container_service_extension.consumer.consumer_thread_pool_executor \
 import container_service_extension.consumer.utils as utils
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.server_constants import EXCHANGE_TYPE
+
+
+MAX_PROCESSED_REQUEST_CACHE_SIZE = 1000
+REQUESTS_BEING_PROCESSSED = LRU(MAX_PROCESSED_REQUEST_CACHE_SIZE)
 
 
 class AMQPConsumer(object):
@@ -218,7 +224,16 @@ class AMQPConsumer(object):
         if channel.is_closed or channel.is_closing:
             return
 
-        self.acknowledge_message(basic_deliver.delivery_tag)
+        req_id = utils.get_request_id(
+            request_msg=body, fsencoding=self.fsencoding)
+        global REQUESTS_BEING_PROCESSSED
+        if req_id not in REQUESTS_BEING_PROCESSSED:
+            REQUESTS_BEING_PROCESSSED[req_id] = time.time()
+            self.acknowledge_message(basic_deliver.delivery_tag)
+        else:
+            self.reject_message(basic_deliver.delivery_tag)
+            return
+
         if self._ctpe.max_threads_busy():
             self.send_too_many_requests_response(properties, body)
         else:
@@ -229,6 +244,11 @@ class AMQPConsumer(object):
     def acknowledge_message(self, delivery_tag):
         LOGGER.debug(f"Acknowledging message ({delivery_tag})")
         self._channel.basic_ack(delivery_tag=delivery_tag)
+
+    def reject_message(self, delivery_tag):
+        LOGGER.debug(f"Rejecting message {delivery_tag}")
+        self._channel.basic_nack(
+            delivery_tag=delivery_tag, requeue=False)
 
     def stop_consuming(self):
         if self._channel:

--- a/container_service_extension/consumer/amqp_consumer.py
+++ b/container_service_extension/consumer/amqp_consumer.py
@@ -230,8 +230,8 @@ class AMQPConsumer(object):
             request_msg=body, fsencoding=self.fsencoding)
         global REQUESTS_BEING_PROCESSSED
         if req_id in REQUESTS_BEING_PROCESSSED:
-            LOGGER.debug(f"Unable to reply to message {delivery_tag}")
             self.reject_message(basic_deliver.delivery_tag)
+            del REQUESTS_BEING_PROCESSSED[req_id]
             return
 
         self.acknowledge_message(basic_deliver.delivery_tag)

--- a/container_service_extension/consumer/constants.py
+++ b/container_service_extension/consumer/constants.py
@@ -14,3 +14,6 @@ MQTT_CLIENT_ID = 'cseMQTT'
 MQTT_CONNECT_PORT = 443
 TRANSPORT_WSS = 'websockets'
 QOS_LEVEL = 2  # No duplicate messages
+
+# Used by only AMQP consumer
+MAX_PROCESSING_REQUEST_CACHE_SIZE = 1000

--- a/container_service_extension/consumer/utils.py
+++ b/container_service_extension/consumer/utils.py
@@ -17,6 +17,19 @@ from container_service_extension.shared_constants import RESPONSE_MESSAGE_KEY
 from container_service_extension.thread_local_data import set_thread_request_id
 
 
+# Note : Only being used by AMQP to reject request that has been already
+# processed, or are being currently processed.
+def get_request_id(request_msg, fsencoding):
+    """."""
+    request_id = None
+    try:
+        msg_json = json.loads(request_msg.decode(fsencoding))[0]
+        request_id = msg_json['id']
+    except Exception:
+        LOGGER.error(traceback.format_exc())
+    return request_id
+
+
 def get_response_fields(request_msg, fsencoding, is_mqtt):
     """Get the msg json and response fields request message."""
     msg_json, request_id = None, None

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,9 @@ cryptography >= 2.8, < 3.0
 # humanfriendly 4.18
 humanfriendly >= 4.8, < 5.0
 
+# lru-dict 1.1.6
+lru-dict >=1.16, < 2.0.0
+
 #paho-mqtt 1.5.1
 paho-mqtt >=1.5.0, < 1.6.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cryptography >= 2.8, < 3.0
 humanfriendly >= 4.8, < 5.0
 
 # lru-dict 1.1.6
-lru-dict >=1.16, < 2.0.0
+lru-dict >=1.1.6, < 2.0.0
 
 #paho-mqtt 1.5.1
 paho-mqtt >=1.5.0, < 1.6.0


### PR DESCRIPTION
CSE today is incapable to handling redelivered messages. This can lead to situations where CSE reprocesses heavy incoming requests multiple times. To make CSE server resilient to redelivered message, in this PR we have added logic to detect duplicate requests and reject them.

Testing done:
As part of testing added an exception in the normal workflow to crash the consumer to guarantee a message redelivery. Checked the logs and made sure that on redelivery of the message it is rejected, as well as removed from the AMQP queue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/851)
<!-- Reviewable:end -->
