### PR TITLE
[VCDA-2035] Fix ovdc list operation to support backward compatibility

### DIFF
--- a/container_service_extension/client/cse_client/api_33/ovdc_api.py
+++ b/container_service_extension/client/cse_client/api_33/ovdc_api.py
@@ -13,7 +13,6 @@ class OvdcApi(CseClient):
     def __init__(self, client: vcd_client.Client):
         super().__init__(client)
         self._uri = f"{self._uri}/{shared_constants.CSE_URL_FRAGMENT}"
-        self._ovdcs_uri = f"{self._uri}/ovdcs"
         self._org_vdcs_uri = f"{self._uri}/orgvdcs"
         self._ovdc_uri = f"{self._uri}/ovdc"
 

--- a/container_service_extension/client/cse_client/api_33/ovdc_api.py
+++ b/container_service_extension/client/cse_client/api_33/ovdc_api.py
@@ -14,10 +14,11 @@ class OvdcApi(CseClient):
         super().__init__(client)
         self._uri = f"{self._uri}/{shared_constants.CSE_URL_FRAGMENT}"
         self._ovdcs_uri = f"{self._uri}/ovdcs"
+        self._org_vdcs_uri = f"{self._uri}/orgvdcs"
         self._ovdc_uri = f"{self._uri}/ovdc"
 
     def get_all_ovdcs(self):
-        url = f"{self._ovdcs_uri}?pageSize={self._request_page_size}"
+        url = f"{self._org_vdcs_uri}?pageSize={self._request_page_size}"
         return self.iterate_results(url)
 
     def get_ovdc(self, ovdc_id):

--- a/container_service_extension/client/cse_client/api_33/ovdc_api.py
+++ b/container_service_extension/client/cse_client/api_33/ovdc_api.py
@@ -17,7 +17,8 @@ class OvdcApi(CseClient):
         self._ovdc_uri = f"{self._uri}/ovdc"
 
     def get_all_ovdcs(self):
-        url = f"{self._org_vdcs_uri}?pageSize={self._request_page_size}"
+        url = f"{self._org_vdcs_uri}?" \
+              f"{shared_constants.PaginationKey.PAGE_SIZE.value}={self._request_page_size}"  # noqa: E501
         return self.iterate_results(url)
 
     def get_ovdc(self, ovdc_id):

--- a/container_service_extension/client/cse_client/api_35/ovdc_api.py
+++ b/container_service_extension/client/cse_client/api_35/ovdc_api.py
@@ -30,7 +30,8 @@ class OvdcApi(CseClient):
             indicating if there are more results.
         :rtype: Generator[(List[dict], int), None, None]
         """
-        url = f"{self._org_vdcs_uri}?pageSize={self._request_page_size}"
+        url = f"{self._org_vdcs_uri}?" \
+              f"{shared_constants.PaginationKey.PAGE_SIZE.value}={self._request_page_size}"  # noqa: E501
         return self.iterate_results(url)
 
     def get_ovdc(self, ovdc_id):

--- a/container_service_extension/client/cse_client/api_35/ovdc_api.py
+++ b/container_service_extension/client/cse_client/api_35/ovdc_api.py
@@ -17,7 +17,6 @@ class OvdcApi(CseClient):
         super().__init__(client)
         self._uri = f"{self._uri}/{shared_constants.CSE_URL_FRAGMENT}/" \
                     f"{shared_constants.CSE_3_0_URL_FRAGMENT}"
-        self._ovdcs_uri = f"{self._uri}/ovdcs"
         self._org_vdcs_uri = f"{self._uri}/orgvdcs"
         self._ovdc_uri = f"{self._uri}/ovdc"
         # NOTE: The request page size is overrided because the CSE server takes

--- a/container_service_extension/client/cse_client/api_35/ovdc_api.py
+++ b/container_service_extension/client/cse_client/api_35/ovdc_api.py
@@ -18,6 +18,7 @@ class OvdcApi(CseClient):
         self._uri = f"{self._uri}/{shared_constants.CSE_URL_FRAGMENT}/" \
                     f"{shared_constants.CSE_3_0_URL_FRAGMENT}"
         self._ovdcs_uri = f"{self._uri}/ovdcs"
+        self._org_vdcs_uri = f"{self._uri}/orgvdcs"
         self._ovdc_uri = f"{self._uri}/ovdc"
         # NOTE: The request page size is overrided because the CSE server takes
         # an average of 10 seconds (Default vCD timeout) if there are 5 OVDCs
@@ -30,7 +31,7 @@ class OvdcApi(CseClient):
             indicating if there are more results.
         :rtype: Generator[(List[dict], int), None, None]
         """
-        url = f"{self._ovdcs_uri}?pageSize={self._request_page_size}"
+        url = f"{self._org_vdcs_uri}?pageSize={self._request_page_size}"
         return self.iterate_results(url)
 
     def get_ovdc(self, ovdc_id):

--- a/container_service_extension/client/cse_client/pks_ovdc_api.py
+++ b/container_service_extension/client/cse_client/pks_ovdc_api.py
@@ -13,11 +13,12 @@ class PksOvdcApi(CseClient):
     def __init__(self, client: vcd_client.Client):
         super().__init__(client)
         self._uri = f"{self._uri}/{shared_constants.PKS_URL_FRAGMENT}"
+        self._org_vdcs_uri = f"{self._uri}/orgvdcs"
         self._ovdcs_uri = f"{self._uri}/ovdcs"
         self._ovdc_uri = f"{self._uri}/ovdc"
 
     def get_all_ovdcs(self, filters={}):
-        url = f"{self._ovdcs_uri}?pageSize={self._request_page_size}"
+        url = f"{self._org_vdcs_uri}?pageSize={self._request_page_size}"
         return self.iterate_results(url, filters=filters)
 
     def get_ovdc(self, ovdc_id):

--- a/container_service_extension/client/cse_client/pks_ovdc_api.py
+++ b/container_service_extension/client/cse_client/pks_ovdc_api.py
@@ -14,7 +14,6 @@ class PksOvdcApi(CseClient):
         super().__init__(client)
         self._uri = f"{self._uri}/{shared_constants.PKS_URL_FRAGMENT}"
         self._org_vdcs_uri = f"{self._uri}/orgvdcs"
-        self._ovdcs_uri = f"{self._uri}/ovdcs"
         self._ovdc_uri = f"{self._uri}/ovdc"
 
     def get_all_ovdcs(self, filters={}):

--- a/container_service_extension/client/cse_client/pks_ovdc_api.py
+++ b/container_service_extension/client/cse_client/pks_ovdc_api.py
@@ -17,7 +17,8 @@ class PksOvdcApi(CseClient):
         self._ovdc_uri = f"{self._uri}/ovdc"
 
     def get_all_ovdcs(self, filters={}):
-        url = f"{self._org_vdcs_uri}?pageSize={self._request_page_size}"
+        url = f"{self._org_vdcs_uri}?" \
+              f"{shared_constants.PaginationKey.PAGE_SIZE.value}={self._request_page_size}"  # noqa: E501
         return self.iterate_results(url, filters=filters)
 
     def get_ovdc(self, ovdc_id):

--- a/container_service_extension/def_/ovdc_service.py
+++ b/container_service_extension/def_/ovdc_service.py
@@ -114,7 +114,7 @@ def get_ovdc(operation_context: ctx.OperationContext, ovdc_id: str) -> dict:
     return result
 
 
-def _filter_ovdc_list(sysadmin_client: vcd_client.Client, ovdc_list: list):
+def _get_cse_ovdc_list(sysadmin_client: vcd_client.Client, ovdc_list: list):
     ovdcs = []
     for ovdc in ovdc_list:
         ovdc_name = ovdc.get('name')
@@ -149,8 +149,8 @@ def list_ovdc(operation_context: ctx.OperationContext) -> list:
                                                  cse_params={})
     # send un-paginated response
     org_vdcs = vcd_utils.get_all_ovdcs(operation_context.client)
-    return _filter_ovdc_list(operation_context.sysadmin_client,
-                             org_vdcs)
+    return _get_cse_ovdc_list(operation_context.sysadmin_client,
+                              org_vdcs)
 
 
 def list_org_vdcs(operation_context: ctx.OperationContext,
@@ -173,8 +173,8 @@ def list_org_vdcs(operation_context: ctx.OperationContext,
         operation_context.cloudapi_client,
         page_number=page_number, page_size=page_size)
     num_results = result[PaginationKey.RESULT_TOTAL]
-    ovdcs = _filter_ovdc_list(operation_context.sysadmin_client,
-                              result[PaginationKey.VALUES])
+    ovdcs = _get_cse_ovdc_list(operation_context.sysadmin_client,
+                               result[PaginationKey.VALUES])
     return {
         PaginationKey.RESULT_TOTAL: num_results,
         PaginationKey.VALUES: ovdcs}

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -17,7 +17,7 @@ import container_service_extension.request_handlers.request_utils as req_utils
 from container_service_extension.server_constants import CseOperation as CseServerOperationInfo  # noqa: E501
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProvider
-from container_service_extension.server_constants import OvdInfoKey
+from container_service_extension.server_constants import OvdcInfoKey
 from container_service_extension.shared_constants import ComputePolicyAction
 from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
 from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
@@ -101,8 +101,8 @@ def ovdc_info(request_data, op_ctx: ctx.OperationContext):
         ovdc_id=request_data[RequestKey.OVDC_ID])
 
 
-def _filter_ovdc_list(sysadmin_client: vcd_client.Client,
-                      org_vdcs: list) -> list:
+def _get_cse_ovdc_list(sysadmin_client: vcd_client.Client,
+                       org_vdcs: list) -> list:
     ovdcs = []
     for ovdc in org_vdcs:
         ovdc_name = ovdc.get('name')
@@ -115,9 +115,9 @@ def _filter_ovdc_list(sysadmin_client: vcd_client.Client,
             org_name=org_name)
         k8s_provider = k8s_metadata[K8S_PROVIDER_KEY]
         ovdc_dict = {
-            OvdInfoKey.OVDC_NAME: ovdc_name,
-            OvdInfoKey.ORG_NAME: org_name,
-            OvdInfoKey.K8S_PROVIDER: k8s_provider
+            OvdcInfoKey.OVDC_NAME: ovdc_name,
+            OvdcInfoKey.ORG_NAME: org_name,
+            OvdcInfoKey.K8S_PROVIDER: k8s_provider
         }
         ovdcs.append(ovdc_dict)
     return ovdcs
@@ -135,7 +135,7 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
                                cse_params=cse_params)
 
     org_vdcs = vcd_utils.get_all_ovdcs(op_ctx.client)
-    return _filter_ovdc_list(op_ctx.sysadmin_client, org_vdcs)
+    return _get_cse_ovdc_list(op_ctx.sysadmin_client, org_vdcs)
 
 
 @record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
@@ -168,7 +168,7 @@ def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
     next_page_uri = result.get(PaginationKey.NEXT_PAGE_URI)
     prev_page_uri = result.get(PaginationKey.PREV_PAGE_URI)
 
-    ovdcs = _filter_ovdc_list(op_ctx.sysadmin_client, org_vdcs)
+    ovdcs = _get_cse_ovdc_list(op_ctx.sysadmin_client, org_vdcs)
 
     api_path = CseServerOperationInfo.OVDC_LIST.api_path_format
     next_page_uri = vcd_utils.create_cse_page_uri(op_ctx.client,

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -144,7 +144,7 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
     record_user_action_details(cse_operation=CseOperation.OVDC_LIST,
                                cse_params=cse_params)
 
-    if is_paginated_response:
+    if not is_paginated_response:
         # Return only the list of OVDCs
         org_vdcs = vcd_utils.get_all_ovdcs(op_ctx.client)
         return _filter_ovdc_list(op_ctx.sysadmin_client, org_vdcs)

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -100,41 +100,15 @@ def ovdc_info(request_data, op_ctx: ctx.OperationContext):
         ovdc_id=request_data[RequestKey.OVDC_ID])
 
 
-@record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
-def ovdc_list(request_data, op_ctx: ctx.OperationContext):
-    """Request handler for ovdc list operation.
-
-    :return: List of dictionaries with org VDC k8s provider metadata.
-    """
-    defaults = {
-        PaginationKey.PAGE_NUMBER: CSE_PAGINATION_FIRST_PAGE_NUMBER,
-        PaginationKey.PAGE_SIZE: CSE_PAGINATION_DEFAULT_PAGE_SIZE
-    }
-    validated_data = {**defaults, **request_data}
-
-    page_number = int(validated_data[PaginationKey.PAGE_NUMBER])
-    page_size = int(validated_data[PaginationKey.PAGE_SIZE])
-
-    # Record telemetry data
-    cse_params = copy.deepcopy(validated_data)
-    record_user_action_details(cse_operation=CseOperation.OVDC_LIST,
-                               cse_params=cse_params)
-
+def _filter_ovdc_list(sysadmin_client: vcd_client.Client,
+                      org_vdcs: list) -> list:
     ovdcs = []
-    result = \
-        vcd_utils.get_ovdcs_by_page(op_ctx.client,
-                                    page=page_number,
-                                    page_size=page_size)
-    org_vdcs = result[PaginationKey.VALUES]
-    result_total = result[PaginationKey.RESULT_TOTAL]
-    next_page_uri = result.get(PaginationKey.NEXT_PAGE_URI)
-    prev_page_uri = result.get(PaginationKey.PREV_PAGE_URI)
     for ovdc in org_vdcs:
         ovdc_name = ovdc.get('name')
         org_name = ovdc.get('orgName')
         ovdc_id = vcd_utils.extract_id(ovdc.get('id'))
         k8s_metadata = ovdc_utils.get_ovdc_k8s_provider_metadata(
-            op_ctx.sysadmin_client,
+            sysadmin_client,
             ovdc_id=ovdc_id,
             ovdc_name=ovdc_name,
             org_name=org_name)
@@ -145,13 +119,52 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
             'k8s provider': k8s_provider
         }
         ovdcs.append(ovdc_dict)
+    return ovdcs
+
+
+@record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
+def ovdc_list(request_data, op_ctx: ctx.OperationContext):
+    """Request handler for ovdc list operation.
+
+    :return: List of dictionaries with org VDC k8s provider metadata.
+    """
+    page_number = request_data.get(PaginationKey.PAGE_NUMBER)
+    page_size = request_data.get(PaginationKey.PAGE_SIZE)
+    is_paginated_response = False
+    if page_number or page_size:
+        is_paginated_response = True
+        # Override the absent parameter if any one of the both is present
+        page_number = int(request_data.get(PaginationKey.PAGE_NUMBER,
+                                           CSE_PAGINATION_FIRST_PAGE_NUMBER))
+        page_size = int(request_data.get(PaginationKey.PAGE_SIZE,
+                                         CSE_PAGINATION_DEFAULT_PAGE_SIZE))
+
+    # Record telemetry data
+    cse_params = copy.deepcopy(request_data)
+    record_user_action_details(cse_operation=CseOperation.OVDC_LIST,
+                               cse_params=cse_params)
+
+    if is_paginated_response:
+        # Return only the list of OVDCs
+        org_vdcs = vcd_utils.get_all_ovdcs(op_ctx.client)
+        return _filter_ovdc_list(op_ctx.sysadmin_client, org_vdcs)
+
+    result = \
+        vcd_utils.get_ovdcs_by_page(op_ctx.client,
+                                    page=page_number,
+                                    page_size=page_size)
     api_path = CseServerOperationInfo.OVDC_LIST.api_path_format
+    result_total = result[PaginationKey.RESULT_TOTAL]
     next_page_uri = vcd_utils.create_cse_page_uri(op_ctx.client,
                                                   api_path,
-                                                  vcd_uri=next_page_uri)
+                                                  vcd_uri=result.get(PaginationKey.NEXT_PAGE_URI))  # noqa: E501
+
     prev_page_uri = vcd_utils.create_cse_page_uri(op_ctx.client,
                                                   api_path,
-                                                  vcd_uri=prev_page_uri)
+                                                  vcd_uri=result.get(PaginationKey.PREV_PAGE_URI))  # noqa: E501
+    ovdcs = _filter_ovdc_list(op_ctx.sysadmin_client,
+                              result[PaginationKey.VALUES])
+
     return utils.construct_paginated_response(values=ovdcs,
                                               result_total=result_total,
                                               page_number=page_number,

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -17,6 +17,7 @@ import container_service_extension.request_handlers.request_utils as req_utils
 from container_service_extension.server_constants import CseOperation as CseServerOperationInfo  # noqa: E501
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProvider
+from container_service_extension.server_constants import OvdInfoKey
 from container_service_extension.shared_constants import ComputePolicyAction
 from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
 from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
@@ -114,9 +115,9 @@ def _filter_ovdc_list(sysadmin_client: vcd_client.Client,
             org_name=org_name)
         k8s_provider = k8s_metadata[K8S_PROVIDER_KEY]
         ovdc_dict = {
-            'name': ovdc_name,
-            'org': org_name,
-            'k8s provider': k8s_provider
+            OvdInfoKey.OVDC_NAME: ovdc_name,
+            OvdInfoKey.ORG_NAME: org_name,
+            OvdInfoKey.K8S_PROVIDER: k8s_provider
         }
         ovdcs.append(ovdc_dict)
     return ovdcs
@@ -139,7 +140,7 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
 
 @record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
 def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
-    """Request handler ofr orgvdc list operation.
+    """Request handler for orgvdc list operation.
 
     This handler returns a paginated response.
     :return: Dictionary containing list of org VDC K8s provider metadata

--- a/container_service_extension/request_handlers/pks_ovdc_handler.py
+++ b/container_service_extension/request_handlers/pks_ovdc_handler.py
@@ -133,7 +133,7 @@ def ovdc_info(request_data, op_ctx: ctx.OperationContext):
 
 
 @record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
-def ovdc_list(request_data, op_ctx: ctx.OperationContext):
+def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
     """Request handler for ovdc list operation.
 
     :return: List of dictionaries with org VDC k8s provider metadata.
@@ -241,3 +241,92 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
                                               page_size=page_size,
                                               next_page_uri=next_page_uri,
                                               prev_page_uri=prev_page_uri)
+
+
+@record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
+def ovdc_list(request_data, op_ctx: ctx.OperationContext):
+    """Request handler for ovdc list operation.
+
+    :return: List of dictionaries with org VDC k8s provider metadata.
+    """
+    defaults = {
+        RequestKey.LIST_PKS_PLANS: False,
+    }
+    validated_data = {**defaults, **request_data}
+
+    list_pks_plans = utils.str_to_bool(validated_data[RequestKey.LIST_PKS_PLANS]) # noqa: E501
+
+    # Record telemetry data
+    cse_params = copy.deepcopy(validated_data)
+    cse_params[RequestKey.LIST_PKS_PLANS] = list_pks_plans
+    record_user_action_details(cse_operation=CseOperation.OVDC_LIST,
+                               cse_params=cse_params)
+
+    if list_pks_plans and not op_ctx.client.is_sysadmin():
+        raise e.UnauthorizedRequestError(
+            'Operation denied. Enterprise PKS plans visible only '
+            'to System Administrators.')
+
+    ovdcs = []
+    org_vdcs = \
+        vcd_utils.get_all_ovdcs(op_ctx.client)
+    for ovdc in org_vdcs:
+        ovdc_name = ovdc.get('name')
+        org_name = ovdc.get('orgName')
+        ovdc_id = vcd_utils.extract_id(ovdc.get('id'))
+        k8s_metadata = ovdc_utils.get_ovdc_k8s_provider_metadata(
+            op_ctx.sysadmin_client,
+            ovdc_id=ovdc_id,
+            ovdc_name=ovdc_name,
+            org_name=org_name)
+        k8s_provider = k8s_metadata[K8S_PROVIDER_KEY]
+        ovdc_dict = {
+            'name': ovdc_name,
+            'org': org_name,
+            'k8s provider': k8s_provider
+        }
+        if list_pks_plans:
+            pks_plans = ''
+            pks_server = ''
+            if k8s_provider == K8sProvider.PKS:
+                # vc name for vdc can only be found using typed query
+                qfilter = f"name=={urllib.parse.quote(ovdc_name)};" \
+                          f"orgName=={urllib.parse.quote(org_name)}"
+                q = op_ctx.client.get_typed_query(
+                    vcd_client.ResourceType.ADMIN_ORG_VDC.value,
+                    query_result_format=vcd_client.QueryResultFormat.RECORDS, # noqa: E501
+                    qfilter=qfilter)
+                # should only ever be one element in the generator
+                ovdc_records = list(q.execute())
+                if len(ovdc_records) == 0:
+                    raise vcd_e.EntityNotFoundException(
+                        f"Org VDC {ovdc_name} not found in org {org_name}")
+                ovdc_record = None
+                for record in ovdc_records:
+                    ovdc_record = pyvcd_utils.to_dict(
+                        record, resource_type=vcd_client.ResourceType.ADMIN_ORG_VDC.value) # noqa: E501
+                    break
+
+                vc_to_pks_plans_map = {}
+                pks_contexts = pksbroker_manager.create_pks_context_for_all_accounts_in_org(op_ctx)  # noqa: E501
+
+                for pks_context in pks_contexts:
+                    if pks_context['vc'] in vc_to_pks_plans_map:
+                        continue
+                    pks_broker = pksbroker.PksBroker(pks_context,
+                                                     op_ctx)
+                    plans = pks_broker.list_plans()
+                    plan_names = [plan.get('name') for plan in plans]
+                    vc_to_pks_plans_map[pks_context['vc']] = \
+                        [plan_names, pks_context['host']]
+
+                pks_plan_and_server_info = vc_to_pks_plans_map.get(
+                    ovdc_record['vcName'], [])
+                if len(pks_plan_and_server_info) > 0:
+                    pks_plans = pks_plan_and_server_info[0]
+                    pks_server = pks_plan_and_server_info[1]
+
+            ovdc_dict['pks api server'] = pks_server
+            ovdc_dict['available pks plans'] = pks_plans
+        ovdcs.append(ovdc_dict)
+    return ovdcs

--- a/container_service_extension/request_handlers/pks_ovdc_handler.py
+++ b/container_service_extension/request_handlers/pks_ovdc_handler.py
@@ -19,6 +19,8 @@ import container_service_extension.request_handlers.request_utils as req_utils
 from container_service_extension.server_constants import CseOperation as CseServerOperationInfo  # noqa: E501
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProvider
+from container_service_extension.server_constants import OvdInfoKey
+from container_service_extension.server_constants import PKSOvdcInfoKey
 from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
 from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
 from container_service_extension.shared_constants import PaginationKey
@@ -180,9 +182,9 @@ def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
             org_name=org_name)
         k8s_provider = k8s_metadata[K8S_PROVIDER_KEY]
         ovdc_dict = {
-            'name': ovdc_name,
-            'org': org_name,
-            'k8s provider': k8s_provider
+            OvdInfoKey.OVDC_NAME: ovdc_name,
+            OvdInfoKey.ORG_NAME: org_name,
+            OvdInfoKey.K8S_PROVIDER: k8s_provider
         }
         if list_pks_plans:
             pks_plans = ''
@@ -225,8 +227,8 @@ def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
                     pks_plans = pks_plan_and_server_info[0]
                     pks_server = pks_plan_and_server_info[1]
 
-            ovdc_dict['pks api server'] = pks_server
-            ovdc_dict['available pks plans'] = pks_plans
+            ovdc_dict[PKSOvdcInfoKey.PKS_API_SERVER] = pks_server
+            ovdc_dict[PKSOvdcInfoKey.AVAILABLE_PKS_PLANS] = pks_plans
         ovdcs.append(ovdc_dict)
     api_path = CseServerOperationInfo.PKS_OVDC_LIST.api_path_format
     next_page_uri = vcd_utils.create_cse_page_uri(op_ctx.client,
@@ -281,9 +283,9 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
             org_name=org_name)
         k8s_provider = k8s_metadata[K8S_PROVIDER_KEY]
         ovdc_dict = {
-            'name': ovdc_name,
-            'org': org_name,
-            'k8s provider': k8s_provider
+            OvdInfoKey.OVDC_NAME: ovdc_name,
+            OvdInfoKey.ORG_NAME: org_name,
+            OvdInfoKey.K8S_PROVIDER: k8s_provider
         }
         if list_pks_plans:
             pks_plans = ''
@@ -326,7 +328,7 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
                     pks_plans = pks_plan_and_server_info[0]
                     pks_server = pks_plan_and_server_info[1]
 
-            ovdc_dict['pks api server'] = pks_server
-            ovdc_dict['available pks plans'] = pks_plans
+            ovdc_dict[PKSOvdcInfoKey.PKS_API_SERVER] = pks_server
+            ovdc_dict[PKSOvdcInfoKey.AVAILABLE_PKS_PLANS] = pks_plans
         ovdcs.append(ovdc_dict)
     return ovdcs

--- a/container_service_extension/request_handlers/pks_ovdc_handler.py
+++ b/container_service_extension/request_handlers/pks_ovdc_handler.py
@@ -19,7 +19,7 @@ import container_service_extension.request_handlers.request_utils as req_utils
 from container_service_extension.server_constants import CseOperation as CseServerOperationInfo  # noqa: E501
 from container_service_extension.server_constants import K8S_PROVIDER_KEY
 from container_service_extension.server_constants import K8sProvider
-from container_service_extension.server_constants import OvdInfoKey
+from container_service_extension.server_constants import OvdcInfoKey
 from container_service_extension.server_constants import PKSOvdcInfoKey
 from container_service_extension.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
 from container_service_extension.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
@@ -182,9 +182,9 @@ def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
             org_name=org_name)
         k8s_provider = k8s_metadata[K8S_PROVIDER_KEY]
         ovdc_dict = {
-            OvdInfoKey.OVDC_NAME: ovdc_name,
-            OvdInfoKey.ORG_NAME: org_name,
-            OvdInfoKey.K8S_PROVIDER: k8s_provider
+            OvdcInfoKey.OVDC_NAME: ovdc_name,
+            OvdcInfoKey.ORG_NAME: org_name,
+            OvdcInfoKey.K8S_PROVIDER: k8s_provider
         }
         if list_pks_plans:
             pks_plans = ''
@@ -283,9 +283,9 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
             org_name=org_name)
         k8s_provider = k8s_metadata[K8S_PROVIDER_KEY]
         ovdc_dict = {
-            OvdInfoKey.OVDC_NAME: ovdc_name,
-            OvdInfoKey.ORG_NAME: org_name,
-            OvdInfoKey.K8S_PROVIDER: k8s_provider
+            OvdcInfoKey.OVDC_NAME: ovdc_name,
+            OvdcInfoKey.ORG_NAME: org_name,
+            OvdcInfoKey.K8S_PROVIDER: k8s_provider
         }
         if list_pks_plans:
             pks_plans = ''

--- a/container_service_extension/request_handlers/v35/ovdc_handler.py
+++ b/container_service_extension/request_handlers/v35/ovdc_handler.py
@@ -52,13 +52,22 @@ def ovdc_list(data, operation_context: ctx.OperationContext):
 
     :return: List of dictionaries with org VDC k8s runtimes.
     """
-    page_number = int(data.get(RequestKey.V35_QUERY, {}).get(PaginationKey.PAGE_NUMBER,  # noqa: E501
-                                                             CSE_PAGINATION_FIRST_PAGE_NUMBER))  # noqa: E501
-    page_size = int(data.get(RequestKey.V35_QUERY, {}).get(PaginationKey.PAGE_SIZE,  # noqa: E501
-                                                           CSE_PAGINATION_DEFAULT_PAGE_SIZE))  # noqa: E501
+    query_params = data.get(RequestKey.V35_QUERY, {})
+    page_number = query_params.get(PaginationKey.PAGE_NUMBER)
+    page_size = query_params.get(PaginationKey.PAGE_SIZE)
+    if page_number or page_size:
+        # Override page_number or page_size if any one of them is
+        # not present
+        page_number = int(query_params.get(PaginationKey.PAGE_NUMBER,  # noqa: E501
+                                           CSE_PAGINATION_FIRST_PAGE_NUMBER))  # noqa: E501
+        page_size = int(query_params.get(PaginationKey.PAGE_SIZE,  # noqa: E501
+                                         CSE_PAGINATION_DEFAULT_PAGE_SIZE))  # noqa: E501
     result = ovdc_service.list_ovdc(operation_context,
                                     page_number=page_number,
                                     page_size=page_size)
+    if not page_number:
+        return result
+
     api_path = CseServerOperationInfo.V35_OVDC_LIST.api_path_format
     base_uri = f"{operation_context.client.get_api_uri().strip('/')}{api_path}"
     return utils.create_links_and_construct_paginated_result(

--- a/container_service_extension/request_handlers/v35/ovdc_handler.py
+++ b/container_service_extension/request_handlers/v35/ovdc_handler.py
@@ -52,22 +52,26 @@ def ovdc_list(data, operation_context: ctx.OperationContext):
 
     :return: List of dictionaries with org VDC k8s runtimes.
     """
-    query_params = data.get(RequestKey.V35_QUERY, {})
-    page_number = query_params.get(PaginationKey.PAGE_NUMBER)
-    page_size = query_params.get(PaginationKey.PAGE_SIZE)
-    if page_number or page_size:
-        # Override page_number or page_size if any one of them is
-        # not present
-        page_number = int(query_params.get(PaginationKey.PAGE_NUMBER,  # noqa: E501
-                                           CSE_PAGINATION_FIRST_PAGE_NUMBER))  # noqa: E501
-        page_size = int(query_params.get(PaginationKey.PAGE_SIZE,  # noqa: E501
-                                         CSE_PAGINATION_DEFAULT_PAGE_SIZE))  # noqa: E501
-    result = ovdc_service.list_ovdc(operation_context,
-                                    page_number=page_number,
-                                    page_size=page_size)
-    if not page_number:
-        return result
+    return ovdc_service.list_ovdc(operation_context)
 
+
+@record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
+@request_utils.v35_api_exception_handler
+def org_vdc_list(data, operation_context: ctx.OperationContext):
+    """Request handler for org vdc list operation.
+
+    This handler returns a paginated response.
+    :return: Dictionary containing paginated response with Org VDC runtime info
+    :rtype: dict
+    """
+    query_params = data.get(RequestKey.V35_QUERY, {})
+    page_number = int(query_params.get(PaginationKey.PAGE_NUMBER,
+                                       CSE_PAGINATION_FIRST_PAGE_NUMBER))
+    page_size = int(query_params.get(PaginationKey.PAGE_SIZE,
+                                     CSE_PAGINATION_DEFAULT_PAGE_SIZE))
+    result = ovdc_service.list_org_vdcs(operation_context,
+                                        page_number=page_number,
+                                        page_size=page_size)
     api_path = CseServerOperationInfo.V35_OVDC_LIST.api_path_format
     base_uri = f"{operation_context.client.get_api_uri().strip('/')}{api_path}"
     return utils.create_links_and_construct_paginated_result(

--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -46,6 +46,7 @@ DELETE /cse/nodes
 GET /cse/node/{node name}?cluster_name={cluster name}&org={org name}&vdc={vdc name}
 
 GET /cse/ovdcs
+GET /cse/orgvdcs
 GET /cse/ovdc/{ovdc id}
 PUT /cse/ovdc/{ovdc id}
 GET /cse/ovdc/{ovdc_id}/compute-policies
@@ -66,7 +67,9 @@ GET /cse/3.0/cluster/{cluster id}/upgrade-plan
 POST /cse/3.0/cluster/{cluster id}/action/upgrade
 DELETE /cse/3.0/cluster/{cluster id}/nfs/{node-name}
 
-GET /cse/3.0/ovdcs
+GET /cse/3.0/ovdcs  (for response which is not paginated.
+                     This will be deprecated soon)
+GET /cse/3.0/orgvdcs  (for paginated response)
 GET /cse/3.0/ovdc/{ovdc_id}
 PUT /cse/3.0/ovdc/{ovdc_id}
 
@@ -84,7 +87,8 @@ GET /pks/cluster/{cluster name}?org={org name}&vdc={vdc name}
 PUT /pks/cluster/{cluster name}?org={org name}&vdc={vdc name}
 DELETE /pks/cluster/{cluster name}?org={org name}&vdc={vdc name}
 GET /pks/cluster/{cluster name}/config?org={org name}&vdc={vdc name}
-GET /pks/ovdcs
+GET /pks/ovdcs  (This endpoint returns non paginated response)
+GET /pks/orgvdcs  (This endpoint returns paginated response)
 GET /pks/ovdc/{ovdc_id}
 PUT /pks/ovdc/{ovdc_id}
 """  # noqa: E501
@@ -115,12 +119,14 @@ OPERATION_TO_HANDLER = {
     CseOperation.V35_NODE_INFO: v35_cluster_handler.node_info,
 
     CseOperation.V35_OVDC_LIST: v35_ovdc_handler.ovdc_list,
+    CseOperation.V35_ORG_VDC_LIST: v35_ovdc_handler.org_vdc_list,
     CseOperation.V35_OVDC_INFO: v35_ovdc_handler.ovdc_info,
     CseOperation.V35_OVDC_UPDATE: v35_ovdc_handler.ovdc_update,
 
     CseOperation.OVDC_UPDATE: ovdc_handler.ovdc_update,
     CseOperation.OVDC_INFO: ovdc_handler.ovdc_info,
     CseOperation.OVDC_LIST: ovdc_handler.ovdc_list,
+    CseOperation.ORG_VDC_LIST: ovdc_handler.org_vdc_list,
     CseOperation.OVDC_COMPUTE_POLICY_LIST: ovdc_handler.ovdc_compute_policy_list,  # noqa: E501
     CseOperation.OVDC_COMPUTE_POLICY_UPDATE: ovdc_handler.ovdc_compute_policy_update,  # noqa: E501
     CseOperation.SYSTEM_INFO: system_handler.system_info,
@@ -134,6 +140,7 @@ OPERATION_TO_HANDLER = {
     CseOperation.PKS_CLUSTER_LIST: pks_cluster_handler.cluster_list,
     CseOperation.PKS_CLUSTER_RESIZE: pks_cluster_handler.cluster_resize,
     CseOperation.PKS_OVDC_LIST: pks_ovdc_handler.ovdc_list,
+    CseOperation.PKS_ORG_VDC_LIST: pks_ovdc_handler.org_vdc_list,
     CseOperation.PKS_OVDC_INFO: pks_ovdc_handler.ovdc_info,
     CseOperation.PKS_OVDC_UPDATE: pks_ovdc_handler.ovdc_update
 }
@@ -433,7 +440,11 @@ def _get_pks_url_data(method: str, url: str):
                     shared_constants.RequestKey.OVDC_ID: tokens[4]
                 }
             raise cse_exception.MethodNotAllowedRequestError()
-
+    elif operation_type == shared_constants.OperationType.ORG_VDCS:
+        if num_tokens == 4:
+            if method == shared_constants.RequestMethod.GET:
+                return {_OPERATION_KEY: CseOperation.PKS_ORG_VDC_LIST}
+            raise cse_exception.MethodNotAllowedRequestError()
     raise cse_exception.NotFoundRequestError()
 
 
@@ -465,6 +476,9 @@ def _get_v35_url_data(method: str, url: str, api_version: str):
 
     if operation_type == shared_constants.OperationType.OVDC:
         return _get_v35_ovdc_url_data(method, tokens)
+
+    if operation_type == shared_constants.OperationType.ORG_VDCS:
+        return _get_v35_org_vdc_url_data(method, tokens)
 
     raise cse_exception.NotFoundRequestError()
 
@@ -560,6 +574,24 @@ def _get_v35_ovdc_url_data(method: str, tokens: list):
                 shared_constants.RequestKey.OVDC_ID: tokens[5]
             }
         raise cse_exception.MethodNotAllowedRequestError()
+
+
+def _get_v35_org_vdc_url_data(method: str, tokens: list):
+    """Parse tokens from url and http method to get v35 ovdc specific data.
+
+    Returns a dictionary with operation and url data.
+
+    :param shared_constants.RequestMethod method: http verb
+    :param str[] tokens: http url
+
+    :rtype: dict
+    """
+    num_tokens = len(tokens)
+    if num_tokens == 5:
+        if method == shared_constants.RequestMethod.GET:
+            return {_OPERATION_KEY: CseOperation.V35_ORG_VDC_LIST}
+        raise cse_exception.MethodNotAllowedRequestError()
+    raise cse_exception.NotFoundRequestError()
 
 
 def _get_legacy_url_data(method: str, url: str, api_version: str):
@@ -670,6 +702,14 @@ def _get_legacy_url_data(method: str, url: str, api_version: str):
                     shared_constants.RequestKey.OVDC_ID: tokens[4]
                 }
             raise cse_exception.MethodNotAllowedRequestError()
+    elif operation_type == shared_constants.OperationType.ORG_VDCS:
+        if api_version not in (VcdApiVersion.VERSION_33.value,
+                               VcdApiVersion.VERSION_34.value):
+            raise cse_exception.NotFoundRequestError()
+        if num_tokens == 4:
+            if method == shared_constants.RequestMethod.GET:
+                return {_OPERATION_KEY: CseOperation.ORG_VDC_LIST}
+            raise cse_exception.NotFoundRequestError()
     elif operation_type == shared_constants.OperationType.SYSTEM:
         if num_tokens == 4:
             if method == shared_constants.RequestMethod.GET:

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -432,7 +432,7 @@ CSE_SERVICE_ROLE_RIGHTS = [
 
 
 @unique
-class OvdInfoKey(str, Enum):
+class OvdcInfoKey(str, Enum):
     OVDC_NAME = 'name'
     ORG_NAME = 'org'
     K8S_PROVIDER = 'k8s provider'

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -429,3 +429,16 @@ CSE_SERVICE_ROLE_RIGHTS = [
     "vmware:tkgcluster: Modify",
     "vmware:tkgcluster: View"
 ]
+
+
+@unique
+class OvdInfoKey(str, Enum):
+    OVDC_NAME = 'name'
+    ORG_NAME = 'org'
+    K8S_PROVIDER = 'k8s provider'
+
+
+@unique
+class PKSOvdcInfoKey(str, Enum):
+    PKS_API_SERVER = 'pks api server'
+    AVAILABLE_PKS_PLANS = 'available pks plans'

--- a/container_service_extension/server_constants.py
+++ b/container_service_extension/server_constants.py
@@ -222,6 +222,7 @@ class CseOperation(Enum):
     OVDC_UPDATE = ('enable or disable ovdc for k8s', '/cse/ovdc/%s', requests.codes.accepted)  # noqa: E501
     OVDC_INFO = ('get info of ovdc', '/cse/ovdc/%s')
     OVDC_LIST = ('list ovdcs', '/cse/ovdcs')
+    ORG_VDC_LIST = ('list org VDCs', '/cse/orgvdcs')
     OVDC_COMPUTE_POLICY_LIST = ('list ovdc compute policies', '/cse/ovdc/%s/compute-policies')  # noqa: E501
     OVDC_COMPUTE_POLICY_UPDATE = ('update ovdc compute policies', '/cse/ovdc/%s/compute-policies')  # noqa: E501
     SYSTEM_INFO = ('get info of system', '/cse/system')
@@ -229,6 +230,7 @@ class CseOperation(Enum):
     TEMPLATE_LIST = ('list all templates', '/cse/templates')
 
     V35_OVDC_LIST = ('list ovdcs for v35', '/cse/3.0/ovdcs')
+    V35_ORG_VDC_LIST = ('list org VDCs', '/cse/3.0/orgvdcs')
     V35_OVDC_INFO = ('get info of ovdc for v35', '/cse/3.0/ovdc/%s')
     V35_OVDC_UPDATE = ('enable or disable ovdc for a cluster kind for v35', '/cse/3.0/ovdc/%s', requests.codes.accepted)  # noqa: E501
     V35_TEMPLATE_LIST = ('list all v35 templates', '/cse/templates')
@@ -240,6 +242,7 @@ class CseOperation(Enum):
     PKS_CLUSTER_LIST = ('list PKS clusters', '/pks/clusters')
     PKS_CLUSTER_RESIZE = ('resize PKS cluster', '/pks/cluster/%s', requests.codes.accepted)  # noqa: E501
     PKS_OVDC_LIST = ('list all ovdcs', '/pks/ovdcs')
+    PKS_ORG_VDC_LIST = ('list  org VDCs', '/pks/orgvdcs')
     PKS_OVDC_INFO = ('get info of the ovdc', '/pks/ovdc/%s')
     PKS_OVDC_UPDATE = ('enable or disable ovdc for pks', '/pks/ovdc/%s', requests.codes.accepted)  # noqa: E501
 

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -58,6 +58,7 @@ class OperationType(str, Enum):
     OVDC = 'ovdc'
     SYSTEM = 'system'
     TEMPLATE = 'template'
+    ORG_VDCS = 'orgvdc'
 
 
 @unique


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

As paginated response cannot be read by older version of the clients, revert to non-paginated responses for the following api endpoints
- `/api/cse/ovdcs`
- `/api/cse/3.0/ovdcs`
- `/api/pks/ovdcs`

Create following new endpoints which return paginated responses
- `/api/cse/orgvdcs`
- `/api/cse/3.0/orgvdcs`
- `/api/pks/orgvdcs`

Make sure the older CSE CLI clients (3.0.x) are compatible with the responses

Testing done:
* Check if `/api/cse/ovdcs`, `/api/cse/3.0/ovdcs` and `/api/pks/ovdcs` return non-paginated responses
* Check if `/api/cse/orgvdcs`, `/api/cse/3.0/orgvdcs` and `/api/pks/orgvdcs` return paginated responses and can read pagination parameters properly
* Check if CLI client is compatible with the CSE server
* Check if older CLI client is compatible with CSE server

@rocknes @sahithi @sakthisunda @arunmk @ChintanShahVMware @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/871)
<!-- Reviewable:end -->
