### PR TITLE
[VCDA-2061] Determine common api versions supported by CSE and VCD

### DIFF
--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -280,6 +280,16 @@ class Service(object, metaclass=Singleton):
         sysadmin_client = None
         try:
             sysadmin_client = vcd_utils.get_sys_admin_client()
+
+            vcd_supported_versions = \
+                set(sysadmin_client.get_supported_versions_list())
+            cse_supported_versions = \
+                set(server_constants.SUPPORTED_VCD_API_VERSIONS)
+            common_supported_versions = \
+                list(cse_supported_versions.intersection(vcd_supported_versions))  # noqa: E501
+            self.config['vcd']['supported_api_versions'] = \
+                common_supported_versions
+
             verify_version_compatibility(sysadmin_client,
                                          self.config['vcd']['api_version'],
                                          utils.should_use_mqtt_protocol(self.config))  # noqa: E501

--- a/container_service_extension/service.py
+++ b/container_service_extension/service.py
@@ -287,7 +287,7 @@ class Service(object, metaclass=Singleton):
                 set(server_constants.SUPPORTED_VCD_API_VERSIONS)
             common_supported_versions = \
                 list(cse_supported_versions.intersection(vcd_supported_versions))  # noqa: E501
-            self.config['vcd']['supported_api_versions'] = \
+            self.config['service']['supported_api_versions'] = \
                 common_supported_versions
 
             verify_version_compatibility(sysadmin_client,


### PR DESCRIPTION
Added logic during server startup to determine the list of api versions supported by both CSE and vCD.

Testing Done:
Added a print statement during server startup to print the runtime server config that holds the api versions supported by both vCD and CSE.

{
  'enforce_authorization': True,
  'processors': 10,
   'log_wire': True,
   'telemetry': {
     'enable': True, 
     'vac_url': 'https://vcsa.vmware.com/ph/api/hyper/send', 
     'collector_id': 'CSE.3_0',
     'vcd_ceip_id': 'f89fd574-8f62-4b85-a2ac-329a2faf85b5',
      'instance_id': 'bccae9c2-ee9c-4e35-8cfc-6a2ae346544f'
  }, 
  'supported_api_versions': ['33.0', '35.0', '34.0']
}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/895)
<!-- Reviewable:end -->
