### PR TITLE
[VCDA-2150] Pick cluster_service file using rde in use

### DIFF
--- a/container_service_extension/common/utils/server_utils.py
+++ b/container_service_extension/common/utils/server_utils.py
@@ -42,6 +42,18 @@ def get_default_storage_profile():
     return config['broker']['storage_profile']
 
 
+def get_rde_version_in_use() -> str:
+    """Get the RDE version used by CSE server.
+
+    :return: rde version
+    :rtype: str
+    """
+    # TODO(VCDA-2151): Uncomment after new RDE version
+    # is installed
+    config = get_server_runtime_config()
+    return config['service']['rde_version_in_use']
+
+
 def get_default_k8_distribution():
     config = get_server_runtime_config()
     import container_service_extension.rde.models.rde_1_0_0 as rde_1_0_0

--- a/container_service_extension/rde/models/common_models.py
+++ b/container_service_extension/rde/models/common_models.py
@@ -106,8 +106,8 @@ class DefEntity:
         entity_type_version = self.entityType.split(":")[-1]
         # Parse the enitty to the right entity class
         NativeEntityClass = get_rde_model(entity_type_version)
-        self.entity = NativeEntityClass(**entity) \
-            if isinstance(entity, dict) else entity
+        self.entity: AbstractNativeEntity = \
+            NativeEntityClass(**entity) if isinstance(entity, dict) else entity
 
         self.name = name or self.entity.metadata.cluster_name
         self.externalId = externalId
@@ -186,7 +186,8 @@ class GenericClusterEntity:
             entity_type_version = self.entityType.split(":")[-1]
             # Parse the enitty to the right entity class
             NativeEntityClass = get_rde_model(entity_type_version)
-            self.entity = NativeEntityClass(**entity_dict) if isinstance(entity, dict) else entity  # noqa: E501
+            self.entity: AbstractNativeEntity = \
+                NativeEntityClass(**entity_dict) if isinstance(entity, dict) else entity  # noqa: E501
         elif entity_dict['kind'] == \
                 shared_constants.ClusterEntityKind.TKG.value:
             self.entity = TKGEntity(**entity) if isinstance(entity, dict) else entity  # noqa: E501

--- a/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
@@ -35,6 +35,7 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     rde_in_use = server_utils.get_rde_version_in_use()
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
+
     # TODO find out the RDE version from the request spec
     # TODO Insert RDE converters and validators
     NativeEntityClass = rde_factory.get_rde_model(rde_in_use)

--- a/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
@@ -243,7 +243,9 @@ def cluster_list(data: dict, op_ctx: ctx.OperationContext):
 
     :return: List
     """
-    svc = cluster_svc.ClusterService(op_ctx)
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
 
     # response should not be paginated
     return [asdict(def_entity) for def_entity in

--- a/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
@@ -16,6 +16,7 @@ import container_service_extension.common.utils.server_utils as server_utils
 import container_service_extension.lib.telemetry.constants as telemetry_constants  # noqa: E501
 import container_service_extension.lib.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
 import container_service_extension.rde.backend.cluster_service_factory as cluster_service_factory  # noqa: E501
+from container_service_extension.rde.models.abstractNativeEntity import AbstractNativeEntity  # noqa: E501
 import container_service_extension.rde.models.rde_factory as rde_factory
 import container_service_extension.security.context.operation_context as ctx
 import container_service_extension.server.request_handlers.request_utils as request_utils  # noqa: E501
@@ -37,7 +38,8 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     # TODO find out the RDE version from the request spec
     # TODO Insert RDE converters and validators
     NativeEntityClass = rde_factory.get_rde_model(rde_in_use)
-    cluster_entity_spec = NativeEntityClass(**data[RequestKey.INPUT_SPEC])
+    cluster_entity_spec: AbstractNativeEntity = \
+        NativeEntityClass(**data[RequestKey.INPUT_SPEC])
     return asdict(svc.create_cluster(cluster_entity_spec))
 
 
@@ -58,7 +60,8 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     # TODO find out the RDE version from the request spec
     # TODO Insert RDE converters and validators
     NativeEntityClass = rde_factory.get_rde_model(rde_in_use)
-    cluster_entity_spec = NativeEntityClass(**data[RequestKey.INPUT_SPEC])  # noqa: E501
+    cluster_entity_spec: AbstractNativeEntity = \
+        NativeEntityClass(**data[RequestKey.INPUT_SPEC])  # noqa: E501
     curr_entity = svc.entity_svc.get_entity(cluster_id)
     request_utils.validate_request_payload(
         asdict(cluster_entity_spec.spec), asdict(curr_entity.entity.spec),
@@ -149,7 +152,8 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     # TODO find out the RDE version from the request spec
     # TODO Insert RDE converters and validators
     NativeEntityClass = rde_factory.get_rde_model(rde_in_use)
-    cluster_entity_spec = NativeEntityClass(**data[RequestKey.INPUT_SPEC])
+    cluster_entity_spec: AbstractNativeEntity = \
+        NativeEntityClass(**data[RequestKey.INPUT_SPEC])
     cluster_id = data[RequestKey.CLUSTER_ID]
     curr_entity = svc.entity_svc.get_entity(cluster_id)
     request_utils.validate_request_payload(

--- a/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
@@ -15,8 +15,8 @@ import container_service_extension.common.thread_local_data as thread_local_data
 import container_service_extension.common.utils.server_utils as server_utils
 import container_service_extension.lib.telemetry.constants as telemetry_constants  # noqa: E501
 import container_service_extension.lib.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
-import container_service_extension.rde.backend.cluster_service_1_x as cluster_svc  # noqa: E501
-import container_service_extension.rde.models.rde_1_0_0 as rde_1_0_0
+import container_service_extension.rde.backend.cluster_service_factory as cluster_service_factory  # noqa: E501
+import container_service_extension.rde.models.rde_factory as rde_factory
 import container_service_extension.security.context.operation_context as ctx
 import container_service_extension.server.request_handlers.request_utils as request_utils  # noqa: E501
 
@@ -31,8 +31,13 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     :return: Defined entity of the native cluster
     :rtype: container_service_extension.def_.models.DefEntity
     """
-    svc = cluster_svc.ClusterService(op_ctx)
-    cluster_entity_spec = rde_1_0_0.NativeEntity(**data[RequestKey.INPUT_SPEC])  # noqa: E501
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
+    # TODO find out the RDE version from the request spec
+    # TODO convert the spec to rde_in_use
+    NativeEntityClass = rde_factory.get_rde_model(rde_in_use)
+    cluster_entity_spec = NativeEntityClass(**data[RequestKey.INPUT_SPEC])
     return asdict(svc.create_cluster(cluster_entity_spec))
 
 
@@ -46,9 +51,14 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     :return: Defined entity of the native cluster
     :rtype: container_service_extension.def_.models.DefEntity
     """
-    svc = cluster_svc.ClusterService(op_ctx)
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
-    cluster_entity_spec = rde_1_0_0.NativeEntity(**data[RequestKey.INPUT_SPEC])  # noqa: E501
+    # TODO find out the RDE version from the request spec
+    # TODO convert the spec to rde_in_use
+    NativeEntityClass = rde_factory.get_rde_model(rde_in_use)
+    cluster_entity_spec = NativeEntityClass(**data[RequestKey.INPUT_SPEC])  # noqa: E501
     curr_entity = svc.entity_svc.get_entity(cluster_id)
     request_utils.validate_request_payload(
         asdict(cluster_entity_spec.spec), asdict(curr_entity.entity.spec),
@@ -69,7 +79,9 @@ def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
 
     :return: Dict
     """
-    svc = cluster_svc.ClusterService(op_ctx)
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
     return asdict(svc.delete_cluster(cluster_id))
 
@@ -86,7 +98,9 @@ def cluster_info(data: dict, op_ctx: ctx.OperationContext):
 
     :return: Dict
     """
-    svc = cluster_svc.ClusterService(op_ctx)
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
     return asdict(svc.get_cluster_info(cluster_id))
 
@@ -100,7 +114,9 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
 
     :return: Dict
     """
-    svc = cluster_svc.ClusterService(op_ctx)
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
     return svc.get_cluster_config(cluster_id)
 
@@ -112,7 +128,9 @@ def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
 
     :return: List[Tuple(str, str)]
     """
-    svc = cluster_svc.ClusterService(op_ctx)
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
     return svc.get_cluster_upgrade_plan(data[RequestKey.CLUSTER_ID])
 
 
@@ -125,8 +143,13 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
 
     :return: Dict
     """
-    svc = cluster_svc.ClusterService(op_ctx)
-    cluster_entity_spec = rde_1_0_0.NativeEntity(**data[RequestKey.INPUT_SPEC])  # noqa: E501
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
+    # TODO find out the RDE version from the request spec
+    # TODO convert the spec to rde_in_use
+    NativeEntityClass = rde_factory.get_rde_model(rde_in_use)
+    cluster_entity_spec = NativeEntityClass(**data[RequestKey.INPUT_SPEC])
     cluster_id = data[RequestKey.CLUSTER_ID]
     curr_entity = svc.entity_svc.get_entity(cluster_id)
     request_utils.validate_request_payload(
@@ -144,7 +167,9 @@ def native_cluster_list(data: dict, op_ctx: ctx.OperationContext):
 
     :return: List
     """
-    svc = cluster_svc.ClusterService(op_ctx)
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
     filters = data.get(RequestKey.V35_QUERY, {})
     page_number = int(filters.get(PaginationKey.PAGE_NUMBER,
                                   CSE_PAGINATION_FIRST_PAGE_NUMBER))
@@ -176,7 +201,9 @@ def native_cluster_list(data: dict, op_ctx: ctx.OperationContext):
 @request_utils.v35_api_exception_handler
 def cluster_acl_info(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster acl list operation."""
-    svc = cluster_svc.ClusterService(op_ctx)
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
     query = data.get(RequestKey.V35_QUERY, {})
     page = int(query.get(PaginationKey.PAGE_NUMBER, CSE_PAGINATION_FIRST_PAGE_NUMBER))  # noqa: E501
@@ -196,7 +223,9 @@ def cluster_acl_info(data: dict, op_ctx: ctx.OperationContext):
 @request_utils.v35_api_exception_handler
 def cluster_acl_update(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster acl update operation."""
-    svc = cluster_svc.ClusterService(op_ctx)
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
     update_acl_entries = data.get(RequestKey.INPUT_SPEC, {}).get(ClusterAclKey.ACCESS_SETTING)  # noqa: E501
     svc.update_cluster_acl(cluster_id, update_acl_entries)
@@ -245,7 +274,9 @@ def nfs_node_delete(data, op_ctx: ctx.OperationContext):
 
     :return: Dict
     """
-    svc = cluster_svc.ClusterService(op_ctx)
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
     node_name = data[RequestKey.NODE_NAME]
 

--- a/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
@@ -35,7 +35,7 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
     # TODO find out the RDE version from the request spec
-    # TODO convert the spec to rde_in_use
+    # TODO Insert RDE converters and validators
     NativeEntityClass = rde_factory.get_rde_model(rde_in_use)
     cluster_entity_spec = NativeEntityClass(**data[RequestKey.INPUT_SPEC])
     return asdict(svc.create_cluster(cluster_entity_spec))
@@ -56,7 +56,7 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
         get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
     # TODO find out the RDE version from the request spec
-    # TODO convert the spec to rde_in_use
+    # TODO Insert RDE converters and validators
     NativeEntityClass = rde_factory.get_rde_model(rde_in_use)
     cluster_entity_spec = NativeEntityClass(**data[RequestKey.INPUT_SPEC])  # noqa: E501
     curr_entity = svc.entity_svc.get_entity(cluster_id)
@@ -147,7 +147,7 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
     # TODO find out the RDE version from the request spec
-    # TODO convert the spec to rde_in_use
+    # TODO Insert RDE converters and validators
     NativeEntityClass = rde_factory.get_rde_model(rde_in_use)
     cluster_entity_spec = NativeEntityClass(**data[RequestKey.INPUT_SPEC])
     cluster_id = data[RequestKey.CLUSTER_ID]

--- a/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
@@ -6,12 +6,13 @@ from dataclasses import asdict
 from container_service_extension.common.constants.shared_constants import RequestKey  # noqa: E501
 import container_service_extension.lib.telemetry.constants as telemetry_constants  # noqa: E501
 import container_service_extension.lib.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
-import container_service_extension.rde.backend.cluster_service_1_x as cluster_svc  # noqa: E501
-import container_service_extension.rde.models.rde_1_0_0 as rde_1_0_0
+import container_service_extension.rde.backend.cluster_service_2_x as cluster_svc  # noqa: E501
+import container_service_extension.rde.models.rde_2_0_0 as rde_2_0_0
 import container_service_extension.security.context.operation_context as ctx
 import container_service_extension.server.request_handlers.request_utils as request_utils  # noqa: E501
 
 
+# TODO change api exception handler.
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_UPDATE)  # noqa: E501
 @request_utils.v35_api_exception_handler
 def cluster_update(data: dict, op_ctx: ctx.OperationContext):
@@ -22,9 +23,13 @@ def cluster_update(data: dict, op_ctx: ctx.OperationContext):
     :return: Defined entity of the native cluster
     :rtype: container_service_extension.def_.models.DefEntity
     """
+    # rde_in_use = server_utils.get_rde_version_in_use()
+    # TODO Reject request if rde_in_use is less than 2.0.0
+    # TODO find out the RDE version from the request spec
+    # TODO convert the spec to rde_in_use
     svc = cluster_svc.ClusterService(op_ctx)
     cluster_id = data[RequestKey.CLUSTER_ID]
-    cluster_entity_spec = rde_1_0_0.NativeEntity(**data[RequestKey.INPUT_SPEC])  # noqa: E501
+    cluster_entity_spec = rde_2_0_0.NativeEntity(**data[RequestKey.INPUT_SPEC])  # noqa: E501
     curr_entity = svc.entity_svc.get_entity(cluster_id)
     is_upgrade_operation = \
         request_utils.validate_cluster_update_request_and_check_cluster_upgrade(  # noqa: E501

--- a/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
@@ -8,6 +8,7 @@ import container_service_extension.common.utils.server_utils as server_utils
 import container_service_extension.lib.telemetry.constants as telemetry_constants  # noqa: E501
 import container_service_extension.lib.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
 import container_service_extension.rde.backend.cluster_service_factory as cluster_service_factory  # noqa: E501
+from container_service_extension.rde.models.abstractNativeEntity import AbstractNativeEntity  # noqa: E501
 import container_service_extension.rde.models.rde_factory as rde_factory
 import container_service_extension.security.context.operation_context as ctx
 import container_service_extension.server.request_handlers.request_utils as request_utils  # noqa: E501
@@ -32,7 +33,8 @@ def cluster_update(data: dict, op_ctx: ctx.OperationContext):
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
     NativeEntityClass = rde_factory.get_rde_model(rde_in_use)
-    cluster_entity_spec = NativeEntityClass(**data[RequestKey.INPUT_SPEC])  # noqa: E501
+    cluster_entity_spec: AbstractNativeEntity = \
+        NativeEntityClass(**data[RequestKey.INPUT_SPEC])  # noqa: E501
     curr_entity = svc.entity_svc.get_entity(cluster_id)
     is_upgrade_operation = \
         request_utils.validate_cluster_update_request_and_check_cluster_upgrade(  # noqa: E501

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -189,10 +189,6 @@ class Service(object, metaclass=Singleton):
         self.consumer = None
         self.consumer_thread = None
         self._consumer_watchdog = None
-        self._rde_schema_version = None
-
-    def get_rde_version_in_use(self):
-        return self.config['service']['rde_version_in_use']
 
     def get_service_config(self):
         return self.config
@@ -498,7 +494,7 @@ class Service(object, metaclass=Singleton):
                 max([float(x) for x in self.config['service']['supported_api_versions']])  # noqa: E501
             self.config['service']['rde_version_in_use'] = \
                 def_utils.get_rde_version_by_vcd_api_version(max_vcd_api_version_supported)  # noqa: E501
-            msg_update_callback.general(f"Using RDE version: {self.get_rde_version_in_use()}")  # noqa: E501
+            msg_update_callback.general(f"Using RDE version: {self.config['service']['rde_version_in_use']}")  # noqa: E501
 
             schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
             # TODO make use of self._rde_version to load Interface and Type

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -494,7 +494,7 @@ class Service(object, metaclass=Singleton):
                 max([float(x) for x in self.config['service']['supported_api_versions']])  # noqa: E501
             self.config['service']['rde_version_in_use'] = \
                 def_utils.get_rde_version_by_vcd_api_version(max_vcd_api_version_supported)  # noqa: E501
-            msg_update_callback.general(f"Using RDE version: {self.config['service']['rde_version_in_use']}")  # noqa: E501
+            msg_update_callback.general(f"Using RDE version: {server_utils.get_rde_version_in_use()}")  # noqa: E501
 
             schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
             # TODO make use of self._rde_version to load Interface and Type


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Use the rde_in_use to determine which cluster_service.py file needs to be used for handling the request.

Testing done:
Checked if the right cluster_service file is being invoked using debugger and log statements

@sahithi @sakthisunda @rocknes @arunmk @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/922)
<!-- Reviewable:end -->
