### PR TITLE
[VCDA-2122] Add utility methods for fetching rde_schema_version

### DIFF
--- a/container_service_extension/rde/constants.py
+++ b/container_service_extension/rde/constants.py
@@ -53,6 +53,15 @@ class DefKey(str, Enum):
     ENTITY_TYPE_SCHEMA_VERSION = 'schema_version'
 
 
+# Defines the RDE versions CSE makes use of.
+# Different RDE versions may be used as CSE
+# is compatible with multiple VCD API versions.
+@unique
+class RDESchemaVersions(str, Enum):
+    RDE_1_X = '1.0.0'
+    RDE_2_X = '2.0.0'
+
+
 MAP_API_VERSION_TO_KEYS = {
     35.0: {
         DefKey.INTERFACE_VENDOR: DEF_VMWARE_VENDOR,
@@ -76,6 +85,14 @@ MAP_API_VERSION_TO_KEYS = {
         DefKey.ENTITY_TYPE_NAME: DEF_NATIVE_ENTITY_TYPE_NAME,
         DefKey.ENTITY_TYPE_SCHEMA_VERSION: 'api_v35',
     }
+}
+
+
+# Dictionary indicating RDE version to use
+# for the VCD API version
+MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION = {
+    35.0: RDESchemaVersions.RDE_1_X.value,
+    36.0: RDESchemaVersions.RDE_2_X.value
 }
 
 

--- a/container_service_extension/rde/constants.py
+++ b/container_service_extension/rde/constants.py
@@ -90,28 +90,34 @@ MAP_API_VERSION_TO_KEYS = {
 
 # Dictionary indicating RDE version to use
 # for the VCD API version
-# During runtime, the max RDE version supported
-# with the VCD API version is used.
-# MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION is a dictionary
-# depicting the current max RDE version in use for each
-# VCD API version.
-# NOTE: The RDE version used by the VCD API version can
-# be different in other CSE releases.
+# Based on the VCD-version CSE server is configured with,
+# CSE server dynamically determines the RDE-version-to-use at runtime.
+# Below dictionary essentially answers this question:
+# "When CSE is configured with VCD of a given api-version, what is the
+# compatible RDE-version CSE-server must use on that VCD?"
+# Key represents the VCD api-version CSE is configured with.
+# Value represents the RDE-version CSE-server must use for that VCD
+#   environment.
+# This map must be carefully updated for every major/minor/patch version
+# increments of RDE for each official CSE release. Below are few examples on
+#  how this map could be updated.
+# NOTE: The RDE version used by the VCD API version can be different in other
+#   CSE releases.
 # Example -
-# Current mapping:
+# Mapping for CSE 3.1:
 # MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION = {
 #     35.0: 1.0.0,
 #     36.0: 2.0.0
 # }
-# For CSE 3.2 with vCD 10.4 (API Version 37) with minor
-# version bump in RDE
+# If CSE 3.2 introduces Minor version bump in RDE (i.e 2.1) and is released
+#   alongside vCD 10.4 (API Version 37), mapping would be -
 # MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION = {
 # 35.0: 1.0.0,
 # 36.0: 2.1.0 (Note the RDE version change),
 # 37.0: 2.1.0 (Newly introduced RDE),
 # }
-# For CSE 3.2 with vCD 10.4 (API version 37) with major
-# version bump in RDE
+# If CSE 3.2 introduces Major version bump in RDE (i.e 3.0) and is released
+#   alongside vCD 10.4 (API version 37), mapping would be -
 # MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION = {
 # 35.0: 1.0.0,
 # 36.0: 2.0.0,

--- a/container_service_extension/rde/constants.py
+++ b/container_service_extension/rde/constants.py
@@ -90,6 +90,33 @@ MAP_API_VERSION_TO_KEYS = {
 
 # Dictionary indicating RDE version to use
 # for the VCD API version
+# During runtime, the max RDE version supported
+# with the VCD API version is used.
+# MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION is a dictionary
+# depicting the current max RDE version in use for each
+# VCD API version.
+# NOTE: The RDE version used by the VCD API version can
+# be different in other CSE releases.
+# Example -
+# Current mapping:
+# MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION = {
+#     35.0: 1.0.0,
+#     36.0: 2.0.0
+# }
+# For CSE 3.2 with vCD 10.4 (API Version 37) with minor
+# version bump in RDE
+# MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION = {
+# 35.0: 1.0.0,
+# 36.0: 2.1.0 (Note the RDE version change),
+# 37.0: 2.1.0 (Newly introduced RDE),
+# }
+# For CSE 3.2 with vCD 10.4 (API version 37) with major
+# version bump in RDE
+# MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION = {
+# 35.0: 1.0.0,
+# 36.0: 2.0.0,
+# 37.0: 3.0.0 (Newly introduced RDE)
+# }
 MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION = {
     35.0: RDESchemaVersions.RDE_1_X.value,
     36.0: RDESchemaVersions.RDE_2_X.value

--- a/container_service_extension/rde/constants.py
+++ b/container_service_extension/rde/constants.py
@@ -117,7 +117,7 @@ MAP_API_VERSION_TO_KEYS = {
 # 36.0: 2.0.0,
 # 37.0: 3.0.0 (Newly introduced RDE)
 # }
-MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION = {
+MAP_VCD_API_VERSION_TO_RDE_VERSION = {
     35.0: RDESchemaVersions.RDE_1_X.value,
     36.0: RDESchemaVersions.RDE_2_X.value
 }

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -63,4 +63,4 @@ def generate_entity_type_id(vendor, nss, version):
 
 
 def get_rde_schema_version_by_vcd_api_version(vcd_api_version: float) -> str:
-    return def_constants.MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION[vcd_api_version]
+    return def_constants.MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION[vcd_api_version]  # noqa: E501

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -60,3 +60,7 @@ def generate_entity_type_id(vendor, nss, version):
     :rtype str
     """
     return f"{def_constants.DEF_ENTITY_TYPE_ID_PREFIX}:{vendor}:{nss}:{version}"  # noqa: E501
+
+
+def get_rde_schema_version_by_vcd_api_version(vcd_api_version: float) -> str:
+    return def_constants.MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION[vcd_api_version]

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -62,5 +62,5 @@ def generate_entity_type_id(vendor, nss, version):
     return f"{def_constants.DEF_ENTITY_TYPE_ID_PREFIX}:{vendor}:{nss}:{version}"  # noqa: E501
 
 
-def get_rde_schema_version_by_vcd_api_version(vcd_api_version: float) -> str:
-    return def_constants.MAP_VCD_API_VERSION_TO_RDE_SCHEMA_VERSION[vcd_api_version]  # noqa: E501
+def get_rde_version_by_vcd_api_version(vcd_api_version: float) -> str:
+    return def_constants.MAP_VCD_API_VERSION_TO_RDE_VERSION[vcd_api_version]  # noqa: E501

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -192,7 +192,7 @@ class Service(object, metaclass=Singleton):
         self._rde_schema_version = None
 
     def get_rde_schema_version(self):
-        return self._rde_schema_version
+        return self.config['service']['rde_schema_version_in_use']
 
     def get_service_config(self):
         return self.config
@@ -496,7 +496,7 @@ class Service(object, metaclass=Singleton):
             # set the RDE version used
             max_vcd_api_version_supported = \
                 max([float(x) for x in self.config['service']['supported_api_versions']])  # noqa: E501
-            self._rde_schema_version = \
+            self.config['service']['rde_schema_version_in_use'] = \
                 def_utils.get_rde_schema_version_by_vcd_api_version(max_vcd_api_version_supported)  # noqa: E501
             msg_update_callback.general(f"Using RDE version: {self._rde_schema_version}")  # noqa: E501
 

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -189,6 +189,10 @@ class Service(object, metaclass=Singleton):
         self.consumer = None
         self.consumer_thread = None
         self._consumer_watchdog = None
+        self._rde_schema_version = None
+
+    def get_rde_schema_version(self):
+        return self._rde_schema_version
 
     def get_service_config(self):
         return self.config
@@ -488,7 +492,16 @@ class Service(object, metaclass=Singleton):
                                                               logger.SERVER_LOGGER, # noqa: E501
                                                               logger_wire)
             raise_error_if_def_not_supported(cloudapi_client)
+            
+            # set the RDE version used
+            max_vcd_api_version_supported = \
+                max([float(x) for x in self.config['service']['supported_api_versions']])
+            self._rde_schema_version = \
+                def_utils.get_rde_schema_version_by_vcd_api_version(max_vcd_api_version_supported)  # noqa: E501
+            msg_update_callback.general(f"Using RDE version: {self._rde_schema_version}")  # noqa: E501
+            
             schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
+            # TODO make use of self._rde_version to get the interface and entity type
             keys_map = def_constants.MAP_API_VERSION_TO_KEYS[float(sysadmin_client.get_api_version())] # noqa: E501
             interface_id = def_utils.generate_interface_id(vendor=keys_map[def_constants.DefKey.INTERFACE_VENDOR], # noqa: E501
                                                            nss=keys_map[def_constants.DefKey.INTERFACE_NSS], # noqa: E501

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -492,16 +492,16 @@ class Service(object, metaclass=Singleton):
                                                               logger.SERVER_LOGGER, # noqa: E501
                                                               logger_wire)
             raise_error_if_def_not_supported(cloudapi_client)
-            
+
             # set the RDE version used
             max_vcd_api_version_supported = \
-                max([float(x) for x in self.config['service']['supported_api_versions']])
+                max([float(x) for x in self.config['service']['supported_api_versions']])  # noqa: E501
             self._rde_schema_version = \
                 def_utils.get_rde_schema_version_by_vcd_api_version(max_vcd_api_version_supported)  # noqa: E501
             msg_update_callback.general(f"Using RDE version: {self._rde_schema_version}")  # noqa: E501
-            
+
             schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
-            # TODO make use of self._rde_version to get the interface and entity type
+            # TODO make use of self._rde_version to load Interface and Type
             keys_map = def_constants.MAP_API_VERSION_TO_KEYS[float(sysadmin_client.get_api_version())] # noqa: E501
             interface_id = def_utils.generate_interface_id(vendor=keys_map[def_constants.DefKey.INTERFACE_VENDOR], # noqa: E501
                                                            nss=keys_map[def_constants.DefKey.INTERFACE_NSS], # noqa: E501

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -191,8 +191,8 @@ class Service(object, metaclass=Singleton):
         self._consumer_watchdog = None
         self._rde_schema_version = None
 
-    def get_rde_schema_version(self):
-        return self.config['service']['rde_schema_version_in_use']
+    def get_rde_version_in_use(self):
+        return self.config['service']['rde_version_in_use']
 
     def get_service_config(self):
         return self.config
@@ -496,9 +496,10 @@ class Service(object, metaclass=Singleton):
             # set the RDE version used
             max_vcd_api_version_supported = \
                 max([float(x) for x in self.config['service']['supported_api_versions']])  # noqa: E501
-            self.config['service']['rde_schema_version_in_use'] = \
-                def_utils.get_rde_schema_version_by_vcd_api_version(max_vcd_api_version_supported)  # noqa: E501
-            msg_update_callback.general(f"Using RDE version: {self._rde_schema_version}")  # noqa: E501
+            self.config['service']['rde_version_in_use'] = \
+                def_utils.get_rde_version_by_vcd_api_version(max_vcd_api_version_supported)  # noqa: E501
+            msg_update_callback.general(f'Max VCD API version supported: {max_vcd_api_version_supported}')
+            msg_update_callback.general(f"Using RDE version: {self.get_rde_version_in_use()}")  # noqa: E501
 
             schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
             # TODO make use of self._rde_version to load Interface and Type

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -498,7 +498,6 @@ class Service(object, metaclass=Singleton):
                 max([float(x) for x in self.config['service']['supported_api_versions']])  # noqa: E501
             self.config['service']['rde_version_in_use'] = \
                 def_utils.get_rde_version_by_vcd_api_version(max_vcd_api_version_supported)  # noqa: E501
-            msg_update_callback.general(f'Max VCD API version supported: {max_vcd_api_version_supported}')
             msg_update_callback.general(f"Using RDE version: {self.get_rde_version_in_use()}")  # noqa: E501
 
             schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Add mapping to get rde_schema_version to be used during CSE configuration

Add method to get currently used schema version when CSE is running

@sahithi @sakthisunda @rocknes @ltimothy7 @arunmk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/913)
<!-- Reviewable:end -->
