### PR TITLE
mqtt maintains only one token- main branch

### DIFF
--- a/container_service_extension/mqtt_extension_manager.py
+++ b/container_service_extension/mqtt_extension_manager.py
@@ -128,7 +128,6 @@ class MQTTExtensionManager:
                          priority=constants.MQTT_EXTENSION_PRIORITY,
                          ext_enabled=True, auth_enabled=False,
                          description=''):
-        # TODO: check if authorization should be enabled as default
         """Create the MQTT extension.
 
         Note: vendor-name-version combination must be unique
@@ -331,9 +330,9 @@ class MQTTExtensionManager:
         :rtype: dict with fields: token and token_id
         """
         self.delete_all_extension_tokens(ext_name, ext_version, ext_vendor)
-        return self.create_extension_token(token_name, ext_urn_id)
+        return self._create_extension_token(token_name, ext_urn_id)
 
-    def create_extension_token(self, token_name, ext_urn_id):
+    def _create_extension_token(self, token_name, ext_urn_id):
         """Create a long live token.
 
         Note: the token can only be retrieved upon creation. Following GET

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -309,8 +309,11 @@ class Service(object, metaclass=Singleton):
                     logger.SERVER_LOGGER.error(msg)
                     raise cse_exception.MQTTExtensionError(msg)
 
-                token_info = mqtt_ext_manager.create_extension_token(
+                token_info = mqtt_ext_manager.setup_extension_token(
                     token_name=server_constants.MQTT_TOKEN_NAME,
+                    ext_name=server_constants.CSE_SERVICE_NAME,
+                    ext_version=server_constants.MQTT_EXTENSION_VERSION,
+                    ext_vendor=server_constants.MQTT_EXTENSION_VENDOR,
                     ext_urn_id=ext_urn_id)
 
                 self.config['mqtt'].update(ext_info)


### PR DESCRIPTION
Signed-off-by: ltimothy <ltimothy@vmware.com>

To help us process your pull request efficiently, please include: 

- (Required) Short description of changes in the PR topic line
Updated service.py so that only one MQTT extension token is active at a time. Previously, there was a bug where an incorrect function was called, so a token was created each time `cse run` was called.

- (Required) Detailed description of changes include tests and
  documentation.  If the pull request contains multiple commits with 
  detailed messages, refer to those instead
I have tested that now at most one extension token is active.

- (Optional) Names of reviewers using @ sign + name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/880)
<!-- Reviewable:end -->
