### PR TITLE
[VCDA-2175] Schema-change-for-RDE-Status-To-Reflect-Cluster-Current-state

### DIFF
--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -91,7 +91,8 @@ class CloudProperties:
         self.org_name = org_name
         self.ovdc_name = ovdc_name
         self.ovdc_network_name = ovdc_network_name
-        self.k8_distribution = k8_distribution
+        self.k8_distribution = Distribution(**k8_distribution) \
+            if isinstance(k8_distribution, dict) else k8_distribution or Distribution()  # noqa: E501
 
 
 @dataclass()

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -85,14 +85,19 @@ class CloudProperties:
     ovdc_name: str = None
     ovdc_network_name: str = None
     k8_distribution: Distribution = None
+    ssh_key: str = None
+    rollback_on_failure: bool = True
 
     def __init__(self, org_name: str, ovdc_name: int, ovdc_network_name: str,
-                 k8_distribution: Distribution, **kwargs):
+                 k8_distribution: Distribution, ssh_key: str,
+                 rollback_on_failure: bool, **kwargs):
         self.org_name = org_name
         self.ovdc_name = ovdc_name
         self.ovdc_network_name = ovdc_network_name
         self.k8_distribution = Distribution(**k8_distribution) \
             if isinstance(k8_distribution, dict) else k8_distribution or Distribution()  # noqa: E501
+        self.ssh_key = ssh_key
+        self.rollback_on_failure = rollback_on_failure
 
 
 @dataclass()

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -84,12 +84,14 @@ class CloudProperties:
     org_name: str = None
     ovdc_name: str = None
     ovdc_network_name: str = None
+    k8_distribution: Distribution = None
 
     def __init__(self, org_name: str, ovdc_name: int, ovdc_network_name: str,
-                 **kwargs):
+                 k8_distribution: Distribution, **kwargs):
         self.org_name = org_name
         self.ovdc_name = ovdc_name
         self.ovdc_network_name = ovdc_network_name
+        self.k8_distribution = k8_distribution
 
 
 @dataclass()

--- a/cse_def_schema/schema_2_0_0.json
+++ b/cse_def_schema/schema_2_0_0.json
@@ -9,7 +9,7 @@
                     "sizing_class": {"type": "string"},
                     "storage_profile": {"type": "string"}
                 },
-                "additionalproperties": true
+                "additionalProperties": true
             },
             "k8_distribution": {
                 "type": "object",
@@ -20,7 +20,8 @@
                 "properties": {
                    "template_name":  { "type": "string"},
                    "template_revision": { "type": "integer"}
-                }
+                },
+                "additionalProperties": true
             }
         },
         "type": "object",
@@ -217,7 +218,7 @@
                       }
                     }
                 },
-                "additionalproperties": true
+                "additionalProperties": true
             },
             "metadata": {
                 "type": "object",
@@ -246,6 +247,6 @@
                 "description":"Yet to be defined."
             }
         },
-        "additionalproperties": false
+        "additionalProperties": false
 
 }

--- a/cse_def_schema/schema_2_0_0.json
+++ b/cse_def_schema/schema_2_0_0.json
@@ -205,6 +205,14 @@
                         },
                         "k8_distribution": {
                           "$ref": "#/definitions/k8_distribution"
+                        },
+                        "ssh_key": {
+                          "type": "string",
+                          "description":"The ssh key that users can use to log into the node VMs without explicitly providing passwords."
+                        },
+                        "rollback_on_failure": {
+                          "type": "boolean",
+                          "description":"On any cluster operation failure, if the value is set to true, affected node VMs will be automatically deleted."
                         }
                       }
                     }

--- a/cse_def_schema/schema_2_0_0.json
+++ b/cse_def_schema/schema_2_0_0.json
@@ -68,7 +68,8 @@
                                 "type": "string",
                                 "description":"The storage-profile with which worker nodes need to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc."
                             }
-                        }
+                        },
+                        "additionalProperties": true
                     },
                     "control_plane": {
                         "type": "object",
@@ -91,7 +92,8 @@
                                 "type": "string",
                                 "description":"The storage-profile with which control-plane needs to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc."
                             }
-                        }
+                        },
+                        "additionalProperties": true
                     },
                     "nfs": {
                         "type": "object",
@@ -114,7 +116,8 @@
                                 "type": "string",
                                 "description":"The storage-profile with which nfs needs to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc."
                             }
-                        }
+                        },
+                        "additionalProperties": true
                     },
                     "settings": {
                         "type": "object",
@@ -134,12 +137,14 @@
                                 "type": "boolean",
                                 "description":"On any cluster operation failure, if the value is set to true, affected node VMs will be automatically deleted."
                             }
-                        }
+                        },
+                        "additionalProperties": true
                     },
                     "k8_distribution": {
                       "$ref": "#/definitions/k8_distribution"
                     }
-                }
+                },
+                "additionalProperties": true
             },
             "status": {
                 "type": "object",
@@ -186,7 +191,8 @@
                           },
                           "default": []
                         }
-                      }
+                      },
+                      "additionalProperties": true
                     },
                     "cloud_properties": {
                       "type": "object",
@@ -215,7 +221,8 @@
                           "type": "boolean",
                           "description":"On any cluster operation failure, if the value is set to true, affected node VMs will be automatically deleted."
                         }
-                      }
+                      },
+                      "additionalProperties": true
                     }
                 },
                 "additionalProperties": true
@@ -240,7 +247,8 @@
                         "type": "string",
                         "description":"The name of the cluster."
                     }
-                }
+                },
+                "additionalProperties": true
             },
             "apiversion": {
                 "type": "string",

--- a/cse_def_schema/schema_2_0_0.json
+++ b/cse_def_schema/schema_2_0_0.json
@@ -202,6 +202,17 @@
                         "ovdc_network_name": {
                           "type":  "string",
                           "description": "The name of the Organization Virtual data center network to which cluster is connected."
+                        },
+                        "k8_distribution": {
+                          "type": "object",
+                          "properties": {
+                            "template_name": {
+                              "type": "string"
+                            },
+                            "template_revision": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }

--- a/cse_def_schema/schema_2_0_0.json
+++ b/cse_def_schema/schema_2_0_0.json
@@ -6,9 +6,21 @@
                 "properties": {
                     "name": {"type": "string"},
                     "ip": {"type": "string"},
-                    "sizing_class": {"type": "string"}
+                    "sizing_class": {"type": "string"},
+                    "storage_profile": {"type": "string"}
                 },
                 "additionalproperties": true
+            },
+            "k8_distribution": {
+                "type": "object",
+                "required": [
+                   "template_name",
+                   "template_revision"
+                ],
+                "properties": {
+                   "template_name":  { "type": "string"},
+                   "template_revision": { "type": "integer"}
+                }
             }
         },
         "type": "object",
@@ -124,19 +136,7 @@
                         }
                     },
                     "k8_distribution": {
-                        "type": "object",
-                        "required": [
-                            "template_name",
-                            "template_revision"
-                        ],
-                        "properties": {
-                            "template_name": {
-                                "type": "string"
-                            },
-                            "template_revision": {
-                                "type": "integer"
-                            }
-                        }
+                      "$ref": "#/definitions/k8_distribution"
                     }
                 }
             },
@@ -204,15 +204,7 @@
                           "description": "The name of the Organization Virtual data center network to which cluster is connected."
                         },
                         "k8_distribution": {
-                          "type": "object",
-                          "properties": {
-                            "template_name": {
-                              "type": "string"
-                            },
-                            "template_revision": {
-                              "type": "integer"
-                            }
-                          }
+                          "$ref": "#/definitions/k8_distribution"
                         }
                       }
                     }


### PR DESCRIPTION
- Schema and RDE change for 2.0.0  
- Requirement: To get the current state of the cluster from Cluster Status
- Update RDE Status to include template name and revision.   
- Tested manually using Postman
- Using cse install registered defined entity schema
- Created Defined Entity for the new schema with dummy values.
- Using `vcd cse cluster list `verfied the created defined entity appears with no deserialization issue
-------------------------------
![image](https://user-images.githubusercontent.com/5530442/108758366-dd1bc800-74ff-11eb-8f83-2001cf3bd1ea.png)
----------
![image](https://user-images.githubusercontent.com/5530442/108793172-cabd8080-7537-11eb-9e69-b537b41dc36f.png)

![image](https://user-images.githubusercontent.com/5530442/108793103-a2ce1d00-7537-11eb-9682-5374ccce0ca9.png)

@Anirudh9794  @rocknes @sahithi


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/920)
<!-- Reviewable:end -->
