### PR TITLE
Api path format fix for ovdc list operation

### DIFF
--- a/container_service_extension/client/cse_client/api_35/ovdc_api.py
+++ b/container_service_extension/client/cse_client/api_35/ovdc_api.py
@@ -21,7 +21,7 @@ class OvdcApi(CseClient):
         self._ovdc_uri = f"{self._uri}/ovdc"
         # NOTE: The request page size is overrided because the CSE server takes
         # an average of 10 seconds (Default vCD timeout) if there are 5 OVDCs
-        self._request_page_size = 5
+        self._request_page_size = 3
 
     def get_all_ovdcs(self):
         """Iterate over all the get ovdc response page by page.

--- a/container_service_extension/request_handlers/ovdc_handler.py
+++ b/container_service_extension/request_handlers/ovdc_handler.py
@@ -170,7 +170,7 @@ def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
 
     ovdcs = _get_cse_ovdc_list(op_ctx.sysadmin_client, org_vdcs)
 
-    api_path = CseServerOperationInfo.OVDC_LIST.api_path_format
+    api_path = CseServerOperationInfo.ORG_VDC_LIST.api_path_format
     next_page_uri = vcd_utils.create_cse_page_uri(op_ctx.client,
                                                   api_path,
                                                   vcd_uri=next_page_uri)

--- a/container_service_extension/request_handlers/pks_ovdc_handler.py
+++ b/container_service_extension/request_handlers/pks_ovdc_handler.py
@@ -230,7 +230,7 @@ def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
             ovdc_dict[PKSOvdcInfoKey.PKS_API_SERVER] = pks_server
             ovdc_dict[PKSOvdcInfoKey.AVAILABLE_PKS_PLANS] = pks_plans
         ovdcs.append(ovdc_dict)
-    api_path = CseServerOperationInfo.PKS_OVDC_LIST.api_path_format
+    api_path = CseServerOperationInfo.PKS_ORG_VDC_LIST.api_path_format
     next_page_uri = vcd_utils.create_cse_page_uri(op_ctx.client,
                                                   api_path,
                                                   vcd_uri=next_page_uri)

--- a/container_service_extension/request_handlers/v35/ovdc_handler.py
+++ b/container_service_extension/request_handlers/v35/ovdc_handler.py
@@ -72,7 +72,7 @@ def org_vdc_list(data, operation_context: ctx.OperationContext):
     result = ovdc_service.list_org_vdcs(operation_context,
                                         page_number=page_number,
                                         page_size=page_size)
-    api_path = CseServerOperationInfo.V35_OVDC_LIST.api_path_format
+    api_path = CseServerOperationInfo.V35_ORG_VDC_LIST.api_path_format
     base_uri = f"{operation_context.client.get_api_uri().strip('/')}{api_path}"
     return utils.create_links_and_construct_paginated_result(
         base_uri,


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

This PR fixes the API path returned in the responses (next and previous page urls) to have the new endpoints.
Testing done:
* OVDC list using CLI with OVDC count more than the page size
* OVDC list using postman (for version 33.0) to verify if previous and next page urls contain proper urls

![Screen Shot 2021-01-15 at 4 28 34 PM](https://user-images.githubusercontent.com/16699642/104791224-d060c300-574e-11eb-9ba3-042f070fc9cf.png)
![Screen Shot 2021-01-15 at 4 28 53 PM](https://user-images.githubusercontent.com/16699642/104791227-d22a8680-574e-11eb-8595-2ce2730c3b95.png)

@rocknes @ltimothy7 @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/876)
<!-- Reviewable:end -->
