### PR TITLE
Port Fix repetitive expensive calls to vdcComputePolicies (#905) to master

### DIFF
--- a/container_service_extension/client/cse_client/api_35/ovdc_api.py
+++ b/container_service_extension/client/cse_client/api_35/ovdc_api.py
@@ -21,7 +21,7 @@ class OvdcApi(CseClient):
         self._ovdc_uri = f"{self._uri}/ovdc"
         # NOTE: The request page size is overrided because the CSE server takes
         # an average of 10 seconds (Default vCD timeout) if there are 5 OVDCs
-        self._request_page_size = 3
+        self._request_page_size = 10
 
     def get_all_ovdcs(self):
         """Iterate over all the get ovdc response page by page.

--- a/container_service_extension/rde/ovdc_service.py
+++ b/container_service_extension/rde/ovdc_service.py
@@ -209,7 +209,7 @@ def get_ovdc_k8s_runtime_details(sysadmin_client: vcd_client.Client,
                                  ovdc_name=None,
                                  org_name=None,
                                  cpm: compute_policy_manager.ComputePolicyManager = None,  # noqa: E501
-                                 log_wire=False) -> def_models.Ovdc:
+                                 log_wire=False) -> common_models.Ovdc:
     """Get k8s runtime details for an ovdc.
 
     Atleast ovdc_id and ovdc_name or org_name and ovdc_name should be provided.

--- a/container_service_extension/server/compute_policy_manager.py
+++ b/container_service_extension/server/compute_policy_manager.py
@@ -64,10 +64,12 @@ class ComputePolicyManager:
             # endpoint. Mere presence of the /cloudapi uri is not enough, we
             # need to make sure that this cloud api client will be of actual
             # use to us.
+            request_uri = f"{cloudapi_constants.CloudApiResource.VDC_COMPUTE_POLICIES}?"  \
+                          f"{PaginationKey.PAGE_SIZE}=1"  # noqa: E501
             self._cloudapi_client.do_request(
                 method=RequestMethod.GET,
                 cloudapi_version=self._cloudapi_version,
-                resource_url_relative_path=f"{cloudapi_constants.CloudApiResource.VDC_COMPUTE_POLICIES}") # noqa: E501
+                resource_url_relative_path=request_uri) # noqa: E501
         except requests.exceptions.HTTPError as err:
             logger.SERVER_LOGGER.error(err)
             self._is_operation_supported = False

--- a/container_service_extension/server/compute_policy_manager.py
+++ b/container_service_extension/server/compute_policy_manager.py
@@ -10,6 +10,7 @@ from pyvcloud.vcd.utils import retrieve_compute_policy_id_from_href
 from pyvcloud.vcd.vm import VM
 import requests
 
+from container_service_extension.common.constants.shared_constants import PaginationKey  # noqa: E501
 from container_service_extension.common.constants.shared_constants import RequestMethod  # noqa: E501
 import container_service_extension.common.utils.core_utils as utils
 import container_service_extension.common.utils.pyvcloud_utils as vcd_utils


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

- call to /vdcComputePolicies is made every time computePolicyManager is initialized. This is an expensive call as computPolicy will be created for every ovdc created in VCD.
- Initialization of compute policy manager in ovdc list code should be done only once.

For 2000 ovdcs, an average of 20s is required for fetching 10 ovdcs per page.
![Screen Shot 2021-02-08 at 5 43 55 PM](https://user-images.githubusercontent.com/16699642/107304206-785b6a80-6a35-11eb-8b46-6726894155fe.png)

@rocknes @sakthisunda @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/915)
<!-- Reviewable:end -->
