### PR TITLE
Fix TKG cluster list operation when CLI is enabled only for TKG

### DIFF
--- a/container_service_extension/client/tkgclient/api/tkg_cluster_api.py
+++ b/container_service_extension/client/tkgclient/api/tkg_cluster_api.py
@@ -57,9 +57,8 @@ class TkgClusterApi(object):
                 "Missing the required parameter `entity_type` when calling `list_tkg_clusters`")
         path_params = {}
         query_params = []
-        if params.get('query_params'):
-            for k, v in params.get('query_params', {}).items():
-                query_params.append((k, v))
+        for k, v in params.get('query_params', {}).items():
+            query_params.append((k, v))
         if params.get('object_filter'):
             query_params.append(('filter', params['object_filter']))
         header_params = {}

--- a/container_service_extension/client/tkgclient/api/tkg_cluster_api.py
+++ b/container_service_extension/client/tkgclient/api/tkg_cluster_api.py
@@ -40,6 +40,7 @@ class TkgClusterApi(object):
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
         all_params.append('object_filter')
+        all_params.append('query_params')
 
         params = locals()
         for key, val in six.iteritems(params['kwargs']):
@@ -56,6 +57,9 @@ class TkgClusterApi(object):
                 "Missing the required parameter `entity_type` when calling `list_tkg_clusters`")
         path_params = {}
         query_params = []
+        if params.get('query_params'):
+            for k, v in params.get('query_params', {}).items():
+                query_params.append((k, v))
         if params.get('object_filter'):
             query_params.append(('filter', params['object_filter']))
         header_params = {}

--- a/container_service_extension/client/tkgclient/api_client.py
+++ b/container_service_extension/client/tkgclient/api_client.py
@@ -155,7 +155,7 @@ class ApiClient(object):
         self.last_response = response_data
 
         return_data = response_data
-        additional_data = None
+        additional_data = {}
         if _preload_content:
             # deserialize response data
             if response_type:
@@ -241,13 +241,23 @@ class ApiClient(object):
             data = data['entity']
             del additional_data['entity']
         elif response_type == 'list[TkgCluster]' and method == 'GET':
+            response_data = data.copy()
             def_entities = data['values']
+            entity_details = []
             additional_data = []
             data = []
             for def_entity in def_entities:
                 data.append(def_entity['entity'])
                 del def_entity['entity']
                 additional_data.append(def_entity)
+                entity_details.append(def_entity)
+            additional_data = {
+                'page': int(response_data['page']),
+                'pageSize': int(response_data['pageSize']),
+                'resultTotal': int(response_data['resultTotal']),
+                'pageCount': int(response_data['pageCount']),
+                'entityDetails': entity_details
+            }
         return self.__deserialize(data, response_type), additional_data
 
     def __deserialize(self, data, klass):


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Currently, cluster list operation will fail because TKG client pagination changes were removed.

This PR Adds back the TKG client changes

The changes in TKG client for pagination are still needed if CSE server is not running (CLI will be enabled only for TKG clusters)

Testing done:
* `vcd cse cluster list` when CLI is enabled only for TKG clusters

@sahithi @sakthisunda @rocknes @ltimothy7 @ChintanShahVMware @arunmk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/872)
<!-- Reviewable:end -->
