### PR TITLE
[VCDA-2128] Fix repetitive expensive calls to vdcComputePolicies

### DIFF
--- a/container_service_extension/client/cse_client/api_35/ovdc_api.py
+++ b/container_service_extension/client/cse_client/api_35/ovdc_api.py
@@ -21,7 +21,7 @@ class OvdcApi(CseClient):
         self._ovdc_uri = f"{self._uri}/ovdc"
         # NOTE: The request page size is overrided because the CSE server takes
         # an average of 10 seconds (Default vCD timeout) if there are 5 OVDCs
-        self._request_page_size = 3
+        self._request_page_size = 10
 
     def get_all_ovdcs(self):
         """Iterate over all the get ovdc response page by page.

--- a/container_service_extension/compute_policy_manager.py
+++ b/container_service_extension/compute_policy_manager.py
@@ -14,6 +14,7 @@ import container_service_extension.cloudapi.constants as cloudapi_constants
 import container_service_extension.exceptions as cse_exceptions
 import container_service_extension.logger as logger
 import container_service_extension.pyvcloud_utils as vcd_utils
+from container_service_extension.shared_constants import PaginationKey
 from container_service_extension.shared_constants import RequestMethod
 import container_service_extension.utils as utils
 
@@ -63,10 +64,12 @@ class ComputePolicyManager:
             # endpoint. Mere presence of the /cloudapi uri is not enough, we
             # need to make sure that this cloud api client will be of actual
             # use to us.
+            request_uri = f"{cloudapi_constants.CloudApiResource.VDC_COMPUTE_POLICIES}?"  \
+                          f"{PaginationKey.PAGE_SIZE}=1"  # noqa: E501
             self._cloudapi_client.do_request(
                 method=RequestMethod.GET,
                 cloudapi_version=self._cloudapi_version,
-                resource_url_relative_path=f"{cloudapi_constants.CloudApiResource.VDC_COMPUTE_POLICIES}") # noqa: E501
+                resource_url_relative_path=request_uri) # noqa: E501
         except requests.exceptions.HTTPError as err:
             logger.SERVER_LOGGER.error(err)
             self._is_operation_supported = False


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

- call to /vdcComputePolicies is made every time computePolicyManager is initialized. This is an expensive call as computPolicy will be created for every ovdc created in VCD.
- Initialization of compute policy manager in ovdc list code should be done only once.

For 2000 ovdcs, an average of 20s is required for fetching 10 ovdcs per page.
![Screen Shot 2021-02-08 at 5 43 55 PM](https://user-images.githubusercontent.com/16699642/107304206-785b6a80-6a35-11eb-8b46-6726894155fe.png)

@rocknes @sakthisunda @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/905)
<!-- Reviewable:end -->
