### PR TITLE
[VCDA-1927 & VCDA-2042] Paginate TKG and legacy native cluster responses

### DIFF
--- a/container_service_extension/authorization.py
+++ b/container_service_extension/authorization.py
@@ -24,6 +24,7 @@ def secure(required_rights=None):
     """
     if required_rights is None:
         required_rights = {}
+
     def decorator_secure(func):
         @functools.wraps(func)
         def decorator_wrapper(*args, **kwargs):

--- a/container_service_extension/authorization.py
+++ b/container_service_extension/authorization.py
@@ -10,7 +10,7 @@ from container_service_extension.server_constants import CSE_SERVICE_NAMESPACE
 import container_service_extension.utils as utils
 
 
-def secure(required_rights=[]):
+def secure(required_rights=None):
     """Secure methods against unauthorized access using this decorator.
 
     Only compatible with methods in AbstractBroker-derived classes.
@@ -22,6 +22,8 @@ def secure(required_rights=[]):
 
     :rtype: method
     """
+    if required_rights is None:
+        required_rights = {}
     def decorator_secure(func):
         @functools.wraps(func)
         def decorator_wrapper(*args, **kwargs):

--- a/container_service_extension/client/cluster_commands.py
+++ b/container_service_extension/client/cluster_commands.py
@@ -51,6 +51,15 @@ words and cannot be used to name a cluster.
     metavar='VDC_NAME',
     help='Filter list to show clusters from a specific org VDC')
 @click.option(
+    '-A',
+    '--all',
+    'should_print_all',
+    is_flag=True,
+    default=False,
+    required=False,
+    metavar='DISPLAY_ALL',
+    help='Display all the clusters non-interactively')
+@click.option(
     '-o',
     '--org',
     'org_name',
@@ -58,7 +67,7 @@ words and cannot be used to name a cluster.
     required=False,
     metavar='ORG_NAME',
     help="Filter list to show clusters from a specific org")
-def list_clusters(ctx, vdc, org_name):
+def list_clusters(ctx, vdc, org_name, should_print_all):
     """Display clusters in vCD that are visible to the logged in user.
 
 \b
@@ -76,8 +85,9 @@ Examples
         cluster = Cluster(client)
         if not client.is_sysadmin() and org_name is None:
             org_name = ctx.obj['profiles'].get('org_in_use')
-        clusters = cluster.list_clusters(vdc=vdc, org=org_name)
-        stdout(clusters, ctx, show_id=True, sort_headers=False)
+        client_utils.print_paginated_result(cluster.list_clusters(vdc=vdc, org=org_name),  # noqa: E501
+                                            should_print_all=should_print_all,
+                                            logger=CLIENT_LOGGER)
     except Exception as e:
         stderr(e, ctx)
         CLIENT_LOGGER.error(str(e))

--- a/container_service_extension/client/cse_client/api_33/native_cluster_api.py
+++ b/container_service_extension/client/cse_client/api_33/native_cluster_api.py
@@ -13,18 +13,17 @@ class NativeClusterApi(CseClient):
     def __init__(self, client: vcd_client.Client):
         super().__init__(client)
         self._uri = f"{self._uri}/{shared_constants.CSE_URL_FRAGMENT}"
-        self._legacy_clusters_uri = f"{self._uri}/legacyclusters"
+        self._native_clusters_uri = f"{self._uri}/nativeclusters"
         self._cluster_uri = f"{self._uri}/cluster"
         self._clusters_uri = f"{self._uri}/clusters"
         self._node_uri = f"{self._uri}/node"
         self._nodes_uri = f"{self._uri}/nodes"
-        self._request_page_size = 1
 
     def get_all_clusters(self, filters=None):
         if filters is None:
             filters = {}
         filter_string = "&".join([f"{k}={v}" for k, v in filters.items() if v is not None])  # noqa: E501
-        url = f"{self._legacy_clusters_uri}?" \
+        url = f"{self._native_clusters_uri}?" \
               f"{shared_constants.PaginationKey.PAGE_SIZE.value}={self._request_page_size}"  # noqa: E501
         if filter_string:
             url += f"&{filter_string}"

--- a/container_service_extension/client/cse_client/api_33/native_cluster_api.py
+++ b/container_service_extension/client/cse_client/api_33/native_cluster_api.py
@@ -13,14 +13,17 @@ class NativeClusterApi(CseClient):
     def __init__(self, client: vcd_client.Client):
         super().__init__(client)
         self._uri = f"{self._uri}/{shared_constants.CSE_URL_FRAGMENT}"
+        self._legacy_clusters_uri = f"{self._uri}/legacyclusters"
         self._cluster_uri = f"{self._uri}/cluster"
         self._clusters_uri = f"{self._uri}/clusters"
         self._node_uri = f"{self._uri}/node"
         self._nodes_uri = f"{self._uri}/nodes"
+        self._request_page_size = 1
 
     def get_all_clusters(self, filters={}):
         filter_string = "&".join([f"{k}={v}" for k, v in filters.items() if v is not None])  # noqa: E501
-        url = f"{self._clusters_uri}?pageSize={self._request_page_size}"
+        url = f"{self._legacy_clusters_uri}?" \
+              f"{shared_constants.PaginationKey.PAGE_SIZE.value}={self._request_page_size}"  # noqa: E501
         if filter_string:
             url += f"&{filter_string}"
         return self.iterate_results(url)

--- a/container_service_extension/client/cse_client/api_33/native_cluster_api.py
+++ b/container_service_extension/client/cse_client/api_33/native_cluster_api.py
@@ -20,7 +20,9 @@ class NativeClusterApi(CseClient):
         self._nodes_uri = f"{self._uri}/nodes"
         self._request_page_size = 1
 
-    def get_all_clusters(self, filters={}):
+    def get_all_clusters(self, filters=None):
+        if filters is None:
+            filters = {}
         filter_string = "&".join([f"{k}={v}" for k, v in filters.items() if v is not None])  # noqa: E501
         url = f"{self._legacy_clusters_uri}?" \
               f"{shared_constants.PaginationKey.PAGE_SIZE.value}={self._request_page_size}"  # noqa: E501
@@ -28,7 +30,9 @@ class NativeClusterApi(CseClient):
             url += f"&{filter_string}"
         return self.iterate_results(url)
 
-    def list_clusters(self, filters={}):
+    def list_clusters(self, filters=None):
+        if filters is None:
+            filters = {}
         response = self._client._do_request_prim(
             shared_constants.RequestMethod.GET,
             self._clusters_uri,
@@ -37,7 +41,9 @@ class NativeClusterApi(CseClient):
             params=filters)
         return process_response(response)
 
-    def get_cluster(self, cluster_name, filters={}):
+    def get_cluster(self, cluster_name, filters=None):
+        if filters is None:
+            filters = {}
         uri = f'{self._cluster_uri}/{cluster_name}'
         response = self._client._do_request_prim(
             shared_constants.RequestMethod.GET,
@@ -47,7 +53,9 @@ class NativeClusterApi(CseClient):
             params=filters)
         return process_response(response)
 
-    def get_cluster_upgrade_plan(self, cluster_name, filters={}):
+    def get_cluster_upgrade_plan(self, cluster_name, filters=None):
+        if filters is None:
+            filters = {}
         uri = f'{self._cluster_uri}/{cluster_name}/upgrade-plan'
         response = self._client._do_request_prim(
             shared_constants.RequestMethod.GET,
@@ -131,7 +139,9 @@ class NativeClusterApi(CseClient):
             accept_type='application/json')
         return process_response(response)
 
-    def delete_cluster(self, cluster_name, filters={}):
+    def delete_cluster(self, cluster_name, filters=None):
+        if filters is None:
+            filters = {}
         uri = f"{self._cluster_uri}/{cluster_name}"
         response = self._client._do_request_prim(
             shared_constants.RequestMethod.DELETE,
@@ -141,7 +151,9 @@ class NativeClusterApi(CseClient):
             params=filters)
         return process_response(response)
 
-    def get_cluster_config(self, cluster_name, filters={}):
+    def get_cluster_config(self, cluster_name, filters=None):
+        if filters is None:
+            filters = {}
         uri = f"{self._cluster_uri}/{cluster_name}/config"
         response = self._client._do_request_prim(
             shared_constants.RequestMethod.GET,
@@ -179,7 +191,9 @@ class NativeClusterApi(CseClient):
             accept_type='application/json')
         return process_response(response)
 
-    def get_node_info(self, cluster_name, node_name, filters={}):
+    def get_node_info(self, cluster_name, node_name, filters=None):
+        if filters is None:
+            filters = {}
         uri = f"{self._node_uri}/{node_name}"
         filters.update({
             shared_constants.RequestKey.CLUSTER_NAME: cluster_name

--- a/container_service_extension/client/cse_client/api_33/native_cluster_api.py
+++ b/container_service_extension/client/cse_client/api_33/native_cluster_api.py
@@ -18,6 +18,13 @@ class NativeClusterApi(CseClient):
         self._node_uri = f"{self._uri}/node"
         self._nodes_uri = f"{self._uri}/nodes"
 
+    def get_all_clusters(self, filters={}):
+        filter_string = "&".join([f"{k}={v}" for k, v in filters.items() if v is not None])  # noqa: E501
+        url = f"{self._clusters_uri}?pageSize={self._request_page_size}"
+        if filter_string:
+            url += f"&{filter_string}"
+        return self.iterate_results(url)
+
     def list_clusters(self, filters={}):
         response = self._client._do_request_prim(
             shared_constants.RequestMethod.GET,

--- a/container_service_extension/client/cse_client/api_35/native_cluster_api.py
+++ b/container_service_extension/client/cse_client/api_35/native_cluster_api.py
@@ -22,7 +22,7 @@ class NativeClusterApi(CseClient):
 
     def create_cluster(self, cluster_entity_definition: def_models.NativeEntity):  # noqa: E501
         cluster_entity_dict = asdict(cluster_entity_definition)
-        uri = self._legacy_clusters_uri
+        uri = self._clusters_uri
         response = self._client._do_request_prim(
             shared_constants.RequestMethod.POST,
             uri,

--- a/container_service_extension/client/cse_client/api_35/native_cluster_api.py
+++ b/container_service_extension/client/cse_client/api_35/native_cluster_api.py
@@ -18,10 +18,11 @@ class NativeClusterApi(CseClient):
         self._uri = f"{self._uri}/{shared_constants.CSE_URL_FRAGMENT}/{shared_constants.CSE_3_0_URL_FRAGMENT}"  # noqa: E501
         self._clusters_uri = f"{self._uri}/clusters"
         self._cluster_uri = f"{self._uri}/cluster"
+        self._request_page_size = 1
 
     def create_cluster(self, cluster_entity_definition: def_models.NativeEntity):  # noqa: E501
         cluster_entity_dict = asdict(cluster_entity_definition)
-        uri = self._clusters_uri
+        uri = self._legacy_clusters_uri
         response = self._client._do_request_prim(
             shared_constants.RequestMethod.POST,
             uri,

--- a/container_service_extension/client/cse_client/api_35/native_cluster_api.py
+++ b/container_service_extension/client/cse_client/api_35/native_cluster_api.py
@@ -19,7 +19,7 @@ class NativeClusterApi(CseClient):
         self._clusters_uri = f"{self._uri}/clusters"
         self._cluster_uri = f"{self._uri}/cluster"
 
-    def create_cluster(self, cluster_entity_definition: def_models.ClusterEntity):  # noqa: E501
+    def create_cluster(self, cluster_entity_definition: def_models.NativeEntity):  # noqa: E501
         cluster_entity_dict = asdict(cluster_entity_definition)
         uri = self._clusters_uri
         response = self._client._do_request_prim(
@@ -32,7 +32,7 @@ class NativeClusterApi(CseClient):
         return def_models.DefEntity(
             **response_processor.process_response(response))
 
-    def update_cluster_by_cluster_id(self, cluster_id, cluster_entity_definition: def_models.ClusterEntity):  # noqa: E501
+    def update_cluster_by_cluster_id(self, cluster_id, cluster_entity_definition: def_models.NativeEntity):  # noqa: E501
         cluster_entity_dict = asdict(cluster_entity_definition)
         uri = f"{self._cluster_uri}/{cluster_id}"
         response = self._client._do_request_prim(

--- a/container_service_extension/client/cse_client/cse_client.py
+++ b/container_service_extension/client/cse_client/cse_client.py
@@ -14,7 +14,7 @@ class CseClient:
         self._uri = self._client.get_api_uri()
         self._request_page_size = 10
 
-    def iterate_results(self, base_url, filters={}):
+    def iterate_results(self, base_url, filters=None):
         """Iterate over paginated response until all the results are obtained.
 
         :param str base_url: initial url
@@ -34,6 +34,8 @@ class CseClient:
             page 3:
                 self.iterate_results("https://vcd-ip/api/cse/3.0/clusters?page=3&pageSize=25")
         """  # noqa: E501
+        if filters is None:
+            filters = {}
         # NOTE: This method is added here to reduce dependency between
         # cse_client package and the rest of the code.
         url = base_url

--- a/container_service_extension/client/cse_client/cse_client.py
+++ b/container_service_extension/client/cse_client/cse_client.py
@@ -12,7 +12,7 @@ class CseClient:
     def __init__(self, client: vcd_client.Client):
         self._client = client
         self._uri = self._client.get_api_uri()
-        self._request_page_size = 25
+        self._request_page_size = 10
 
     def iterate_results(self, base_url, filters={}):
         """Iterate over paginated response until all the results are obtained.

--- a/container_service_extension/client/cse_client/pks_cluster_api.py
+++ b/container_service_extension/client/cse_client/pks_cluster_api.py
@@ -16,7 +16,9 @@ class PksClusterApi(CseClient):
         self._clusters_uri = f"{self._uri}/clusters"
         self._cluster_uri = f"{self._uri}/cluster"
 
-    def list_clusters(self, filters={}):
+    def list_clusters(self, filters=None):
+        if filters is None:
+            filters = {}
         response = self._client._do_request_prim(
             shared_constants.RequestMethod.GET,
             self._clusters_uri,
@@ -25,7 +27,9 @@ class PksClusterApi(CseClient):
             params=filters)
         return response_processor.process_response(response)
 
-    def get_cluster(self, cluster_name, filters={}):
+    def get_cluster(self, cluster_name, filters=None):
+        if filters is None:
+            filters = {}
         uri = f'{self._cluster_uri}/{cluster_name}'
         response = self._client._do_request_prim(
             shared_constants.RequestMethod.GET,

--- a/container_service_extension/client/cse_client/pks_ovdc_api.py
+++ b/container_service_extension/client/cse_client/pks_ovdc_api.py
@@ -16,7 +16,9 @@ class PksOvdcApi(CseClient):
         self._org_vdcs_uri = f"{self._uri}/orgvdcs"
         self._ovdc_uri = f"{self._uri}/ovdc"
 
-    def get_all_ovdcs(self, filters={}):
+    def get_all_ovdcs(self, filters=None):
+        if filters is None:
+            filters = {}
         url = f"{self._org_vdcs_uri}?" \
               f"{shared_constants.PaginationKey.PAGE_SIZE.value}={self._request_page_size}"  # noqa: E501
         return self.iterate_results(url, filters=filters)

--- a/container_service_extension/client/de_cluster.py
+++ b/container_service_extension/client/de_cluster.py
@@ -5,6 +5,7 @@
 from dataclasses import asdict
 import json
 import os
+from typing import List
 
 import requests
 import yaml
@@ -15,12 +16,15 @@ from container_service_extension.client.de_cluster_tkg import DEClusterTKG
 import container_service_extension.client.tkgclient.rest as tkg_rest
 import container_service_extension.client.utils as client_utils
 import container_service_extension.def_.entity_service as def_entity_svc
-from container_service_extension.def_.utils import DEF_CSE_VENDOR
-from container_service_extension.def_.utils import DEF_NATIVE_ENTITY_TYPE_NSS
-from container_service_extension.def_.utils import DEF_NATIVE_ENTITY_TYPE_VERSION # noqa: E501
+import container_service_extension.def_.models as def_models
+from container_service_extension.def_.utils import DEF_VMWARE_INTERFACE_NSS
+from container_service_extension.def_.utils import DEF_VMWARE_INTERFACE_VERSION
+from container_service_extension.def_.utils import DEF_VMWARE_VENDOR
 import container_service_extension.exceptions as cse_exceptions
 import container_service_extension.logger as logger
 import container_service_extension.pyvcloud_utils as vcd_utils
+from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE, PaginationKey  # noqa: E501
+from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
 
 DUPLICATE_CLUSTER_ERROR_MSG = "Duplicate clusters found. Please use --k8-runtime for the unique identification"  # noqa: E501
 
@@ -58,51 +62,70 @@ class DECluster:
         :return: cluster list information
         :rtype: list(dict)
         """
-        has_native_rights = True
-        has_tkg_rights = True
         clusters = []
-        try:
-            clusters += self._tkgCluster.list_tkg_clusters(vdc=vdc, org=org)
-        except tkg_rest.ApiException as e:
-            if e.status not in [requests.codes.FORBIDDEN, requests.codes.UNAUTHORIZED]:  # noqa: E501
-                server_message = json.loads(e.body).get('message') or e.reason
-                msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{server_message}")  # noqa: E501
-                logger.CLIENT_LOGGER.error(msg)
-                raise Exception(msg)
-            logger.CLIENT_LOGGER.debug(f"No rights present to fetch TKG clusters: {e}") # noqa: E501
-            has_tkg_rights = False
-        if not client_utils.is_cli_for_tkg_only():
+        if client_utils.is_cli_for_tkg_only():
+            try:
+                for clusters, has_more_results in \
+                        self._tkgCluster.list_tkg_clusters(vdc=vdc, org=org):
+                    yield clusters, has_more_results
+            except tkg_rest.ApiException as e:
+                if e.status not in [requests.codes.FORBIDDEN, requests.codes.UNAUTHORIZED]:  # noqa: E501
+                    server_message = json.loads(e.body).get('message') or e.reason  # noqa: E501
+                    msg = cli_constants.TKG_RESPONSE_MESSAGES_BY_STATUS_CODE.get(e.status, f"{server_message}")  # noqa: E501
+                    logger.CLIENT_LOGGER.error(msg)
+                    raise Exception(msg)
+                msg = f"User not authorized to fetch TKG clusters: {e}"
+                logger.CLIENT_LOGGER.debug(msg)
+                raise e
+        else:
+            # display all clusters
             filters = client_utils.construct_filters(org=org, vdc=vdc)
             entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
-            native_entities = entity_svc.list_entities_by_entity_type(
-                vendor=DEF_CSE_VENDOR,
-                nss=DEF_NATIVE_ENTITY_TYPE_NSS,
-                version=DEF_NATIVE_ENTITY_TYPE_VERSION,
-                filters=filters)
+            has_more_results = True
+            page_number = CSE_PAGINATION_FIRST_PAGE_NUMBER
+            page_size = CSE_PAGINATION_DEFAULT_PAGE_SIZE
             try:
-                for def_entity in native_entities:
-                    entity = def_entity.entity
-                    logger.CLIENT_LOGGER.debug(f"Native Defined entity list from server: {def_entity}")  # noqa: E501
-                    cluster = {
-                        cli_constants.CLIOutputKey.CLUSTER_NAME.value: def_entity.name,  # noqa: E501
-                        cli_constants.CLIOutputKey.VDC.value: entity.metadata.ovdc_name, # noqa: E501
-                        cli_constants.CLIOutputKey.ORG.value: entity.metadata.org_name, # noqa: E501
-                        cli_constants.CLIOutputKey.K8S_RUNTIME.value: entity.kind, # noqa: E501
-                        cli_constants.CLIOutputKey.K8S_VERSION.value: entity.status.kubernetes, # noqa: E501
-                        cli_constants.CLIOutputKey.STATUS.value: entity.status.phase, # noqa: E501
-                        cli_constants.CLIOutputKey.OWNER.value: def_entity.owner.name  # noqa: E501
-                    }
-                    clusters.append(cluster)
+                while has_more_results:
+                    clusters_page_results = entity_svc.get_all_entities_per_page_by_interface(  # noqa: E501
+                        vendor=DEF_VMWARE_VENDOR,
+                        nss=DEF_VMWARE_INTERFACE_NSS,
+                        version=DEF_VMWARE_INTERFACE_VERSION,
+                        filters=filters,
+                        page_number=page_number,
+                        page_size=page_size)
+                    # Get the list of cluster defined entities
+                    entities: List[def_models.GenericClusterEntity] = clusters_page_results[PaginationKey.VALUES]  # noqa: E501
+                    clusters = []
+                    for de in entities:
+                        entity = de.entity
+                        logger.CLIENT_LOGGER.debug(f"Native Defined entity list from server: {entity}")  # noqa: E501
+                        cluster = {
+                            cli_constants.CLIOutputKey.CLUSTER_NAME.value: de.name,  # noqa: E501
+                            cli_constants.CLIOutputKey.ORG.value: de.org.name, # noqa: E501
+                            cli_constants.CLIOutputKey.OWNER.value: de.owner.name  # noqa: E501
+                        }
+                        if type(entity) == def_models.NativeEntity:
+                            cluster[cli_constants.CLIOutputKey.VDC.value] = \
+                                entity.metadata.ovdc_name
+                            cluster[cli_constants.CLIOutputKey.K8S_RUNTIME.value] = entity.kind  # noqa: E501
+                            cluster[cli_constants.CLIOutputKey.K8S_VERSION.value] = entity.status.kubernetes  # noqa: E501
+                            cluster[cli_constants.CLIOutputKey.STATUS.value] = entity.status.phase  # noqa: E501
+                        elif type(entity) == def_models.TKGEntity:
+                            cluster[cli_constants.CLIOutputKey.VDC.value] = \
+                                entity.metadata.virtualDataCenterName
+                            cluster[cli_constants.CLIOutputKey.K8S_RUNTIME.value] = entity.kind  # noqa: E501
+                            cluster[cli_constants.CLIOutputKey.K8S_VERSION.value] = entity.spec.distribution.version  # noqa: E501
+                            cluster[cli_constants.CLIOutputKey.STATUS.value] = \
+                                entity.status.phase if entity.status else 'N/A'  # noqa: E501
+                        clusters.append(cluster)
+                    has_more_results = page_number * page_size < \
+                        clusters_page_results[PaginationKey.RESULT_TOTAL]
+                    yield clusters, has_more_results
+                    page_number += 1
             except requests.exceptions.HTTPError as e:
-                if e.response.status_code not in [requests.codes.FORBIDDEN, requests.codes.UNAUTHORIZED]:  # noqa: E501
-                    logger.CLIENT_LOGGER.error(f"Failed to fetch native clusters: {str(e)}")  # noqa: E501
-                    raise
-                logger.CLIENT_LOGGER.debug(f"No rights present to fetch native clusters: {str(e)}")  # noqa: E501
-                has_native_rights = False
-        if not (has_tkg_rights or has_native_rights):
-            raise Exception("Logged in user doesn't have Native cluster rights"
-                            " or TKG rights. Please contact administrator.")
-        return clusters
+                msg = f"Failed to fetch clusters: {e}"
+                logger.CLIENT_LOGGER.debug(msg)
+                raise e
 
     def _get_tkg_native_clusters_by_name(self, cluster_name: str,
                                          org=None, vdc=None):

--- a/container_service_extension/client/de_cluster_native.py
+++ b/container_service_extension/client/de_cluster_native.py
@@ -38,19 +38,19 @@ class DEClusterNative:
                 logger_wire=logger_wire)
         self._native_cluster_api = NativeClusterApi(client)
 
-    def create_cluster(self, cluster_entity: def_models.ClusterEntity):
+    def create_cluster(self, cluster_entity: def_models.NativeEntity):
         """Create a new Kubernetes cluster.
 
-        :param models.ClusterEntity cluster_entity: native cluster entity
+        :param models.NativeEntity cluster_entity: native cluster entity
         :return: (json) A parsed json object describing the requested cluster.
         """
         msg = "Operation not supported; Under implementation"
         raise vcd_exceptions.OperationNotSupportedException(msg)
 
-    def resize_cluster(self, cluster_entity: def_models.ClusterEntity):
+    def resize_cluster(self, cluster_entity: def_models.NativeEntity):
         """Resize the existing Kubernetes cluster.
 
-        :param models.ClusterEntity cluster_entity: native cluster entity
+        :param models.NativeEntity cluster_entity: native cluster entity
         :return: (json) A parsed json object describing the requested cluster.
         """
         msg = "Operation not supported; Under implementation"
@@ -256,7 +256,7 @@ class DEClusterNative:
         :rtype: dict
         """
         entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
-        cluster_spec = def_models.ClusterEntity(**cluster_config)
+        cluster_spec = def_models.NativeEntity(**cluster_config)
         cluster_name = cluster_spec.metadata.cluster_name
         if cluster_id:
             # If cluster id doesn't exist, an exception will be raised

--- a/container_service_extension/client/de_cluster_tkg.py
+++ b/container_service_extension/client/de_cluster_tkg.py
@@ -98,31 +98,41 @@ class DEClusterTKG:
         if vdc:
             filters[cli_constants.TKGEntityFilterKey.VDC_NAME.value] = vdc
         filter_string = utils.construct_filter_string(filters)
-        # tkg_def_entities in the following statement represents the
-        # information associated with the defined entity
-        (entities, status, headers, tkg_def_entities) = \
-            self._tkg_client_api.list_tkg_clusters(
-                f"{DEF_VMWARE_VENDOR}/{DEF_TKG_ENTITY_TYPE_NSS}/{DEF_TKG_ENTITY_TYPE_VERSION}",  # noqa: E501
-                _return_http_data_only=False,
-                object_filter=filter_string)
-        clusters = []
-        for i in range(len(entities)):
-            # NOTE: tkg_def_entities will contain corresponding defined entity
-            # details
-            entity: TkgCluster = entities[i]
-            entity_properties = tkg_def_entities[i]
-            logger.CLIENT_LOGGER.debug(f"TKG Defined entity list from server: {entity}")  # noqa: E501
-            cluster = {
-                cli_constants.CLIOutputKey.CLUSTER_NAME.value: entity.metadata.name, # noqa: E501
-                cli_constants.CLIOutputKey.VDC.value: entity.metadata.virtual_data_center_name, # noqa: E501
-                cli_constants.CLIOutputKey.ORG.value: entity_properties['org']['name'], # noqa: E501
-                cli_constants.CLIOutputKey.K8S_RUNTIME.value: shared_constants.ClusterEntityKind.TKG.value, # noqa: E501
-                cli_constants.CLIOutputKey.K8S_VERSION.value: entity.spec.distribution.version, # noqa: E501
-                cli_constants.CLIOutputKey.STATUS.value: entity.status.phase if entity.status else 'N/A',  # noqa: E501
-                cli_constants.CLIOutputKey.OWNER.value: entity_properties['owner']['name'],  # noqa: E501
-            }
-            clusters.append(cluster)
-        return clusters
+        query_params = {
+            shared_constants.PaginationKey.PAGE_NUMBER.value: shared_constants.CSE_PAGINATION_FIRST_PAGE_NUMBER,  # noqa: E501
+            shared_constants.PaginationKey.PAGE_SIZE.value: shared_constants.CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
+        }
+        has_more_results = True
+        while has_more_results:
+            (entities, status, headers, additional_details) = \
+                self._tkg_client_api.list_tkg_clusters(
+                    f"{DEF_VMWARE_VENDOR}/{DEF_TKG_ENTITY_TYPE_NSS}/{DEF_TKG_ENTITY_TYPE_VERSION}",  # noqa: E501
+                    _return_http_data_only=False,
+                    object_filter=filter_string,
+                    query_params=query_params)
+            # tkg_def_entities in the following statement represents the
+            # information associated with the defined entity
+            tkg_def_entities = additional_details['entityDetails']
+            clusters = []
+            for i in range(len(entities)):
+                # NOTE: tkg_def_entities will contain corresponding defined
+                # entity details
+                entity: TkgCluster = entities[i]
+                entity_properties = tkg_def_entities[i]
+                logger.CLIENT_LOGGER.debug(f"TKG Defined entity list from server: {entity}")  # noqa: E501
+                cluster = {
+                    cli_constants.CLIOutputKey.CLUSTER_NAME.value: entity.metadata.name, # noqa: E501
+                    cli_constants.CLIOutputKey.VDC.value: entity.metadata.virtual_data_center_name, # noqa: E501
+                    cli_constants.CLIOutputKey.ORG.value: entity_properties['org']['name'], # noqa: E501
+                    cli_constants.CLIOutputKey.K8S_RUNTIME.value: shared_constants.ClusterEntityKind.TKG.value, # noqa: E501
+                    cli_constants.CLIOutputKey.K8S_VERSION.value: entity.spec.distribution.version, # noqa: E501
+                    cli_constants.CLIOutputKey.STATUS.value: entity.status.phase if entity.status else 'N/A',  # noqa: E501
+                    cli_constants.CLIOutputKey.OWNER.value: entity_properties['owner']['name'],  # noqa: E501
+                }
+                clusters.append(cluster)
+            has_more_results = additional_details['page'] < additional_details['pageCount']  # noqa: E501
+            yield clusters, has_more_results
+            query_params[shared_constants.PaginationKey.PAGE_NUMBER.value] += 1
 
     def get_tkg_clusters_by_name(self, name, vdc=None, org=None):
         self.set_tenant_org_context(org_name=org)

--- a/container_service_extension/client/legacy_cluster_native.py
+++ b/container_service_extension/client/legacy_cluster_native.py
@@ -17,23 +17,24 @@ class LegacyClusterNative:
         filters = {
             shared_constants.RequestKey.ORG_NAME: org,
             shared_constants.RequestKey.OVDC_NAME: vdc}
-        clusters_resp = self._native_cluster_api.list_clusters(filters=filters)
-        CLIENT_LOGGER.debug(clusters_resp)
-        clusters = []
-        for c in clusters_resp:
-            # TODO cluster api response keys need to be more well defined
-            cluster = {
-                'Name': c.get('name', 'N/A'),
-                'Owner': c.get('owner_name', 'N/A'),
-                'VDC': c.get('vdc', 'N/A'),
-                'Org': c.get('org_name', 'N/A'),
-                'K8s Runtime': c.get('k8s_type', 'N/A'),
-                'K8s Version': c.get('k8s_version', 'N/A'),
-                'Status': c.get('status', 'N/A'),
-                'Provider': c.get('k8s_provider', 'N/A'),
-            }
-            clusters.append(cluster)
-        return clusters
+        for clusters_rep, has_more_results in \
+                self._native_cluster_api.get_all_clusters(filters=filters):
+            clusters = []
+            CLIENT_LOGGER.debug(clusters_rep)
+            for c in clusters_rep:
+                # TODO cluster api response keys need to be more well defined
+                cluster = {
+                    'Name': c.get('name', 'N/A'),
+                    'Owner': c.get('owner_name', 'N/A'),
+                    'VDC': c.get('vdc', 'N/A'),
+                    'Org': c.get('org_name', 'N/A'),
+                    'K8s Runtime': c.get('k8s_type', 'N/A'),
+                    'K8s Version': c.get('k8s_version', 'N/A'),
+                    'Status': c.get('status', 'N/A'),
+                    'Provider': c.get('k8s_provider', 'N/A'),
+                }
+                clusters.append(cluster)
+            yield clusters, has_more_results
 
     def get_cluster_info(self, name, org=None, vdc=None, **kwargs):
         filters = {shared_constants.RequestKey.ORG_NAME: org,

--- a/container_service_extension/client/sample_generator.py
+++ b/container_service_extension/client/sample_generator.py
@@ -125,7 +125,7 @@ def _get_sample_cluster_configuration_by_k8_runtime(k8_runtime):
         workers=workers,
         nfs=nfs
     )
-    cluster_entity = def_models.ClusterEntity(
+    cluster_entity = def_models.NativeEntity(
         metadata=metadata,
         spec=cluster_spec,
         status=status,

--- a/container_service_extension/client/tkgclient/api/tkg_cluster_api.py
+++ b/container_service_extension/client/tkgclient/api/tkg_cluster_api.py
@@ -40,6 +40,7 @@ class TkgClusterApi(object):
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
         all_params.append('object_filter')
+        all_params.append('query_params')
 
         params = locals()
         for key, val in six.iteritems(params['kwargs']):
@@ -56,6 +57,10 @@ class TkgClusterApi(object):
                 "Missing the required parameter `entity_type` when calling `list_tkg_clusters`")
         path_params = {}
         query_params = []
+        if params.get('query_params'):
+            for k, v in params.get('query_params', {}).items():
+                query_params.append((k, v))
+
         if params.get('object_filter'):
             query_params.append(('filter', params['object_filter']))
         header_params = {}

--- a/container_service_extension/client/tkgclient/api_client.py
+++ b/container_service_extension/client/tkgclient/api_client.py
@@ -155,7 +155,7 @@ class ApiClient(object):
         self.last_response = response_data
 
         return_data = response_data
-        additional_data = None
+        additional_data = {}
         if _preload_content:
             # deserialize response data
             if response_type:
@@ -241,13 +241,21 @@ class ApiClient(object):
             data = data['entity']
             del additional_data['entity']
         elif response_type == 'list[TkgCluster]' and method == 'GET':
+            response_data = data.copy()
             def_entities = data['values']
-            additional_data = []
+            entity_details = []
             data = []
             for def_entity in def_entities:
                 data.append(def_entity['entity'])
                 del def_entity['entity']
-                additional_data.append(def_entity)
+                entity_details.append(def_entity)
+            additional_data = {
+                'page': int(response_data['page']),
+                'pageSize': int(response_data['pageSize']),
+                'resultTotal': int(response_data['resultTotal']),
+                'pageCount': int(response_data['pageCount']),
+                'entityDetails': entity_details
+            }
         return self.__deserialize(data, response_type), additional_data
 
     def __deserialize(self, data, klass):

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -356,7 +356,7 @@ class ComputePolicyManager:
                                 is_admin_operation=True)
         return vdc.add_compute_policy(compute_policy_href)
 
-    def list_vdc_placement_policies_on_vdc(self, vdc_id, filters={}):
+    def list_vdc_placement_policies_on_vdc(self, vdc_id, filters=None):
         """List all placement policies assigned to a given vdc.
 
         :param str vdc_id: id of the vdc for which policies need to be
@@ -366,11 +366,13 @@ class ComputePolicyManager:
             the vdc
         :rtype: Generator[Dict, None, None]
         """
+        if filters is None:
+            filters = {}
         sizing_filter = {'isSizingOnly': 'false'}
         filters.update(sizing_filter)
         return self.list_compute_policies_on_vdc(vdc_id, filters=filters)
 
-    def list_vdc_sizing_policies_on_vdc(self, vdc_id, filters={}):
+    def list_vdc_sizing_policies_on_vdc(self, vdc_id, filters=None):
         """List all sizing policies created by CSE and assigned to a given vdc.
 
         :param str vdc_id: id of the vdc for which policies need to be
@@ -380,6 +382,8 @@ class ComputePolicyManager:
             the vdc
         :rtpe: Generator[Dict, None, None]
         """
+        if filters is None:
+            filters = {}
         sizing_filter = {'isSizingOnly': 'true'}
         filters.update(sizing_filter)
         return self.list_compute_policies_on_vdc(vdc_id, filters=filters)

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -2346,7 +2346,7 @@ def _create_def_entity_for_existing_clusters(
                 ip=item['ipAddress'],
                 exports=item['exports']))
 
-        cluster_entity = def_models.ClusterEntity(
+        cluster_entity = def_models.NativeEntity(
             kind=kind,
             spec=def_models.ClusterSpec(
                 workers=def_models.Workers(

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -745,7 +745,7 @@ def _register_def_schema(client: Client,
     :param bool log_wire: wire logging enabled
     """
     if config is None:
-        config = []
+        config = {}
     msg = "Registering defined entity schema"
     msg_update_callback.info(msg)
     INSTALL_LOGGER.info(msg)

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -730,7 +730,7 @@ def _update_user_role_with_right_bundle(right_bundle_name,
 
 
 def _register_def_schema(client: Client,
-                         config=[],
+                         config=None,
                          msg_update_callback=utils.NullPrinter(),
                          log_wire=False):
     """Register defined entity interface and defined entity type.
@@ -744,6 +744,8 @@ def _register_def_schema(client: Client,
     :param utils.ConsoleMessagePrinter msg_update_callback: Callback object.
     :param bool log_wire: wire logging enabled
     """
+    if config is None:
+        config = []
     msg = "Registering defined entity schema"
     msg_update_callback.info(msg)
     INSTALL_LOGGER.info(msg)

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -468,8 +468,10 @@ class ClusterService(abstract_broker.AbstractBroker):
                                     template=template)
         return curr_entity
 
-    def delete_nodes(self, cluster_id: str, nodes_to_del=[]):
+    def delete_nodes(self, cluster_id: str, nodes_to_del=None):
         """Start the delete nodes operation."""
+        if nodes_to_del is None:
+            nodes_to_del = []
         curr_entity: def_models.DefEntity = self.entity_svc.get_entity(
             cluster_id)
 
@@ -1218,7 +1220,7 @@ class ClusterService(abstract_broker.AbstractBroker):
     @utils.run_async
     def _delete_nodes_async(self, cluster_id: str,
                             cluster_spec: def_models.NativeEntity = None,
-                            nodes_to_del=[]):
+                            nodes_to_del=None):
         """Delete worker and/or nfs nodes in vCD.
 
         This method is executed by a thread in an asynchronous manner.
@@ -1234,6 +1236,8 @@ class ClusterService(abstract_broker.AbstractBroker):
         Let the caller monitor thread or method to set SUCCESS task status,
           end the client context
         """
+        if nodes_to_del is None:
+            nodes_to_del = []
         curr_entity: def_models.DefEntity = self.entity_svc.get_entity(cluster_id)  # noqa: E501
         vapp_href = curr_entity.externalId
         cluster_name = curr_entity.entity.metadata.cluster_name

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -34,8 +34,6 @@ from container_service_extension.server_constants import LocalTemplateKey
 from container_service_extension.server_constants import NodeType
 from container_service_extension.server_constants import ScriptFile
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
-from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
-from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
 from container_service_extension.shared_constants import DefEntityOperation
 from container_service_extension.shared_constants import DefEntityOperationStatus  # noqa: E501
 from container_service_extension.shared_constants import DefEntityPhase
@@ -77,21 +75,29 @@ class ClusterService(abstract_broker.AbstractBroker):
         return self._sync_def_entity(cluster_id)
 
     def list_clusters(self, filters: dict = {},
-                      page_number=CSE_PAGINATION_FIRST_PAGE_NUMBER,
-                      page_size=CSE_PAGINATION_DEFAULT_PAGE_SIZE) -> dict:
+                      page_number=None,
+                      page_size=None) -> dict:
         """List corresponding defined entities of all native clusters."""
         telemetry_handler.record_user_action_details(
             cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_LIST,
             cse_params={telemetry_constants.PayloadKey.FILTER_KEYS: ','.join(filters.keys())}  # noqa: E501
         )
+        # Override page_number and page_size to defaults if any one of them
+        # is present
         ent_type: def_models.DefEntityType = def_utils.get_registered_def_entity_type()  # noqa: E501
-        return self.entity_svc.get_entities_per_page_by_entity_type(
+        if page_number and page_size:
+            return self.entity_svc.get_entities_per_page_by_entity_type(
+                vendor=ent_type.vendor,
+                nss=ent_type.nss,
+                version=ent_type.version,
+                filters=filters,
+                page_number=page_number,
+                page_size=page_size)
+        return self.entity_svc.list_entities_by_entity_type(
             vendor=ent_type.vendor,
             nss=ent_type.nss,
             version=ent_type.version,
-            filters=filters,
-            page_number=page_number,
-            page_size=page_size)
+            filters=filters)
 
     def get_cluster_config(self, cluster_id: str):
         """Get the cluster's kube config contents.

--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -129,7 +129,7 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         return result.content.decode()
 
-    def create_cluster(self, cluster_spec: def_models.ClusterEntity):
+    def create_cluster(self, cluster_spec: def_models.NativeEntity):
         """Start the cluster creation operation.
 
         Creates corresponding defined entity in vCD for every native cluster.
@@ -218,7 +218,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         return def_entity
 
     def resize_cluster(self, cluster_id: str,
-                       cluster_spec: def_models.ClusterEntity):
+                       cluster_spec: def_models.NativeEntity):
         """Start the resize cluster operation.
 
         :param str cluster_id: Defined entity Id of the cluster
@@ -356,14 +356,14 @@ class ClusterService(abstract_broker.AbstractBroker):
                                               curr_entity.entity.spec.k8_distribution.template_revision) # noqa: E501
 
     def upgrade_cluster(self, cluster_id: str,
-                        upgrade_spec: def_models.ClusterEntity):
+                        upgrade_spec: def_models.NativeEntity):
         """Start the upgrade cluster operation.
 
         Upgrading cluster is an asynchronous task, so the returned
         `result['task_href']` can be polled to get updates on task progress.
 
         :param str cluster_id: id of the cluster to be upgraded
-        :param def_models.ClusterEntity upgrade_spec: cluster spec with new
+        :param def_models.NativeEntity upgrade_spec: cluster spec with new
             kubernetes distribution and revision
 
         :return: Defined entity with upgrade in progress set
@@ -473,7 +473,7 @@ class ClusterService(abstract_broker.AbstractBroker):
 
     @utils.run_async
     def _create_cluster_async(self, cluster_id: str,
-                              cluster_spec: def_models.ClusterEntity):
+                              cluster_spec: def_models.NativeEntity):
         try:
             cluster_name = cluster_spec.metadata.cluster_name
             org_name = cluster_spec.metadata.org_name
@@ -769,7 +769,7 @@ class ClusterService(abstract_broker.AbstractBroker):
 
     @utils.run_async
     def _create_nodes_async(self, cluster_id: str,
-                            cluster_spec: def_models.ClusterEntity):
+                            cluster_spec: def_models.NativeEntity):
         """Create worker and/or nfs nodes in vCD.
 
         This method is executed by a thread in an asynchronous manner.
@@ -1182,7 +1182,7 @@ class ClusterService(abstract_broker.AbstractBroker):
 
     @utils.run_async
     def _delete_nodes_async(self, cluster_id: str,
-                            cluster_spec: def_models.ClusterEntity = None,
+                            cluster_spec: def_models.NativeEntity = None,
                             nodes_to_del=[]):
         """Delete worker and/or nfs nodes in vCD.
 

--- a/container_service_extension/def_/entity_service.py
+++ b/container_service_extension/def_/entity_service.py
@@ -13,7 +13,8 @@ from requests.exceptions import HTTPError
 from container_service_extension.cloudapi.cloudapi_client import CloudApiClient
 from container_service_extension.cloudapi.constants import CloudApiResource
 from container_service_extension.cloudapi.constants import CloudApiVersion
-from container_service_extension.def_.models import DefEntity, DefEntityType
+from container_service_extension.def_.models import DefEntity, DefEntityType, \
+    GenericClusterEntity
 import container_service_extension.def_.schema_service as def_schema_svc
 import container_service_extension.def_.utils as def_utils
 import container_service_extension.exceptions as cse_exception
@@ -183,6 +184,42 @@ class DefEntityService():
                 break
             for entity in response_body['values']:
                 yield DefEntity(**entity)
+
+    def get_all_entities_per_page_by_interface(self, vendor: str, nss: str, version: str,  # noqa: E501
+                                               filters: dict = None,
+                                               page_number: int = CSE_PAGINATION_FIRST_PAGE_NUMBER,  # noqa: E501
+                                               page_size: int = CSE_PAGINATION_DEFAULT_PAGE_SIZE):  # noqa: E501
+        """Get a page of entities belonging to an interface.
+
+        An interface is uniquely identified by properties vendor, nss and
+        version.
+
+        :param str vendor: Vendor of the interface
+        :param str nss: nss of the interface
+        :param str version: version of the interface
+        :return: Generator of entities of that interface type
+        :rtype: Generator[List, None, None]
+        """
+        filter_string = utils.construct_filter_string(filters)
+        query_string = f"page={page_number}&pageSize={page_size}"
+        if filter_string:
+            query_string = f"filter={filter_string}&{query_string}"
+        response_body = self._cloudapi_client.do_request(
+            method=RequestMethod.GET,
+            cloudapi_version=CloudApiVersion.VERSION_1_0_0,
+            resource_url_relative_path=f"{CloudApiResource.ENTITIES}/"
+                                       f"{CloudApiResource.INTERFACES}/"
+                                       f"{vendor}/{nss}/{version}?{query_string}")  # noqa: E501
+        result = {}
+        entity_list = []
+        for entity in response_body['values']:
+            entity_list.append(GenericClusterEntity(**entity))
+        result[PaginationKey.RESULT_TOTAL] = int(response_body['resultTotal'])
+        result[PaginationKey.PAGE_COUNT] = int(response_body['pageCount'])
+        result[PaginationKey.PAGE_NUMBER] = page_number
+        result[PaginationKey.PAGE_SIZE] = page_size
+        result[PaginationKey.VALUES] = entity_list
+        return result
 
     @handle_entity_service_exception
     def update_entity(self, entity_id: str, entity: DefEntity) -> DefEntity:

--- a/container_service_extension/def_/models.py
+++ b/container_service_extension/def_/models.py
@@ -1,10 +1,12 @@
 # container-service-extension
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
+from dataclasses import asdict
 from dataclasses import dataclass
 from typing import List
 
 import container_service_extension.def_.utils as def_utils
+import container_service_extension.shared_constants as shared_constants
 
 
 @dataclass(frozen=True)
@@ -187,7 +189,7 @@ class ClusterSpec:
 
 
 @dataclass()
-class ClusterEntity:
+class NativeEntity:
     """Represents the Native Cluster entity.
 
     If dictionaries are passed as arguments, the constructor auto-converts
@@ -271,7 +273,7 @@ class DefEntity:
     """
 
     name: str
-    entity: ClusterEntity
+    entity: NativeEntity
     id: str = None
     entityType: str = None
     externalId: str = None
@@ -279,10 +281,10 @@ class DefEntity:
     owner: Owner = None
     org: Org = None
 
-    def __init__(self, entity: ClusterEntity, name: str = None, id: str = None,
+    def __init__(self, entity: NativeEntity, name: str = None, id: str = None,
                  entityType: str = None, externalId: str = None,
                  state: str = None, owner: Owner = None, org: Org = None):
-        self.entity = ClusterEntity(**entity) if isinstance(entity, dict) else entity  # noqa: E501
+        self.entity = NativeEntity(**entity) if isinstance(entity, dict) else entity  # noqa: E501
         self.name = name or self.entity.metadata.cluster_name
         self.id = id
         self.entityType = entityType
@@ -298,3 +300,96 @@ class Ovdc:
     ovdc_name: str = None
     ovdc_id: str = None
     remove_cp_from_vms_on_disable: bool = False
+
+
+# NOTE: Only used for cluster list operation to get entities by interface
+# include the following properties:
+@dataclass()
+class GenericClusterEntity:
+    # Properties being used for List operation attributes representiing them
+    # for native and TKG clusters:
+    # name:
+    #   def_entity.name
+    # vdc:
+    #   def_entity.entity.metadata.ovdc_name for native
+    #   de_entity.entity.metadata.virtualDataCenterName for TKG
+    # org:
+    #   def_entity.org.name for both native and TKG
+    # runtime:
+    #   def_entity.entity.kind for both native and TKG
+    # version:
+    #   def_entity.entity.status.kubernetes for native,
+    #   def_entity.entity.spec.distribution.version for TKG
+    # status:
+    #   def_entity.entity.status.phase for both native and TKG
+    # owner:
+    #   def_entity.owner.name for both native and TKG
+    name: str = None
+    org: Org = None
+    entity = None
+    owner: Owner = None
+
+    def __init__(self, name: str, org: Org, entity, owner: Owner, **kwargs):
+        self.name = name
+        self.org = Org(**org) if isinstance(org, dict) else org
+        entity_dict = asdict(entity) if not isinstance(entity, dict) else entity  # noqa: E501
+        if entity_dict['kind'] in \
+                [shared_constants.ClusterEntityKind.NATIVE.value,
+                 shared_constants.ClusterEntityKind.TKG_PLUS.value]:
+            self.entity = NativeEntity(**entity_dict) if isinstance(entity, dict) else entity  # noqa: E501
+        elif entity_dict['kind'] == \
+                shared_constants.ClusterEntityKind.TKG.value:
+            self.entity = TKGEntity(**entity) if isinstance(entity, dict) else entity  # noqa: E501
+        else:
+            raise Exception("Invalid cluster kind")
+        self.owner = Owner(**owner) if isinstance(owner, dict) else owner
+
+
+@dataclass()
+class TKGDistribution:
+    version: str = None
+
+    def __init__(self, version: str, **kwargs):
+        self.version = version
+
+
+@dataclass()
+class TKGSpec:
+    distribution: TKGDistribution = None
+
+    def __init__(self, distribution: TKGDistribution, **kwargs):
+        self.distribution = TKGDistribution(**distribution) \
+            if isinstance(distribution, dict) else distribution
+
+
+@dataclass()
+class TKGStatus:
+    phase: str = None
+
+    def __init__(self, phase: str, **kwargs):
+        self.phase = phase
+
+
+@dataclass()
+class TKGMetadata:
+    virtualDataCenterName: str = None
+
+    def __init__(self, virtualDataCenterName: str, **kwargs):
+        self.virtualDataCenterName = virtualDataCenterName
+
+
+@dataclass()
+class TKGEntity:
+    kind: str = None
+    spec: TKGSpec = None
+    status: TKGStatus = None
+    metadata: TKGMetadata = None
+
+    def __init__(self, kind: str, spec: TKGSpec, status: TKGStatus,
+                 metadata: TKGMetadata, **kwargs):
+        self.kind = kind
+        self.spec = TKGSpec(**spec) if isinstance(spec, dict) else spec
+        self.status = TKGStatus(**status) \
+            if isinstance(status, dict) else status
+        self.metadata = TKGMetadata(**metadata) \
+            if isinstance(metadata, dict) else metadata

--- a/container_service_extension/def_/ovdc_service.py
+++ b/container_service_extension/def_/ovdc_service.py
@@ -167,7 +167,7 @@ def list_org_vdcs(operation_context: ctx.OperationContext,
     # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
     # Prevent showing information about TKG+ by skipping TKG+ from the result.
     # Record telemetry
-    #TODO: enhance telemetry to record the page number and page size data.
+    # TODO: enhance telemetry to record the page number and page size data.
     telemetry_handler.record_user_action_details(cse_operation=CseOperation.OVDC_LIST,  # noqa: E501
                                                  cse_params={})
     result = cloudapi_utils.get_vdcs_by_page(

--- a/container_service_extension/def_/ovdc_service.py
+++ b/container_service_extension/def_/ovdc_service.py
@@ -167,6 +167,7 @@ def list_org_vdcs(operation_context: ctx.OperationContext,
     # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
     # Prevent showing information about TKG+ by skipping TKG+ from the result.
     # Record telemetry
+    #TODO: enhance telemetry to record the page number and page size data.
     telemetry_handler.record_user_action_details(cse_operation=CseOperation.OVDC_LIST,  # noqa: E501
                                                  cse_params={})
     result = cloudapi_utils.get_vdcs_by_page(

--- a/container_service_extension/ovdc_utils.py
+++ b/container_service_extension/ovdc_utils.py
@@ -252,7 +252,9 @@ def create_pks_compute_profile(request_data,
             raise
 
 
-def _remove_metadata_from_ovdc(ovdc: VDC, keys=[]):
+def _remove_metadata_from_ovdc(ovdc: VDC, keys=None):
+    if keys is None:
+        keys = []
     metadata = pyvcd_utils.metadata_to_dict(ovdc.get_all_metadata())
     for k in keys:
         if k in metadata:

--- a/container_service_extension/pyvcloud_utils.py
+++ b/container_service_extension/pyvcloud_utils.py
@@ -536,7 +536,7 @@ def get_all_ovdcs(client: vcd_client.Client):
     return list(query.execute())
 
 
-def create_cse_page_uri(client: vcd_client.Client, cse_path: str, vcd_uri=None, query_params={}):  # noqa: E501
+def create_cse_page_uri(client: vcd_client.Client, cse_path: str, vcd_uri=None, query_params=None):  # noqa: E501
     """Create a CSE URI equivalent to the VCD uri.
 
     :param vcd_client.Client client:
@@ -551,6 +551,8 @@ def create_cse_page_uri(client: vcd_client.Client, cse_path: str, vcd_uri=None, 
         Output:
             https://vcd-ip/api/cse/3.0/ovdcs?page=2&pageSize=25
     """  # noqa: E501
+    if query_params is None:
+        query_params = {}
     if vcd_uri:
         base_uri = f"{client.get_api_uri().strip('/')}{cse_path}"
         query_dict = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(vcd_uri).query))  # noqa: E501

--- a/container_service_extension/request_handlers/native_cluster_handler.py
+++ b/container_service_extension/request_handlers/native_cluster_handler.py
@@ -121,6 +121,15 @@ def cluster_upgrade(request_data, op_ctx: ctx.OperationContext):
     return vcd_broker.upgrade_cluster(data=request_data)
 
 
+def _filter_cluster_list_common_properties(cluster_list: list, common_properties: list = []) -> list:  # noqa: E501
+    result = []
+    for cluster_info in cluster_list:
+        filtered_cluster_info = \
+            {k: cluster_info.get(k) for k in common_properties}
+        result.append(filtered_cluster_info)
+    return result
+
+
 @record_user_action_telemetry(cse_operation=CseOperation.CLUSTER_LIST)
 def cluster_list(request_data, op_ctx: ctx.OperationContext):
     """Request handler for cluster list operation.
@@ -132,8 +141,13 @@ def cluster_list(request_data, op_ctx: ctx.OperationContext):
     :return: List
     """
     vcd_broker = VcdBroker(op_ctx)
-    page_number = int(request_data.get(PaginationKey.PAGE_NUMBER, CSE_PAGINATION_FIRST_PAGE_NUMBER))  # noqa: E501
-    page_size = int(request_data.get(PaginationKey.PAGE_SIZE, CSE_PAGINATION_DEFAULT_PAGE_SIZE))  # noqa: E501
+    page_number = request_data.get(PaginationKey.PAGE_NUMBER)
+    page_size = request_data.get(PaginationKey.PAGE_SIZE)
+    if page_number or page_size:
+        # override page_number and page_size to default values if any one
+        # of them is already set
+        page_number = int(request_data.get('page_number', CSE_PAGINATION_FIRST_PAGE_NUMBER))  # noqa: E501
+        page_size = int(request_data.get('page_size', CSE_PAGINATION_DEFAULT_PAGE_SIZE))  # noqa: E501
     # remove page number and page size from the filters as it is treated
     # differently from other filters
     if PaginationKey.PAGE_NUMBER in request_data:
@@ -141,6 +155,8 @@ def cluster_list(request_data, op_ctx: ctx.OperationContext):
     if PaginationKey.PAGE_SIZE in request_data:
         del request_data[PaginationKey.PAGE_SIZE]
 
+    # list_clusters will return a list if page number and page_size are None
+    # else it will return a paginated result
     vcd_clusters_info = vcd_broker.list_clusters(data=request_data,
                                                  page_number=page_number,
                                                  page_size=page_size)
@@ -154,15 +170,16 @@ def cluster_list(request_data, op_ctx: ctx.OperationContext):
         K8S_PROVIDER_KEY
     ]
 
+    if isinstance(vcd_clusters_info, list):
+        return _filter_cluster_list_common_properties(vcd_clusters_info, common_cluster_properties)  # noqa: E501
+
+    clusters = vcd_clusters_info[PaginationKey.VALUES]
+    result = _filter_cluster_list_common_properties(clusters,
+                                                    common_cluster_properties)
+
     # Extract the query params
     query_keys = [RequestKey.ORG_NAME, RequestKey.OVDC_NAME]
     query_params = {k: request_data[k] for k in query_keys if request_data.get(k) is not None}  # noqa: E501
-
-    result = []
-    for cluster_info in vcd_clusters_info[PaginationKey.VALUES]:
-        filtered_cluster_info = \
-            {k: cluster_info.get(k) for k in common_cluster_properties}
-        result.append(filtered_cluster_info)
 
     base_url = f"{op_ctx.client.get_api_uri().strip('/')}{CseOperationInfo.CLUSTER_LIST._api_path_format}"  # noqa: E501
     return utils.create_links_and_construct_paginated_result(base_url, result,

--- a/container_service_extension/request_handlers/native_cluster_handler.py
+++ b/container_service_extension/request_handlers/native_cluster_handler.py
@@ -131,7 +131,7 @@ def _filter_cluster_list_common_properties(cluster_list: list, common_properties
 
 
 @record_user_action_telemetry(cse_operation=CseOperation.CLUSTER_LIST)
-def legacy_cluster_list(request_data, op_ctx: ctx.OperationContext):
+def native_cluster_list(request_data, op_ctx: ctx.OperationContext):
     """Request handler for cluster list operation.
 
     Optional data and default values: org_name=None, ovdc_name=None
@@ -164,7 +164,7 @@ def legacy_cluster_list(request_data, op_ctx: ctx.OperationContext):
     query_params = {k: request_data[k] for k in query_keys if request_data.get(k) is not None}  # noqa: E501
 
     base_url = f"{op_ctx.client.get_api_uri().strip('/')}" \
-               f"{CseOperationInfo.LEGACY_CLUSTER_LIST.api_path_format}"
+               f"{CseOperationInfo.NATIVE_CLUSTER_LIST.api_path_format}"
     return utils.create_links_and_construct_paginated_result(
         base_url, result,
         vcd_clusters_info[PaginationKey.RESULT_TOTAL],

--- a/container_service_extension/request_handlers/native_cluster_handler.py
+++ b/container_service_extension/request_handlers/native_cluster_handler.py
@@ -3,10 +3,16 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import container_service_extension.operation_context as ctx
+from container_service_extension.server_constants import CseOperation as CseOperationInfo  # noqa: E501
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
+from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
+from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
+from container_service_extension.shared_constants import PaginationKey
+from container_service_extension.shared_constants import RequestKey
 from container_service_extension.telemetry.constants import CseOperation
 from container_service_extension.telemetry.telemetry_handler import \
     record_user_action_telemetry
+import container_service_extension.utils as utils
 from container_service_extension.vcdbroker import VcdBroker
 
 
@@ -126,7 +132,18 @@ def cluster_list(request_data, op_ctx: ctx.OperationContext):
     :return: List
     """
     vcd_broker = VcdBroker(op_ctx)
-    vcd_clusters_info = vcd_broker.list_clusters(data=request_data)
+    page_number = int(request_data.get(PaginationKey.PAGE_NUMBER, CSE_PAGINATION_FIRST_PAGE_NUMBER))  # noqa: E501
+    page_size = int(request_data.get(PaginationKey.PAGE_SIZE, CSE_PAGINATION_DEFAULT_PAGE_SIZE))  # noqa: E501
+    # remove page number and page size from the filters as it is treated
+    # differently from other filters
+    if PaginationKey.PAGE_NUMBER in request_data:
+        del request_data[PaginationKey.PAGE_NUMBER]
+    if PaginationKey.PAGE_SIZE in request_data:
+        del request_data[PaginationKey.PAGE_SIZE]
+
+    vcd_clusters_info = vcd_broker.list_clusters(data=request_data,
+                                                 page_number=page_number,
+                                                 page_size=page_size)
 
     common_cluster_properties = [
         'name',
@@ -137,13 +154,22 @@ def cluster_list(request_data, op_ctx: ctx.OperationContext):
         K8S_PROVIDER_KEY
     ]
 
+    # Extract the query params
+    query_keys = [RequestKey.ORG_NAME, RequestKey.OVDC_NAME]
+    query_params = {k: request_data[k] for k in query_keys if request_data.get(k) is not None}  # noqa: E501
+
     result = []
-    for cluster_info in vcd_clusters_info:
+    for cluster_info in vcd_clusters_info[PaginationKey.VALUES]:
         filtered_cluster_info = \
             {k: cluster_info.get(k) for k in common_cluster_properties}
         result.append(filtered_cluster_info)
 
-    return result
+    base_url = f"{op_ctx.client.get_api_uri().strip('/')}{CseOperationInfo.CLUSTER_LIST._api_path_format}"  # noqa: E501
+    return utils.create_links_and_construct_paginated_result(base_url, result,
+                                                             vcd_clusters_info[PaginationKey.RESULT_TOTAL],  # noqa: E501
+                                                             page_number=page_number,  # noqa: E501
+                                                             page_size=page_size,  # noqa: E501
+                                                             query_params=query_params)  # noqa: E501
 
 
 @record_user_action_telemetry(cse_operation=CseOperation.NODE_CREATE)

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -157,6 +157,7 @@ def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
     page_size = int(validated_data[PaginationKey.PAGE_SIZE])
 
     # Record telemetry data
+    #TODO: enhance telemetry to record the page number and page size data.
     cse_params = copy.deepcopy(validated_data)
     record_user_action_details(cse_operation=CseOperation.OVDC_LIST,
                                cse_params=cse_params)

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -138,6 +138,7 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
     return _get_cse_ovdc_list(op_ctx.sysadmin_client, org_vdcs)
 
 
+# TODO: Record telemetry in a different telemetry handler
 @record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
 def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
     """Request handler for orgvdc list operation.

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -157,7 +157,7 @@ def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
     page_size = int(validated_data[PaginationKey.PAGE_SIZE])
 
     # Record telemetry data
-    #TODO: enhance telemetry to record the page number and page size data.
+    # TODO: enhance telemetry to record the page number and page size data.
     cse_params = copy.deepcopy(validated_data)
     record_user_action_details(cse_operation=CseOperation.OVDC_LIST,
                                cse_params=cse_params)

--- a/container_service_extension/request_handlers/pks_ovdc_handler.py
+++ b/container_service_extension/request_handlers/pks_ovdc_handler.py
@@ -152,6 +152,7 @@ def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
     list_pks_plans = utils.str_to_bool(validated_data[RequestKey.LIST_PKS_PLANS]) # noqa: E501
 
     # Record telemetry data
+    #TODO: enhance telemetry to record the page number and page size data.
     cse_params = copy.deepcopy(validated_data)
     cse_params[RequestKey.LIST_PKS_PLANS] = list_pks_plans
     record_user_action_details(cse_operation=CseOperation.OVDC_LIST,

--- a/container_service_extension/request_handlers/pks_ovdc_handler.py
+++ b/container_service_extension/request_handlers/pks_ovdc_handler.py
@@ -152,7 +152,7 @@ def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
     list_pks_plans = utils.str_to_bool(validated_data[RequestKey.LIST_PKS_PLANS]) # noqa: E501
 
     # Record telemetry data
-    #TODO: enhance telemetry to record the page number and page size data.
+    # TODO: enhance telemetry to record the page number and page size data.
     cse_params = copy.deepcopy(validated_data)
     cse_params[RequestKey.LIST_PKS_PLANS] = list_pks_plans
     record_user_action_details(cse_operation=CseOperation.OVDC_LIST,

--- a/container_service_extension/request_handlers/request_utils.py
+++ b/container_service_extension/request_handlers/request_utils.py
@@ -88,7 +88,7 @@ def validate_payload(payload, required_keys):
 
 
 def validate_request_payload(input_spec: dict, reference_spec: dict,
-                             exclude_fields=[]):
+                             exclude_fields=None):
     """Validate the desired spec with the current spec.
 
     :param dict input_spec: input spec
@@ -98,6 +98,8 @@ def validate_request_payload(input_spec: dict, reference_spec: dict,
     :rtype: bool
     :raises: BadRequestError on encountering invalid payload value
     """
+    if exclude_fields is None:
+        exclude_fields = []
     input_dict = utils.flatten_dictionary(input_spec)
     reference_dict = utils.flatten_dictionary(reference_spec)
     exclude_key_set = set(exclude_fields)

--- a/container_service_extension/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/request_handlers/v35/def_cluster_handler.py
@@ -134,6 +134,9 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     return asdict(svc.upgrade_cluster(cluster_id, cluster_entity_spec))
 
 
+# TODO: Record telemetry in a different telemetry handler
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE)  # noqa: E501
+@request_utils.v35_api_exception_handler
 def native_cluster_list(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster list operation.
 

--- a/container_service_extension/request_handlers/v35/ovdc_handler.py
+++ b/container_service_extension/request_handlers/v35/ovdc_handler.py
@@ -55,6 +55,7 @@ def ovdc_list(data, operation_context: ctx.OperationContext):
     return ovdc_service.list_ovdc(operation_context)
 
 
+# TODO: Record telemetry in a different telemetry handler
 @record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
 @request_utils.v35_api_exception_handler
 def org_vdc_list(data, operation_context: ctx.OperationContext):

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -32,7 +32,7 @@ Following are the valid api endpoints.
 
 API version 33.0 and 34.0
 --------------------------
-GET /cse/nativeclusters
+GET /cse/legacyclusters
 GET /cse/clusters?org={org name}&vdc={vdc name}
 POST /cse/clusters
 GET /cse/cluster/{cluster name}?org={org name}&vdc={vdc name}
@@ -56,7 +56,7 @@ PUT /cse/ovdc/{ovdc_id}/compute-policies
 
 API version 35.0
 ----------------
-GET /cse/3.0/legacyclusters
+GET /cse/3.0/nativeclusters
 GET /cse/3.0/clusters
 Entities can be filtered by nested properties as defined per the schema
 GET /cse/3.0/clusters?entity.kind={native}&entity.metadata.org_name={org name}
@@ -83,7 +83,6 @@ PUT /cse/system
 
 GET /cse/templates
 
-GET /pks/pksClusters?org={org name}&vdc={vdc name}
 GET /pks/clusters?org={org name}&vdc={vdc name}
 POST /pks/clusters
 GET /pks/cluster/{cluster name}?org={org name}&vdc={vdc name}

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -32,7 +32,7 @@ Following are the valid api endpoints.
 
 API version 33.0 and 34.0
 --------------------------
-GET /cse/legacyclusters
+GET /cse/nativeclusters
 GET /cse/clusters?org={org name}&vdc={vdc name}
 POST /cse/clusters
 GET /cse/cluster/{cluster name}?org={org name}&vdc={vdc name}
@@ -100,7 +100,7 @@ OPERATION_TO_HANDLER = {
     CseOperation.CLUSTER_CREATE: native_cluster_handler.cluster_create,
     CseOperation.CLUSTER_DELETE: native_cluster_handler.cluster_delete,
     CseOperation.CLUSTER_INFO: native_cluster_handler.cluster_info,
-    CseOperation.LEGACY_CLUSTER_LIST: native_cluster_handler.legacy_cluster_list,  # noqa: E501
+    CseOperation.NATIVE_CLUSTER_LIST: native_cluster_handler.native_cluster_list,  # noqa: E501
     CseOperation.CLUSTER_LIST: native_cluster_handler.cluster_list,
     CseOperation.CLUSTER_RESIZE: native_cluster_handler.cluster_resize,
     CseOperation.CLUSTER_UPGRADE_PLAN: native_cluster_handler.cluster_upgrade_plan,  # noqa: E501
@@ -626,13 +626,13 @@ def _get_legacy_url_data(method: str, url: str, api_version: str):
     if operation_type.endswith('s'):
         operation_type = operation_type[:-1]
 
-    if operation_type == shared_constants.OperationType.LEGACY_CLUSTER:
+    if operation_type == shared_constants.OperationType.NATIVE_CLUSTER:
         if api_version not in (VcdApiVersion.VERSION_33.value,
                                VcdApiVersion.VERSION_35.value):
             raise cse_exception.NotFoundRequestError()
         if num_tokens == 4:
             if method == shared_constants.RequestMethod.GET:
-                return {_OPERATION_KEY: CseOperation.LEGACY_CLUSTER_LIST}
+                return {_OPERATION_KEY: CseOperation.NATIVE_CLUSTER_LIST}
             raise cse_exception.MethodNotAllowedRequestError()
 
     if operation_type == shared_constants.OperationType.CLUSTER:

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -479,8 +479,6 @@ def _get_v35_url_data(method: str, url: str, api_version: str):
     if operation_type == shared_constants.OperationType.CLUSTER:
         return _get_v35_cluster_url_data(method, tokens)
 
-    from container_service_extension.logger import SERVER_LOGGER
-    SERVER_LOGGER.debug(f"********Operation type = {operation_type}")
     if operation_type == shared_constants.OperationType.NATIVE_CLUSTER:
         return _get_v35_native_cluster_url_data(method, tokens)
 

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -199,6 +199,7 @@ class CseOperation(Enum):
     CLUSTER_CREATE = ('create cluster', '/cse/clusters', requests.codes.accepted)  # noqa: E501
     CLUSTER_DELETE = ('delete cluster', '/cse/cluster/%s', requests.codes.accepted)  # noqa: E501
     CLUSTER_INFO = ('get info of cluster', '/cse/cluster/%s')
+    LEGACY_CLUSTER_LIST = ('list legacy clusters', '/cse/legacyclusters')
     CLUSTER_LIST = ('list clusters', '/cse/clusters')
     CLUSTER_RESIZE = ('resize cluster', '/cse/cluster/%s', requests.codes.accepted)  # noqa: E501
     CLUSTER_UPGRADE_PLAN = ('get supported cluster upgrade paths', '/cse/cluster/%s/upgrade-plan')  # noqa: E501
@@ -211,6 +212,7 @@ class CseOperation(Enum):
     V35_CLUSTER_CREATE = ('create DEF cluster', '/cse/3.0/clusters', requests.codes.accepted)  # noqa: E501
     V35_CLUSTER_DELETE = ('delete DEF cluster', '/cse/3.0/cluster/%s', requests.codes.accepted)  # noqa: E501
     V35_CLUSTER_INFO = ('get info of DEF cluster', '/cse/3.0/cluster/%s')
+    V35_NATIVE_CLUSTER_LIST = ('list paginated DEF clusters', '/cse/3.0/nativeclusters')  # noqa: E501
     V35_CLUSTER_LIST = ('list DEF clusters', '/cse/3.0/clusters')
     V35_CLUSTER_RESIZE = ('resize DEF cluster', '/cse/3.0/cluster/%s', requests.codes.accepted)  # noqa: E501
     V35_CLUSTER_UPGRADE_PLAN = ('get supported DEF cluster upgrade paths', '/cse/3.0/cluster/%s/upgrade-plan')  # noqa: E501

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -199,7 +199,7 @@ class CseOperation(Enum):
     CLUSTER_CREATE = ('create cluster', '/cse/clusters', requests.codes.accepted)  # noqa: E501
     CLUSTER_DELETE = ('delete cluster', '/cse/cluster/%s', requests.codes.accepted)  # noqa: E501
     CLUSTER_INFO = ('get info of cluster', '/cse/cluster/%s')
-    LEGACY_CLUSTER_LIST = ('list legacy clusters', '/cse/legacyclusters')
+    NATIVE_CLUSTER_LIST = ('list legacy clusters', '/cse/nativeclusters')
     CLUSTER_LIST = ('list clusters', '/cse/clusters')
     CLUSTER_RESIZE = ('resize cluster', '/cse/cluster/%s', requests.codes.accepted)  # noqa: E501
     CLUSTER_UPGRADE_PLAN = ('get supported cluster upgrade paths', '/cse/cluster/%s/upgrade-plan')  # noqa: E501

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -53,7 +53,6 @@ CSE_PAGINATION_DEFAULT_PAGE_SIZE = 25
 
 @unique
 class OperationType(str, Enum):
-    LEGACY_CLUSTER = 'legacycluster'
     NATIVE_CLUSTER = 'nativecluster'
     CLUSTER = 'cluster'
     NODE = 'node'

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -141,6 +141,7 @@ class RequestKey(str, Enum):
 class PaginationKey(str, Enum):
     PAGE_NUMBER = 'page'
     PAGE_SIZE = 'pageSize'
+    PAGE_COUNT = 'pageCount'
     NEXT_PAGE_URI = 'nextPageUri'
     PREV_PAGE_URI = 'previousPageUri'
     RESULT_TOTAL = 'resultTotal'

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -53,6 +53,8 @@ CSE_PAGINATION_DEFAULT_PAGE_SIZE = 25
 
 @unique
 class OperationType(str, Enum):
+    LEGACY_CLUSTER = 'legacycluster'
+    NATIVE_CLUSTER = 'nativecluster'
     CLUSTER = 'cluster'
     NODE = 'node'
     OVDC = 'ovdc'

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -474,18 +474,28 @@ def construct_filter_string(filters: dict):
 def construct_paginated_response(values, result_total,
                                  page_number=CSE_PAGINATION_FIRST_PAGE_NUMBER,  # noqa: E501
                                  page_size=CSE_PAGINATION_DEFAULT_PAGE_SIZE,  # noqa: E501
+                                 page_count=None,
                                  next_page_uri=None,
                                  prev_page_uri=None):
+    if not page_count:
+        extra_page = 1 if bool(result_total % page_size) else 0
+        page_count = result_total // page_size + extra_page
     resp = {
-        PaginationKey.VALUES: values,
         PaginationKey.RESULT_TOTAL: result_total,
+        PaginationKey.PAGE_COUNT: page_count,
         PaginationKey.PAGE_NUMBER: page_number,
-        PaginationKey.PAGE_SIZE: page_size
+        PaginationKey.PAGE_SIZE: page_size,
+        PaginationKey.NEXT_PAGE_URI: next_page_uri,
+        PaginationKey.PREV_PAGE_URI: prev_page_uri,
+        PaginationKey.VALUES: values
     }
-    if next_page_uri:
-        resp[PaginationKey.NEXT_PAGE_URI] = next_page_uri
-    if prev_page_uri:
-        resp[PaginationKey.PREV_PAGE_URI] = prev_page_uri
+
+    # Conditionally deleting instead of conditionally adding the entry
+    # maintains the order for the response
+    if not prev_page_uri:
+        del resp[PaginationKey.PREV_PAGE_URI]
+    if not next_page_uri:
+        del resp[PaginationKey.NEXT_PAGE_URI]
     return resp
 
 

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -508,8 +508,10 @@ def create_links_and_construct_paginated_result(base_uri, values, result_total,
 
     # add the rest of the query parameters
     for q in query_params.keys():
-        next_page_uri += f"&{q}={query_params[q]}"
-        prev_page_uri += f"&{q}={query_params[q]}"
+        if next_page_uri:
+            next_page_uri += f"&{q}={query_params[q]}"
+        if prev_page_uri:
+            prev_page_uri += f"&{q}={query_params[q]}"
 
     return construct_paginated_response(values=values,
                                         result_total=result_total,

--- a/container_service_extension/utils.py
+++ b/container_service_extension/utils.py
@@ -173,7 +173,7 @@ def get_duplicate_items_in_list(items):
 
 
 def check_keys_and_value_types(dikt, ref_dict, location='dictionary',
-                               excluded_keys=[],
+                               excluded_keys=None,
                                msg_update_callback=NullPrinter()):
     """Compare a dictionary with a reference dictionary.
 
@@ -191,6 +191,8 @@ def check_keys_and_value_types(dikt, ref_dict, location='dictionary',
     :raises TypeError: if the value of a property in @dikt does not match with
         the value of the same property in @ref_dict
     """
+    if excluded_keys is None:
+        excluded_keys = []
     ref_keys = set(ref_dict.keys())
     keys = set(dikt.keys())
 
@@ -502,7 +504,9 @@ def construct_paginated_response(values, result_total,
 def create_links_and_construct_paginated_result(base_uri, values, result_total,
                                                 page_number=CSE_PAGINATION_FIRST_PAGE_NUMBER,  # noqa: E501
                                                 page_size=CSE_PAGINATION_DEFAULT_PAGE_SIZE,  # noqa: E501
-                                                query_params={}):
+                                                query_params=None):
+    if query_params is None:
+        query_params = {}
     next_page_uri: str = None
     if page_number * page_size < result_total:
         # TODO find a way to get the initial url part

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -38,8 +38,7 @@ from container_service_extension.server_constants import LocalTemplateKey
 from container_service_extension.server_constants import NodeType
 from container_service_extension.server_constants import ScriptFile
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
-from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE, PaginationKey  # noqa: E501
-from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
+from container_service_extension.shared_constants import PaginationKey
 from container_service_extension.shared_constants import RequestKey
 from container_service_extension.telemetry.constants import CseOperation
 from container_service_extension.telemetry.constants import PayloadKey
@@ -102,6 +101,10 @@ class VcdBroker(abstract_broker.AbstractBroker):
     def list_clusters(self, **kwargs):
         """List all native clusters and their relevant metadata.
 
+        :return: a list of all clusters if 'page_number' or 'page_size' are
+            not part of the kwargs. If 'page_number' or 'page_size' is present,
+            a paginated response is returned.
+
         Common broker function that validates data for the 'list clusters'
         operation and returns a list of cluster data.
 
@@ -110,11 +113,9 @@ class VcdBroker(abstract_broker.AbstractBroker):
         **telemetry: Optional
         """
         data = kwargs.get(KwargKey.DATA, {})
-        page_number = kwargs.get('page_number', None)
-        page_size = kwargs.get('page_size', None)
-        if page_number or page_size:
-            page_number = int(kwargs.get('page_number', CSE_PAGINATION_FIRST_PAGE_NUMBER))  # noqa: E501
-            page_size = int(kwargs.get('page_size', CSE_PAGINATION_DEFAULT_PAGE_SIZE))  # noqa: E501
+        page_number = kwargs.get('page_number')
+        page_size = kwargs.get('page_size')
+
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None
@@ -136,7 +137,7 @@ class VcdBroker(abstract_broker.AbstractBroker):
             page_size=page_size)
 
         raw_clusters = raw_clusters_info
-        if page_number:
+        if page_number and page_size:
             raw_clusters = raw_clusters_info[PaginationKey.VALUES]
 
         clusters = []

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -110,8 +110,11 @@ class VcdBroker(abstract_broker.AbstractBroker):
         **telemetry: Optional
         """
         data = kwargs.get(KwargKey.DATA, {})
-        page_number = kwargs.get('page_number', CSE_PAGINATION_FIRST_PAGE_NUMBER)  # noqa: E501
-        page_size = kwargs.get('page_size', CSE_PAGINATION_DEFAULT_PAGE_SIZE)
+        page_number = kwargs.get('page_number', None)
+        page_size = kwargs.get('page_size', None)
+        if page_number or page_size:
+            page_number = int(kwargs.get('page_number', CSE_PAGINATION_FIRST_PAGE_NUMBER))  # noqa: E501
+            page_size = int(kwargs.get('page_size', CSE_PAGINATION_DEFAULT_PAGE_SIZE))  # noqa: E501
         defaults = {
             RequestKey.ORG_NAME: None,
             RequestKey.OVDC_NAME: None
@@ -131,7 +134,10 @@ class VcdBroker(abstract_broker.AbstractBroker):
             ovdc_name=validated_data[RequestKey.OVDC_NAME],
             page_number=page_number,
             page_size=page_size)
-        raw_clusters = raw_clusters_info[PaginationKey.VALUES]
+
+        raw_clusters = raw_clusters_info
+        if page_number:
+            raw_clusters = raw_clusters_info[PaginationKey.VALUES]
 
         clusters = []
         for c in raw_clusters:
@@ -152,8 +158,12 @@ class VcdBroker(abstract_broker.AbstractBroker):
                 'owner_name': c['owner_name'],
                 K8S_PROVIDER_KEY: K8sProvider.NATIVE
             })
-        raw_clusters_info[PaginationKey.VALUES] = clusters
-        return raw_clusters_info
+
+        if page_number:
+            raw_clusters_info[PaginationKey.VALUES] = clusters
+            return raw_clusters_info
+
+        return clusters
 
     def get_cluster_config(self, **kwargs):
         """Get the cluster's kube config contents.

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -38,6 +38,8 @@ from container_service_extension.server_constants import LocalTemplateKey
 from container_service_extension.server_constants import NodeType
 from container_service_extension.server_constants import ScriptFile
 from container_service_extension.server_constants import SYSTEM_ORG_NAME
+from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
+from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
 from container_service_extension.shared_constants import PaginationKey
 from container_service_extension.shared_constants import RequestKey
 from container_service_extension.telemetry.constants import CseOperation
@@ -98,7 +100,7 @@ class VcdBroker(abstract_broker.AbstractBroker):
 
         return cluster
 
-    def list_clusters(self, **kwargs):
+    def get_clusters_by_page(self, **kwargs):
         """List all native clusters and their relevant metadata.
 
         :return: a list of all clusters if 'page_number' or 'page_size' are
@@ -113,12 +115,14 @@ class VcdBroker(abstract_broker.AbstractBroker):
         **telemetry: Optional
         """
         data = kwargs.get(KwargKey.DATA, {})
-        page_number = kwargs.get('page_number')
-        page_size = kwargs.get('page_size')
+        page_number = kwargs.get('page_number',
+                                 CSE_PAGINATION_FIRST_PAGE_NUMBER)
+        page_size = kwargs.get('page_size',
+                               CSE_PAGINATION_DEFAULT_PAGE_SIZE)
 
         defaults = {
             RequestKey.ORG_NAME: None,
-            RequestKey.OVDC_NAME: None
+            RequestKey.OVDC_NAME: None,
         }
         validated_data = {**defaults, **data}
 
@@ -136,35 +140,47 @@ class VcdBroker(abstract_broker.AbstractBroker):
             page_number=page_number,
             page_size=page_size)
 
-        raw_clusters = raw_clusters_info
-        if page_number and page_size:
-            raw_clusters = raw_clusters_info[PaginationKey.VALUES]
+        raw_clusters_info[PaginationKey.VALUES] = \
+            _extract_cse_cluster_list_info(self.context.sysadmin_client,
+                                           raw_clusters_info[PaginationKey.VALUES])  # noqa: E501
+        return raw_clusters_info
 
-        clusters = []
-        for c in raw_clusters:
-            org_name = vcd_utils.get_org_name_from_ovdc_id(
-                self.context.sysadmin_client, c['vdc_id'])
-            clusters.append({
-                'name': c['name'],
-                'control_plane_ip': c['leader_endpoint'],
-                'template_name': c.get('template_name'),
-                'template_revision': c.get('template_revision'),
-                'k8s_type': c.get('kubernetes'),
-                'k8s_version': c.get('kubernetes_version'),
-                'VMs': c['number_of_vms'],
-                'vdc': c['vdc_name'],
-                'status': c['status'],
-                'vdc_id': c['vdc_id'],
-                'org_name': org_name,
-                'owner_name': c['owner_name'],
-                K8S_PROVIDER_KEY: K8sProvider.NATIVE
-            })
+    def list_clusters(self, **kwargs):
+        """List all native clusters and their relevant metadata.
 
-        if page_number:
-            raw_clusters_info[PaginationKey.VALUES] = clusters
-            return raw_clusters_info
+        :return: a list of all clusters if 'page_number' or 'page_size' are
+            not part of the kwargs. If 'page_number' or 'page_size' is present,
+            a paginated response is returned.
 
-        return clusters
+        Common broker function that validates data for the 'list clusters'
+        operation and returns a list of cluster data.
+
+        **data: Optional
+            Optional data and default values: org_name=None, ovdc_name=None
+        **telemetry: Optional
+        """
+        data = kwargs.get(KwargKey.DATA, {})
+
+        defaults = {
+            RequestKey.ORG_NAME: None,
+            RequestKey.OVDC_NAME: None
+        }
+        validated_data = {**defaults, **data}
+
+        if kwargs.get(KwargKey.TELEMETRY, True):
+            # Record the data for telemetry
+            record_user_action_details(
+                cse_operation=CseOperation.CLUSTER_LIST,
+                cse_params=copy.deepcopy(validated_data))
+
+        # "raw clusters" do not have well-defined cluster data keys
+        raw_clusters = get_all_clusters(
+            self.context.client,
+            org_name=validated_data[RequestKey.ORG_NAME],
+            ovdc_name=validated_data[RequestKey.OVDC_NAME])
+
+        return _extract_cse_cluster_list_info(self.context.sysadmin_client,
+                                              raw_clusters)
 
     def get_cluster_config(self, **kwargs):
         """Get the cluster's kube config contents.
@@ -1866,6 +1882,30 @@ def _add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
 
         vapp.reload()
         return {'task': task, 'specs': specs}
+
+
+def _extract_cse_cluster_list_info(sysadmin_client: vcd_client.Client,
+                                   raw_clusters: list) -> list:
+    clusters = []
+    for c in raw_clusters:
+        org_name = vcd_utils.get_org_name_from_ovdc_id(sysadmin_client,
+                                                       c['vdc_id'])
+        clusters.append({
+            'name': c['name'],
+            'control_plane_ip': c['leader_endpoint'],
+            'template_name': c.get('template_name'),
+            'template_revision': c.get('template_revision'),
+            'k8s_type': c.get('kubernetes'),
+            'k8s_version': c.get('kubernetes_version'),
+            'VMs': c['number_of_vms'],
+            'vdc': c['vdc_name'],
+            'status': c['status'],
+            'vdc_id': c['vdc_id'],
+            'org_name': org_name,
+            'owner_name': c['owner_name'],
+            K8S_PROVIDER_KEY: K8sProvider.NATIVE
+        })
+    return clusters
 
 
 def _get_node_names(vapp, node_type):

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -101,14 +101,10 @@ class VcdBroker(abstract_broker.AbstractBroker):
         return cluster
 
     def get_clusters_by_page(self, **kwargs):
-        """List all native clusters and their relevant metadata.
+        """Get native clusters by page and their relevant metadata.
 
-        :return: a list of all clusters if 'page_number' or 'page_size' are
-            not part of the kwargs. If 'page_number' or 'page_size' is present,
-            a paginated response is returned.
-
-        Common broker function that validates data for the 'list clusters'
-        operation and returns a list of cluster data.
+        :return: paginated dictionary containing list of clusters in
+            that page as values.
 
         **data: Optional
             Optional data and default values: org_name=None, ovdc_name=None


### PR DESCRIPTION
To help us process your pull request efficiently, please include:

Port changes from master to cse_3_0_updates

Add a generic model to parse both TKG and native clusters.
Modify legacy native list clusters endpoint to support pagination
CLI changes to print paginated response for list cluster operation
Testing done:

vcd cse cluster list with API server running in API version 35
vcd cse cluster list with API server running in API version 33
Check postman response for /api/cse/clusters endpont

@rocknes @sahithi @arunmk @sakthisunda @ltimothy7 @ChintanShahVMware

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/868)
<!-- Reviewable:end -->
