### PR TITLE
Port Prevent returning response dict on server busy response (#901) to master

### DIFF
--- a/container_service_extension/client/response_processor.py
+++ b/container_service_extension/client/response_processor.py
@@ -55,7 +55,6 @@ def process_response(response):
         requests.codes.ok,
         requests.codes.created,
         requests.codes.accepted,
-        requests.codes.too_many_requests,
         requests.codes.no_content
     ]:
         return response_content
@@ -103,6 +102,8 @@ def response_to_exception(response):
     if response.status_code == requests.codes.unauthorized:
         error_message = 'Session has expired or user not logged in.'\
                         ' Please re-login.'
+    elif response.status_code == requests.codes.too_many_requests:
+        error_message = 'Server is busy. Please try again later.'
     elif 'json' in response.headers['Content-Type']:
         response_dict = deserialize_response_content(response)
         if RESPONSE_MESSAGE_KEY in response_dict:


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

Raise exception on server busy response

Testing done:
Overloaded the CSE server by sending multiple requests. Checked if CLI doesn't throw any python error on Server busy
<img width="376" alt="Screen Shot 2021-02-03 at 5 41 59 PM" src="https://user-images.githubusercontent.com/16699642/106833134-deb44780-6647-11eb-8444-25af179f0b48.png">

@rocknes @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/914)
<!-- Reviewable:end -->
