### PR TITLE
[VCDA-1927] paginate ovdc list (apiV 33 & 35) and cluster list (api 35)

### DIFF
--- a/container_service_extension/client/constants.py
+++ b/container_service_extension/client/constants.py
@@ -16,7 +16,6 @@ TKG_ENTITY_TYPE_ID = def_utils.generate_entity_type_id(
     def_utils.TKG_ENTITY_TYPE_NSS,
     def_utils.TKG_ENTITY_TYPE_VERSION)
 
-TKG_CLUSTER_RUNTIME = 'TkgCluster'
 
 # if cse_server_running key is set to false in profiles.yaml, CSE CLI can
 # only be used to work with TKG clusters. This key is set when the first call

--- a/container_service_extension/client/cse_client/api_33/ovdc_api.py
+++ b/container_service_extension/client/cse_client/api_33/ovdc_api.py
@@ -16,14 +16,9 @@ class OvdcApi(CseClient):
         self._ovdcs_uri = f"{self._uri}/ovdcs"
         self._ovdc_uri = f"{self._uri}/ovdc"
 
-    def list_ovdcs(self, filters={}):
-        response = self._client._do_request_prim(
-            shared_constants.RequestMethod.GET,
-            self._ovdcs_uri,
-            self._client._session,
-            accept_type='application/json',
-            params=filters)
-        return process_response(response)
+    def get_all_ovdcs(self):
+        url = f"{self._ovdcs_uri}?pageSize={self._request_page_size}"
+        return self.iterate_results(url)
 
     def get_ovdc(self, ovdc_id):
         uri = f"{self._ovdc_uri}/{ovdc_id}"

--- a/container_service_extension/client/cse_client/api_35/ovdc_api.py
+++ b/container_service_extension/client/cse_client/api_35/ovdc_api.py
@@ -19,14 +19,19 @@ class OvdcApi(CseClient):
                     f"{shared_constants.CSE_3_0_URL_FRAGMENT}"
         self._ovdcs_uri = f"{self._uri}/ovdcs"
         self._ovdc_uri = f"{self._uri}/ovdc"
+        # NOTE: The request page size is overrided because the CSE server takes
+        # an average of 10 seconds (Default vCD timeout) if there are 5 OVDCs
+        self._request_page_size = 5
 
-    def list_ovdcs(self):
-        response = self._client._do_request_prim(
-            shared_constants.RequestMethod.GET,
-            self._ovdcs_uri,
-            self._client._session,
-            accept_type='application/json')
-        return process_response(response)
+    def get_all_ovdcs(self):
+        """Iterate over all the get ovdc response page by page.
+
+        :returns: Yields the list of values in the page and a boolean
+            indicating if there are more results.
+        :rtype: Generator[(List[dict], int), None, None]
+        """
+        url = f"{self._ovdcs_uri}?pageSize={self._request_page_size}"
+        return self.iterate_results(url)
 
     def get_ovdc(self, ovdc_id):
         uri = f"{self._ovdc_uri}/{ovdc_id}"

--- a/container_service_extension/client/cse_client/cse_client.py
+++ b/container_service_extension/client/cse_client/cse_client.py
@@ -4,8 +4,46 @@
 
 import pyvcloud.vcd.client as vcd_client
 
+from container_service_extension.client.response_processor import process_response  # noqa: E501
+import container_service_extension.shared_constants as shared_constants
+
 
 class CseClient:
     def __init__(self, client: vcd_client.Client):
         self._client = client
         self._uri = self._client.get_api_uri()
+        self._request_page_size = 25
+
+    def iterate_results(self, base_url, filters={}):
+        """Iterate over paginated response until all the results are obtained.
+
+        :param str base_url: initial url
+        :param dict filters: filters for making the API call
+        :returns: Generator which yields values and a boolean indicating if
+            more results are present
+        :rtype: Generator[(List[dict], bool), None, None]
+
+        page and pageSize is not needed if iteration should start from the
+        first page.
+
+        Example: Iterating through all the pages for get cluster
+            (/cse/3.0/clusters) response from CSE server:
+                self.iterate_results("https://vcd-api/api/cse/3.0/clusters")
+
+        Example: Iterating through all the pages for get cluster starting from
+            page 3:
+                self.iterate_results("https://vcd-ip/api/cse/3.0/clusters?page=3&pageSize=25")
+        """  # noqa: E501
+        # NOTE: This method is added here to reduce dependency between
+        # cse_client package and the rest of the code.
+        url = base_url
+        while url:
+            response = self._client._do_request_prim(
+                shared_constants.RequestMethod.GET,
+                url,
+                self._client._session,
+                accept_type='application/json',
+                params=filters)
+            processed_response = process_response(response)
+            url = processed_response.get(shared_constants.PaginationKey.NEXT_PAGE_URI)  # noqa: E501
+            yield processed_response[shared_constants.PaginationKey.VALUES], bool(url) # noqa: E501

--- a/container_service_extension/client/cse_client/pks_ovdc_api.py
+++ b/container_service_extension/client/cse_client/pks_ovdc_api.py
@@ -16,14 +16,9 @@ class PksOvdcApi(CseClient):
         self._ovdcs_uri = f"{self._uri}/ovdcs"
         self._ovdc_uri = f"{self._uri}/ovdc"
 
-    def list_ovdcs(self, filters={}):
-        response = self._client._do_request_prim(
-            shared_constants.RequestMethod.GET,
-            self._ovdcs_uri,
-            self._client._session,
-            accept_type='application/json',
-            params=filters)
-        return process_response(response)
+    def get_all_ovdcs(self, filters={}):
+        url = f"{self._ovdcs_uri}?pageSize={self._request_page_size}"
+        return self.iterate_results(url, filters=filters)
 
     def get_ovdc(self, ovdc_id):
         uri = f"{self._ovdc_uri}/{ovdc_id}"

--- a/container_service_extension/client/metadata_based_ovdc.py
+++ b/container_service_extension/client/metadata_based_ovdc.py
@@ -16,9 +16,9 @@ class MetadataBasedOvdc:
         self._uri = f"{self.client.get_api_uri()}/{shared_constants.CSE_URL_FRAGMENT}"  # noqa: E501
         self._ovdc_api = ovdc_api_v33.OvdcApi(self.client)
 
-    def list_ovdc(self, list_pks_plans=False):
-        filters = {shared_constants.RequestKey.LIST_PKS_PLANS: list_pks_plans}
-        return self._ovdc_api.list_ovdcs(filters=filters)
+    def list_ovdc(self):
+        for ovdc_list, has_more_results in self._ovdc_api.get_all_ovdcs():  # noqa: E501
+            yield ovdc_list, has_more_results
 
     # TODO(metadata based enablement for < v35): Revisit after decision
     # to support metadata way of enabling for native clusters

--- a/container_service_extension/client/ovdc_commands.py
+++ b/container_service_extension/client/ovdc_commands.py
@@ -31,23 +31,36 @@ organization. Use a different organization by using the '--org' option.
                     short_help='Display org VDCs in vCD that are visible '
                                'to the logged in user')
 @click.pass_context
-def list_ovdcs(ctx):
+@click.option(
+    '-A',
+    '--all',
+    'should_print_all',
+    is_flag=True,
+    default=False,
+    required=False,
+    metavar='DISPLAY_ALL',
+    help='Display all the OVDCs non-interactively')
+def list_ovdcs(ctx, should_print_all=False):
     """Display org VDCs in vCD that are visible to the logged in user.
 
 \b
 Example
     vcd cse ovdc list
         Display ovdcs in vCD that are visible to the logged in user.
-        vcd cse ovdc list
+        The user might be prompted if more results needs to be displayed
+\b
+    vcd cse ovdc list -A
+        Display ovdcs in vCD that are visible to the logged in user without
+        prompting the user.
     """
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
         client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
         ovdc = Ovdc(client)
-        result = ovdc.list_ovdc()
-        stdout(result, ctx, sort_headers=False)
-        CLIENT_LOGGER.debug(result)
+        client_utils.print_paginated_result(ovdc.list_ovdc(),
+                                            should_print_all=should_print_all,
+                                            logger=CLIENT_LOGGER)
     except Exception as e:
         stderr(e, ctx)
         CLIENT_LOGGER.error(str(e))

--- a/container_service_extension/client/pks.py
+++ b/container_service_extension/client/pks.py
@@ -397,17 +397,27 @@ Examples
     is_flag=True,
     help="Display available PKS plans if org VDC is backed by "
          "Enterprise PKS infrastructure")
+@click.option(
+    '-A',
+    '--all',
+    'should_print_all',
+    is_flag=True,
+    default=False,
+    required=False,
+    metavar='DISPLAY_ALL',
+    help='Display all the OVDCs non-interactively')
 @click.pass_context
-def list_ovdcs(ctx, list_pks_plans):
+def list_ovdcs(ctx, list_pks_plans, should_print_all=False):
     """Display org VDCs in vCD that are visible to the logged in user."""
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
         client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
         ovdc = PksOvdc(client)
-        result = ovdc.list_ovdc(list_pks_plans=list_pks_plans)
-        stdout(result, ctx, sort_headers=False)
-        CLIENT_LOGGER.debug(result)
+        client_utils.print_paginated_result(
+            ovdc.list_ovdc(list_pks_plans=list_pks_plans),
+            should_print_all=should_print_all,
+            logger=CLIENT_LOGGER)
     except Exception as e:
         stderr(e, ctx)
         CLIENT_LOGGER.error(str(e))

--- a/container_service_extension/client/pks_ovdc.py
+++ b/container_service_extension/client/pks_ovdc.py
@@ -17,10 +17,9 @@ class PksOvdc:
         self._pks_ovdc_api = PksOvdcApi(client)
 
     def list_ovdc(self, list_pks_plans=False):
-        filters = {
-            shared_constants.RequestKey.LIST_PKS_PLANS: list_pks_plans
-        }
-        return self._pks_ovdc_api.list_ovdcs(filters=filters)
+        filters = {shared_constants.RequestKey.LIST_PKS_PLANS: list_pks_plans}
+        for ovdc_list, has_more_results in self._pks_ovdc_api.get_all_ovdcs(filters=filters):  # noqa: E501
+            yield ovdc_list, has_more_results
 
     def update_ovdc(self, enable, ovdc_name, org_name=None,
                     pks_plan=None, pks_cluster_domain=None):

--- a/container_service_extension/client/policy_based_ovdc.py
+++ b/container_service_extension/client/policy_based_ovdc.py
@@ -16,13 +16,13 @@ class PolicyBasedOvdc:
         self._ovdc_api = ovdc_api_v35.OvdcApi(self.client)
 
     def list_ovdc(self):
-        result = self._ovdc_api.list_ovdcs()
-        value_field_to_display_field = {
-            'ovdc_name': 'Name',
-            'ovdc_id': 'ID',
-            'k8s_runtime': 'K8s Runtime'
-        }
-        return client_utils.filter_columns(result, value_field_to_display_field)  # noqa: E501
+        for ovdc_list, has_more_results in self._ovdc_api.get_all_ovdcs():
+            value_field_to_display_field = {
+                'ovdc_name': 'Name',
+                'ovdc_id': 'ID',
+                'k8s_runtime': 'K8s Runtime'
+            }
+            yield client_utils.filter_columns(ovdc_list, value_field_to_display_field), has_more_results  # noqa: E501
 
     def update_ovdc(self, ovdc_name, k8s_runtime, enable=True, org_name=None,
                     remove_cp_from_vms_on_disable=False):

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -6,11 +6,13 @@ from pyvcloud.vcd.client import Client
 import requests
 import six
 from vcd_cli.profiles import Profiles
+from vcd_cli.utils import stdout
 
 from container_service_extension.client import system as syst
 from container_service_extension.client.constants import CSE_SERVER_RUNNING
 import container_service_extension.def_.utils as def_utils
 from container_service_extension.exceptions import CseResponseError
+from container_service_extension.logger import NULL_LOGGER
 from container_service_extension.shared_constants import CSE_SERVER_API_VERSION
 from container_service_extension.shared_constants import CSE_SERVER_BUSY_KEY
 
@@ -201,3 +203,28 @@ def filter_columns(result, value_field_to_display_field):
             for value_field, display_field in value_field_to_display_field.items()  # noqa: E501
         }
         return filtered_result
+
+
+def print_paginated_result(generator, should_print_all=False, logger=NULL_LOGGER):  # noqa: E501
+    """Print results by prompting the user for more results.
+
+    :param Generator[(List[dict], int), None, None] generator: generator which
+        yields a list of results and a boolean indicating if more results
+        are present.
+    :param bool should_print_all: print all the results without promting the
+        user.
+    :param logger logger: logger to log the results or exceptions.
+    """
+    try:
+        headers_printed = False
+        for result, has_more_results in generator:
+            stdout(result, sort_headers=False,
+                   show_headers=not headers_printed)
+            headers_printed = True
+            logger.debug(result)
+            if not has_more_results or \
+                    not (should_print_all or click.confirm("Do you want more results?")):  # noqa: E501
+                break
+    except Exception as e:
+        logger.error(f"Error while iterating over the paginated response: {e}")
+        raise

--- a/container_service_extension/cloudapi/constants.py
+++ b/container_service_extension/cloudapi/constants.py
@@ -4,7 +4,6 @@
 
 from enum import Enum
 
-CLOUDAPI_VERSION_1_0_0 = '1.0.0'
 CLOUDAPI_URN_PREFIX = 'urn:vcloud'
 
 
@@ -26,3 +25,4 @@ class CloudApiResource(str, Enum):
     ENTITY_RESOLVE = 'resolve'
     RIGHT_BUNDLES = 'rightsBundles'
     ACL = 'accessControls'
+    VDCS = 'vdcs'

--- a/container_service_extension/cloudapi_utils.py
+++ b/container_service_extension/cloudapi_utils.py
@@ -1,0 +1,31 @@
+# container-service-extension
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from container_service_extension.cloudapi.cloudapi_client import CloudApiClient
+from container_service_extension.cloudapi.constants import CloudApiResource
+from container_service_extension.cloudapi.constants import CloudApiVersion
+from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
+from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
+from container_service_extension.shared_constants import PaginationKey
+from container_service_extension.shared_constants import RequestMethod
+
+
+def get_vdcs_by_page(cloudapi_client: CloudApiClient,
+                     page_number=CSE_PAGINATION_FIRST_PAGE_NUMBER, page_size=CSE_PAGINATION_DEFAULT_PAGE_SIZE):  # noqa: E501
+    """Return a single page list vdc response for the page number and size.
+
+    :param CloudApiClient cloudapi_cliet
+    :param int page: page number for the response
+    :param int page_size: page size of the response
+    :return: touple containing total number of vdcs present and the list of
+        vdcs for the current request
+    """
+    filter_string = f"page={page_number}&pageSize={page_size}"
+    resp = cloudapi_client.do_request(method=RequestMethod.GET,
+                                      cloudapi_version=CloudApiVersion.VERSION_1_0_0,  # noqa: E501
+                                      resource_url_relative_path=f"{CloudApiResource.VDCS}?{filter_string}")  # noqa: E501
+    result = {}
+    result[PaginationKey.VALUES] = resp['values']
+    result[PaginationKey.RESULT_TOTAL] = int(resp['resultTotal'])
+    return result

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -1534,6 +1534,7 @@ def _legacy_upgrade_to_33_34(client, config, ext_vcd_api_version,
 
     # Fix cluster metadata and admin password
     clusters = get_all_cse_clusters(client)
+
     _fix_cluster_metadata(
         client=client,
         config=config,

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -34,6 +34,8 @@ from container_service_extension.server_constants import LocalTemplateKey
 from container_service_extension.server_constants import NodeType
 from container_service_extension.server_constants import ScriptFile
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
+from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
+from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
 from container_service_extension.shared_constants import DefEntityOperation
 from container_service_extension.shared_constants import DefEntityOperationStatus  # noqa: E501
 from container_service_extension.shared_constants import DefEntityPhase
@@ -74,18 +76,22 @@ class ClusterService(abstract_broker.AbstractBroker):
         )
         return self._sync_def_entity(cluster_id)
 
-    def list_clusters(self, filters: dict = {}) -> List[def_models.DefEntity]:
+    def list_clusters(self, filters: dict = {},
+                      page_number=CSE_PAGINATION_FIRST_PAGE_NUMBER,
+                      page_size=CSE_PAGINATION_DEFAULT_PAGE_SIZE) -> dict:
         """List corresponding defined entities of all native clusters."""
         telemetry_handler.record_user_action_details(
             cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_LIST,
             cse_params={telemetry_constants.PayloadKey.FILTER_KEYS: ','.join(filters.keys())}  # noqa: E501
         )
         ent_type: def_models.DefEntityType = def_utils.get_registered_def_entity_type()  # noqa: E501
-        return self.entity_svc.list_entities_by_entity_type(
+        return self.entity_svc.get_entities_per_page_by_entity_type(
             vendor=ent_type.vendor,
             nss=ent_type.nss,
             version=ent_type.version,
-            filters=filters)
+            filters=filters,
+            page_number=page_number,
+            page_size=page_size)
 
     def get_cluster_config(self, cluster_id: str):
         """Get the cluster's kube config contents.

--- a/container_service_extension/def_/entity_service.py
+++ b/container_service_extension/def_/entity_service.py
@@ -19,6 +19,8 @@ import container_service_extension.def_.utils as def_utils
 import container_service_extension.exceptions as cse_exception
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.minor_error_codes import MinorErrorCode
+from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE, PaginationKey  # noqa: E501
+from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
 from container_service_extension.shared_constants import RequestMethod
 import container_service_extension.utils as utils
 
@@ -120,6 +122,38 @@ class DefEntityService():
                 break
             for entity in response_body['values']:
                 yield DefEntity(**entity)
+
+    @handle_entity_service_exception
+    def get_entities_per_page_by_entity_type(self, vendor: str, nss: str, version: str,  # noqa: E501
+                                             filters: dict = None, page_number: int = CSE_PAGINATION_FIRST_PAGE_NUMBER,  # noqa: E501
+                                             page_size: int = CSE_PAGINATION_DEFAULT_PAGE_SIZE):  # noqa: E501
+        """List all the entities per page and entity type.
+
+        :param str vendor: entity type vendor name
+        :param str nss: entity type namespace
+        :param str version: entity type version
+        :param dict filters: additional filters
+        :param int page_number: page to return
+        :param int page_size: number of records per page
+        :rtype: Generator[(List[DefEntity], int), None, None]
+        """
+        filter_string = utils.construct_filter_string(filters)
+        query_string = f"page={page_number}&pageSize={page_size}"
+        if filter_string:
+            query_string = f"filter={filter_string}&{query_string}"
+        response_body = self._cloudapi_client.do_request(
+            method=RequestMethod.GET,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
+            resource_url_relative_path=f"{CloudApiResource.ENTITIES}/"
+                                       f"{CloudApiResource.ENTITY_TYPES_TOKEN}/"  # noqa: E501
+                                       f"{vendor}/{nss}/{version}?{query_string}")  # noqa: E501
+        result = {}
+        entity_list = []
+        for v in response_body['values']:
+            entity_list.append(DefEntity(**v))
+        result[PaginationKey.RESULT_TOTAL] = int(response_body['resultTotal'])
+        result[PaginationKey.VALUES] = entity_list
+        return result
 
     @handle_entity_service_exception
     def list_entities_by_interface(self, vendor: str, nss: str, version: str):

--- a/container_service_extension/def_/ovdc_service.py
+++ b/container_service_extension/def_/ovdc_service.py
@@ -3,17 +3,20 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # import copy
 from dataclasses import asdict
-from typing import List
 
 import pyvcloud.vcd.client as vcd_client
 import pyvcloud.vcd.task as vcd_task
 
+import container_service_extension.cloudapi_utils as cloudapi_utils
 import container_service_extension.compute_policy_manager as compute_policy_manager # noqa: E501
 import container_service_extension.def_.models as def_models
 import container_service_extension.logger as logger
 import container_service_extension.operation_context as ctx
 import container_service_extension.pyvcloud_utils as vcd_utils
 from container_service_extension.shared_constants import ClusterEntityKind
+from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
+from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
+from container_service_extension.shared_constants import PaginationKey
 from container_service_extension.shared_constants import RequestKey
 from container_service_extension.shared_constants import RUNTIME_DISPLAY_NAME_TO_INTERNAL_NAME_MAP  # noqa: E501
 from container_service_extension.shared_constants import RUNTIME_INTERNAL_NAME_TO_DISPLAY_NAME_MAP  # noqa: E501
@@ -111,12 +114,14 @@ def get_ovdc(operation_context: ctx.OperationContext, ovdc_id: str) -> dict:
     return result
 
 
-def list_ovdc(operation_context: ctx.OperationContext) -> List[dict]:
+def list_ovdc(operation_context: ctx.OperationContext,
+              page_number=CSE_PAGINATION_FIRST_PAGE_NUMBER,
+              page_size=CSE_PAGINATION_DEFAULT_PAGE_SIZE) -> dict:
     """List all ovdc and their k8s runtimes.
 
     :param ctx.OperationContext operation_context: context for the request
-    :return: list of dictionary containing details about the ovdc
-    :rtype: List[dict]
+    :return: dictionary containing list of details about the ovdc
+    :rtype: dict
     """
     # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
     # Prevent showing information about TKG+ by skipping TKG+ from the result.
@@ -125,7 +130,11 @@ def list_ovdc(operation_context: ctx.OperationContext) -> List[dict]:
                                                  cse_params={})
 
     ovdcs = []
-    org_vdcs = vcd_utils.get_all_ovdcs(operation_context.client)
+    result = cloudapi_utils.get_vdcs_by_page(
+        operation_context.cloudapi_client,
+        page_number=page_number, page_size=page_size)
+    org_vdcs = result[PaginationKey.VALUES]
+    num_results = result[PaginationKey.RESULT_TOTAL]
     for ovdc in org_vdcs:
         ovdc_name = ovdc.get('name')
         config = utils.get_server_runtime_config()
@@ -142,7 +151,10 @@ def list_ovdc(operation_context: ctx.OperationContext) -> List[dict]:
         # TODO: Find a better way to remove remove_cp_from_vms_on_disable
         del ovdc_details['remove_cp_from_vms_on_disable']
         ovdcs.append(ovdc_details)
-    return ovdcs
+    return {
+        PaginationKey.RESULT_TOTAL: num_results,
+        PaginationKey.VALUES: ovdcs
+    }
 
 
 def get_ovdc_k8s_runtime_details(sysadmin_client: vcd_client.Client,

--- a/container_service_extension/operation_context.py
+++ b/container_service_extension/operation_context.py
@@ -8,7 +8,7 @@ import container_service_extension.utils as utils
 
 
 class OperationContext:
-    def __init__(self, auth_token, is_jwt=True, request_id=None):
+    def __init__(self, auth_token, is_jwt=True, request_id=None):  # noqa: E501
         self._auth_token: str = auth_token
         self._is_jwt: bool = is_jwt
 

--- a/container_service_extension/request_handlers/pks_ovdc_handler.py
+++ b/container_service_extension/request_handlers/pks_ovdc_handler.py
@@ -2,22 +2,23 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 import copy
+import urllib
 
 import pyvcloud.vcd.client as vcd_client
 import pyvcloud.vcd.exceptions as vcd_e
-import pyvcloud.vcd.task as vcd_task
+import pyvcloud.vcd.utils as pyvcd_utils
 
-import container_service_extension.compute_policy_manager as compute_policy_manager # noqa: E501
 import container_service_extension.exceptions as e
 import container_service_extension.logger as logger
 import container_service_extension.operation_context as ctx
 import container_service_extension.ovdc_utils as ovdc_utils
+import container_service_extension.pksbroker as pksbroker
+import container_service_extension.pksbroker_manager as pksbroker_manager
 import container_service_extension.pyvcloud_utils as vcd_utils
 import container_service_extension.request_handlers.request_utils as req_utils
 from container_service_extension.server_constants import CseOperation as CseServerOperationInfo  # noqa: E501
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProvider
-from container_service_extension.shared_constants import ComputePolicyAction
 from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
 from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
 from container_service_extension.shared_constants import PaginationKey
@@ -61,6 +62,36 @@ def ovdc_update(request_data, op_ctx: ctx.OperationContext):
     record_user_action_details(cse_operation=cse_operation, cse_params=cse_params)  # noqa: E501
 
     try:
+        if k8s_provider == K8sProvider.PKS:
+            if not utils.is_pks_enabled():
+                raise e.CseServerError('CSE server is not '
+                                       'configured to work with PKS.')
+            required = [
+                RequestKey.PKS_PLAN_NAME,
+                RequestKey.PKS_CLUSTER_DOMAIN
+            ]
+            req_utils.validate_payload(validated_data, required)
+
+            # Check if target ovdc is not already enabled for other non PKS k8 providers # noqa: E501
+            ovdc_metadata = ovdc_utils.get_ovdc_k8s_provider_metadata(
+                op_ctx.sysadmin_client,
+                ovdc_id=validated_data[RequestKey.OVDC_ID])
+            ovdc_k8_provider = ovdc_metadata.get(K8S_PROVIDER_KEY)
+            if ovdc_k8_provider != K8sProvider.NONE and \
+                    ovdc_k8_provider != k8s_provider:
+                raise e.CseServerError("Ovdc already enabled for different K8 provider")  # noqa: E501
+
+            k8s_provider_info = ovdc_utils.construct_k8s_metadata_from_pks_cache(  # noqa: E501
+                op_ctx.sysadmin_client,
+                ovdc_id=validated_data[RequestKey.OVDC_ID],
+                org_name=validated_data[RequestKey.ORG_NAME],
+                pks_plans=validated_data[RequestKey.PKS_PLAN_NAME],
+                pks_cluster_domain=validated_data[RequestKey.PKS_CLUSTER_DOMAIN],  # noqa: E501
+                k8s_provider=k8s_provider)
+            ovdc_utils.create_pks_compute_profile(validated_data,
+                                                  op_ctx,
+                                                  k8s_provider_info)
+
         task = ovdc_utils.update_ovdc_k8s_provider_metadata(
             op_ctx.sysadmin_client,
             validated_data[RequestKey.OVDC_ID],
@@ -72,6 +103,7 @@ def ovdc_update(request_data, op_ctx: ctx.OperationContext):
 
         return {'task_href': task.get('href')}
     except Exception as err:
+        logger.SERVER_LOGGER.error(f"Error while updating OVDC: {str(err)}")
         # Telemetry - Record failed enabling/disabling of ovdc
         record_user_action(cse_operation, status=OperationStatus.FAILED)
         raise err
@@ -107,6 +139,7 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
     :return: List of dictionaries with org VDC k8s provider metadata.
     """
     defaults = {
+        RequestKey.LIST_PKS_PLANS: False,
         PaginationKey.PAGE_NUMBER: CSE_PAGINATION_FIRST_PAGE_NUMBER,
         PaginationKey.PAGE_SIZE: CSE_PAGINATION_DEFAULT_PAGE_SIZE
     }
@@ -114,11 +147,18 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
 
     page_number = int(validated_data[PaginationKey.PAGE_NUMBER])
     page_size = int(validated_data[PaginationKey.PAGE_SIZE])
+    list_pks_plans = utils.str_to_bool(validated_data[RequestKey.LIST_PKS_PLANS]) # noqa: E501
 
     # Record telemetry data
     cse_params = copy.deepcopy(validated_data)
+    cse_params[RequestKey.LIST_PKS_PLANS] = list_pks_plans
     record_user_action_details(cse_operation=CseOperation.OVDC_LIST,
                                cse_params=cse_params)
+
+    if list_pks_plans and not op_ctx.client.is_sysadmin():
+        raise e.UnauthorizedRequestError(
+            'Operation denied. Enterprise PKS plans visible only '
+            'to System Administrators.')
 
     ovdcs = []
     result = \
@@ -144,8 +184,51 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
             'org': org_name,
             'k8s provider': k8s_provider
         }
+        if list_pks_plans:
+            pks_plans = ''
+            pks_server = ''
+            if k8s_provider == K8sProvider.PKS:
+                # vc name for vdc can only be found using typed query
+                qfilter = f"name=={urllib.parse.quote(ovdc_name)};" \
+                          f"orgName=={urllib.parse.quote(org_name)}"
+                q = op_ctx.client.get_typed_query(
+                    vcd_client.ResourceType.ADMIN_ORG_VDC.value,
+                    query_result_format=vcd_client.QueryResultFormat.RECORDS, # noqa: E501
+                    qfilter=qfilter)
+                # should only ever be one element in the generator
+                ovdc_records = list(q.execute())
+                if len(ovdc_records) == 0:
+                    raise vcd_e.EntityNotFoundException(
+                        f"Org VDC {ovdc_name} not found in org {org_name}")
+                ovdc_record = None
+                for record in ovdc_records:
+                    ovdc_record = pyvcd_utils.to_dict(
+                        record, resource_type=vcd_client.ResourceType.ADMIN_ORG_VDC.value) # noqa: E501
+                    break
+
+                vc_to_pks_plans_map = {}
+                pks_contexts = pksbroker_manager.create_pks_context_for_all_accounts_in_org(op_ctx)  # noqa: E501
+
+                for pks_context in pks_contexts:
+                    if pks_context['vc'] in vc_to_pks_plans_map:
+                        continue
+                    pks_broker = pksbroker.PksBroker(pks_context,
+                                                     op_ctx)
+                    plans = pks_broker.list_plans()
+                    plan_names = [plan.get('name') for plan in plans]
+                    vc_to_pks_plans_map[pks_context['vc']] = \
+                        [plan_names, pks_context['host']]
+
+                pks_plan_and_server_info = vc_to_pks_plans_map.get(
+                    ovdc_record['vcName'], [])
+                if len(pks_plan_and_server_info) > 0:
+                    pks_plans = pks_plan_and_server_info[0]
+                    pks_server = pks_plan_and_server_info[1]
+
+            ovdc_dict['pks api server'] = pks_server
+            ovdc_dict['available pks plans'] = pks_plans
         ovdcs.append(ovdc_dict)
-    api_path = CseServerOperationInfo.OVDC_LIST.api_path_format
+    api_path = CseServerOperationInfo.PKS_OVDC_LIST.api_path_format
     next_page_uri = vcd_utils.create_cse_page_uri(op_ctx.client,
                                                   api_path,
                                                   vcd_uri=next_page_uri)
@@ -158,150 +241,3 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
                                               page_size=page_size,
                                               next_page_uri=next_page_uri,
                                               prev_page_uri=prev_page_uri)
-
-
-@record_user_action_telemetry(cse_operation=CseOperation.OVDC_COMPUTE_POLICY_LIST)  # noqa: E501
-def ovdc_compute_policy_list(request_data,
-                             op_ctx: ctx.OperationContext):
-    """Request handler for ovdc compute-policy list operation.
-
-    Required data: ovdc_id
-
-    :return: Dictionary with task href.
-    """
-    required = [
-        RequestKey.OVDC_ID
-    ]
-    req_utils.validate_payload(request_data, required)
-
-    config = utils.get_server_runtime_config()
-    cpm = compute_policy_manager.ComputePolicyManager(
-        op_ctx.sysadmin_client,
-        log_wire=utils.str_to_bool(config['service'].get('log_wire')))
-    compute_policies = []
-    for cp in \
-            compute_policy_manager.list_cse_sizing_policies_on_vdc(
-                cpm,
-                request_data[RequestKey.OVDC_ID]):
-        policy = {
-            'name': cp['display_name'],
-            'id': cp['id'],
-            'href': cp['href']
-        }
-        compute_policies.append(policy)
-    return compute_policies
-
-
-def ovdc_compute_policy_update(request_data,
-                               op_ctx: ctx.OperationContext):
-    """Request handler for ovdc compute-policy update operation.
-
-    Required data: ovdc_id, compute_policy_action, compute_policy_names
-
-    :return: Dictionary with task href.
-    """
-    required = [
-        RequestKey.OVDC_ID,
-        RequestKey.COMPUTE_POLICY_ACTION,
-        RequestKey.COMPUTE_POLICY_NAME
-    ]
-    defaults = {
-        RequestKey.REMOVE_COMPUTE_POLICY_FROM_VMS: False,
-    }
-    validated_data = {**defaults, **request_data}
-    req_utils.validate_payload(validated_data, required)
-
-    action = validated_data[RequestKey.COMPUTE_POLICY_ACTION]
-    cp_name = validated_data[RequestKey.COMPUTE_POLICY_NAME]
-    ovdc_id = validated_data[RequestKey.OVDC_ID]
-    remove_compute_policy_from_vms = validated_data[RequestKey.REMOVE_COMPUTE_POLICY_FROM_VMS] # noqa: E501
-    try:
-        config = utils.get_server_runtime_config()
-        cpm = compute_policy_manager.ComputePolicyManager(
-            op_ctx.sysadmin_client,
-            log_wire=utils.str_to_bool(config['service'].get('log_wire'))) # noqa: E501
-        cp_href = None
-        cp_id = None
-        if cp_name == SYSTEM_DEFAULT_COMPUTE_POLICY_NAME:
-            for _cp in cpm.list_compute_policies_on_vdc(ovdc_id):
-                if _cp['name'] == cp_name:
-                    cp_href = _cp['href']
-                    cp_id = _cp['id']
-        else:
-            try:
-                _cp = compute_policy_manager.get_cse_vdc_compute_policy(cpm, cp_name)  # noqa: E501
-                cp_href = _cp['href']
-                cp_id = _cp['id']
-            except vcd_e.EntityNotFoundException:
-                pass
-
-        if cp_href is None:
-            raise e.BadRequestError(f"Compute policy '{cp_name}' not found.")
-
-        if action == ComputePolicyAction.ADD:
-            cpm.add_compute_policy_to_vdc(ovdc_id, cp_href)
-            # Record telemetry data
-            record_user_action(CseOperation.OVDC_COMPUTE_POLICY_ADD)
-            return f"Added compute policy '{cp_name}' ({cp_id}) to ovdc " \
-                   f"({ovdc_id})"
-
-        if action == ComputePolicyAction.REMOVE:
-            # TODO: fix remove_compute_policy by implementing a proper way
-            # for calling async methods without having to pass op_ctx
-            # outside handlers.
-            op_ctx.is_async = True
-            response = cpm.remove_vdc_compute_policy_from_vdc(
-                ovdc_id,
-                cp_href,
-                force=remove_compute_policy_from_vms)
-            # Follow task_href to completion in a different thread and end
-            # operation context
-            _follow_task(op_ctx, response['task_href'], ovdc_id)
-            # Record telemetry data
-            record_user_action(CseOperation.OVDC_COMPUTE_POLICY_REMOVE)
-            return response
-
-        raise e.BadRequestError("Unsupported compute policy action")
-
-    except Exception as err:
-        # Record telemetry data failure`
-        if action == ComputePolicyAction.ADD:
-            record_user_action(CseOperation.OVDC_COMPUTE_POLICY_ADD,
-                               status=OperationStatus.FAILED)
-        elif action == ComputePolicyAction.REMOVE:
-            record_user_action(CseOperation.OVDC_COMPUTE_POLICY_REMOVE,
-                               status=OperationStatus.FAILED)
-        raise err
-
-
-@utils.run_async
-def _follow_task(op_ctx: ctx.OperationContext, task_href: str, ovdc_id: str):
-    try:
-        task = vcd_task.Task(client=op_ctx.sysadmin_client)
-        session = op_ctx.sysadmin_client.get_vcloud_session()
-        vdc = vcd_utils.get_vdc(op_ctx.sysadmin_client, vdc_id=ovdc_id)
-        org = vcd_utils.get_org(op_ctx.sysadmin_client)
-        user_name = session.get('user')
-        user_href = org.get_user(user_name).get('href')
-        msg = "Remove ovdc compute policy"
-        # TODO(pyvcloud): Add method to retireve task from task href
-        t = task.update(
-            status=vcd_task.TaskStatus.RUNNING.value,
-            namespace='vcloud.cse',
-            operation=msg,
-            operation_name=msg,
-            details='',
-            progress=None,
-            owner_href=vdc.href,
-            owner_name=vdc.name,
-            owner_type=vcd_client.EntityType.VDC.value,
-            user_href=user_href,
-            user_name=user_name,
-            org_href=op_ctx.user.org_href,
-            task_href=task_href)
-        op_ctx.sysadmin_client.get_task_monitor().wait_for_status(t)
-    except Exception as err:
-        logger.SERVER_LOGGER.error(f"{err}")
-    finally:
-        if op_ctx.sysadmin_client:
-            op_ctx.end()

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -7,10 +7,15 @@ import container_service_extension.def_.cluster_service as cluster_svc
 import container_service_extension.def_.models as def_models
 import container_service_extension.operation_context as ctx
 import container_service_extension.request_handlers.request_utils as request_utils  # noqa: E501
+from container_service_extension.server_constants import CseOperation as CseServerOperationInfo  # noqa: E501
+from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
+from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
 from container_service_extension.shared_constants import FlattenedClusterSpecKey  # noqa: E501
+from container_service_extension.shared_constants import PaginationKey
 from container_service_extension.shared_constants import RequestKey
 import container_service_extension.telemetry.constants as telemetry_constants
 import container_service_extension.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
+import container_service_extension.utils as utils
 
 
 _OPERATION_KEY = 'operation'
@@ -137,8 +142,29 @@ def cluster_list(data: dict, op_ctx: ctx.OperationContext):
     :return: List
     """
     svc = cluster_svc.ClusterService(op_ctx)
-    return [asdict(def_entity) for def_entity in
-            svc.list_clusters(data.get(RequestKey.V35_QUERY, {}))]
+    filters = data.get(RequestKey.V35_QUERY, {})
+    # TODO create default constants for PAGE_NUMBER and PAGE_SIZE
+    page_number = int(filters.get(PaginationKey.PAGE_NUMBER, CSE_PAGINATION_FIRST_PAGE_NUMBER))  # noqa: E501
+    page_size = int(filters.get(PaginationKey.PAGE_SIZE, CSE_PAGINATION_DEFAULT_PAGE_SIZE))  # noqa: E501
+    # remove page number and page size from the filters as it is treated
+    # differently from other filters
+    if PaginationKey.PAGE_NUMBER in filters:
+        del filters[PaginationKey.PAGE_NUMBER]
+    if PaginationKey.PAGE_SIZE in filters:
+        del filters[PaginationKey.PAGE_SIZE]
+    result = svc.list_clusters(filters=filters,
+                               page_number=page_number,
+                               page_size=page_size)
+    cluster_list = [asdict(def_entity) for def_entity in result[PaginationKey.VALUES]]  # noqa: E501
+    api_path = CseServerOperationInfo.V35_CLUSTER_LIST.api_path_format
+    uri = f"{op_ctx.client.get_api_uri().strip('/')}{api_path}"
+    return utils.create_links_and_construct_paginated_result(
+        uri,
+        cluster_list,
+        result_total=result[PaginationKey.RESULT_TOTAL],
+        page_number=page_number,
+        page_size=page_size,
+        query_params=filters)
 
 
 @request_utils.v35_api_exception_handler

--- a/container_service_extension/request_handlers/v35/ovdc_handler.py
+++ b/container_service_extension/request_handlers/v35/ovdc_handler.py
@@ -5,9 +5,14 @@ import container_service_extension.def_.models as def_models
 import container_service_extension.def_.ovdc_service as ovdc_service
 import container_service_extension.operation_context as ctx
 import container_service_extension.request_handlers.request_utils as request_utils  # noqa: E501
+from container_service_extension.server_constants import CseOperation as CseServerOperationInfo  # noqa: E501
+from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
+from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
+from container_service_extension.shared_constants import PaginationKey
 from container_service_extension.shared_constants import RequestKey
 from container_service_extension.telemetry.constants import CseOperation
 from container_service_extension.telemetry.telemetry_handler import record_user_action_telemetry  # noqa: E501
+import container_service_extension.utils as utils
 
 
 @request_utils.v35_api_exception_handler
@@ -47,4 +52,18 @@ def ovdc_list(data, operation_context: ctx.OperationContext):
 
     :return: List of dictionaries with org VDC k8s runtimes.
     """
-    return ovdc_service.list_ovdc(operation_context)
+    page_number = int(data.get(RequestKey.V35_QUERY, {}).get(PaginationKey.PAGE_NUMBER,  # noqa: E501
+                                                             CSE_PAGINATION_FIRST_PAGE_NUMBER))  # noqa: E501
+    page_size = int(data.get(RequestKey.V35_QUERY, {}).get(PaginationKey.PAGE_SIZE,  # noqa: E501
+                                                           CSE_PAGINATION_DEFAULT_PAGE_SIZE))  # noqa: E501
+    result = ovdc_service.list_ovdc(operation_context,
+                                    page_number=page_number,
+                                    page_size=page_size)
+    api_path = CseServerOperationInfo.V35_OVDC_LIST.api_path_format
+    base_uri = f"{operation_context.client.get_api_uri().strip('/')}{api_path}"
+    return utils.create_links_and_construct_paginated_result(
+        base_uri,
+        result[PaginationKey.VALUES],
+        result[PaginationKey.RESULT_TOTAL],
+        page_number=page_number,
+        page_size=page_size)

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -16,6 +16,7 @@ import container_service_extension.operation_context as ctx
 import container_service_extension.request_handlers.native_cluster_handler as native_cluster_handler  # noqa: E501
 import container_service_extension.request_handlers.ovdc_handler as ovdc_handler  # noqa: E501
 import container_service_extension.request_handlers.pks_cluster_handler as pks_cluster_handler  # noqa: E501
+import container_service_extension.request_handlers.pks_ovdc_handler as pks_ovdc_handler  # noqa: E501
 import container_service_extension.request_handlers.system_handler as system_handler  # noqa: E501
 import container_service_extension.request_handlers.template_handler as template_handler  # noqa: E501 E501
 import container_service_extension.request_handlers.v35.def_cluster_handler as v35_cluster_handler # noqa: E501
@@ -131,7 +132,10 @@ OPERATION_TO_HANDLER = {
     CseOperation.PKS_CLUSTER_DELETE: pks_cluster_handler.cluster_delete,
     CseOperation.PKS_CLUSTER_INFO: pks_cluster_handler.cluster_info,
     CseOperation.PKS_CLUSTER_LIST: pks_cluster_handler.cluster_list,
-    CseOperation.PKS_CLUSTER_RESIZE: pks_cluster_handler.cluster_resize
+    CseOperation.PKS_CLUSTER_RESIZE: pks_cluster_handler.cluster_resize,
+    CseOperation.PKS_OVDC_LIST: pks_ovdc_handler.ovdc_list,
+    CseOperation.PKS_OVDC_INFO: pks_ovdc_handler.ovdc_info,
+    CseOperation.PKS_OVDC_UPDATE: pks_ovdc_handler.ovdc_update
 }
 
 _OPERATION_KEY = 'operation'
@@ -244,7 +248,6 @@ def process_request(message):
         accept_header=message['headers'].get('Accept'))
     api_version = _get_api_version_from_accept_header(
         api_version_header=api_version_header)
-
     url_data = _get_url_data(method=message['method'],
                              url=message['requestUri'],
                              api_version=api_version)  # noqa: E501
@@ -416,17 +419,17 @@ def _get_pks_url_data(method: str, url: str):
     elif operation_type == shared_constants.OperationType.OVDC:
         if num_tokens == 4:
             if method == shared_constants.RequestMethod.GET:
-                return {_OPERATION_KEY: CseOperation.OVDC_LIST}
+                return {_OPERATION_KEY: CseOperation.PKS_OVDC_LIST}
             raise cse_exception.MethodNotAllowedRequestError()
         if num_tokens == 5:
             if method == shared_constants.RequestMethod.GET:
                 return {
-                    _OPERATION_KEY: CseOperation.OVDC_INFO,
+                    _OPERATION_KEY: CseOperation.PKS_OVDC_INFO,
                     shared_constants.RequestKey.OVDC_ID: tokens[4]
                 }
             if method == shared_constants.RequestMethod.PUT:
                 return {
-                    _OPERATION_KEY: CseOperation.OVDC_UPDATE,
+                    _OPERATION_KEY: CseOperation.PKS_OVDC_UPDATE,
                     shared_constants.RequestKey.OVDC_ID: tokens[4]
                 }
             raise cse_exception.MethodNotAllowedRequestError()

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -182,58 +182,66 @@ class RemoteTemplateKey(str, Enum):
 # CSE requests
 @unique
 class CseOperation(Enum):
-    def __init__(self, description, ideal_response_code=requests.codes.ok):
+    def __init__(self, description, api_path_format, ideal_response_code=requests.codes.ok):  # noqa: E501
         self._description = description
         self._ideal_response_code = ideal_response_code
+        self._api_path_format = api_path_format
 
     @property
     def ideal_response_code(self):
         return int(self._ideal_response_code)
 
-    CLUSTER_CONFIG = ('get config of cluster')
-    CLUSTER_CREATE = ('create cluster', requests.codes.accepted)
-    CLUSTER_DELETE = ('delete cluster', requests.codes.accepted)
-    CLUSTER_INFO = ('get info of cluster')
-    CLUSTER_LIST = ('list clusters')
-    CLUSTER_RESIZE = ('resize cluster', requests.codes.accepted)
-    CLUSTER_UPGRADE_PLAN = ('get supported cluster upgrade paths')
-    CLUSTER_UPGRADE = ('upgrade cluster software', requests.codes.accepted)
-    NODE_CREATE = ('create node', requests.codes.accepted)
-    NODE_DELETE = ('delete node', requests.codes.accepted)
-    NODE_INFO = ('get info of node')
+    @property
+    def api_path_format(self):
+        return self._api_path_format
 
-    V35_CLUSTER_CONFIG = ('get config of DEF cluster')
-    V35_CLUSTER_CREATE = ('create DEF cluster', requests.codes.accepted)
-    V35_CLUSTER_DELETE = ('delete DEF cluster', requests.codes.accepted)
-    V35_CLUSTER_INFO = ('get info of DEF cluster')
-    V35_CLUSTER_LIST = ('list DEF clusters')
-    V35_CLUSTER_RESIZE = ('resize DEF cluster', requests.codes.accepted)
-    V35_CLUSTER_UPGRADE_PLAN = ('get supported DEF cluster upgrade paths')
-    V35_CLUSTER_UPGRADE = ('upgrade DEF cluster software', requests.codes.accepted)  # noqa: E501
-    V35_NODE_CREATE = ('create DEF node', requests.codes.accepted)
-    V35_NODE_DELETE = ('delete DEF node', requests.codes.accepted)
-    V35_NODE_INFO = ('get info of DEF node')
+    CLUSTER_CONFIG = ('get config of cluster', '/cse/cluster/%s/config')
+    CLUSTER_CREATE = ('create cluster', '/cse/clusters', requests.codes.accepted)  # noqa: E501
+    CLUSTER_DELETE = ('delete cluster', '/cse/cluster/%s', requests.codes.accepted)  # noqa: E501
+    CLUSTER_INFO = ('get info of cluster', '/cse/cluster/%s')
+    CLUSTER_LIST = ('list clusters', '/cse/clusters')
+    CLUSTER_RESIZE = ('resize cluster', '/cse/cluster/%s', requests.codes.accepted)  # noqa: E501
+    CLUSTER_UPGRADE_PLAN = ('get supported cluster upgrade paths', '/cse/cluster/%s/upgrade-plan')  # noqa: E501
+    CLUSTER_UPGRADE = ('upgrade cluster software', '/cse/cluster/%s/action/upgrade', requests.codes.accepted)  # noqa: E501
+    NODE_CREATE = ('create node', '/cse/nodes', requests.codes.accepted)
+    NODE_DELETE = ('delete node', '/cse/nodes/%s', requests.codes.accepted)
+    NODE_INFO = ('get info of node', '/cse/nodes/%s')
 
-    OVDC_UPDATE = ('enable or disable ovdc for k8s', requests.codes.accepted)
-    OVDC_INFO = ('get info of ovdc')
-    OVDC_LIST = ('list ovdcs')
-    OVDC_COMPUTE_POLICY_LIST = ('list ovdc compute policies')
-    OVDC_COMPUTE_POLICY_UPDATE = ('update ovdc compute policies')
-    SYSTEM_INFO = ('get info of system')
-    SYSTEM_UPDATE = ('update system status')
-    TEMPLATE_LIST = ('list all templates')
+    V35_CLUSTER_CONFIG = ('get config of DEF cluster', '/cse/3.0/cluster/%s/config')  # noqa: E501
+    V35_CLUSTER_CREATE = ('create DEF cluster', '/cse/3.0/clusters', requests.codes.accepted)  # noqa: E501
+    V35_CLUSTER_DELETE = ('delete DEF cluster', '/cse/3.0/cluster/%s', requests.codes.accepted)  # noqa: E501
+    V35_CLUSTER_INFO = ('get info of DEF cluster', '/cse/3.0/cluster/%s')
+    V35_CLUSTER_LIST = ('list DEF clusters', '/cse/3.0/clusters')
+    V35_CLUSTER_RESIZE = ('resize DEF cluster', '/cse/3.0/cluster/%s', requests.codes.accepted)  # noqa: E501
+    V35_CLUSTER_UPGRADE_PLAN = ('get supported DEF cluster upgrade paths', '/cse/3.0/cluster/%s/upgrade-plan')  # noqa: E501
+    V35_CLUSTER_UPGRADE = ('upgrade DEF cluster software', '/cse/3.0/cluster/%s/action/upgrade', requests.codes.accepted)  # noqa: E501
+    V35_NODE_CREATE = ('create DEF node', 'NOT IMPLEMENTED', requests.codes.accepted)  # noqa: E501
+    V35_NODE_DELETE = ('delete DEF node', '/cse/3.0/cluster/%s/nfs/%s', requests.codes.accepted)  # noqa: E501
+    V35_NODE_INFO = ('get info of DEF node', 'NOT IMPLEMENTED')
 
-    V35_OVDC_LIST = ('list ovdcs for v35')
-    V35_OVDC_INFO = ('get info of ovdc for v35')
-    V35_OVDC_UPDATE = ('enable or disable ovdc for a cluster kind for v35', requests.codes.accepted)  # noqa: E501
-    V35_TEMPLATE_LIST = ('list all v35 templates')
+    OVDC_UPDATE = ('enable or disable ovdc for k8s', '/cse/ovdc/%s', requests.codes.accepted)  # noqa: E501
+    OVDC_INFO = ('get info of ovdc', '/cse/ovdc/%s')
+    OVDC_LIST = ('list ovdcs', '/cse/ovdcs')
+    OVDC_COMPUTE_POLICY_LIST = ('list ovdc compute policies', '/cse/ovdc/%s/compute-policies')  # noqa: E501
+    OVDC_COMPUTE_POLICY_UPDATE = ('update ovdc compute policies', '/cse/ovdc/%s/compute-policies')  # noqa: E501
+    SYSTEM_INFO = ('get info of system', '/cse/system')
+    SYSTEM_UPDATE = ('update system status', '/cse/system')
+    TEMPLATE_LIST = ('list all templates', '/cse/templates')
 
-    PKS_CLUSTER_CONFIG = ('get config of PKS cluster')
-    PKS_CLUSTER_CREATE = ('create PKS cluster', requests.codes.accepted)
-    PKS_CLUSTER_DELETE = ('delete PKS cluster', requests.codes.accepted)
-    PKS_CLUSTER_INFO = ('get info of PKS cluster')
-    PKS_CLUSTER_LIST = ('list PKS clusters')
-    PKS_CLUSTER_RESIZE = ('resize PKS cluster', requests.codes.accepted)
+    V35_OVDC_LIST = ('list ovdcs for v35', '/cse/3.0/ovdcs')
+    V35_OVDC_INFO = ('get info of ovdc for v35', '/cse/3.0/ovdc/%s')
+    V35_OVDC_UPDATE = ('enable or disable ovdc for a cluster kind for v35', '/cse/3.0/ovdc/%s', requests.codes.accepted)  # noqa: E501
+    V35_TEMPLATE_LIST = ('list all v35 templates', '/cse/templates')
+
+    PKS_CLUSTER_CONFIG = ('get config of PKS cluster', '/pks/clusters/%s/config')  # noqa: E501
+    PKS_CLUSTER_CREATE = ('create PKS cluster', '/pks/clusters', requests.codes.accepted)  # noqa: E501
+    PKS_CLUSTER_DELETE = ('delete PKS cluster', '/pks/cluster/%s', requests.codes.accepted)  # noqa: E501
+    PKS_CLUSTER_INFO = ('get info of PKS cluster', '/pks/cluster/%s')
+    PKS_CLUSTER_LIST = ('list PKS clusters', '/pks/clusters')
+    PKS_CLUSTER_RESIZE = ('resize PKS cluster', '/pks/cluster/%s', requests.codes.accepted)  # noqa: E501
+    PKS_OVDC_LIST = ('list all ovdcs', '/pks/ovdcs')
+    PKS_OVDC_INFO = ('get info of the ovdc', '/pks/ovdc/%s')
+    PKS_OVDC_UPDATE = ('enable or disable ovdc for pks', '/pks/ovdc/%s', requests.codes.accepted)  # noqa: E501
 
 
 @unique

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -46,6 +46,11 @@ RUNTIME_INTERNAL_NAME_TO_DISPLAY_NAME_MAP = {
 CSE_SERVER_BUSY_KEY = 'CSE Server Busy'
 
 
+# CSE Pagination default values
+CSE_PAGINATION_FIRST_PAGE_NUMBER = 1
+CSE_PAGINATION_DEFAULT_PAGE_SIZE = 25
+
+
 @unique
 class OperationType(str, Enum):
     CLUSTER = 'cluster'
@@ -129,6 +134,16 @@ class RequestKey(str, Enum):
 
     # keys that are only used internally at server side
     PKS_EXT_HOST = 'pks_ext_host'
+
+
+@unique
+class PaginationKey(str, Enum):
+    PAGE_NUMBER = 'page'
+    PAGE_SIZE = 'pageSize'
+    NEXT_PAGE_URI = 'nextPageUri'
+    PREV_PAGE_URI = 'previousPageUri'
+    RESULT_TOTAL = 'resultTotal'
+    VALUES = 'values'
 
 
 @unique

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -19,6 +19,9 @@ import semantic_version
 
 from container_service_extension.logger import NULL_LOGGER
 from container_service_extension.server_constants import MQTT_MIN_API_VERSION
+from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
+from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
+from container_service_extension.shared_constants import PaginationKey
 from container_service_extension.thread_local_data import get_thread_request_id
 from container_service_extension.thread_local_data import set_thread_request_id
 
@@ -466,3 +469,51 @@ def construct_filter_string(filters: dict):
                 filter_expressions.append(filter_exp)
         filter_string = ";".join(filter_expressions)
     return filter_string
+
+
+def construct_paginated_response(values, result_total,
+                                 page_number=CSE_PAGINATION_FIRST_PAGE_NUMBER,  # noqa: E501
+                                 page_size=CSE_PAGINATION_DEFAULT_PAGE_SIZE,  # noqa: E501
+                                 next_page_uri=None,
+                                 prev_page_uri=None):
+    resp = {
+        PaginationKey.VALUES: values,
+        PaginationKey.RESULT_TOTAL: result_total,
+        PaginationKey.PAGE_NUMBER: page_number,
+        PaginationKey.PAGE_SIZE: page_size
+    }
+    if next_page_uri:
+        resp[PaginationKey.NEXT_PAGE_URI] = next_page_uri
+    if prev_page_uri:
+        resp[PaginationKey.PREV_PAGE_URI] = prev_page_uri
+    return resp
+
+
+def create_links_and_construct_paginated_result(base_uri, values, result_total,
+                                                page_number=CSE_PAGINATION_FIRST_PAGE_NUMBER,  # noqa: E501
+                                                page_size=CSE_PAGINATION_DEFAULT_PAGE_SIZE,  # noqa: E501
+                                                query_params={}):
+    next_page_uri: str = None
+    if page_number * page_size < result_total:
+        # TODO find a way to get the initial url part
+        # ideally the request details should be passed down to each of the
+        # handler funcions as request context
+        next_page_uri = f"{base_uri}?page={page_number+1}&pageSize={page_size}"
+        for q in query_params.keys():
+            next_page_uri += f"&{q}={query_params[q]}"
+
+    prev_page_uri: str = None
+    if page_number > 1:
+        prev_page_uri = f"{base_uri}?page={page_number-1}&pageSize={page_size}"
+
+    # add the rest of the query parameters
+    for q in query_params.keys():
+        next_page_uri += f"&{q}={query_params[q]}"
+        prev_page_uri += f"&{q}={query_params[q]}"
+
+    return construct_paginated_response(values=values,
+                                        result_total=result_total,
+                                        page_number=page_number,
+                                        page_size=page_size,
+                                        next_page_uri=next_page_uri,
+                                        prev_page_uri=prev_page_uri)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,8 @@ paho-mqtt >=1.5.0, < 1.6.0
 # pika 0.13.1
 pika >= 1.0.0, < 2.0.0
 
-# pyvcloud 23.0.0
-pyvcloud >= 23.0.0, < 24.0.0
+# pyvcloud >= 23.0.0, < 24.0.0
+pyvcloud == 23.0.1.dev4
 
 # pyvmomi 6.7.3
 pyvmomi >= 6.7.0 , < 7.0.0
@@ -25,8 +25,8 @@ pyvmomi >= 6.7.0 , < 7.0.0
 # semantic-version 2.8.5
 semantic-version >= 2.8.4, < 3.0.0
 
-# vcd-cli 24.0.0
-vcd-cli >= 24.0.0, < 25.0.0
+# vcd-cli >= 24.0.0, < 25.0.0
+vcd-cli == 24.0.1.dev1
 
 # vsphere-guest-run 0.0.7
 vsphere-guest-run >= 0.0.7, < 1.0.0


### PR DESCRIPTION
Porting changes from master:

- Pagination of ovdc list to prevent the client from timing out. Cluster list changes made as of now for only the server side.

- Testing done:
- vcd cse ovdc list (for api V 35)
- vcd cse pks ovdc list ( for api V 33)

- Default page size is set to 25 in the client

Sample output with default page size set to 3 (for convenience of displaying the functionality)
![Screen Shot 2020-11-23 at 3 43 49 PM](https://user-images.githubusercontent.com/16699642/100028060-e2ebfb00-2da2-11eb-852c-46fbfc83f51a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/863)
<!-- Reviewable:end -->
