### PR TITLE
Port Fix ovdc list operation to support backward compatibility (#871) to master

### DIFF
--- a/container_service_extension/client/cse_client/api_33/ovdc_api.py
+++ b/container_service_extension/client/cse_client/api_33/ovdc_api.py
@@ -13,11 +13,12 @@ class OvdcApi(CseClient):
     def __init__(self, client: vcd_client.Client):
         super().__init__(client)
         self._uri = f"{self._uri}/{shared_constants.CSE_URL_FRAGMENT}"
-        self._ovdcs_uri = f"{self._uri}/ovdcs"
+        self._org_vdcs_uri = f"{self._uri}/orgvdcs"
         self._ovdc_uri = f"{self._uri}/ovdc"
 
     def get_all_ovdcs(self):
-        url = f"{self._ovdcs_uri}?pageSize={self._request_page_size}"
+        url = f"{self._org_vdcs_uri}?" \
+              f"{shared_constants.PaginationKey.PAGE_SIZE.value}={self._request_page_size}"  # noqa: E501
         return self.iterate_results(url)
 
     def get_ovdc(self, ovdc_id):

--- a/container_service_extension/client/cse_client/api_35/ovdc_api.py
+++ b/container_service_extension/client/cse_client/api_35/ovdc_api.py
@@ -21,7 +21,7 @@ class OvdcApi(CseClient):
         self._ovdc_uri = f"{self._uri}/ovdc"
         # NOTE: The request page size is overrided because the CSE server takes
         # an average of 10 seconds (Default vCD timeout) if there are 5 OVDCs
-        self._request_page_size = 5
+        self._request_page_size = 3
 
     def get_all_ovdcs(self):
         """Iterate over all the get ovdc response page by page.

--- a/container_service_extension/client/cse_client/api_35/ovdc_api.py
+++ b/container_service_extension/client/cse_client/api_35/ovdc_api.py
@@ -17,7 +17,7 @@ class OvdcApi(CseClient):
         super().__init__(client)
         self._uri = f"{self._uri}/{ shared_constants.CSE_URL_FRAGMENT}/" \
                     f"{shared_constants.CSE_3_0_URL_FRAGMENT}"
-        self._ovdcs_uri = f"{self._uri}/ovdcs"
+        self._org_vdcs_uri = f"{self._uri}/orgvdcs"
         self._ovdc_uri = f"{self._uri}/ovdc"
         # NOTE: The request page size is overrided because the CSE server takes
         # an average of 10 seconds (Default vCD timeout) if there are 5 OVDCs
@@ -30,7 +30,8 @@ class OvdcApi(CseClient):
             indicating if there are more results.
         :rtype: Generator[(List[dict], int), None, None]
         """
-        url = f"{self._ovdcs_uri}?pageSize={self._request_page_size}"
+        url = f"{self._org_vdcs_uri}?" \
+              f"{shared_constants.PaginationKey.PAGE_SIZE.value}={self._request_page_size}"  # noqa: E501
         return self.iterate_results(url)
 
     def get_ovdc(self, ovdc_id):

--- a/container_service_extension/client/cse_client/pks_ovdc_api.py
+++ b/container_service_extension/client/cse_client/pks_ovdc_api.py
@@ -13,13 +13,14 @@ class PksOvdcApi(CseClient):
     def __init__(self, client: vcd_client.Client):
         super().__init__(client)
         self._uri = f"{self._uri}/{shared_constants.PKS_URL_FRAGMENT}"
-        self._ovdcs_uri = f"{self._uri}/ovdcs"
+        self._org_vdcs_uri = f"{self._uri}/orgvdcs"
         self._ovdc_uri = f"{self._uri}/ovdc"
 
     def get_all_ovdcs(self, filters=None):
         if filters is None:
             filters = {}
-        url = f"{self._ovdcs_uri}?pageSize={self._request_page_size}"
+        url = f"{self._org_vdcs_uri}?" \
+              f"{shared_constants.PaginationKey.PAGE_SIZE.value}={self._request_page_size}"  # noqa: E501
         return self.iterate_results(url, filters=filters)
 
     def get_ovdc(self, ovdc_id):

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -94,6 +94,7 @@ class OperationType(str, Enum):
     OVDC = 'ovdc'
     SYSTEM = 'system'
     TEMPLATE = 'template'
+    ORG_VDCS = 'orgvdc'
 
 
 @unique

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -284,6 +284,7 @@ class CseOperation(Enum):
     OVDC_UPDATE = ('enable or disable ovdc for k8s', '/cse/ovdc/%s', requests.codes.accepted)  # noqa: E501
     OVDC_INFO = ('get info of ovdc', '/cse/ovdc/%s')
     OVDC_LIST = ('list ovdcs', '/cse/ovdcs')
+    ORG_VDC_LIST = ('list org VDCs', '/cse/orgvdcs')
     OVDC_COMPUTE_POLICY_LIST = ('list ovdc compute policies', '/cse/ovdc/%s/compute-policies')  # noqa: E501
     OVDC_COMPUTE_POLICY_UPDATE = ('update ovdc compute policies', '/cse/ovdc/%s/compute-policies')  # noqa: E501
     SYSTEM_INFO = ('get info of system', '/cse/system')
@@ -291,6 +292,7 @@ class CseOperation(Enum):
     TEMPLATE_LIST = ('list all templates', '/cse/templates')
 
     V35_OVDC_LIST = ('list ovdcs for v35', '/cse/3.0/ovdcs')
+    V35_ORG_VDC_LIST = ('list org VDCs', '/cse/3.0/orgvdcs')
     V35_OVDC_INFO = ('get info of ovdc for v35', '/cse/3.0/ovdc/%s')
     V35_OVDC_UPDATE = ('enable or disable ovdc for a cluster kind for v35', '/cse/3.0/ovdc/%s', requests.codes.accepted)  # noqa: E501
     V35_TEMPLATE_LIST = ('list all v35 templates', '/cse/templates')
@@ -302,6 +304,7 @@ class CseOperation(Enum):
     PKS_CLUSTER_LIST = ('list PKS clusters', '/pks/clusters')
     PKS_CLUSTER_RESIZE = ('resize PKS cluster', '/pks/cluster/%s', requests.codes.accepted)  # noqa: E501
     PKS_OVDC_LIST = ('list all ovdcs', '/pks/ovdcs')
+    PKS_ORG_VDC_LIST = ('list  org VDCs', '/pks/orgvdcs')
     PKS_OVDC_INFO = ('get info of the ovdc', '/pks/ovdc/%s')
     PKS_OVDC_UPDATE = ('enable or disable ovdc for pks', '/pks/ovdc/%s', requests.codes.accepted)  # noqa: E501
 
@@ -532,3 +535,16 @@ class DefEntityPhase:
 
     def is_entity_busy(self) -> bool:
         return self.status == DefEntityOperationStatus.IN_PROGRESS
+
+
+@unique
+class OvdcInfoKey(str, Enum):
+    OVDC_NAME = 'name'
+    ORG_NAME = 'org'
+    K8S_PROVIDER = 'k8s provider'
+
+
+@unique
+class PKSOvdcInfoKey(str, Enum):
+    PKS_API_SERVER = 'pks api server'
+    AVAILABLE_PKS_PLANS = 'available pks plans'

--- a/container_service_extension/rde/ovdc_service.py
+++ b/container_service_extension/rde/ovdc_service.py
@@ -128,11 +128,15 @@ def _get_cse_ovdc_list(sysadmin_client: vcd_client.Client, ovdc_list: list):
         config = server_utils.get_server_runtime_config()
         log_wire = utils.str_to_bool(config.get('service', {}).get('log_wire'))
         ovdc_id = vcd_utils.extract_id(ovdc.get('id'))
+        # obtain ovdc runtime details for the ovdc
         ovdc_details = asdict(
             get_ovdc_k8s_runtime_details(sysadmin_client,
                                          ovdc_id=ovdc_id,
                                          ovdc_name=ovdc_name,
                                          log_wire=log_wire))
+        # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in
+        # config is set to false, Prevent showing information
+        # about TKG+ by skipping TKG+ from the result.
         if ClusterEntityKind.TKG_PLUS.value in ovdc_details['k8s_runtime'] \
                 and not server_utils.is_tkg_plus_enabled():  # noqa: E501
             ovdc_details['k8s_runtime'].remove(ClusterEntityKind.TKG_PLUS.value)  # noqa: E501
@@ -149,8 +153,10 @@ def list_ovdc(operation_context: ctx.OperationContext) -> list:
     :return: list of org vdcs
     :rtype: list
     """
-    # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
-    # Prevent showing information about TKG+ by skipping TKG+ from the result.
+    # NOTE: Response sent out by this function should not be
+    # paginated. The purpose of this handler is to maintain
+    # backward compatibility
+    # TODO: Deprecate handler once support for CSE 3.0 is removed
     # Record telemetry
     telemetry_handler.record_user_action_details(
         cse_operation=CseOperation.OVDC_LIST,
@@ -175,8 +181,8 @@ def list_org_vdcs(operation_context: ctx.OperationContext,
     :return: dictionary containing list of details about the ovdc
     :rtype: dict
     """
-    # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
-    # Prevent showing information about TKG+ by skipping TKG+ from the result.
+    # NOTE: The response sent out by this function needs to be
+    # paginated
     # Record telemetry
     telemetry_handler.record_user_action_details(
         cse_operation=CseOperation.OVDC_LIST,

--- a/container_service_extension/rde/ovdc_service.py
+++ b/container_service_extension/rde/ovdc_service.py
@@ -121,12 +121,57 @@ def get_ovdc(operation_context: ctx.OperationContext, ovdc_id: str) -> dict:
     return result
 
 
-def list_ovdc(operation_context: ctx.OperationContext,
-              page_number=CSE_PAGINATION_FIRST_PAGE_NUMBER,
-              page_size=CSE_PAGINATION_DEFAULT_PAGE_SIZE) -> dict:
+def _get_cse_ovdc_list(sysadmin_client: vcd_client.Client, ovdc_list: list):
+    ovdcs = []
+    for ovdc in ovdc_list:
+        ovdc_name = ovdc.get('name')
+        config = server_utils.get_server_runtime_config()
+        log_wire = utils.str_to_bool(config.get('service', {}).get('log_wire'))
+        ovdc_id = vcd_utils.extract_id(ovdc.get('id'))
+        ovdc_details = asdict(
+            get_ovdc_k8s_runtime_details(sysadmin_client,
+                                         ovdc_id=ovdc_id,
+                                         ovdc_name=ovdc_name,
+                                         log_wire=log_wire))
+        if ClusterEntityKind.TKG_PLUS.value in ovdc_details['k8s_runtime'] \
+                and not server_utils.is_tkg_plus_enabled():  # noqa: E501
+            ovdc_details['k8s_runtime'].remove(ClusterEntityKind.TKG_PLUS.value)  # noqa: E501
+        # TODO: Find a better way to remove remove_cp_from_vms_on_disable
+        del ovdc_details['remove_cp_from_vms_on_disable']
+        ovdcs.append(ovdc_details)
+    return ovdcs
+
+
+def list_ovdc(operation_context: ctx.OperationContext) -> list:
     """List all ovdc and their k8s runtimes.
 
     :param ctx.OperationContext operation_context: context for the request
+    :return: list of org vdcs
+    :rtype: list
+    """
+    # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
+    # Prevent showing information about TKG+ by skipping TKG+ from the result.
+    # Record telemetry
+    telemetry_handler.record_user_action_details(
+        cse_operation=CseOperation.OVDC_LIST,
+        cse_params={
+            PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
+        }
+    )
+    # send un-paginated response
+    org_vdcs = vcd_utils.get_all_ovdcs(operation_context.client)
+    return _get_cse_ovdc_list(operation_context.sysadmin_client,
+                              org_vdcs)
+
+
+def list_org_vdcs(operation_context: ctx.OperationContext,
+                  page_number=CSE_PAGINATION_FIRST_PAGE_NUMBER,
+                  page_size=CSE_PAGINATION_DEFAULT_PAGE_SIZE) -> dict:
+    """Fetch org VDCs and their k8s runtimes.
+
+    :param ctx.OperationContext operation_context: context for the request
+    :param int page_number: page_number to fetch
+    :param int page_size: size of each page to return
     :return: dictionary containing list of details about the ovdc
     :rtype: dict
     """
@@ -139,33 +184,15 @@ def list_ovdc(operation_context: ctx.OperationContext,
             PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
         }
     )
-
-    ovdcs = []
     result = cloudapi_utils.get_vdcs_by_page(
         operation_context.cloudapi_client,
         page_number=page_number, page_size=page_size)
-    org_vdcs = result[PaginationKey.VALUES]
     num_results = result[PaginationKey.RESULT_TOTAL]
-    for ovdc in org_vdcs:
-        ovdc_name = ovdc.get('name')
-        config = server_utils.get_server_runtime_config()
-        log_wire = utils.str_to_bool(config.get('service', {}).get('log_wire'))
-        ovdc_id = vcd_utils.extract_id(ovdc.get('id'))
-        ovdc_details = asdict(
-            get_ovdc_k8s_runtime_details(operation_context.sysadmin_client,
-                                         ovdc_id=ovdc_id,
-                                         ovdc_name=ovdc_name,
-                                         log_wire=log_wire))
-        if ClusterEntityKind.TKG_PLUS.value in ovdc_details['k8s_runtime'] \
-                and not server_utils.is_tkg_plus_enabled():  # noqa: E501
-            ovdc_details['k8s_runtime'].remove(ClusterEntityKind.TKG_PLUS.value)  # noqa: E501
-        # TODO: Find a better way to remove remove_cp_from_vms_on_disable
-        del ovdc_details['remove_cp_from_vms_on_disable']
-        ovdcs.append(ovdc_details)
+    ovdcs = _get_cse_ovdc_list(operation_context.sysadmin_client,
+                               result[PaginationKey.VALUES])
     return {
         PaginationKey.RESULT_TOTAL: num_results,
-        PaginationKey.VALUES: ovdcs
-    }
+        PaginationKey.VALUES: ovdcs}
 
 
 def get_ovdc_k8s_runtime_details(sysadmin_client: vcd_client.Client,

--- a/container_service_extension/server/request_handlers/ovdc_handler.py
+++ b/container_service_extension/server/request_handlers/ovdc_handler.py
@@ -178,7 +178,7 @@ def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
 
     ovdcs = _get_cse_ovdc_list(op_ctx.sysadmin_client, org_vdcs)
 
-    api_path = CseServerOperationInfo.OVDC_LIST.api_path_format
+    api_path = CseServerOperationInfo.ORG_VDC_LIST.api_path_format
     next_page_uri = vcd_utils.create_cse_page_uri(op_ctx.client,
                                                   api_path,
                                                   vcd_uri=next_page_uri)

--- a/container_service_extension/server/request_handlers/ovdc_handler.py
+++ b/container_service_extension/server/request_handlers/ovdc_handler.py
@@ -10,6 +10,7 @@ import pyvcloud.vcd.task as vcd_task
 from container_service_extension.common.constants.server_constants import CseOperation as CseServerOperationInfo  # noqa: E501
 from container_service_extension.common.constants.server_constants import K8S_PROVIDER_KEY  # noqa: E501
 from container_service_extension.common.constants.server_constants import K8sProvider  # noqa: E501
+from container_service_extension.common.constants.server_constants import OvdcInfoKey  # noqa: E501
 from container_service_extension.common.constants.server_constants import ThreadLocalData  # noqa: E501
 from container_service_extension.common.constants.shared_constants import ComputePolicyAction  # noqa: E501
 from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
@@ -107,11 +108,50 @@ def ovdc_info(request_data, op_ctx: ctx.OperationContext):
         ovdc_id=request_data[RequestKey.OVDC_ID])
 
 
+def _get_cse_ovdc_list(sysadmin_client: vcd_client.Client,
+                       org_vdcs: list) -> list:
+    ovdcs = []
+    for ovdc in org_vdcs:
+        ovdc_name = ovdc.get('name')
+        org_name = ovdc.get('orgName')
+        ovdc_id = vcd_utils.extract_id(ovdc.get('id'))
+        k8s_metadata = ovdc_utils.get_ovdc_k8s_provider_metadata(
+            sysadmin_client,
+            ovdc_id=ovdc_id,
+            ovdc_name=ovdc_name,
+            org_name=org_name)
+        k8s_provider = k8s_metadata[K8S_PROVIDER_KEY]
+        ovdc_dict = {
+            OvdcInfoKey.OVDC_NAME: ovdc_name,
+            OvdcInfoKey.ORG_NAME: org_name,
+            OvdcInfoKey.K8S_PROVIDER: k8s_provider
+        }
+        ovdcs.append(ovdc_dict)
+    return ovdcs
+
+
 @record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
 def ovdc_list(request_data, op_ctx: ctx.OperationContext):
     """Request handler for ovdc list operation.
 
     :return: List of dictionaries with org VDC k8s provider metadata.
+    """
+    # Record telemetry data
+    cse_params = copy.deepcopy(request_data)
+    record_user_action_details(cse_operation=CseOperation.OVDC_LIST,
+                               cse_params=cse_params)
+
+    org_vdcs = vcd_utils.get_all_ovdcs(op_ctx.client)
+    return _get_cse_ovdc_list(op_ctx.sysadmin_client, org_vdcs)
+
+
+@record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
+def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
+    """Request handler for orgvdc list operation.
+
+    This handler returns a paginated response.
+    :return: Dictionary containing list of org VDC K8s provider metadata
+    :rtype: dict
     """
     defaults = {
         PaginationKey.PAGE_NUMBER: CSE_PAGINATION_FIRST_PAGE_NUMBER,
@@ -127,8 +167,6 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
     cse_params[PayloadKey.SOURCE_DESCRIPTION] = thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
     record_user_action_details(cse_operation=CseOperation.OVDC_LIST,
                                cse_params=cse_params)
-
-    ovdcs = []
     result = \
         vcd_utils.get_ovdcs_by_page(op_ctx.client,
                                     page=page_number,
@@ -137,22 +175,9 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
     result_total = result[PaginationKey.RESULT_TOTAL]
     next_page_uri = result.get(PaginationKey.NEXT_PAGE_URI)
     prev_page_uri = result.get(PaginationKey.PREV_PAGE_URI)
-    for ovdc in org_vdcs:
-        ovdc_name = ovdc.get('name')
-        org_name = ovdc.get('orgName')
-        ovdc_id = vcd_utils.extract_id(ovdc.get('id'))
-        k8s_metadata = ovdc_utils.get_ovdc_k8s_provider_metadata(
-            op_ctx.sysadmin_client,
-            ovdc_id=ovdc_id,
-            ovdc_name=ovdc_name,
-            org_name=org_name)
-        k8s_provider = k8s_metadata[K8S_PROVIDER_KEY]
-        ovdc_dict = {
-            'name': ovdc_name,
-            'org': org_name,
-            'k8s provider': k8s_provider
-        }
-        ovdcs.append(ovdc_dict)
+
+    ovdcs = _get_cse_ovdc_list(op_ctx.sysadmin_client, org_vdcs)
+
     api_path = CseServerOperationInfo.OVDC_LIST.api_path_format
     next_page_uri = vcd_utils.create_cse_page_uri(op_ctx.client,
                                                   api_path,

--- a/container_service_extension/server/request_handlers/ovdc_handler.py
+++ b/container_service_extension/server/request_handlers/ovdc_handler.py
@@ -115,6 +115,8 @@ def _get_cse_ovdc_list(sysadmin_client: vcd_client.Client,
         ovdc_name = ovdc.get('name')
         org_name = ovdc.get('orgName')
         ovdc_id = vcd_utils.extract_id(ovdc.get('id'))
+        # obtain the runtimes supported stored in
+        # ovdc metadata
         k8s_metadata = ovdc_utils.get_ovdc_k8s_provider_metadata(
             sysadmin_client,
             ovdc_id=ovdc_id,
@@ -136,6 +138,8 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
 
     :return: List of dictionaries with org VDC k8s provider metadata.
     """
+    # NOTE: Response sent out by this function should not be
+    # paginated
     # Record telemetry data
     cse_params = copy.deepcopy(request_data)
     record_user_action_details(cse_operation=CseOperation.OVDC_LIST,
@@ -153,6 +157,7 @@ def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
     :return: Dictionary containing list of org VDC K8s provider metadata
     :rtype: dict
     """
+    # NOTE: Response sent out by this funciton should be paginated
     defaults = {
         PaginationKey.PAGE_NUMBER: CSE_PAGINATION_FIRST_PAGE_NUMBER,
         PaginationKey.PAGE_SIZE: CSE_PAGINATION_DEFAULT_PAGE_SIZE

--- a/container_service_extension/server/request_handlers/pks_ovdc_handler.py
+++ b/container_service_extension/server/request_handlers/pks_ovdc_handler.py
@@ -11,6 +11,8 @@ import pyvcloud.vcd.utils as pyvcd_utils
 from container_service_extension.common.constants.server_constants import CseOperation as CseServerOperationInfo  # noqa: E501
 from container_service_extension.common.constants.server_constants import K8S_PROVIDER_KEY  # noqa: E501
 from container_service_extension.common.constants.server_constants import K8sProvider  # noqa: E501
+from container_service_extension.common.constants.server_constants import OvdcInfoKey  # noqa: E501
+from container_service_extension.common.constants.server_constants import PKSOvdcInfoKey  # noqa: E501
 from container_service_extension.common.constants.server_constants import ThreadLocalData  # noqa: E501
 from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
 from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
@@ -139,7 +141,7 @@ def ovdc_info(request_data, op_ctx: ctx.OperationContext):
 
 
 @record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
-def ovdc_list(request_data, op_ctx: ctx.OperationContext):
+def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
     """Request handler for ovdc list operation.
 
     :return: List of dictionaries with org VDC k8s provider metadata.
@@ -187,9 +189,9 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
             org_name=org_name)
         k8s_provider = k8s_metadata[K8S_PROVIDER_KEY]
         ovdc_dict = {
-            'name': ovdc_name,
-            'org': org_name,
-            'k8s provider': k8s_provider
+            OvdcInfoKey.OVDC_NAME: ovdc_name,
+            OvdcInfoKey.ORG_NAME: org_name,
+            OvdcInfoKey.K8S_PROVIDER: k8s_provider
         }
         if list_pks_plans:
             pks_plans = ''
@@ -232,8 +234,8 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
                     pks_plans = pks_plan_and_server_info[0]
                     pks_server = pks_plan_and_server_info[1]
 
-            ovdc_dict['pks api server'] = pks_server
-            ovdc_dict['available pks plans'] = pks_plans
+            ovdc_dict[PKSOvdcInfoKey.PKS_API_SERVER] = pks_server
+            ovdc_dict[PKSOvdcInfoKey.AVAILABLE_PKS_PLANS] = pks_plans
         ovdcs.append(ovdc_dict)
     api_path = CseServerOperationInfo.PKS_OVDC_LIST.api_path_format
     next_page_uri = vcd_utils.create_cse_page_uri(op_ctx.client,
@@ -248,3 +250,92 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
                                                      page_size=page_size,
                                                      next_page_uri=next_page_uri,  # noqa: E501
                                                      prev_page_uri=prev_page_uri)  # noqa: E501
+
+
+@record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
+def ovdc_list(request_data, op_ctx: ctx.OperationContext):
+    """Request handler for ovdc list operation.
+
+    :return: List of dictionaries with org VDC k8s provider metadata.
+    """
+    defaults = {
+        RequestKey.LIST_PKS_PLANS: False,
+    }
+    validated_data = {**defaults, **request_data}
+
+    list_pks_plans = utils.str_to_bool(validated_data[RequestKey.LIST_PKS_PLANS]) # noqa: E501
+
+    # Record telemetry data
+    cse_params = copy.deepcopy(validated_data)
+    cse_params[RequestKey.LIST_PKS_PLANS] = list_pks_plans
+    record_user_action_details(cse_operation=CseOperation.OVDC_LIST,
+                               cse_params=cse_params)
+
+    if list_pks_plans and not op_ctx.client.is_sysadmin():
+        raise e.UnauthorizedRequestError(
+            'Operation denied. Enterprise PKS plans visible only '
+            'to System Administrators.')
+
+    ovdcs = []
+    org_vdcs = \
+        vcd_utils.get_all_ovdcs(op_ctx.client)
+    for ovdc in org_vdcs:
+        ovdc_name = ovdc.get('name')
+        org_name = ovdc.get('orgName')
+        ovdc_id = vcd_utils.extract_id(ovdc.get('id'))
+        k8s_metadata = ovdc_utils.get_ovdc_k8s_provider_metadata(
+            op_ctx.sysadmin_client,
+            ovdc_id=ovdc_id,
+            ovdc_name=ovdc_name,
+            org_name=org_name)
+        k8s_provider = k8s_metadata[K8S_PROVIDER_KEY]
+        ovdc_dict = {
+            OvdcInfoKey.OVDC_NAME: ovdc_name,
+            OvdcInfoKey.ORG_NAME: org_name,
+            OvdcInfoKey.K8S_PROVIDER: k8s_provider
+        }
+        if list_pks_plans:
+            pks_plans = ''
+            pks_server = ''
+            if k8s_provider == K8sProvider.PKS:
+                # vc name for vdc can only be found using typed query
+                qfilter = f"name=={urllib.parse.quote(ovdc_name)};" \
+                          f"orgName=={urllib.parse.quote(org_name)}"
+                q = op_ctx.client.get_typed_query(
+                    vcd_client.ResourceType.ADMIN_ORG_VDC.value,
+                    query_result_format=vcd_client.QueryResultFormat.RECORDS, # noqa: E501
+                    qfilter=qfilter)
+                # should only ever be one element in the generator
+                ovdc_records = list(q.execute())
+                if len(ovdc_records) == 0:
+                    raise vcd_e.EntityNotFoundException(
+                        f"Org VDC {ovdc_name} not found in org {org_name}")
+                ovdc_record = None
+                for record in ovdc_records:
+                    ovdc_record = pyvcd_utils.to_dict(
+                        record, resource_type=vcd_client.ResourceType.ADMIN_ORG_VDC.value) # noqa: E501
+                    break
+
+                vc_to_pks_plans_map = {}
+                pks_contexts = pksbroker_manager.create_pks_context_for_all_accounts_in_org(op_ctx)  # noqa: E501
+
+                for pks_context in pks_contexts:
+                    if pks_context['vc'] in vc_to_pks_plans_map:
+                        continue
+                    pks_broker = pksbroker.PksBroker(pks_context,
+                                                     op_ctx)
+                    plans = pks_broker.list_plans()
+                    plan_names = [plan.get('name') for plan in plans]
+                    vc_to_pks_plans_map[pks_context['vc']] = \
+                        [plan_names, pks_context['host']]
+
+                pks_plan_and_server_info = vc_to_pks_plans_map.get(
+                    ovdc_record['vcName'], [])
+                if len(pks_plan_and_server_info) > 0:
+                    pks_plans = pks_plan_and_server_info[0]
+                    pks_server = pks_plan_and_server_info[1]
+
+            ovdc_dict[PKSOvdcInfoKey.PKS_API_SERVER] = pks_server
+            ovdc_dict[PKSOvdcInfoKey.AVAILABLE_PKS_PLANS] = pks_plans
+        ovdcs.append(ovdc_dict)
+    return ovdcs

--- a/container_service_extension/server/request_handlers/pks_ovdc_handler.py
+++ b/container_service_extension/server/request_handlers/pks_ovdc_handler.py
@@ -237,7 +237,7 @@ def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
             ovdc_dict[PKSOvdcInfoKey.PKS_API_SERVER] = pks_server
             ovdc_dict[PKSOvdcInfoKey.AVAILABLE_PKS_PLANS] = pks_plans
         ovdcs.append(ovdc_dict)
-    api_path = CseServerOperationInfo.PKS_OVDC_LIST.api_path_format
+    api_path = CseServerOperationInfo.PKS_ORG_VDC_LIST.api_path_format
     next_page_uri = vcd_utils.create_cse_page_uri(op_ctx.client,
                                                   api_path,
                                                   vcd_uri=next_page_uri)

--- a/container_service_extension/server/request_handlers/pks_ovdc_handler.py
+++ b/container_service_extension/server/request_handlers/pks_ovdc_handler.py
@@ -144,8 +144,10 @@ def ovdc_info(request_data, op_ctx: ctx.OperationContext):
 def org_vdc_list(request_data, op_ctx: ctx.OperationContext):
     """Request handler for ovdc list operation.
 
-    :return: List of dictionaries with org VDC k8s provider metadata.
+    :return: dictionary containing list of Org VDCs
+    :rtype: dict
     """
+    # NOTE: Response sent out by this handler should be paginated
     defaults = {
         RequestKey.LIST_PKS_PLANS: False,
         PaginationKey.PAGE_NUMBER: CSE_PAGINATION_FIRST_PAGE_NUMBER,
@@ -257,7 +259,9 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
     """Request handler for ovdc list operation.
 
     :return: List of dictionaries with org VDC k8s provider metadata.
+    :rtype: list
     """
+    # NOTE: response sent out by this handler should not be paginated
     defaults = {
         RequestKey.LIST_PKS_PLANS: False,
     }

--- a/container_service_extension/server/request_handlers/pks_ovdc_handler.py
+++ b/container_service_extension/server/request_handlers/pks_ovdc_handler.py
@@ -268,6 +268,7 @@ def ovdc_list(request_data, op_ctx: ctx.OperationContext):
     # Record telemetry data
     cse_params = copy.deepcopy(validated_data)
     cse_params[RequestKey.LIST_PKS_PLANS] = list_pks_plans
+    cse_params[PayloadKey.SOURCE_DESCRIPTION] = thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
     record_user_action_details(cse_operation=CseOperation.OVDC_LIST,
                                cse_params=cse_params)
 

--- a/container_service_extension/server/request_handlers/v35/ovdc_handler.py
+++ b/container_service_extension/server/request_handlers/v35/ovdc_handler.py
@@ -72,7 +72,7 @@ def org_vdc_list(data, operation_context: ctx.OperationContext):
     result = ovdc_service.list_org_vdcs(operation_context,
                                         page_number=page_number,
                                         page_size=page_size)
-    api_path = CseServerOperationInfo.V35_OVDC_LIST.api_path_format
+    api_path = CseServerOperationInfo.V35_ORG_VDC_LIST.api_path_format
     base_uri = f"{operation_context.client.get_api_uri().strip('/')}{api_path}"
     return server_utils.create_links_and_construct_paginated_result(
         base_uri,

--- a/container_service_extension/server/request_handlers/v35/ovdc_handler.py
+++ b/container_service_extension/server/request_handlers/v35/ovdc_handler.py
@@ -52,13 +52,26 @@ def ovdc_list(data, operation_context: ctx.OperationContext):
 
     :return: List of dictionaries with org VDC k8s runtimes.
     """
-    page_number = int(data.get(RequestKey.V35_QUERY, {}).get(PaginationKey.PAGE_NUMBER,  # noqa: E501
-                                                             CSE_PAGINATION_FIRST_PAGE_NUMBER))  # noqa: E501
-    page_size = int(data.get(RequestKey.V35_QUERY, {}).get(PaginationKey.PAGE_SIZE,  # noqa: E501
-                                                           CSE_PAGINATION_DEFAULT_PAGE_SIZE))  # noqa: E501
-    result = ovdc_service.list_ovdc(operation_context,
-                                    page_number=page_number,
-                                    page_size=page_size)
+    return ovdc_service.list_ovdc(operation_context)
+
+
+@record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
+@request_utils.v35_api_exception_handler
+def org_vdc_list(data, operation_context: ctx.OperationContext):
+    """Request handler for org vdc list operation.
+
+    This handler returns a paginated response.
+    :return: Dictionary containing paginated response with Org VDC runtime info
+    :rtype: dict
+    """
+    query_params = data.get(RequestKey.V35_QUERY, {})
+    page_number = int(query_params.get(PaginationKey.PAGE_NUMBER,
+                                       CSE_PAGINATION_FIRST_PAGE_NUMBER))
+    page_size = int(query_params.get(PaginationKey.PAGE_SIZE,
+                                     CSE_PAGINATION_DEFAULT_PAGE_SIZE))
+    result = ovdc_service.list_org_vdcs(operation_context,
+                                        page_number=page_number,
+                                        page_size=page_size)
     api_path = CseServerOperationInfo.V35_OVDC_LIST.api_path_format
     base_uri = f"{operation_context.client.get_api_uri().strip('/')}{api_path}"
     return server_utils.create_links_and_construct_paginated_result(

--- a/container_service_extension/server/request_processor.py
+++ b/container_service_extension/server/request_processor.py
@@ -448,7 +448,7 @@ def _get_pks_url_data(method: str, url: str):
                     shared_constants.RequestKey.OVDC_ID: tokens[4]
                 }
             raise cse_exception.MethodNotAllowedRequestError()
-    elif operation_type == shared_constants.OperationType.ORG_VDCS:
+    elif operation_type == OperationType.ORG_VDCS:
         if num_tokens == 4:
             if method == shared_constants.RequestMethod.GET:
                 return {_OPERATION_KEY: CseOperation.PKS_ORG_VDC_LIST}
@@ -486,7 +486,7 @@ def _get_v35_plus_url_data(method: str, url: str, api_version: str):
     if operation_type == OperationType.OVDC:
         return _get_v35_plus_ovdc_url_data(method, tokens)
 
-    if operation_type == shared_constants.OperationType.ORG_VDCS:
+    if operation_type == OperationType.ORG_VDCS:
         return _get_v35_org_vdc_url_data(method, tokens)
 
     raise cse_exception.NotFoundRequestError()
@@ -730,7 +730,7 @@ def _get_legacy_url_data(method: str, url: str, api_version: str):
                     shared_constants.RequestKey.OVDC_ID: tokens[4]
                 }
             raise cse_exception.MethodNotAllowedRequestError()
-    elif operation_type == shared_constants.OperationType.ORG_VDCS:
+    elif operation_type == OperationType.ORG_VDCS:
         if api_version not in (VcdApiVersion.VERSION_33.value,
                                VcdApiVersion.VERSION_34.value):
             raise cse_exception.NotFoundRequestError()
@@ -738,7 +738,7 @@ def _get_legacy_url_data(method: str, url: str, api_version: str):
             if method == shared_constants.RequestMethod.GET:
                 return {_OPERATION_KEY: CseOperation.ORG_VDC_LIST}
             raise cse_exception.NotFoundRequestError()
-    elif operation_type == shared_constants.OperationType.SYSTEM:
+    elif operation_type == OperationType.SYSTEM:
         if num_tokens == 4:
             if method == shared_constants.RequestMethod.GET:
                 return {_OPERATION_KEY: CseOperation.SYSTEM_INFO}


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

To help us process your pull request efficiently, please include: 

As paginated response cannot be read by older version of the clients, revert to non-paginated responses for the following api endpoints
- `/api/cse/ovdcs`
- `/api/cse/3.0/ovdcs`
- `/api/pks/ovdcs`

Create following new endpoints which return paginated responses
- `/api/cse/orgvdcs`
- `/api/cse/3.0/orgvdcs`
- `/api/pks/orgvdcs`

Make sure the older CSE CLI clients (3.0.x) are compatible with the responses

Testing done:
* Check if `/api/cse/ovdcs`, `/api/cse/3.0/ovdcs` and `/api/pks/ovdcs` return non-paginated responses
* Check if `/api/cse/orgvdcs`, `/api/cse/3.0/orgvdcs` and `/api/pks/orgvdcs` return paginated responses and can read pagination parameters properly
* Check if CLI client is compatible with the CSE server
* Check if older CLI client is compatible with CSE server

@rocknes @sakthisunda @sahithi @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/898)
<!-- Reviewable:end -->
