### PR TITLE
[VCDA-1683] Skip unavailable vCenter registered in VCD on CSE server start/restart

### DIFF
--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -306,6 +306,10 @@ def _validate_vcd_and_vcs_config(vcd_dict,
         # Check that all VCs listed in config file are registered in vCD
         for vc in vcs:
             vcenter = platform.get_vcenter(vc['name'])
+            if not (hasattr(vcenter, 'IsConnected') and vcenter.IsConnected):
+                msg = f"vCenter Server '{vc['name']}' not available"
+                msg_update_callback.info(msg)
+                continue
             vsphere_url = urlparse(vcenter.Url.text)
             vsphere_url_port = vsphere_url.port
             if vsphere_url_port:


### PR DESCRIPTION
- Use case: When there is more than one vcenter registered with vCD and CSE has properly configured for those.
- Issue: CSE server start/restart failure on any unavailable vCenter.
- Skip the vCenter that is not currently connected and continue CSE server start/restart. Display warning information about the server unavailability
- Manually tested and verified

![image](https://user-images.githubusercontent.com/5530442/108013820-54fa6780-6fc1-11eb-8d52-e7e65d4bad01.png)
@Anirudh9794 @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/912)
<!-- Reviewable:end -->
