### PR TITLE
[VCDA-1600] Reorganize shared constants and utility methods

### DIFF
--- a/container_service_extension/authorization.py
+++ b/container_service_extension/authorization.py
@@ -7,7 +7,7 @@ import functools
 import container_service_extension.abstract_broker as abstract_broker
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.server_constants import CSE_SERVICE_NAMESPACE
-import container_service_extension.utils as utils
+import container_service_extension.server_utils as server_utils
 
 
 def secure(required_rights=[]):
@@ -25,7 +25,7 @@ def secure(required_rights=[]):
     def decorator_secure(func):
         @functools.wraps(func)
         def decorator_wrapper(*args, **kwargs):
-            server_config = utils.get_server_runtime_config()
+            server_config = server_utils.get_server_runtime_config()
 
             if (server_config['service']['enforce_authorization']
                     and required_rights is not None

--- a/container_service_extension/client/constants.py
+++ b/container_service_extension/client/constants.py
@@ -2,9 +2,12 @@
 # Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+"""Constants used only in the CSE CLI."""
+
 from enum import Enum
 from enum import unique
 
+import container_service_extension.def_.constants as def_constants
 import container_service_extension.def_.utils as def_utils
 import container_service_extension.shared_constants as shared_constants
 
@@ -13,9 +16,9 @@ ENV_CSE_CLIENT_WIRE_LOGGING = 'CSE_CLIENT_WIRE_LOGGING'
 ENV_CSE_TKG_PLUS_ENABLED = 'CSE_TKG_PLUS_ENABLED'
 
 TKG_ENTITY_TYPE_ID = def_utils.generate_entity_type_id(
-    def_utils.DEF_VMWARE_VENDOR,
-    def_utils.TKG_ENTITY_TYPE_NSS,
-    def_utils.TKG_ENTITY_TYPE_VERSION)
+    def_constants.DEF_VMWARE_VENDOR,
+    def_constants.TKG_ENTITY_TYPE_NSS,
+    def_constants.TKG_ENTITY_TYPE_VERSION)
 
 
 # if cse_server_running key is set to false in profiles.yaml, CSE CLI can

--- a/container_service_extension/client/de_cluster.py
+++ b/container_service_extension/client/de_cluster.py
@@ -15,11 +15,14 @@ from container_service_extension.client.de_cluster_native import DEClusterNative
 from container_service_extension.client.de_cluster_tkg import DEClusterTKG
 import container_service_extension.client.tkgclient.rest as tkg_rest
 import container_service_extension.client.utils as client_utils
+from container_service_extension.def_.constants import DEF_CSE_VENDOR
+from container_service_extension.def_.constants import DEF_NATIVE_ENTITY_TYPE_NSS  # noqa: E501
+from container_service_extension.def_.constants import DEF_NATIVE_ENTITY_TYPE_VERSION # noqa: E501
 import container_service_extension.def_.entity_service as def_entity_svc
 import container_service_extension.def_.models as def_models
-from container_service_extension.def_.utils import DEF_VMWARE_INTERFACE_NSS
-from container_service_extension.def_.utils import DEF_VMWARE_INTERFACE_VERSION
-from container_service_extension.def_.utils import DEF_VMWARE_VENDOR
+from container_service_extension.def_.constants import DEF_VMWARE_INTERFACE_NSS
+from container_service_extension.def_.constants import DEF_VMWARE_INTERFACE_VERSION
+from container_service_extension.def_.constants import DEF_VMWARE_VENDOR
 import container_service_extension.exceptions as cse_exceptions
 import container_service_extension.logger as logger
 import container_service_extension.pyvcloud_utils as vcd_utils

--- a/container_service_extension/client/de_cluster.py
+++ b/container_service_extension/client/de_cluster.py
@@ -15,14 +15,11 @@ from container_service_extension.client.de_cluster_native import DEClusterNative
 from container_service_extension.client.de_cluster_tkg import DEClusterTKG
 import container_service_extension.client.tkgclient.rest as tkg_rest
 import container_service_extension.client.utils as client_utils
-from container_service_extension.def_.constants import DEF_CSE_VENDOR
-from container_service_extension.def_.constants import DEF_NATIVE_ENTITY_TYPE_NSS  # noqa: E501
-from container_service_extension.def_.constants import DEF_NATIVE_ENTITY_TYPE_VERSION # noqa: E501
+from container_service_extension.def_.constants import DEF_VMWARE_INTERFACE_NSS
+from container_service_extension.def_.constants import DEF_VMWARE_INTERFACE_VERSION  # noqa: E501
+from container_service_extension.def_.constants import DEF_VMWARE_VENDOR
 import container_service_extension.def_.entity_service as def_entity_svc
 import container_service_extension.def_.models as def_models
-from container_service_extension.def_.constants import DEF_VMWARE_INTERFACE_NSS
-from container_service_extension.def_.constants import DEF_VMWARE_INTERFACE_VERSION
-from container_service_extension.def_.constants import DEF_VMWARE_VENDOR
 import container_service_extension.exceptions as cse_exceptions
 import container_service_extension.logger as logger
 import container_service_extension.pyvcloud_utils as vcd_utils

--- a/container_service_extension/client/de_cluster_tkg.py
+++ b/container_service_extension/client/de_cluster_tkg.py
@@ -14,11 +14,11 @@ from container_service_extension.client.tkgclient.models.tkg_cluster import TkgC
 import container_service_extension.client.tkgclient.rest as tkg_rest
 import container_service_extension.client.utils as client_utils
 import container_service_extension.def_.acl_service as cluster_acl_svc
-import container_service_extension.def_.constants as def_constants
+from container_service_extension.def_.constants import CLUSTER_ACL_LIST_FIELDS
+from container_service_extension.def_.constants import DEF_TKG_ENTITY_TYPE_NSS
+from container_service_extension.def_.constants import DEF_TKG_ENTITY_TYPE_VERSION  # noqa: E501
+from container_service_extension.def_.constants import DEF_VMWARE_VENDOR
 import container_service_extension.def_.models as def_models
-from container_service_extension.def_.utils import DEF_TKG_ENTITY_TYPE_NSS
-from container_service_extension.def_.utils import DEF_TKG_ENTITY_TYPE_VERSION
-from container_service_extension.def_.utils import DEF_VMWARE_VENDOR
 import container_service_extension.exceptions as cse_exceptions
 import container_service_extension.logger as logger
 import container_service_extension.pyvcloud_utils as vcd_utils
@@ -397,7 +397,7 @@ class DEClusterTKG:
         org_href = self._client.get_org_by_name(org).get('href')
         name_to_id: dict = client_utils.create_user_name_to_id_dict(
             self._client, users, org_href)
-        org_user_id_to_name_dict = utils.create_org_user_id_to_name_dict(
+        org_user_id_to_name_dict = vcd_utils.create_org_user_id_to_name_dict(
             self._client, org)
         acl_svc = cluster_acl_svc.ClusterACLService(cluster_id, self._client)
         for acl_entry in acl_svc.list_def_entity_acl_entries():
@@ -453,7 +453,7 @@ class DEClusterTKG:
         if not cluster_id:
             cluster_id = self.get_cluster_id_by_name(cluster_name, org, vdc)
 
-        org_user_id_to_name_dict = utils.create_org_user_id_to_name_dict(
+        org_user_id_to_name_dict = vcd_utils.create_org_user_id_to_name_dict(
             self._client, org)
         acl_svc = cluster_acl_svc.ClusterACLService(cluster_id, self._client)
         page_num = result_count = 0
@@ -470,6 +470,6 @@ class DEClusterTKG:
                 acl_entry = def_models.ClusterAclEntry(**entry)
                 acl_entry.username = org_user_id_to_name_dict.get(acl_entry.memberId)  # noqa: E501
                 acl_values.append(acl_entry.construct_filtered_dict(
-                    include=def_constants.CLUSTER_ACL_LIST_FIELDS))
+                    include=CLUSTER_ACL_LIST_FIELDS))
             result_count += len(values)
             yield acl_values, result_count < result_total

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -1,6 +1,9 @@
 # container-service-extension
 # Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
+
+"""Utility methods used only by the CLI client."""
+
 import click
 from pyvcloud.vcd.client import Client
 import pyvcloud.vcd.org as vcd_org
@@ -12,7 +15,7 @@ from vcd_cli.utils import stdout
 
 from container_service_extension.client import system as syst
 from container_service_extension.client.constants import CSE_SERVER_RUNNING
-import container_service_extension.def_.utils as def_utils
+import container_service_extension.def_.constants as def_constants
 from container_service_extension.exceptions import CseResponseError
 from container_service_extension.logger import NULL_LOGGER
 import container_service_extension.shared_constants as shared_constants
@@ -138,9 +141,9 @@ def _override_client(ctx) -> None:
 def construct_filters(**kwargs):
     filters = {}
     if kwargs.get('org'):
-        filters[def_utils.ClusterEntityFilterKey.ORG_NAME.value] = kwargs['org']  # noqa: E501
+        filters[def_constants.ClusterEntityFilterKey.ORG_NAME.value] = kwargs['org']  # noqa: E501
     if kwargs.get('vdc'):
-        filters[def_utils.ClusterEntityFilterKey.OVDC_NAME.value] = kwargs['vdc']  # noqa: E501
+        filters[def_constants.ClusterEntityFilterKey.OVDC_NAME.value] = kwargs['vdc']  # noqa: E501
     return filters
 
 

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -15,6 +15,7 @@ import container_service_extension.exceptions as cse_exceptions
 import container_service_extension.logger as logger
 import container_service_extension.pyvcloud_utils as vcd_utils
 from container_service_extension.shared_constants import RequestMethod
+import container_service_extension.thread_utils as thread_utils
 import container_service_extension.utils as utils
 
 # cse compute policy prefix
@@ -641,7 +642,7 @@ class ComputePolicyManager:
             'task_href': task_href
         }
 
-    @utils.run_async
+    @thread_utils.run_async
     def _remove_compute_policy_from_vdc_async(self, *args,
                                               ovdc_id,
                                               compute_policy_href,

--- a/container_service_extension/config_validator.py
+++ b/container_service_extension/config_validator.py
@@ -44,6 +44,7 @@ from container_service_extension.server_constants import SYSTEM_ORG_NAME
 from container_service_extension.server_constants import \
     VCENTER_LOGIN_ERROR_MSG
 from container_service_extension.server_constants import VERSION_V1
+from container_service_extension.server_utils import should_use_mqtt_protocol
 from container_service_extension.telemetry.telemetry_utils import\
     store_telemetry_settings
 from container_service_extension.uaaclient.uaaclient import UaaClient
@@ -51,7 +52,6 @@ from container_service_extension.utils import check_file_permissions
 from container_service_extension.utils import check_keys_and_value_types
 from container_service_extension.utils import get_duplicate_items_in_list
 from container_service_extension.utils import NullPrinter
-from container_service_extension.utils import should_use_mqtt_protocol
 from container_service_extension.utils import str_to_bool
 
 

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -764,32 +764,31 @@ def _register_def_schema(client: Client,
         def_utils.raise_error_if_def_not_supported(cloudapi_client)
         schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
         keys_map = def_constants.MAP_API_VERSION_TO_KEYS[float(client.get_api_version())] # noqa: E501
-        defKey = def_constants.DefKey
         kubernetes_interface = def_models.\
-            DefInterface(name=keys_map[defKey.INTERFACE_NAME],
-                         vendor=keys_map[defKey.INTERFACE_VENDOR],
-                         nss=keys_map[defKey.INTERFACE_NSS],
-                         version=keys_map[defKey.INTERFACE_VERSION], # noqa: E501
+            DefInterface(name=keys_map[def_constants.DefKey.INTERFACE_NAME],
+                         vendor=keys_map[def_constants.DefKey.INTERFACE_VENDOR],  # noqa: E501
+                         nss=keys_map[def_constants.DefKey.INTERFACE_NSS],
+                         version=keys_map[def_constants.DefKey.INTERFACE_VERSION], # noqa: E501
                          readonly=False)
         try:
             # k8s interface should always be present
             schema_svc.get_interface(kubernetes_interface.get_id())
         except cse_exception.DefSchemaServiceError:
             msg = "Failed to obtain built-in defined entity interface " \
-                  f"{keys_map[defKey.INTERFACE_NAME]}"
+                  f"{keys_map[def_constants.DefKey.INTERFACE_NAME]}"
             msg_update_callback.error(msg)
             INSTALL_LOGGER.error(msg)
             raise
 
         schema_module = importlib.import_module(
-            f'{def_constants.DEF_SCHEMA_DIRECTORY}.{keys_map[defKey.ENTITY_TYPE_SCHEMA_VERSION]}') # noqa: E501
+            f'{def_constants.DEF_SCHEMA_DIRECTORY}.{keys_map[def_constants.DefKey.ENTITY_TYPE_SCHEMA_VERSION]}') # noqa: E501
         schema_file = pkg_resources.open_text(schema_module, def_constants.DEF_ENTITY_TYPE_SCHEMA_FILE) # noqa: E501
         native_entity_type = def_models.\
-            DefEntityType(name=keys_map[defKey.ENTITY_TYPE_NAME],
+            DefEntityType(name=keys_map[def_constants.DefKey.ENTITY_TYPE_NAME],
                           description='',
-                          vendor=keys_map[defKey.ENTITY_TYPE_VENDOR],
-                          nss=keys_map[defKey.ENTITY_TYPE_NSS],
-                          version=keys_map[defKey.ENTITY_TYPE_VERSION],
+                          vendor=keys_map[def_constants.DefKey.ENTITY_TYPE_VENDOR],  # noqa: E501
+                          nss=keys_map[def_constants.DefKey.ENTITY_TYPE_NSS],
+                          version=keys_map[def_constants.DefKey.ENTITY_TYPE_VERSION],  # noqa: E501
                           schema=json.load(schema_file),
                           interfaces=[kubernetes_interface.get_id()],
                           readonly=False)

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -24,6 +24,7 @@ import requests
 import semantic_version
 
 import container_service_extension.compute_policy_manager as compute_policy_manager # noqa: E501
+import container_service_extension.def_.constants as def_constants
 import container_service_extension.def_.entity_service as def_entity_svc
 import container_service_extension.def_.models as def_models
 import container_service_extension.def_.schema_service as def_schema_svc
@@ -47,6 +48,7 @@ from container_service_extension.remote_template_manager import \
     RemoteTemplateManager
 from container_service_extension.right_bundle_manager import RightBundleManager
 import container_service_extension.server_constants as server_constants
+import container_service_extension.server_utils as server_utils
 import container_service_extension.shared_constants as shared_constants
 from container_service_extension.telemetry.constants import CseOperation
 from container_service_extension.telemetry.constants import OperationStatus
@@ -108,7 +110,7 @@ def check_cse_installation(config, msg_update_callback=utils.NullPrinter()):
                                             config['vcd']['password'])
         client.set_credentials(credentials)
 
-        if utils.should_use_mqtt_protocol(config):
+        if server_utils.should_use_mqtt_protocol(config):
             _check_mqtt_extension_installation(client, msg_update_callback,
                                                err_msgs)
         else:
@@ -247,7 +249,7 @@ def _check_mqtt_extension_installation(client, msg_update_callback, err_msgs):
 
 def _construct_cse_extension_description(target_vcd_api_version):
     """."""
-    cse_version = utils.get_installed_cse_version()
+    cse_version = server_utils.get_installed_cse_version()
     description = f"cse-{cse_version},vcd_api-{target_vcd_api_version}"
     return description
 
@@ -378,7 +380,7 @@ def install_cse(config_file_name, config, skip_template_creation,
                              log_wire=log_wire)
 
         # set up placement policies for all types of clusters
-        is_tkg_plus_enabled = utils.is_tkg_plus_enabled(config=config)
+        is_tkg_plus_enabled = server_utils.is_tkg_plus_enabled(config=config)  # noqa: E501
         _setup_placement_policies(
             client=client,
             policy_list=shared_constants.CLUSTER_RUNTIME_PLACEMENT_POLICIES,
@@ -415,7 +417,7 @@ def install_cse(config_file_name, config, skip_template_creation,
             )
 
         # Setup extension based on message bus protocol
-        if utils.should_use_mqtt_protocol(config):
+        if server_utils.should_use_mqtt_protocol(config):
             _register_cse_as_mqtt_extension(client,
                                             config['vcd']['api_version'],
                                             msg_update_callback)
@@ -761,8 +763,8 @@ def _register_def_schema(client: Client,
     try:
         def_utils.raise_error_if_def_not_supported(cloudapi_client)
         schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
-        keys_map = def_utils.MAP_API_VERSION_TO_KEYS[float(client.get_api_version())] # noqa: E501
-        defKey = def_utils.DefKey
+        keys_map = def_constants.MAP_API_VERSION_TO_KEYS[float(client.get_api_version())] # noqa: E501
+        defKey = def_constants.DefKey
         kubernetes_interface = def_models.\
             DefInterface(name=keys_map[defKey.INTERFACE_NAME],
                          vendor=keys_map[defKey.INTERFACE_VENDOR],
@@ -780,8 +782,8 @@ def _register_def_schema(client: Client,
             raise
 
         schema_module = importlib.import_module(
-            f'{def_utils.DEF_SCHEMA_DIRECTORY}.{keys_map[defKey.ENTITY_TYPE_SCHEMA_VERSION]}') # noqa: E501
-        schema_file = pkg_resources.open_text(schema_module, def_utils.DEF_ENTITY_TYPE_SCHEMA_FILE) # noqa: E501
+            f'{def_constants.DEF_SCHEMA_DIRECTORY}.{keys_map[defKey.ENTITY_TYPE_SCHEMA_VERSION]}') # noqa: E501
+        schema_file = pkg_resources.open_text(schema_module, def_constants.DEF_ENTITY_TYPE_SCHEMA_FILE) # noqa: E501
         native_entity_type = def_models.\
             DefEntityType(name=keys_map[defKey.ENTITY_TYPE_NAME],
                           description='',
@@ -815,7 +817,7 @@ def _register_def_schema(client: Client,
         # Update user's role with right bundle associated with native defined
         # entity
         if(_update_user_role_with_right_bundle(
-                def_utils.DEF_NATIVE_ENTITY_TYPE_RIGHT_BUNDLE,
+                def_constants.DEF_NATIVE_ENTITY_TYPE_RIGHT_BUNDLE,
                 client=client,
                 msg_update_callback=msg_update_callback,
                 logger_debug=INSTALL_LOGGER,
@@ -1062,7 +1064,7 @@ def _install_all_templates(
             force_update=force_create,
             retain_temp_vapp=retain_temp_vapp,
             ssh_key=ssh_key,
-            is_tkg_plus_enabled=utils.is_tkg_plus_enabled(config),
+            is_tkg_plus_enabled=server_utils.is_tkg_plus_enabled(config),
             msg_update_callback=msg_update_callback)
 
 
@@ -1160,7 +1162,7 @@ def install_template(template_name, template_revision, config_file_name,
                     force_update=force_create,
                     retain_temp_vapp=retain_temp_vapp,
                     ssh_key=ssh_key,
-                    is_tkg_plus_enabled=utils.is_tkg_plus_enabled(config),
+                    is_tkg_plus_enabled=server_utils.is_tkg_plus_enabled(config),  # noqa: E501
                     msg_update_callback=msg_update_callback)
 
         if not found_template:
@@ -1331,7 +1333,7 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
                 "of 'cse upgrade'."
             raise Exception(msg)
         elif existing_ext_type == server_constants.ExtensionType.MQTT and \
-                not utils.should_use_mqtt_protocol(config):
+                not server_utils.should_use_mqtt_protocol(config):
             # Upgrading from MQTT to AMQP extension
             msg = "Upgrading from MQTT extension to AMQP extension is not " \
                   "supported"
@@ -1339,7 +1341,7 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
 
         ext_cse_version, ext_vcd_api_version = \
             parse_cse_extension_description(
-                client, utils.should_use_mqtt_protocol(config))
+                client, server_utils.should_use_mqtt_protocol(config))
         if ext_cse_version == server_constants.UNKNOWN_CSE_VERSION or \
                 ext_vcd_api_version == server_constants.UNKNOWN_VCD_API_VERSION: # noqa: E501
             msg = "Found CSE api extension registered with vCD, but " \
@@ -1355,7 +1357,7 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
             INSTALL_LOGGER.info(msg)
 
         target_vcd_api_version = config['vcd']['api_version']
-        target_cse_version = utils.get_installed_cse_version()
+        target_cse_version = server_utils.get_installed_cse_version()
 
         telemetry_data = {
             PayloadKey.SOURCE_CSE_VERSION: str(ext_cse_version),
@@ -1573,7 +1575,7 @@ def _upgrade_to_35(client, config, ext_vcd_api_version,
     :raises requests.exceptions.HTTPError: (when using MQTT) if the MQTT
         components were not installed correctly
     """
-    is_tkg_plus_enabled = utils.is_tkg_plus_enabled(config=config)
+    is_tkg_plus_enabled = server_utils.is_tkg_plus_enabled(config=config)
 
     # Add global placement polcies
     _setup_placement_policies(
@@ -1670,7 +1672,7 @@ def _upgrade_to_35(client, config, ext_vcd_api_version,
         cse_clusters=clusters, msg_update_callback=msg_update_callback)
 
     # update extension
-    if utils.should_use_mqtt_protocol(config):
+    if server_utils.should_use_mqtt_protocol(config):
         # Caller guarantees that there is an extension present
         existing_ext_type = _get_existing_extension_type(client)
         if existing_ext_type == server_constants.ExtensionType.AMQP:
@@ -2189,7 +2191,7 @@ def _assign_placement_policy_to_vdc_and_right_bundle_to_org(
         try:
             rbm = RightBundleManager(client, log_wire=log_wire, logger_debug=INSTALL_LOGGER)  # noqa: E501
             cse_right_bundle = rbm.get_right_bundle_by_name(
-                def_utils.DEF_NATIVE_ENTITY_TYPE_RIGHT_BUNDLE)
+                def_constants.DEF_NATIVE_ENTITY_TYPE_RIGHT_BUNDLE)
             rbm.publish_cse_right_bundle_to_tenants(
                 right_bundle_id=cse_right_bundle['id'],
                 org_ids=list(org_ids))
@@ -2295,11 +2297,11 @@ def _create_def_entity_for_existing_clusters(
     entity_svc = def_entity_svc.DefEntityService(cloudapi_client)
 
     schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
-    keys_map = def_utils.MAP_API_VERSION_TO_KEYS[float(client.get_api_version())] # noqa: E501
+    keys_map = def_constants.MAP_API_VERSION_TO_KEYS[float(client.get_api_version())] # noqa: E501
     entity_type_id = def_utils.generate_entity_type_id(
-        vendor=keys_map[def_utils.DefKey.ENTITY_TYPE_VENDOR],
-        nss=keys_map[def_utils.DefKey.ENTITY_TYPE_NSS],
-        version=keys_map[def_utils.DefKey.ENTITY_TYPE_VERSION])
+        vendor=keys_map[def_constants.DefKey.ENTITY_TYPE_VENDOR],
+        nss=keys_map[def_constants.DefKey.ENTITY_TYPE_NSS],
+        version=keys_map[def_constants.DefKey.ENTITY_TYPE_VERSION])
     native_entity_type = schema_svc.get_entity_type(entity_type_id)
 
     for cluster in cse_clusters:
@@ -2372,9 +2374,9 @@ def _create_def_entity_for_existing_clusters(
                     template_name=cluster['template_name'],
                     template_revision=int(cluster['template_revision']))),
             status=def_models.Status(
-                phase=str(shared_constants.DefEntityPhase(
-                    shared_constants.DefEntityOperation.CREATE,
-                    shared_constants.DefEntityOperationStatus.SUCCEEDED)),
+                phase=str(server_constants.DefEntityPhase(
+                    server_constants.DefEntityOperation.CREATE,
+                    server_constants.DefEntityOperationStatus.SUCCEEDED)),
                 kubernetes=f"{cluster['kubernetes']} {cluster['kubernetes_version']}", # noqa: E501
                 cni=f"{cluster['cni']} {cluster['cni_version']}",
                 os=cluster['os'],

--- a/container_service_extension/consumer/consumer.py
+++ b/container_service_extension/consumer/consumer.py
@@ -7,7 +7,7 @@ from container_service_extension.consumer.mqtt_consumer import MQTTConsumer
 import container_service_extension.server_constants as server_constants
 from container_service_extension.server_constants import MQTTExtKey, \
     MQTTExtTokenKey
-from container_service_extension.utils import should_use_mqtt_protocol
+from container_service_extension.server_utils import should_use_mqtt_protocol
 
 
 class MessageConsumer:

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -838,8 +838,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                 #  error between node creation and deletion threads. Below
                 #  serializes the sequence of node creation and deletion.
                 #  Remove the below block once the issue is fixed in pyvcloud.
-                create_nodes_async_thread_name = utils.generate_thread_name(
-                    self._create_nodes_async.__name__)
+                create_nodes_async_thread_name = \
+                    thread_utils.generate_thread_name(self._create_nodes_async.__name__)  # noqa: E501
                 for t in threading.enumerate():
                     if t.getName() == create_nodes_async_thread_name:
                         t.join()

--- a/container_service_extension/def_/constants.py
+++ b/container_service_extension/def_/constants.py
@@ -2,6 +2,11 @@
 # Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+"""Constants used for interaction with defined entity framework."""
+
+from enum import Enum
+from enum import unique
+
 import container_service_extension.shared_constants as shared_constants
 
 CLUSTER_ACL_LIST_FIELDS = [shared_constants.AccessControlKey.ACCESS_LEVEL_ID,
@@ -10,3 +15,87 @@ CLUSTER_ACL_LIST_FIELDS = [shared_constants.AccessControlKey.ACCESS_LEVEL_ID,
 
 # ACL Path
 ACTION_CONTROL_ACCESS_PATH = '/action/controlAccess/'
+
+DEF_CSE_VENDOR = 'cse'
+DEF_VMWARE_VENDOR = 'vmware'
+DEF_VMWARE_INTERFACE_NSS = 'k8s'
+DEF_VMWARE_INTERFACE_VERSION = '1.0.0'
+DEF_VMWARE_INTERFACE_NAME = 'Kubernetes'
+DEF_TKG_ENTITY_TYPE_NSS = 'tkgcluster'
+DEF_TKG_ENTITY_TYPE_VERSION = '1.0.0'
+DEF_INTERFACE_ID_PREFIX = 'urn:vcloud:interface'
+DEF_NATIVE_ENTITY_TYPE_NSS = 'nativeCluster'
+DEF_NATIVE_ENTITY_TYPE_VERSION = '1.0.0'
+DEF_NATIVE_ENTITY_TYPE_NAME = 'nativeClusterEntityType'
+DEF_NATIVE_ENTITY_TYPE_RIGHT_BUNDLE = \
+    f'{DEF_CSE_VENDOR}:{DEF_NATIVE_ENTITY_TYPE_NSS} Entitlement'
+
+DEF_ENTITY_TYPE_ID_PREFIX = 'urn:vcloud:type'
+DEF_API_MIN_VERSION = 35.0
+DEF_SCHEMA_DIRECTORY = 'cse_def_schema'
+DEF_ENTITY_TYPE_SCHEMA_FILE = 'schema.json'
+DEF_ERROR_MESSAGE_KEY = 'message'
+DEF_RESOLVED_STATE = 'RESOLVED'
+TKG_ENTITY_TYPE_NSS = 'tkgcluster'
+TKG_ENTITY_TYPE_VERSION = '1.0.0'
+
+
+@unique
+class DefKey(str, Enum):
+    INTERFACE_VENDOR = 'interface_vendor'
+    INTERFACE_NSS = 'interface_nss'
+    INTERFACE_VERSION = 'interface_version'
+    INTERFACE_NAME = 'interface_name'
+    ENTITY_TYPE_VENDOR = 'entity_type_vendor'
+    ENTITY_TYPE_NAME = 'entity_type_name'
+    ENTITY_TYPE_NSS = 'entity_type_nss'
+    ENTITY_TYPE_VERSION = 'entity_type_version'
+    ENTITY_TYPE_SCHEMA_VERSION = 'schema_version'
+
+
+MAP_API_VERSION_TO_KEYS = {
+    35.0: {
+        DefKey.INTERFACE_VENDOR: DEF_VMWARE_VENDOR,
+        DefKey.INTERFACE_NSS: DEF_VMWARE_INTERFACE_NSS,
+        DefKey.INTERFACE_VERSION: DEF_VMWARE_INTERFACE_VERSION,
+        DefKey.INTERFACE_NAME: DEF_VMWARE_INTERFACE_NAME,
+        DefKey.ENTITY_TYPE_VENDOR: DEF_CSE_VENDOR,
+        DefKey.ENTITY_TYPE_NSS: DEF_NATIVE_ENTITY_TYPE_NSS,
+        DefKey.ENTITY_TYPE_VERSION: DEF_NATIVE_ENTITY_TYPE_VERSION,
+        DefKey.ENTITY_TYPE_NAME: DEF_NATIVE_ENTITY_TYPE_NAME,
+        DefKey.ENTITY_TYPE_SCHEMA_VERSION: 'api_v35',
+    },
+    36.0: {
+        DefKey.INTERFACE_VENDOR: DEF_VMWARE_VENDOR,
+        DefKey.INTERFACE_NSS: DEF_VMWARE_INTERFACE_NSS,
+        DefKey.INTERFACE_VERSION: DEF_VMWARE_INTERFACE_VERSION,
+        DefKey.INTERFACE_NAME: DEF_VMWARE_INTERFACE_NAME,
+        DefKey.ENTITY_TYPE_VENDOR: DEF_CSE_VENDOR,
+        DefKey.ENTITY_TYPE_NSS: DEF_NATIVE_ENTITY_TYPE_NSS,
+        DefKey.ENTITY_TYPE_VERSION: DEF_NATIVE_ENTITY_TYPE_VERSION,
+        DefKey.ENTITY_TYPE_NAME: DEF_NATIVE_ENTITY_TYPE_NAME,
+        DefKey.ENTITY_TYPE_SCHEMA_VERSION: 'api_v35',
+    }
+}
+
+
+class ClusterEntityFilterKey(Enum):
+    """Keys to filter cluster entities in CSE (or) vCD.
+
+    Below Keys are commonly used filters. An entity can be filtered by any of
+    its properties.
+
+    Usage examples:
+    ..api/cse/internal/clusters?entity.kind=native
+    ..api/cse/internal/clusters?entity.metadata.org_name=org1
+    ..cloudapi/1.0.0/entities?filter=entity.metadata.org_name==org1
+    """
+
+    # TODO(DEF) CLI can leverage this enum for the filter implementation.
+    CLUSTER_NAME = 'name'
+    ORG_NAME = 'entity.metadata.org_name'
+    OVDC_NAME = 'entity.metadata.ovdc_name'
+    KIND = 'entity.kind'
+    K8_DISTRIBUTION = 'entity.spec.k8_distribution.template_name'
+    STATE = 'state'
+    PHASE = 'entity.status.phase'

--- a/container_service_extension/def_/entity_service.py
+++ b/container_service_extension/def_/entity_service.py
@@ -13,8 +13,10 @@ from requests.exceptions import HTTPError
 from container_service_extension.cloudapi.cloudapi_client import CloudApiClient
 from container_service_extension.cloudapi.constants import CloudApiResource
 from container_service_extension.cloudapi.constants import CloudApiVersion
-from container_service_extension.def_.models import DefEntity, DefEntityType, \
-    GenericClusterEntity
+import container_service_extension.def_.constants as def_constants
+from container_service_extension.def_.models import DefEntity
+from container_service_extension.def_.models import DefEntityType
+from container_service_extension.def_.models import GenericClusterEntity
 import container_service_extension.def_.schema_service as def_schema_svc
 import container_service_extension.def_.utils as def_utils
 import container_service_extension.exceptions as cse_exception
@@ -290,7 +292,7 @@ class DefEntityService():
         :param dict filters: key-value pairs representing filter options
         :return:
         """
-        filters[def_utils.ClusterEntityFilterKey.CLUSTER_NAME.value] = name
+        filters[def_constants.ClusterEntityFilterKey.CLUSTER_NAME.value] = name
         entity_type: DefEntityType = self.get_def_entity_type()
         for entity in \
             self.list_entities_by_entity_type(vendor=entity_type.vendor,
@@ -327,12 +329,12 @@ class DefEntityService():
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITIES}/"
                                        f"{entity_id}/{CloudApiResource.ENTITY_RESOLVE}")  # noqa: E501
-        msg = response_body[def_utils.DEF_ERROR_MESSAGE_KEY]
-        del response_body[def_utils.DEF_ERROR_MESSAGE_KEY]
+        msg = response_body[def_constants.DEF_ERROR_MESSAGE_KEY]
+        del response_body[def_constants.DEF_ERROR_MESSAGE_KEY]
         entity = DefEntity(**response_body)
         # TODO: Just record the error message; revisit after HTTP response code
         # is good enough to decide if exception should be thrown or not
-        if entity.state != def_utils.DEF_RESOLVED_STATE:
+        if entity.state != def_constants.DEF_RESOLVED_STATE:
             LOGGER.error(msg)
         return entity
 
@@ -347,11 +349,11 @@ class DefEntityService():
         :rtype: DefEntityType
         """
         schema_svc = def_schema_svc.DefSchemaService(self._cloudapi_client)
-        keys_map = def_utils.MAP_API_VERSION_TO_KEYS[float(self._cloudapi_client.get_api_version())]  # noqa: E501
+        keys_map = def_constants.MAP_API_VERSION_TO_KEYS[float(self._cloudapi_client.get_api_version())]  # noqa: E501
         entity_type_id = def_utils.generate_entity_type_id(
-            vendor=keys_map[def_utils.DefKey.ENTITY_TYPE_VENDOR],
-            nss=keys_map[def_utils.DefKey.ENTITY_TYPE_NSS],
-            version=keys_map[def_utils.DefKey.ENTITY_TYPE_VERSION])
+            vendor=keys_map[def_constants.DefKey.ENTITY_TYPE_VENDOR],
+            nss=keys_map[def_constants.DefKey.ENTITY_TYPE_NSS],
+            version=keys_map[def_constants.DefKey.ENTITY_TYPE_VERSION])
         return schema_svc.get_entity_type(entity_type_id)
 
     def is_native_entity(self, entity_id: str):
@@ -361,4 +363,4 @@ class DefEntityService():
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITIES}/"
                                        f"{entity_id}")
-        return def_utils.DEF_NATIVE_ENTITY_TYPE_NSS in response_body['entityType']  # noqa: E501
+        return def_constants.DEF_NATIVE_ENTITY_TYPE_NSS in response_body['entityType']  # noqa: E501

--- a/container_service_extension/def_/models.py
+++ b/container_service_extension/def_/models.py
@@ -5,6 +5,7 @@ from dataclasses import asdict
 from dataclasses import dataclass
 from typing import List
 
+import container_service_extension.def_.constants as def_constants
 import container_service_extension.def_.utils as def_utils
 import container_service_extension.shared_constants as shared_constants
 
@@ -14,9 +15,9 @@ class DefInterface:
     """Provides interface for the defined entity type."""
 
     name: str
-    vendor: str = def_utils.DEF_VMWARE_VENDOR
-    nss: str = def_utils.DEF_VMWARE_INTERFACE_NSS
-    version: str = def_utils.DEF_VMWARE_INTERFACE_VERSION
+    vendor: str = def_constants.DEF_VMWARE_VENDOR
+    nss: str = def_constants.DEF_VMWARE_INTERFACE_NSS
+    version: str = def_constants.DEF_VMWARE_INTERFACE_VERSION
     id: str = None
     readonly: bool = False
 
@@ -43,9 +44,9 @@ class DefEntityType:
     description: str
     schema: dict
     interfaces: list
-    vendor: str = def_utils.DEF_CSE_VENDOR
-    nss: str = def_utils.DEF_NATIVE_ENTITY_TYPE_NSS
-    version: str = def_utils.DEF_NATIVE_ENTITY_TYPE_VERSION
+    vendor: str = def_constants.DEF_CSE_VENDOR
+    nss: str = def_constants.DEF_NATIVE_ENTITY_TYPE_NSS
+    version: str = def_constants.DEF_NATIVE_ENTITY_TYPE_VERSION
     id: str = None
     externalId: str = None
     readonly: bool = False
@@ -237,11 +238,11 @@ class NativeEntity:
     metadata: Metadata
     spec: ClusterSpec
     status: Status = Status()
-    kind: str = def_utils.DEF_NATIVE_ENTITY_TYPE_NSS
+    kind: str = def_constants.DEF_NATIVE_ENTITY_TYPE_NSS
     api_version: str = ''
 
     def __init__(self, metadata: Metadata, spec: ClusterSpec, status=Status(),
-                 kind: str = def_utils.DEF_VMWARE_INTERFACE_NSS,
+                 kind: str = def_constants.DEF_VMWARE_INTERFACE_NSS,
                  api_version: str = ''):
 
         self.metadata = Metadata(**metadata) \

--- a/container_service_extension/def_/utils.py
+++ b/container_service_extension/def_/utils.py
@@ -1,96 +1,12 @@
 # container-service-extension
 # Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-from enum import Enum
-from enum import unique
+
+"""Utility methods to help interaction with defined entities framework."""
 
 from container_service_extension.cloudapi.cloudapi_client import CloudApiClient
+import container_service_extension.def_.constants as def_constants
 import container_service_extension.exceptions as excptn
-
-# Defined Entity Framework related constants
-DEF_CSE_VENDOR = 'cse'
-DEF_VMWARE_VENDOR = 'vmware'
-DEF_VMWARE_INTERFACE_NSS = 'k8s'
-DEF_VMWARE_INTERFACE_VERSION = '1.0.0'
-DEF_VMWARE_INTERFACE_NAME = 'Kubernetes'
-DEF_TKG_ENTITY_TYPE_NSS = 'tkgcluster'
-DEF_TKG_ENTITY_TYPE_VERSION = '1.0.0'
-DEF_INTERFACE_ID_PREFIX = 'urn:vcloud:interface'
-DEF_NATIVE_ENTITY_TYPE_NSS = 'nativeCluster'
-DEF_NATIVE_ENTITY_TYPE_VERSION = '1.0.0'
-DEF_NATIVE_ENTITY_TYPE_NAME = 'nativeClusterEntityType'
-DEF_NATIVE_ENTITY_TYPE_RIGHT_BUNDLE = \
-    f'{DEF_CSE_VENDOR}:{DEF_NATIVE_ENTITY_TYPE_NSS} Entitlement'
-
-DEF_ENTITY_TYPE_ID_PREFIX = 'urn:vcloud:type'
-DEF_API_MIN_VERSION = 35.0
-DEF_SCHEMA_DIRECTORY = 'cse_def_schema'
-DEF_ENTITY_TYPE_SCHEMA_FILE = 'schema.json'
-DEF_ERROR_MESSAGE_KEY = 'message'
-DEF_RESOLVED_STATE = 'RESOLVED'
-TKG_ENTITY_TYPE_NSS = 'tkgcluster'
-TKG_ENTITY_TYPE_VERSION = '1.0.0'
-
-
-@unique
-class DefKey(str, Enum):
-    INTERFACE_VENDOR = 'interface_vendor'
-    INTERFACE_NSS = 'interface_nss'
-    INTERFACE_VERSION = 'interface_version'
-    INTERFACE_NAME = 'interface_name'
-    ENTITY_TYPE_VENDOR = 'entity_type_vendor'
-    ENTITY_TYPE_NAME = 'entity_type_name'
-    ENTITY_TYPE_NSS = 'entity_type_nss'
-    ENTITY_TYPE_VERSION = 'entity_type_version'
-    ENTITY_TYPE_SCHEMA_VERSION = 'schema_version'
-
-
-MAP_API_VERSION_TO_KEYS = {
-    35.0: {
-        DefKey.INTERFACE_VENDOR: DEF_VMWARE_VENDOR,
-        DefKey.INTERFACE_NSS: DEF_VMWARE_INTERFACE_NSS,
-        DefKey.INTERFACE_VERSION: DEF_VMWARE_INTERFACE_VERSION,
-        DefKey.INTERFACE_NAME: DEF_VMWARE_INTERFACE_NAME,
-        DefKey.ENTITY_TYPE_VENDOR: DEF_CSE_VENDOR,
-        DefKey.ENTITY_TYPE_NSS: DEF_NATIVE_ENTITY_TYPE_NSS,
-        DefKey.ENTITY_TYPE_VERSION: DEF_NATIVE_ENTITY_TYPE_VERSION,
-        DefKey.ENTITY_TYPE_NAME: DEF_NATIVE_ENTITY_TYPE_NAME,
-        DefKey.ENTITY_TYPE_SCHEMA_VERSION: 'api_v35',
-    },
-    36.0: {
-        DefKey.INTERFACE_VENDOR: DEF_VMWARE_VENDOR,
-        DefKey.INTERFACE_NSS: DEF_VMWARE_INTERFACE_NSS,
-        DefKey.INTERFACE_VERSION: DEF_VMWARE_INTERFACE_VERSION,
-        DefKey.INTERFACE_NAME: DEF_VMWARE_INTERFACE_NAME,
-        DefKey.ENTITY_TYPE_VENDOR: DEF_CSE_VENDOR,
-        DefKey.ENTITY_TYPE_NSS: DEF_NATIVE_ENTITY_TYPE_NSS,
-        DefKey.ENTITY_TYPE_VERSION: DEF_NATIVE_ENTITY_TYPE_VERSION,
-        DefKey.ENTITY_TYPE_NAME: DEF_NATIVE_ENTITY_TYPE_NAME,
-        DefKey.ENTITY_TYPE_SCHEMA_VERSION: 'api_v35',
-    }
-}
-
-
-class ClusterEntityFilterKey(Enum):
-    """Keys to filter cluster entities in CSE (or) vCD.
-
-    Below Keys are commonly used filters. An entity can be filtered by any of
-    its properties.
-
-    Usage examples:
-    ..api/cse/internal/clusters?entity.kind=native
-    ..api/cse/internal/clusters?entity.metadata.org_name=org1
-    ..cloudapi/1.0.0/entities?filter=entity.metadata.org_name==org1
-    """
-
-    # TODO(DEF) CLI can leverage this enum for the filter implementation.
-    CLUSTER_NAME = 'name'
-    ORG_NAME = 'entity.metadata.org_name'
-    OVDC_NAME = 'entity.metadata.ovdc_name'
-    KIND = 'entity.kind'
-    K8_DISTRIBUTION = 'entity.spec.k8_distribution.template_name'
-    STATE = 'state'
-    PHASE = 'entity.status.phase'
 
 
 def raise_error_if_def_not_supported(cloudapi_client: CloudApiClient):
@@ -98,7 +14,8 @@ def raise_error_if_def_not_supported(cloudapi_client: CloudApiClient):
 
     :param cloudapi_client CloudApiClient
     """
-    if float(cloudapi_client.get_api_version()) < DEF_API_MIN_VERSION:
+    if float(cloudapi_client.get_api_version()) < \
+            def_constants.DEF_API_MIN_VERSION:
         raise excptn.DefNotSupportedException("Defined entity framework is not"
                                               " supported for {cloudapi_client.get_api_version()}")  # noqa: E501
 
@@ -127,7 +44,7 @@ def generate_interface_id(vendor, nss, version):
 
     :rtype str
     """
-    return f"{DEF_INTERFACE_ID_PREFIX}:{vendor}:{nss}:{version}"
+    return f"{def_constants.DEF_INTERFACE_ID_PREFIX}:{vendor}:{nss}:{version}"
 
 
 def generate_entity_type_id(vendor, nss, version):
@@ -142,4 +59,4 @@ def generate_entity_type_id(vendor, nss, version):
 
     :rtype str
     """
-    return f"{DEF_ENTITY_TYPE_ID_PREFIX}:{vendor}:{nss}:{version}"
+    return f"{def_constants.DEF_ENTITY_TYPE_ID_PREFIX}:{vendor}:{nss}:{version}"  # noqa: E501

--- a/container_service_extension/operation_context.py
+++ b/container_service_extension/operation_context.py
@@ -3,8 +3,8 @@ import pyvcloud.vcd.client as vcd_client
 import container_service_extension.cloudapi.cloudapi_client as cloudApiClient
 import container_service_extension.logger as logger
 import container_service_extension.pyvcloud_utils as vcd_utils
+import container_service_extension.server_utils as server_utils
 import container_service_extension.user_context as user_context
-import container_service_extension.utils as utils
 
 
 class OperationContext:
@@ -39,8 +39,8 @@ class OperationContext:
     @property
     def cloudapi_client(self):
         if self._cloudapi_client is None:
-            log_wire = utils.get_server_runtime_config() \
-                            .get('service', {}).get('log_wire', False)
+            log_wire = server_utils.get_server_runtime_config() \
+                .get('service', {}).get('log_wire', False)
             logger_wire = logger.NULL_LOGGER
             if log_wire:
                 logger_wire = logger.SERVER_CLOUDAPI_WIRE_LOGGER

--- a/container_service_extension/operation_context.py
+++ b/container_service_extension/operation_context.py
@@ -39,8 +39,7 @@ class OperationContext:
     @property
     def cloudapi_client(self):
         if self._cloudapi_client is None:
-            log_wire = server_utils.get_server_runtime_config() \
-                .get('service', {}).get('log_wire', False)
+            log_wire = server_utils.get_server_runtime_config().get('service', {}).get('log_wire', False)  # noqa: E501
             logger_wire = logger.NULL_LOGGER
             if log_wire:
                 logger_wire = logger.SERVER_CLOUDAPI_WIRE_LOGGER

--- a/container_service_extension/ovdc_utils.py
+++ b/container_service_extension/ovdc_utils.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-"""Utilities for performing operations for metadata based ovdc."""
+"""Utilities to manage CSE metadata on Ovdcs."""
 
 from collections import namedtuple
 

--- a/container_service_extension/ovdc_utils.py
+++ b/container_service_extension/ovdc_utils.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+"""Utilities for performing operations for metadata based ovdc."""
+
 from collections import namedtuple
 
 import pyvcloud.vcd.client as vcd_client
@@ -20,8 +22,8 @@ from container_service_extension.server_constants import K8sProvider
 from container_service_extension.server_constants import PKS_CLUSTER_DOMAIN_KEY
 from container_service_extension.server_constants import PKS_COMPUTE_PROFILE_KEY # noqa: E501
 from container_service_extension.server_constants import PKS_PLANS_KEY
+import container_service_extension.server_utils as server_utils
 from container_service_extension.shared_constants import RequestKey
-import container_service_extension.utils as utils
 
 
 def get_ovdc_k8s_provider_metadata(sysadmin_client: vcd_client.Client,
@@ -57,7 +59,7 @@ def get_ovdc_k8s_provider_metadata(sysadmin_client: vcd_client.Client,
 
         # Get the credentials from PksCache
         if include_credentials or include_nsxt_info:
-            pks_cache = utils.get_pks_cache()
+            pks_cache = server_utils.get_pks_cache()
             pvdc_info = pks_cache.get_pvdc_info(
                 vcd_utils.get_pvdc_id(sysadmin_client, ovdc))
             if include_credentials:
@@ -169,12 +171,12 @@ def construct_k8s_metadata_from_pks_cache(sysadmin_client: vcd_client.Client,
         K8S_PROVIDER_KEY: k8s_provider,
     }
     if k8s_provider == K8sProvider.PKS:
-        if not utils.is_pks_enabled():
+        if not server_utils.is_pks_enabled():
             raise e.CseServerError('CSE is not configured to work with PKS.')
 
         ovdc = vcd_utils.get_vdc(client=sysadmin_client, vdc_id=ovdc_id,
                                  is_admin_operation=True)
-        pks_cache = utils.get_pks_cache()
+        pks_cache = server_utils.get_pks_cache()
         pvdc_id = vcd_utils.get_pvdc_id(sysadmin_client, ovdc)
         pvdc_info = pks_cache.get_pvdc_info(pvdc_id)
         if not pvdc_info:

--- a/container_service_extension/pksbroker.py
+++ b/container_service_extension/pksbroker.py
@@ -50,6 +50,7 @@ from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProvider
 from container_service_extension.server_constants import KwargKey
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
+import container_service_extension.server_utils as server_utils
 from container_service_extension.shared_constants import RequestKey
 from container_service_extension.uaaclient.uaaclient import UaaClient
 import container_service_extension.utils as utils
@@ -105,11 +106,11 @@ class PksBroker(AbstractBroker):
             self.proxy_uri = f"http://{pks_ctx['proxy']}:80"
         self.compute_profile = pks_ctx.get(PKS_COMPUTE_PROFILE_KEY, None)
         self.nsxt_server = \
-            utils.get_pks_cache().get_nsxt_info(pks_ctx.get('vc'))
+            server_utils.get_pks_cache().get_nsxt_info(pks_ctx.get('vc'))
         self.nsxt_client = None
         self.pks_wire_logger = NULL_LOGGER
         nsxt_wire_logger = NULL_LOGGER
-        config = utils.get_server_runtime_config()
+        config = server_utils.get_server_runtime_config()
         if utils.str_to_bool(config['service'].get('log_wire')):
             nsxt_wire_logger = SERVER_NSXT_WIRE_LOGGER
             self.pks_wire_logger = SERVER_PKS_WIRE_LOGGER

--- a/container_service_extension/pksbroker_manager.py
+++ b/container_service_extension/pksbroker_manager.py
@@ -9,7 +9,7 @@ import container_service_extension.ovdc_utils as ovdc_utils
 from container_service_extension.pksbroker import PksBroker
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProvider
-import container_service_extension.utils as utils
+import container_service_extension.server_utils as server_utils
 
 
 def list_clusters(request_data, op_ctx: ctx.OperationContext):
@@ -40,7 +40,7 @@ def create_pks_context_for_all_accounts_in_org(op_ctx: ctx.OperationContext): # 
 
     :rtype: list
     """
-    pks_cache = utils.get_pks_cache()
+    pks_cache = server_utils.get_pks_cache()
     if pks_cache is None:
         return []
 

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -18,6 +18,7 @@ from container_service_extension.server_constants import CseOperation as CseServ
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProvider
 from container_service_extension.server_constants import ThreadLocalData
+import container_service_extension.server_utils as server_utils
 from container_service_extension.shared_constants import ComputePolicyAction
 from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
 from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
@@ -30,6 +31,7 @@ from container_service_extension.telemetry.telemetry_handler import record_user_
 from container_service_extension.telemetry.telemetry_handler import record_user_action_details  # noqa: E501
 from container_service_extension.telemetry.telemetry_handler import record_user_action_telemetry  # noqa: E501
 import container_service_extension.thread_local_data as thread_local_data
+import container_service_extension.thread_utils as thread_utils
 import container_service_extension.utils as utils
 
 SYSTEM_DEFAULT_COMPUTE_POLICY_NAME = "System Default"
@@ -158,12 +160,12 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
     prev_page_uri = vcd_utils.create_cse_page_uri(op_ctx.client,
                                                   api_path,
                                                   vcd_uri=prev_page_uri)
-    return utils.construct_paginated_response(values=ovdcs,
-                                              result_total=result_total,
-                                              page_number=page_number,
-                                              page_size=page_size,
-                                              next_page_uri=next_page_uri,
-                                              prev_page_uri=prev_page_uri)
+    return server_utils.construct_paginated_response(values=ovdcs,
+                                                     result_total=result_total,
+                                                     page_number=page_number,
+                                                     page_size=page_size,
+                                                     next_page_uri=next_page_uri,  # noqa: E501
+                                                     prev_page_uri=prev_page_uri)  # noqa: E501
 
 
 @record_user_action_telemetry(cse_operation=CseOperation.OVDC_COMPUTE_POLICY_LIST)  # noqa: E501
@@ -180,7 +182,7 @@ def ovdc_compute_policy_list(request_data,
     ]
     req_utils.validate_payload(request_data, required)
 
-    config = utils.get_server_runtime_config()
+    config = server_utils.get_server_runtime_config()
     cpm = compute_policy_manager.ComputePolicyManager(
         op_ctx.sysadmin_client,
         log_wire=utils.str_to_bool(config['service'].get('log_wire')))
@@ -222,7 +224,7 @@ def ovdc_compute_policy_update(request_data,
     ovdc_id = validated_data[RequestKey.OVDC_ID]
     remove_compute_policy_from_vms = validated_data[RequestKey.REMOVE_COMPUTE_POLICY_FROM_VMS] # noqa: E501
     try:
-        config = utils.get_server_runtime_config()
+        config = server_utils.get_server_runtime_config()
         cpm = compute_policy_manager.ComputePolicyManager(
             op_ctx.sysadmin_client,
             log_wire=utils.str_to_bool(config['service'].get('log_wire'))) # noqa: E501
@@ -280,7 +282,7 @@ def ovdc_compute_policy_update(request_data,
         raise err
 
 
-@utils.run_async
+@thread_utils.run_async
 def _follow_task(op_ctx: ctx.OperationContext, task_href: str, ovdc_id: str):
     try:
         task = vcd_task.Task(client=op_ctx.sysadmin_client)

--- a/container_service_extension/request_handlers/pks_cluster_handler.py
+++ b/container_service_extension/request_handlers/pks_cluster_handler.py
@@ -21,12 +21,12 @@ from container_service_extension.server_constants import K8sProvider
 from container_service_extension.server_constants import PKS_CLUSTER_DOMAIN_KEY
 from container_service_extension.server_constants import PKS_PLANS_KEY
 from container_service_extension.server_constants import ThreadLocalData
+import container_service_extension.server_utils as server_utils
 from container_service_extension.shared_constants import RequestKey
 from container_service_extension.telemetry.constants import CseOperation
 from container_service_extension.telemetry.constants import PayloadKey
 import container_service_extension.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
 import container_service_extension.thread_local_data as thread_local_data
-import container_service_extension.utils as utils
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=CseOperation.PKS_CLUSTER_LIST)  # noqa: E501
@@ -273,7 +273,7 @@ def _get_broker_from_k8s_metadata(k8s_metadata,
 
 
 def _raise_error_if_pks_not_enabled():
-    if not utils.is_pks_enabled():
+    if not server_utils.is_pks_enabled():
         raise CseServerError('CSE is not configured to work with PKS.')
 
 

--- a/container_service_extension/request_handlers/pks_ovdc_handler.py
+++ b/container_service_extension/request_handlers/pks_ovdc_handler.py
@@ -20,6 +20,7 @@ from container_service_extension.server_constants import CseOperation as CseServ
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProvider
 from container_service_extension.server_constants import ThreadLocalData
+import container_service_extension.server_utils as server_utils
 from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
 from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
 from container_service_extension.shared_constants import PaginationKey
@@ -67,7 +68,7 @@ def ovdc_update(request_data, op_ctx: ctx.OperationContext):
 
     try:
         if k8s_provider == K8sProvider.PKS:
-            if not utils.is_pks_enabled():
+            if not server_utils.is_pks_enabled():
                 raise e.CseServerError('CSE server is not '
                                        'configured to work with PKS.')
             required = [
@@ -241,9 +242,9 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
     prev_page_uri = vcd_utils.create_cse_page_uri(op_ctx.client,
                                                   api_path,
                                                   vcd_uri=prev_page_uri)
-    return utils.construct_paginated_response(values=ovdcs,
-                                              result_total=result_total,
-                                              page_number=page_number,
-                                              page_size=page_size,
-                                              next_page_uri=next_page_uri,
-                                              prev_page_uri=prev_page_uri)
+    return server_utils.construct_paginated_response(values=ovdcs,
+                                                     result_total=result_total,
+                                                     page_number=page_number,
+                                                     page_size=page_size,
+                                                     next_page_uri=next_page_uri,  # noqa: E501
+                                                     prev_page_uri=prev_page_uri)  # noqa: E501

--- a/container_service_extension/request_handlers/request_utils.py
+++ b/container_service_extension/request_handlers/request_utils.py
@@ -7,7 +7,8 @@ import container_service_extension.exceptions as cse_exception
 from container_service_extension.exceptions import BadRequestError
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.minor_error_codes import MinorErrorCode
-from container_service_extension.shared_constants import FlattenedClusterSpecKey, VALID_UPDATE_FIELDS  # noqa: E501
+from container_service_extension.server_constants import FlattenedClusterSpecKey  # noqa: E501
+from container_service_extension.server_constants import VALID_UPDATE_FIELDS
 from container_service_extension.shared_constants import RequestKey
 import container_service_extension.utils as utils
 

--- a/container_service_extension/request_handlers/template_handler.py
+++ b/container_service_extension/request_handlers/template_handler.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from container_service_extension.server_constants import LocalTemplateKey
+import container_service_extension.server_utils as server_utils
 from container_service_extension.telemetry.constants import CseOperation
 from container_service_extension.telemetry.telemetry_handler import record_user_action_telemetry  # noqa: E501
-import container_service_extension.utils as utils
 
 
 @record_user_action_telemetry(cse_operation=CseOperation.TEMPLATE_LIST_CLIENT_SIDE)  # noqa: E501
@@ -14,7 +14,7 @@ def template_list(request_data, op_ctx):
 
     :return: List of dictionaries with template info.
     """
-    config = utils.get_server_runtime_config()
+    config = server_utils.get_server_runtime_config()
     templates = []
     default_template_name = config['broker']['default_template_name']
     default_template_revision = str(config['broker']['default_template_revision'])  # noqa: E501

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -8,11 +8,11 @@ import container_service_extension.def_.models as def_models
 import container_service_extension.operation_context as ctx
 import container_service_extension.request_handlers.request_utils as request_utils  # noqa: E501
 from container_service_extension.server_constants import CseOperation as CseServerOperationInfo  # noqa: E501
+from container_service_extension.server_constants import FlattenedClusterSpecKey  # noqa: E501
 from container_service_extension.server_constants import ThreadLocalData
 from container_service_extension.shared_constants import ClusterAclKey
 from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
 from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
-from container_service_extension.shared_constants import FlattenedClusterSpecKey  # noqa: E501
 from container_service_extension.shared_constants import PaginationKey
 from container_service_extension.shared_constants import RequestKey
 import container_service_extension.telemetry.constants as telemetry_constants

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -23,8 +23,9 @@ import container_service_extension.request_handlers.v35.def_cluster_handler as v
 import container_service_extension.request_handlers.v35.ovdc_handler as v35_ovdc_handler # noqa: E501
 import container_service_extension.request_handlers.v36.def_cluster_handler as v36_cluster_handler  # noqa: E501
 from container_service_extension.server_constants import CseOperation
+from container_service_extension.server_constants import OperationType
+import container_service_extension.server_utils as server_utils
 import container_service_extension.shared_constants as shared_constants
-import container_service_extension.utils as utils
 
 
 """Process incoming requests
@@ -268,7 +269,7 @@ def process_request(message):
                 error_message='CSE service is disabled. '
                               'Contact the System Administrator.')
         else:
-            server_api_version = utils.get_server_api_version()
+            server_api_version = server_utils.get_server_api_version()
             if api_version != server_api_version:
                 raise cse_exception.NotAcceptableRequestError(
                     error_message="Invalid api version specified. Expected "
@@ -391,7 +392,7 @@ def _get_pks_url_data(method: str, url: str):
     if operation_type.endswith('s'):
         operation_type = operation_type[:-1]
 
-    if operation_type == shared_constants.OperationType.CLUSTER:
+    if operation_type == OperationType.CLUSTER:
         if num_tokens == 4:
             if method == shared_constants.RequestMethod.GET:
                 return {_OPERATION_KEY: CseOperation.PKS_CLUSTER_LIST}
@@ -423,7 +424,7 @@ def _get_pks_url_data(method: str, url: str):
                         shared_constants.RequestKey.CLUSTER_NAME: tokens[4]
                     }
             raise cse_exception.MethodNotAllowedRequestError()
-    elif operation_type == shared_constants.OperationType.OVDC:
+    elif operation_type == OperationType.OVDC:
         if num_tokens == 4:
             if method == shared_constants.RequestMethod.GET:
                 return {_OPERATION_KEY: CseOperation.PKS_OVDC_LIST}
@@ -468,10 +469,10 @@ def _get_v35_plus_url_data(method: str, url: str, api_version: str):
     if operation_type.endswith('s'):
         operation_type = operation_type[:-1]
 
-    if operation_type == shared_constants.OperationType.CLUSTER:
+    if operation_type == OperationType.CLUSTER:
         return _get_v35_plus_cluster_url_data(method, tokens, api_version)
 
-    if operation_type == shared_constants.OperationType.OVDC:
+    if operation_type == OperationType.OVDC:
         return _get_v35_plus_ovdc_url_data(method, tokens)
 
     raise cse_exception.NotFoundRequestError()
@@ -597,7 +598,7 @@ def _get_legacy_url_data(method: str, url: str, api_version: str):
     if operation_type.endswith('s'):
         operation_type = operation_type[:-1]
 
-    if operation_type == shared_constants.OperationType.CLUSTER:
+    if operation_type == OperationType.CLUSTER:
         if api_version not in (VcdApiVersion.VERSION_33.value,
                                VcdApiVersion.VERSION_34.value):
             raise cse_exception.NotFoundRequestError()
@@ -646,7 +647,7 @@ def _get_legacy_url_data(method: str, url: str, api_version: str):
                         shared_constants.RequestKey.CLUSTER_NAME: tokens[4]
                     }
             raise cse_exception.MethodNotAllowedRequestError()
-    elif operation_type == shared_constants.OperationType.NODE:
+    elif operation_type == OperationType.NODE:
         if api_version not in (VcdApiVersion.VERSION_33.value,
                                VcdApiVersion.VERSION_34.value):
             raise cse_exception.NotFoundRequestError()
@@ -664,7 +665,7 @@ def _get_legacy_url_data(method: str, url: str, api_version: str):
                     shared_constants.RequestKey.NODE_NAME: tokens[4]
                 }
             raise cse_exception.MethodNotAllowedRequestError()
-    elif operation_type == shared_constants.OperationType.OVDC:
+    elif operation_type == OperationType.OVDC:
         if api_version not in (VcdApiVersion.VERSION_33.value,
                                VcdApiVersion.VERSION_34.value):
             raise cse_exception.NotFoundRequestError()
@@ -697,14 +698,14 @@ def _get_legacy_url_data(method: str, url: str, api_version: str):
                     shared_constants.RequestKey.OVDC_ID: tokens[4]
                 }
             raise cse_exception.MethodNotAllowedRequestError()
-    elif operation_type == shared_constants.OperationType.SYSTEM:
+    elif operation_type == OperationType.SYSTEM:
         if num_tokens == 4:
             if method == shared_constants.RequestMethod.GET:
                 return {_OPERATION_KEY: CseOperation.SYSTEM_INFO}
             if method == shared_constants.RequestMethod.PUT:
                 return {_OPERATION_KEY: CseOperation.SYSTEM_UPDATE}
             raise cse_exception.MethodNotAllowedRequestError()
-    elif operation_type == shared_constants.OperationType.TEMPLATE:
+    elif operation_type == OperationType.TEMPLATE:
         if num_tokens == 4:
             if method == shared_constants.RequestMethod.GET:
                 return {_OPERATION_KEY: CseOperation.TEMPLATE_LIST}

--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -46,6 +46,7 @@ from container_service_extension.server_constants import LocalTemplateKey
 from container_service_extension.server_constants import RemoteTemplateKey
 from container_service_extension.server_constants import SUPPORTED_VCD_API_VERSIONS  # noqa: E501
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
+import container_service_extension.server_utils as server_utils
 import container_service_extension.service as cse_service
 from container_service_extension.shared_constants import ClusterEntityKind
 from container_service_extension.shared_constants import RequestMethod
@@ -59,11 +60,6 @@ from container_service_extension.telemetry.telemetry_handler import \
 from container_service_extension.telemetry.telemetry_utils \
     import store_telemetry_settings
 import container_service_extension.utils as utils
-from container_service_extension.utils import check_python_version
-from container_service_extension.utils import ConsoleMessagePrinter
-from container_service_extension.utils import NullPrinter
-from container_service_extension.utils import prompt_text
-from container_service_extension.utils import str_to_bool
 
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
@@ -220,7 +216,7 @@ def cli(ctx):
             prompted for password to encrypt/decrypt the CSE configuration files.
     """  # noqa: E501
     if ctx.invoked_subcommand is None:
-        console_message_printer = ConsoleMessagePrinter()
+        console_message_printer = utils.ConsoleMessagePrinter()
         console_message_printer.general_no_color(ctx.get_help())
         return
 
@@ -324,19 +320,19 @@ def version(ctx):
 def create_service_role(ctx, vcd_host, verify_ssl_certs):
     """Create CSE service Role."""
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
-    console_message_printer = ConsoleMessagePrinter()
+    console_message_printer = utils.ConsoleMessagePrinter()
     requests.packages.urllib3.disable_warnings()
 
     # The console_message_printer is not being passed to the python version
     # check, because we want to suppress the version check messages from being
     # printed onto console.
-    check_python_version()
+    utils.check_python_version()
 
     # Prompt user for administrator username/password
-    admin_username = prompt_text(USERNAME_FOR_SYSTEM_ADMINISTRATOR,
-                                 color='green', hide_input=False)
-    admin_password = prompt_text(PASSWORD_FOR_SYSTEM_ADMINISTRATOR + str(admin_username), # noqa: E501
-                                 color='green', hide_input=True)
+    admin_username = utils.prompt_text(USERNAME_FOR_SYSTEM_ADMINISTRATOR,
+                                       color='green', hide_input=False)
+    admin_password = utils.prompt_text(PASSWORD_FOR_SYSTEM_ADMINISTRATOR + str(admin_username), # noqa: E501
+                                       color='green', hide_input=True)
 
     msg = f"Connecting to vCD: {vcd_host}"
     console_message_printer.general_no_color(msg)
@@ -419,11 +415,11 @@ def create_service_role(ctx, vcd_host, verify_ssl_certs):
 def sample(ctx, output, pks_config, api_version):
     """Display sample CSE config file contents."""
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
-    console_message_printer = ConsoleMessagePrinter()
+    console_message_printer = utils.ConsoleMessagePrinter()
     # The console_message_printer is not being passed to the python version
     # check, because we want to suppress the version check messages from being
     # printed onto console, and pollute the sample config.
-    check_python_version()
+    utils.check_python_version()
 
     try:
         api_version = float(api_version)
@@ -471,12 +467,12 @@ def check(ctx, config_file_path, pks_config_file_path, skip_config_decryption,
           check_install):
     """Validate CSE config file."""
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
-    console_message_printer = ConsoleMessagePrinter()
-    check_python_version(console_message_printer)
+    console_message_printer = utils.ConsoleMessagePrinter()
+    utils.check_python_version(console_message_printer)
 
     password = None
     if not skip_config_decryption:
-        password = os.getenv('CSE_CONFIG_PASSWORD') or prompt_text(
+        password = os.getenv('CSE_CONFIG_PASSWORD') or utils.prompt_text(
             PASSWORD_FOR_CONFIG_DECRYPTION_MSG,
             color='green', hide_input=True)
 
@@ -547,12 +543,12 @@ def check(ctx, config_file_path, pks_config_file_path, skip_config_decryption,
 def decrypt(ctx, input_file, output_file):
     """Decrypt CSE configuration file."""
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
-    console_message_printer = ConsoleMessagePrinter()
-    check_python_version(console_message_printer)
+    console_message_printer = utils.ConsoleMessagePrinter()
+    utils.check_python_version(console_message_printer)
 
     try:
         try:
-            password = os.getenv('CSE_CONFIG_PASSWORD') or prompt_text(
+            password = os.getenv('CSE_CONFIG_PASSWORD') or utils.prompt_text(
                 PASSWORD_FOR_CONFIG_DECRYPTION_MSG,
                 hide_input=True,
                 color='green')
@@ -583,12 +579,12 @@ def decrypt(ctx, input_file, output_file):
 def encrypt(ctx, input_file, output_file):
     """Encrypt CSE configuration file."""
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
-    console_message_printer = ConsoleMessagePrinter()
-    check_python_version(console_message_printer)
+    console_message_printer = utils.ConsoleMessagePrinter()
+    utils.check_python_version(console_message_printer)
 
     try:
         try:
-            password = os.getenv('CSE_CONFIG_PASSWORD') or prompt_text(
+            password = os.getenv('CSE_CONFIG_PASSWORD') or utils.prompt_text(
                 PASSWORD_FOR_CONFIG_ENCRYPTION_MSG,
                 hide_input=True,
                 color='green')
@@ -659,8 +655,8 @@ def install(ctx, config_file_path, pks_config_file_path,
     # an Exception will be thrown if TKG+ template is present in the
     # remote_template_cookbook.
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
-    console_message_printer = ConsoleMessagePrinter()
-    check_python_version(console_message_printer)
+    console_message_printer = utils.ConsoleMessagePrinter()
+    utils.check_python_version(console_message_printer)
 
     if retain_temp_vapp and not ssh_key_file:
         msg = "Must provide ssh-key file (using --ssh-key OR -k) if " \
@@ -676,7 +672,7 @@ def install(ctx, config_file_path, pks_config_file_path,
 
     password = None
     if not skip_config_decryption:
-        password = os.getenv('CSE_CONFIG_PASSWORD') or prompt_text(
+        password = os.getenv('CSE_CONFIG_PASSWORD') or utils.prompt_text(
             PASSWORD_FOR_CONFIG_DECRYPTION_MSG,
             color='green', hide_input=True)
 
@@ -723,13 +719,13 @@ def install(ctx, config_file_path, pks_config_file_path,
 def pks_configure(ctx, pks_config_file_path, skip_config_decryption):
 
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
-    console_message_printer = ConsoleMessagePrinter()
-    check_python_version(console_message_printer)
+    console_message_printer = utils.ConsoleMessagePrinter()
+    utils.check_python_version(console_message_printer)
     requests.packages.urllib3.disable_warnings()
 
     password = None
     if not skip_config_decryption:
-        password = os.getenv('CSE_CONFIG_PASSWORD') or prompt_text(
+        password = os.getenv('CSE_CONFIG_PASSWORD') or utils.prompt_text(
             PASSWORD_FOR_CONFIG_DECRYPTION_MSG,
             color='green', hide_input=True)
     try:
@@ -797,12 +793,12 @@ def run(ctx, config_file_path, pks_config_file_path, skip_check,
         skip_config_decryption):
     """Run CSE service."""
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
-    console_message_printer = ConsoleMessagePrinter()
-    check_python_version(console_message_printer)
+    console_message_printer = utils.ConsoleMessagePrinter()
+    utils.check_python_version(console_message_printer)
 
     password = None
     if not skip_config_decryption:
-        password = os.getenv('CSE_CONFIG_PASSWORD') or prompt_text(
+        password = os.getenv('CSE_CONFIG_PASSWORD') or utils.prompt_text(
             PASSWORD_FOR_CONFIG_DECRYPTION_MSG,
             color='green', hide_input=True)
 
@@ -911,8 +907,8 @@ def upgrade(ctx, config_file_path, skip_config_decryption,
     # 1. If there is an existing TKG+ template
     # 2. If remote template cookbook contains a TKG+ template.
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
-    console_message_printer = ConsoleMessagePrinter()
-    check_python_version(console_message_printer)
+    console_message_printer = utils.ConsoleMessagePrinter()
+    utils.check_python_version(console_message_printer)
 
     if retain_temp_vapp and not ssh_key_file:
         msg = "Must provide ssh-key file (using --ssh-key OR -k) if " \
@@ -928,7 +924,7 @@ def upgrade(ctx, config_file_path, skip_config_decryption,
 
     password = None
     if not skip_config_decryption:
-        password = os.getenv('CSE_CONFIG_PASSWORD') or prompt_text(
+        password = os.getenv('CSE_CONFIG_PASSWORD') or utils.prompt_text(
             PASSWORD_FOR_CONFIG_DECRYPTION_MSG,
             color='green', hide_input=True)
 
@@ -992,10 +988,10 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                   display_option):
     """List CSE k8s templates."""
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
-    console_message_printer = ConsoleMessagePrinter()
+    console_message_printer = utils.ConsoleMessagePrinter()
     # Not passing the console_message_printer, because we want to suppress
     # the python version check messages from being printed onto console.
-    check_python_version()
+    utils.check_python_version()
 
     config_dict = None
     try:
@@ -1022,7 +1018,7 @@ def list_template(ctx, config_file_path, skip_config_decryption,
             client = None
             try:
                 log_wire_file = None
-                log_wire = str_to_bool(config_dict['service'].get('log_wire'))
+                log_wire = utils.str_to_bool(config_dict['service'].get('log_wire'))  # noqa: E501
                 if log_wire:
                     log_wire_file = SERVER_DEBUG_WIRELOG_FILEPATH
 
@@ -1032,7 +1028,7 @@ def list_template(ctx, config_file_path, skip_config_decryption,
 
                 org_name = config_dict['broker']['org']
                 catalog_name = config_dict['broker']['catalog']
-                is_tkg_plus_enabled = utils.is_tkg_plus_enabled(config_dict)
+                is_tkg_plus_enabled = server_utils.is_tkg_plus_enabled(config_dict)  # noqa: E501
                 local_template_definitions = \
                     ltm.get_all_k8s_local_template_definition(
                         client=client,
@@ -1070,7 +1066,7 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                         template['default'] = 'Yes'
                     else:
                         template['default'] = 'No'
-                    template['deprecated'] = 'Yes' if str_to_bool(definition[LocalTemplateKey.DEPRECATED]) else 'No' # noqa: E501
+                    template['deprecated'] = 'Yes' if utils.str_to_bool(definition[LocalTemplateKey.DEPRECATED]) else 'No' # noqa: E501
                     template['cpu'] = definition[LocalTemplateKey.CPU]
                     template['memory'] = definition[LocalTemplateKey.MEMORY]
                     template['description'] = \
@@ -1098,7 +1094,7 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                 template['remote'] = 'Yes'
                 if display_option is DISPLAY_ALL:
                     template['default'] = 'No'
-                template['deprecated'] = 'Yes' if str_to_bool(definition[RemoteTemplateKey.DEPRECATED]) else 'No' # noqa: E501
+                template['deprecated'] = 'Yes' if utils.str_to_bool(definition[RemoteTemplateKey.DEPRECATED]) else 'No' # noqa: E501
                 template['cpu'] = definition[RemoteTemplateKey.CPU]
                 template['memory'] = definition[RemoteTemplateKey.MEMORY]
                 template['description'] = \
@@ -1213,8 +1209,8 @@ def install_cse_template(ctx, template_name, template_revision,
     # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
     # Throw an error if TKG+ template creation is issued.
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
-    console_message_printer = ConsoleMessagePrinter()
-    check_python_version(console_message_printer)
+    console_message_printer = utils.ConsoleMessagePrinter()
+    utils.check_python_version(console_message_printer)
 
     if retain_temp_vapp and not ssh_key_file:
         msg = "Must provide ssh-key file (using --ssh-key OR -k) if " \
@@ -1226,7 +1222,7 @@ def install_cse_template(ctx, template_name, template_revision,
 
     password = None
     if not skip_config_decryption:
-        password = os.getenv('CSE_CONFIG_PASSWORD') or prompt_text(
+        password = os.getenv('CSE_CONFIG_PASSWORD') or utils.prompt_text(
             PASSWORD_FOR_CONFIG_DECRYPTION_MSG,
             color='green', hide_input=True)
 
@@ -1288,8 +1284,8 @@ def register_ui_plugin(ctx, plugin_file_path, config_file_path,
                        skip_config_decryption):
     """."""
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
-    console_message_printer = ConsoleMessagePrinter()
-    check_python_version(console_message_printer)
+    console_message_printer = utils.ConsoleMessagePrinter()
+    utils.check_python_version(console_message_printer)
 
     client = None
     tempdir = None
@@ -1330,7 +1326,7 @@ def register_ui_plugin(ctx, plugin_file_path, config_file_path,
         }
 
         log_wire_file = None
-        log_wire = str_to_bool(config_dict['service'].get('log_wire'))
+        log_wire = utils.str_to_bool(config_dict['service'].get('log_wire'))
         if log_wire:
             log_wire_file = SERVER_DEBUG_WIRELOG_FILEPATH
 
@@ -1439,8 +1435,8 @@ def deregister_ui_plugin(ctx, plugin_id, config_file_path,
                          skip_config_decryption):
     """."""
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
-    console_message_printer = ConsoleMessagePrinter()
-    check_python_version(console_message_printer)
+    console_message_printer = utils.ConsoleMessagePrinter()
+    utils.check_python_version(console_message_printer)
 
     client = None
     try:
@@ -1454,7 +1450,7 @@ def deregister_ui_plugin(ctx, plugin_id, config_file_path,
             msg_update_callback=console_message_printer)
 
         log_filename = None
-        log_wire = str_to_bool(config_dict['service'].get('log_wire'))
+        log_wire = utils.str_to_bool(config_dict['service'].get('log_wire'))
         if log_wire:
             log_filename = SERVER_CLI_WIRELOG_FILEPATH
 
@@ -1498,10 +1494,10 @@ def deregister_ui_plugin(ctx, plugin_id, config_file_path,
 def list_ui_plugin(ctx, config_file_path, skip_config_decryption):
     """."""
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
-    console_message_printer = ConsoleMessagePrinter()
+    console_message_printer = utils.ConsoleMessagePrinter()
     # Suppress the python version check message from being printed on
     # console
-    check_python_version()
+    utils.check_python_version()
 
     client = None
     try:
@@ -1515,7 +1511,7 @@ def list_ui_plugin(ctx, config_file_path, skip_config_decryption):
             msg_update_callback=console_message_printer)
 
         log_filename = None
-        log_wire = str_to_bool(config_dict['service'].get('log_wire'))
+        log_wire = utils.str_to_bool(config_dict['service'].get('log_wire'))
         if log_wire:
             log_filename = SERVER_DEBUG_WIRELOG_FILEPATH
 
@@ -1548,10 +1544,10 @@ def list_ui_plugin(ctx, config_file_path, skip_config_decryption):
 
 def _get_unvalidated_config(config_file_path,
                             skip_config_decryption,
-                            msg_update_callback=NullPrinter()):
+                            msg_update_callback=utils.NullPrinter()):
     password = None
     if not skip_config_decryption:
-        password = os.getenv('CSE_CONFIG_PASSWORD') or prompt_text(
+        password = os.getenv('CSE_CONFIG_PASSWORD') or utils.prompt_text(
             PASSWORD_FOR_CONFIG_DECRYPTION_MSG,
             color='green', hide_input=True)
 

--- a/container_service_extension/server_utils.py
+++ b/container_service_extension/server_utils.py
@@ -1,0 +1,160 @@
+# container-service-extension
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Server utility methods used only by the CSE server."""
+
+import math
+
+import semantic_version
+
+import container_service_extension.server_constants as server_constants
+import container_service_extension.shared_constants as shared_constants
+import container_service_extension.utils as utils
+
+
+def get_installed_cse_version():
+    """."""
+    cse_version_raw = utils.get_cse_info()['version']
+    # Cleanup version string. Strip dev version string segment.
+    # e.g. convert '2.6.0.0b2.dev5' to '2.6.0'
+    tokens = cse_version_raw.split('.')[:3]
+    cse_version = semantic_version.Version('.'.join(tokens))
+    return cse_version
+
+
+def get_server_runtime_config():
+    import container_service_extension.service as cse_service
+    return cse_service.Service().get_service_config()
+
+
+def get_server_api_version():
+    """Get the API version with which CSE server is running.
+
+    :return: api version
+    """
+    config = get_server_runtime_config()
+    return config['vcd']['api_version']
+
+
+def get_default_storage_profile():
+    config = get_server_runtime_config()
+    return config['broker']['storage_profile']
+
+
+def get_default_k8_distribution():
+    config = get_server_runtime_config()
+    import container_service_extension.def_.models as def_models
+    return def_models.Distribution(template_name=config['broker']['default_template_name'],  # noqa: E501
+                                   template_revision=config['broker']['default_template_revision'])  # noqa: E501
+
+
+def get_pks_cache():
+    from container_service_extension.service import Service
+    return Service().get_pks_cache()
+
+
+def is_pks_enabled():
+    from container_service_extension.service import Service
+    return Service().is_pks_enabled()
+
+
+def is_tkg_plus_enabled(config: dict = None):
+    """
+    Check if TKG plus is enabled by the provider in the config.
+
+    :param dict config: configuration provided by the user.
+    :rtype: bool
+    """
+    if not config:
+        try:
+            config = get_server_runtime_config()
+        except Exception:
+            return False
+    service_section = config.get('service', {})
+    tkg_plus_enabled = service_section.get('enable_tkg_plus', False)
+    if isinstance(tkg_plus_enabled, bool):
+        return tkg_plus_enabled
+    elif isinstance(tkg_plus_enabled, str):
+        return utils.str_to_bool(tkg_plus_enabled)
+    return False
+
+
+def should_use_mqtt_protocol(config):
+    """Return true if should use the mqtt protocol; false otherwise.
+
+    The MQTT protocol should be used if the config file contains an "mqtt" key
+        and the api version is greater than or equal to the minimum mqtt
+        api version.
+
+    :param dict config: config yaml file as a dictionary
+
+    :return: whether to use the mqtt protocol
+    :rtype: str
+    """
+    return config.get('mqtt') is not None and \
+        config.get('vcd') is not None and \
+        config['vcd'].get('api_version') is not None and \
+        float(config['vcd']['api_version']) >= server_constants.MQTT_MIN_API_VERSION  # noqa: E501
+
+
+def construct_paginated_response(values, result_total,
+                                 page_number=shared_constants.CSE_PAGINATION_FIRST_PAGE_NUMBER,  # noqa: E501
+                                 page_size=shared_constants.CSE_PAGINATION_DEFAULT_PAGE_SIZE,  # noqa: E501
+                                 page_count=None,
+                                 next_page_uri=None,
+                                 prev_page_uri=None):
+    if not page_count:
+        extra_page = 1 if bool(result_total % page_size) else 0
+        page_count = result_total // page_size + extra_page
+    resp = {
+        shared_constants.PaginationKey.RESULT_TOTAL: result_total,
+        shared_constants.PaginationKey.PAGE_COUNT: page_count,
+        shared_constants.PaginationKey.PAGE_NUMBER: page_number,
+        shared_constants.PaginationKey.PAGE_SIZE: page_size,
+        shared_constants.PaginationKey.NEXT_PAGE_URI: next_page_uri,
+        shared_constants.PaginationKey.PREV_PAGE_URI: prev_page_uri,
+        shared_constants.PaginationKey.VALUES: values
+    }
+
+    # Conditionally deleting instead of conditionally adding the entry
+    # maintains the order for the response
+    if not prev_page_uri:
+        del resp[shared_constants.PaginationKey.PREV_PAGE_URI]
+    if not next_page_uri:
+        del resp[shared_constants.PaginationKey.NEXT_PAGE_URI]
+    return resp
+
+
+def create_links_and_construct_paginated_result(base_uri, values, result_total,
+                                                page_number=shared_constants.CSE_PAGINATION_FIRST_PAGE_NUMBER,  # noqa: E501
+                                                page_size=shared_constants.CSE_PAGINATION_DEFAULT_PAGE_SIZE,  # noqa: E501
+                                                query_params={}):
+    next_page_uri: str = None
+    if 0 < page_number * page_size < result_total:
+        # TODO find a way to get the initial url part
+        # ideally the request details should be passed down to each of the
+        # handler funcions as request context
+        next_page_uri = f"{base_uri}?page={page_number+1}&pageSize={page_size}"
+        for q in query_params.keys():
+            next_page_uri += f"&{q}={query_params[q]}"
+
+    page_count = math.ceil(result_total / page_size)
+    prev_page_uri: str = None
+    if page_count >= page_number > 1:
+        prev_page_uri = f"{base_uri}?page={page_number-1}&pageSize={page_size}"
+
+    # add the rest of the query parameters
+    for q in query_params.keys():
+        if next_page_uri:
+            next_page_uri += f"&{q}={query_params[q]}"
+        if prev_page_uri:
+            prev_page_uri += f"&{q}={query_params[q]}"
+
+    return construct_paginated_response(values=values,
+                                        result_total=result_total,
+                                        page_number=page_number,
+                                        page_size=page_size,
+                                        page_count=page_count,
+                                        next_page_uri=next_page_uri,
+                                        prev_page_uri=prev_page_uri)

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -476,14 +476,13 @@ class Service(object, metaclass=Singleton):
                                                               logger_wire)
             raise_error_if_def_not_supported(cloudapi_client)
             schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
-            defKey = def_constants.DefKey
             keys_map = def_constants.MAP_API_VERSION_TO_KEYS[float(sysadmin_client.get_api_version())] # noqa: E501
-            interface_id = def_utils.generate_interface_id(vendor=keys_map[defKey.INTERFACE_VENDOR], # noqa: E501
-                                                           nss=keys_map[defKey.INTERFACE_NSS], # noqa: E501
-                                                           version=keys_map[defKey.INTERFACE_VERSION]) # noqa: E501
-            entity_type_id = def_utils.generate_entity_type_id(vendor=keys_map[defKey.ENTITY_TYPE_VENDOR], # noqa: E501
-                                                               nss=keys_map[defKey.ENTITY_TYPE_NSS], # noqa: E501
-                                                               version=keys_map[defKey.ENTITY_TYPE_VERSION]) # noqa: E501
+            interface_id = def_utils.generate_interface_id(vendor=keys_map[def_constants.DefKey.INTERFACE_VENDOR], # noqa: E501
+                                                           nss=keys_map[def_constants.DefKey.INTERFACE_NSS], # noqa: E501
+                                                           version=keys_map[def_constants.DefKey.INTERFACE_VERSION]) # noqa: E501
+            entity_type_id = def_utils.generate_entity_type_id(vendor=keys_map[def_constants.DefKey.ENTITY_TYPE_VENDOR], # noqa: E501
+                                                               nss=keys_map[def_constants.DefKey.ENTITY_TYPE_NSS], # noqa: E501
+                                                               version=keys_map[def_constants.DefKey.ENTITY_TYPE_VERSION]) # noqa: E501
             self._kubernetesInterface = schema_svc.get_interface(interface_id)
             self._nativeEntityType = schema_svc.get_entity_type(entity_type_id)
             msg = "Successfully loaded defined entity schema to global context"

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -101,7 +101,7 @@ def watchdog_thread_run(service_obj, num_processors):
 
 def verify_version_compatibility(sysadmin_client: Client,
                                  target_vcd_api_version, is_mqtt_extension):
-    cse_version = utils.get_installed_cse_version()
+    cse_version = server_utils.get_installed_cse_version()
     ext_cse_version, ext_vcd_api_version = \
         configure_cse.parse_cse_extension_description(
             sysadmin_client, is_mqtt_extension)

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-from dataclasses import dataclass
+"""Constants shared between the client CLI and the server."""
+
 from enum import Enum
 from enum import unique
 
@@ -28,21 +29,23 @@ class ClusterEntityKind(Enum):
     TKG_PLUS = 'TKG+'
 
 
+# Cluster runtimes and placement policies
 NATIVE_CLUSTER_RUNTIME_INTERNAL_NAME = 'native'
 TKG_PLUS_CLUSTER_RUNTIME_INTERNAL_NAME = 'tkgplus'
 CLUSTER_RUNTIME_PLACEMENT_POLICIES = [NATIVE_CLUSTER_RUNTIME_INTERNAL_NAME,
                                       TKG_PLUS_CLUSTER_RUNTIME_INTERNAL_NAME]
+
 
 RUNTIME_DISPLAY_NAME_TO_INTERNAL_NAME_MAP = {
     ClusterEntityKind.NATIVE.value: NATIVE_CLUSTER_RUNTIME_INTERNAL_NAME,
     ClusterEntityKind.TKG_PLUS.value: TKG_PLUS_CLUSTER_RUNTIME_INTERNAL_NAME
 }
 
+
 RUNTIME_INTERNAL_NAME_TO_DISPLAY_NAME_MAP = {
     NATIVE_CLUSTER_RUNTIME_INTERNAL_NAME: ClusterEntityKind.NATIVE.value,
     TKG_PLUS_CLUSTER_RUNTIME_INTERNAL_NAME: ClusterEntityKind.TKG_PLUS.value
 }
-
 
 # CSE Server Busy string
 CSE_SERVER_BUSY_KEY = 'CSE Server Busy'
@@ -69,15 +72,6 @@ ACCESS_LEVEL_TYPE_TO_ID = {
 # CSE Pagination default values
 CSE_PAGINATION_FIRST_PAGE_NUMBER = 1
 CSE_PAGINATION_DEFAULT_PAGE_SIZE = 25
-
-
-@unique
-class OperationType(str, Enum):
-    CLUSTER = 'cluster'
-    NODE = 'node'
-    OVDC = 'ovdc'
-    SYSTEM = 'system'
-    TEMPLATE = 'template'
 
 
 @unique
@@ -168,35 +162,6 @@ class PaginationKey(str, Enum):
 
 
 @unique
-class DefEntityOperation(str, Enum):
-    CREATE = 'CREATE'
-    DELETE = 'DELETE'
-    UPDATE = 'UPDATE'
-    UPGRADE = 'UPGRADE'
-    UNKNOWN = 'UNKNOWN'
-
-
-@unique
-class DefEntityOperationStatus(str, Enum):
-    IN_PROGRESS = 'IN_PROGRESS'
-    SUCCEEDED = 'SUCCEEDED'
-    FAILED = 'FAILED'
-    UNKNOWN = 'UNKNOWN'
-
-
-@unique
-class FlattenedClusterSpecKey(Enum):
-    WORKERS_COUNT = 'workers.count'
-    NFS_COUNT = 'nfs.count'
-    TEMPLATE_NAME = 'k8_distribution.template_name'
-    TEMPLATE_REVISION = 'k8_distribution.template_revision'
-
-
-VALID_UPDATE_FIELDS = [FlattenedClusterSpecKey.WORKERS_COUNT.value, FlattenedClusterSpecKey.NFS_COUNT.value,  # noqa: E501
-                       FlattenedClusterSpecKey.TEMPLATE_NAME.value, FlattenedClusterSpecKey.TEMPLATE_REVISION.value]  # noqa: E501
-
-
-@unique
 class AccessControlKey(str, Enum):
     """Keys for access control requests."""
 
@@ -215,38 +180,3 @@ class AccessControlKey(str, Enum):
 class ClusterAclKey(str, Enum):
     ACCESS_SETTING = 'accessSetting'
     UPDATE_ACL_ENTRIES = 'update_acl_entries'
-
-
-@dataclass
-class DefEntityPhase:
-    """Supports two ways of creation.
-
-    1. DefEntityPhase(DefEntityOperation.CREATE, DefEntityOperationStatus.SUCCEEDED) # noqa: E501
-    2. DefEntityPhase.from_phase('CREATE:SUCCEEDED')
-    """
-
-    operation: DefEntityOperation
-    status: DefEntityOperationStatus
-
-    def __str__(self):
-        return f'{self.operation}:{self.status}'
-
-    @classmethod
-    def from_phase(cls, phase: str):
-        """Return instance of DefEntityPhase.
-
-        :param str phase: defined entity phase value. ex: "CREATE:SUCCEEDED"
-        :return: DefEntityPhase
-        :rtype: <class DefEntityPhase>
-        """
-        operation, status = phase.split(':')
-        return cls(DefEntityOperation[operation], DefEntityOperationStatus[status])  # noqa: E501
-
-    def is_operation_status_success(self) -> bool:
-        try:
-            return self.status == DefEntityOperationStatus.SUCCEEDED
-        except Exception:
-            return False
-
-    def is_entity_busy(self) -> bool:
-        return self.status == DefEntityOperationStatus.IN_PROGRESS

--- a/container_service_extension/telemetry/telemetry_handler.py
+++ b/container_service_extension/telemetry/telemetry_handler.py
@@ -5,6 +5,7 @@
 import functools
 
 from container_service_extension.logger import SERVER_LOGGER as LOGGER
+from container_service_extension.server_utils import get_server_runtime_config
 from container_service_extension.telemetry.constants import CseOperation
 from container_service_extension.telemetry.constants import OperationStatus
 import container_service_extension.telemetry.payload_generator as\
@@ -12,8 +13,7 @@ import container_service_extension.telemetry.payload_generator as\
 from container_service_extension.telemetry.payload_generator \
     import get_payload_for_user_action
 from container_service_extension.telemetry.vac_client import VacClient
-from container_service_extension.utils import get_server_runtime_config
-from container_service_extension.utils import run_async
+from container_service_extension.thread_utils import run_async
 
 # Payload generator function mappings for CSE operations
 # Each command has its own payload generator

--- a/container_service_extension/telemetry/telemetry_utils.py
+++ b/container_service_extension/telemetry/telemetry_utils.py
@@ -17,10 +17,10 @@ from container_service_extension.server_constants import MQTT_EXTENSION_VENDOR
 from container_service_extension.server_constants import MQTT_EXTENSION_VERSION
 from container_service_extension.server_constants import MQTTExtKey
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
+from container_service_extension.server_utils import should_use_mqtt_protocol
 from container_service_extension.telemetry.constants import COLLECTOR_ID
 from container_service_extension.telemetry.constants import VAC_URL
 from container_service_extension.utils import NullPrinter
-from container_service_extension.utils import should_use_mqtt_protocol
 
 
 CEIP_HEADER_NAME = "x-vmware-vcloud-ceip-id"

--- a/container_service_extension/thread_utils.py
+++ b/container_service_extension/thread_utils.py
@@ -1,0 +1,38 @@
+# container-service-extension
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Thread utils for managing multiple threads in the server."""
+
+import functools
+import threading
+
+import container_service_extension.thread_local_data as thread_local_data
+
+
+def transfer_thread_local_data_wrapper(func):
+    cur_thread_data = thread_local_data.get_thread_local_data_as_dict()
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        thread_local_data.set_thread_local_data_from_dict(cur_thread_data)
+        func(*args, **kwargs)
+        thread_local_data.reset_thread_local_data()
+    return wrapper
+
+
+def run_async(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        thread_local_data_wrapper = transfer_thread_local_data_wrapper(func)
+        t = threading.Thread(name=generate_thread_name(func.__name__),
+                             target=thread_local_data_wrapper, args=args, kwargs=kwargs,  # noqa: E501
+                             daemon=True)
+        t.start()
+        return t
+    return wrapper
+
+
+def generate_thread_name(function_name):
+    parent_thread_id = threading.current_thread().ident
+    return function_name + ':' + str(parent_thread_id)

--- a/container_service_extension/thread_utils.py
+++ b/container_service_extension/thread_utils.py
@@ -10,7 +10,7 @@ import threading
 import container_service_extension.thread_local_data as thread_local_data
 
 
-def transfer_thread_local_data_wrapper(func):
+def _transfer_thread_local_data_wrapper(func):
     cur_thread_data = thread_local_data.get_thread_local_data_as_dict()
 
     @functools.wraps(func)
@@ -24,7 +24,7 @@ def transfer_thread_local_data_wrapper(func):
 def run_async(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        thread_local_data_wrapper = transfer_thread_local_data_wrapper(func)
+        thread_local_data_wrapper = _transfer_thread_local_data_wrapper(func)
         t = threading.Thread(name=generate_thread_name(func.__name__),
                              target=thread_local_data_wrapper, args=args, kwargs=kwargs,  # noqa: E501
                              daemon=True)

--- a/container_service_extension/user_context.py
+++ b/container_service_extension/user_context.py
@@ -6,7 +6,7 @@ import pyvcloud.vcd.role as vcd_role
 import container_service_extension.cloudapi.cloudapi_client as cloudApiClient
 import container_service_extension.logger as logger
 import container_service_extension.pyvcloud_utils as vcd_utils
-import container_service_extension.utils as utils
+import container_service_extension.server_utils as server_utils
 
 
 ORG_ADMIN_RIGHTS = [
@@ -107,8 +107,8 @@ class UserContext:
     @property
     def sysadmin_cloudapi_client(self):
         if self._sysadmin_cloudapi_client is None:
-            log_wire = utils.get_server_runtime_config() \
-                            .get('service', {}).get('log_wire', False)
+            log_wire = server_utils.get_server_runtime_config() \
+                .get('service', {}).get('log_wire', False)
             logger_wire = logger.NULL_LOGGER
             if log_wire:
                 logger_wire = logger.SERVER_CLOUDAPI_WIRE_LOGGER

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -2,32 +2,21 @@
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-import functools
+"""Basic utility methods to perform data transformation and file operations."""
+
 import hashlib
-import math
 import os
 import pathlib
 import platform
 import stat
 import sys
-import threading
 import urllib
 
 import click
 import pkg_resources
-import pyvcloud.vcd.client as vcd_client
-import pyvcloud.vcd.org as vcd_org
-import pyvcloud.vcd.utils as vcd_utils
 import requests
-import semantic_version
 
 from container_service_extension.logger import NULL_LOGGER
-import container_service_extension.server_constants as server_constants
-import container_service_extension.shared_constants as shared_constants
-from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
-from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
-from container_service_extension.shared_constants import PaginationKey
-import container_service_extension.thread_local_data as thread_local_data
 
 
 # chunk size in bytes for file reading
@@ -85,73 +74,17 @@ def get_cse_info():
     }
 
 
-def get_installed_cse_version():
-    """."""
-    cse_version_raw = get_cse_info()['version']
-    # Cleanup version string. Strip dev version string segment.
-    # e.g. convert '2.6.0.0b2.dev5' to '2.6.0'
-    tokens = cse_version_raw.split('.')[:3]
-    cse_version = semantic_version.Version('.'.join(tokens))
-    return cse_version
-
-
 def prompt_text(text, color='black', hide_input=False):
     click_text = click.style(str(text), fg=color)
     return click.prompt(click_text, hide_input=hide_input, type=str)
 
 
-def get_server_runtime_config():
-    import container_service_extension.service as cse_service
-    return cse_service.Service().get_service_config()
-
-
-def get_server_api_version():
-    """Get the API version with which CSE server is running.
-
-    :return: api version
-    """
-    config = get_server_runtime_config()
-    return config['vcd']['api_version']
-
-
-def get_default_storage_profile():
-    config = get_server_runtime_config()
-    return config['broker']['storage_profile']
-
-
-def get_default_k8_distribution():
-    config = get_server_runtime_config()
-    import container_service_extension.def_.models as def_models
-    return def_models.Distribution(template_name=config['broker']['default_template_name'],  # noqa: E501
-                                   template_revision=config['broker']['default_template_revision'])  # noqa: E501
-
-
-def get_pks_cache():
-    from container_service_extension.service import Service
-    return Service().get_pks_cache()
-
-
-def is_pks_enabled():
-    from container_service_extension.service import Service
-    return Service().is_pks_enabled()
-
-
-def is_tkg_plus_enabled(config: dict = None):
-    if not config:
-        try:
-            config = get_server_runtime_config()
-        except Exception:
-            return False
-    service_section = config.get('service', {})
-    tkg_plus_enabled = service_section.get('enable_tkg_plus', False)
-    if isinstance(tkg_plus_enabled, bool):
-        return tkg_plus_enabled
-    elif isinstance(tkg_plus_enabled, str):
-        return str_to_bool(tkg_plus_enabled)
-    return False
-
-
 def is_environment_variable_enabled(env_name):
+    """Check if the environment variable is set.
+
+    :param str env_name: Name of the environment variable
+    :rtype: bool
+    """
     return str_to_bool(os.getenv(env_name))
 
 
@@ -383,52 +316,6 @@ def read_data_file(filepath, logger=NULL_LOGGER,
     return contents
 
 
-def transfer_thread_local_data_wrapper(func):
-    cur_thread_data = thread_local_data.get_thread_local_data_as_dict()
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        thread_local_data.set_thread_local_data_from_dict(cur_thread_data)
-        func(*args, **kwargs)
-        thread_local_data.reset_thread_local_data()
-    return wrapper
-
-
-def run_async(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        thread_local_data_wrapper = transfer_thread_local_data_wrapper(func)
-        t = threading.Thread(name=generate_thread_name(func.__name__),
-                             target=thread_local_data_wrapper, args=args, kwargs=kwargs,  # noqa: E501
-                             daemon=True)
-        t.start()
-        return t
-    return wrapper
-
-
-def generate_thread_name(function_name):
-    parent_thread_id = threading.current_thread().ident
-    return function_name + ':' + str(parent_thread_id)
-
-
-def should_use_mqtt_protocol(config):
-    """Return true if should use the mqtt protocol; false otherwise.
-
-    The MQTT protocol should be used if the config file contains an "mqtt" key
-        and the api version is greater than or equal to the minimum mqtt
-        api version.
-
-    :param dict config: config yaml file as a dictionary
-
-    :return: whether to use the mqtt protocol
-    :rtype: str
-    """
-    return config.get('mqtt') is not None and \
-        config.get('vcd') is not None and \
-        config['vcd'].get('api_version') is not None and \
-        float(config['vcd']['api_version']) >= server_constants.MQTT_MIN_API_VERSION  # noqa: E501
-
-
 def flatten_dictionary(input_dict, parent_key='', separator='.'):
     """Flatten a given dictionary with nested dictionaries if any.
 
@@ -464,6 +351,10 @@ def escape_query_filter_expression_value(value):
 
 
 def construct_filter_string(filters: dict):
+    """Construct anded filter string from the dict.
+
+    :param dict filters: dictionary containing key and values for the filters
+    """
     filter_string = ""
     if filters:
         filter_expressions = []
@@ -473,29 +364,6 @@ def construct_filter_string(filters: dict):
                 filter_expressions.append(filter_exp)
         filter_string = ";".join(filter_expressions)
     return filter_string
-
-
-def create_org_user_id_to_name_dict(client: vcd_client.Client, org_name):
-    """Get a dictionary of users ids to user names.
-
-    :param vcd_client.Client client: current client
-    :param str org_name: org name to search for users
-
-    :return: dict of user id keys and user name values
-    :rtype: dict
-    """
-    org_href = client.get_org_by_name(org_name).get('href')
-    org = vcd_org.Org(client, org_href)
-    users: list = org.list_users()
-    user_id_to_name_dict = {}
-    for user_str_elem in users:
-        curr_user_dict = vcd_utils.to_dict(user_str_elem, exclude=[])
-        user_name = curr_user_dict['name']
-        user_urn = shared_constants.USER_URN_PREFIX + \
-            extract_id_from_href(curr_user_dict['href'])
-        user_id_to_name_dict[user_urn] = user_name
-
-    return user_id_to_name_dict
 
 
 def extract_id_from_href(href):
@@ -512,65 +380,3 @@ def extract_id_from_href(href):
     if '/' in href:
         return href.split('/')[-1]
     return href
-
-
-def construct_paginated_response(values, result_total,
-                                 page_number=CSE_PAGINATION_FIRST_PAGE_NUMBER,  # noqa: E501
-                                 page_size=CSE_PAGINATION_DEFAULT_PAGE_SIZE,  # noqa: E501
-                                 page_count=None,
-                                 next_page_uri=None,
-                                 prev_page_uri=None):
-    if not page_count:
-        extra_page = 1 if bool(result_total % page_size) else 0
-        page_count = result_total // page_size + extra_page
-    resp = {
-        PaginationKey.RESULT_TOTAL: result_total,
-        PaginationKey.PAGE_COUNT: page_count,
-        PaginationKey.PAGE_NUMBER: page_number,
-        PaginationKey.PAGE_SIZE: page_size,
-        PaginationKey.NEXT_PAGE_URI: next_page_uri,
-        PaginationKey.PREV_PAGE_URI: prev_page_uri,
-        PaginationKey.VALUES: values
-    }
-
-    # Conditionally deleting instead of conditionally adding the entry
-    # maintains the order for the response
-    if not prev_page_uri:
-        del resp[PaginationKey.PREV_PAGE_URI]
-    if not next_page_uri:
-        del resp[PaginationKey.NEXT_PAGE_URI]
-    return resp
-
-
-def create_links_and_construct_paginated_result(base_uri, values, result_total,
-                                                page_number=CSE_PAGINATION_FIRST_PAGE_NUMBER,  # noqa: E501
-                                                page_size=CSE_PAGINATION_DEFAULT_PAGE_SIZE,  # noqa: E501
-                                                query_params={}):
-    next_page_uri: str = None
-    if 0 < page_number * page_size < result_total:
-        # TODO find a way to get the initial url part
-        # ideally the request details should be passed down to each of the
-        # handler funcions as request context
-        next_page_uri = f"{base_uri}?page={page_number+1}&pageSize={page_size}"
-        for q in query_params.keys():
-            next_page_uri += f"&{q}={query_params[q]}"
-
-    page_count = math.ceil(result_total / page_size)
-    prev_page_uri: str = None
-    if page_count >= page_number > 1:
-        prev_page_uri = f"{base_uri}?page={page_number-1}&pageSize={page_size}"
-
-    # add the rest of the query parameters
-    for q in query_params.keys():
-        if next_page_uri:
-            next_page_uri += f"&{q}={query_params[q]}"
-        if prev_page_uri:
-            prev_page_uri += f"&{q}={query_params[q]}"
-
-    return construct_paginated_response(values=values,
-                                        result_total=result_total,
-                                        page_number=page_number,
-                                        page_size=page_size,
-                                        page_count=page_count,
-                                        next_page_uri=next_page_uri,
-                                        prev_page_uri=prev_page_uri)

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -39,10 +39,10 @@ from container_service_extension.server_constants import NodeType
 from container_service_extension.server_constants import ScriptFile
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
 from container_service_extension.server_constants import ThreadLocalData
+import container_service_extension.server_utils as server_utils
 from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
 from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
 from container_service_extension.shared_constants import PaginationKey
-import container_service_extension.server_utils as server_utils
 from container_service_extension.shared_constants import RequestKey
 from container_service_extension.telemetry.constants import CseOperation
 from container_service_extension.telemetry.constants import PayloadKey

--- a/container_service_extension/vsphere_utils.py
+++ b/container_service_extension/vsphere_utils.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+"""Contains utility methods for interacting with vSphere."""
+
 from urllib.parse import urlparse
 
 from cachetools import LRUCache


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

* Add docstrings to constant files and utility files
* Describe the scope of each of the utility modules
* move utility functions or constants to meaningful modules

The following files were split:
utils.py -> 
* server_utils.py (containing utility methods used only by the server), 
* thread_utils.py ( containing utility methods used for thread operations)
* utils.py (containing common utility methods used both by the server and the CLI) (Basic utility methods to perform data transformation and file operations.)
* Moved the function `create_org_user_id_to_name_dict` to pyvcloud_utils.py

Moved constants present in def_utils.py to def_constants.py

Moved constants which were used only in server code from `shared_constants` to `server_constants`

Added docstrings describing where the utility methods/constants present in the module should be used


Testing done:
* cse run
* cse install
* cse upgrade
* cluster create/resize/upgrade (TODO)
* ovdc update/list (TODO)

@sahithi @sakthisunda @rocknes @ChintanShahVMware @ltimothy7 @arunmk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/866)
<!-- Reviewable:end -->
