### PR TITLE
[VCDA-2175] Schema-change-for-Cluster-Status-To-Reflect-Cluster-Current-state 

### DIFF
--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -59,6 +59,7 @@ class Node:
     name: str
     ip: str
     sizing_class: str = None
+    storage_profile: str = None
 
 
 @dataclass()


### PR DESCRIPTION

- Added storage profile as part Node dataclass. This has been already added to schema. 
@sahithi @Anirudh9794

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/926)
<!-- Reviewable:end -->
