### PR TITLE
[VCDA-2052] Get current state of cluster from Defined Entity Status

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -301,7 +301,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         curr_entity: common_models.DefEntity = self.entity_svc.get_entity(cluster_id)  # noqa: E501
         cluster_name: str = curr_entity.name
         current_spec = def_utils.construct_cluster_spec_from_entity_status(
-            curr_entity.entity.status, def_constants.RDESchemaVersions.RDE_2_X)  # noqa: E501
+            curr_entity.entity.status, "2.0.0")  # noqa: E501
         curr_worker_count: int = current_spec.workers.count
         curr_nfs_count: int = current_spec.nfs.count
         state: str = curr_entity.state
@@ -918,7 +918,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                 cluster_id)
             cluster_name: str = curr_entity.name
             current_spec = def_utils.construct_cluster_spec_from_entity_status(
-                curr_entity.entity.status, def_constants.RDESchemaVersions.RDE_2_X)  # noqa: E501
+                curr_entity.entity.status, "2.0.0")  # noqa: E501
             curr_worker_count: int = current_spec.workers.count
             curr_nfs_count: int = current_spec.nfs.count
             template_name = current_spec.k8_distribution.template_name  # noqa: E501
@@ -1031,7 +1031,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             vapp_href = curr_entity.externalId
             cluster_name = curr_entity.entity.metadata.cluster_name
             current_spec = def_utils.construct_cluster_spec_from_entity_status(
-                curr_entity.entity.status, def_constants.RDESchemaVersions.RDE_2_X)  # noqa: E501
+                curr_entity.entity.status, "2.0.0")  # noqa: E501
             org_name = curr_entity.entity.metadata.org_name
             ovdc_name = curr_entity.entity.metadata.ovdc_name
             curr_worker_count: int = current_spec.workers.count

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -242,6 +242,13 @@ class ClusterService(abstract_broker.AbstractBroker):
                                         template[LocalTemplateKey.CNI_VERSION])
         def_entity.entity.status.docker_version = template[LocalTemplateKey.DOCKER_VERSION] # noqa: E501
         def_entity.entity.status.os = template[LocalTemplateKey.OS]
+        def_entity.entity.status.cloud_properties.k8_distribution.template_name = template_name  # noqa: E501
+        def_entity.entity.status.cloud_properties.k8_distribution.template_revision = template_revision  # noqa: E501
+        def_entity.entity.status.cloud_properties.org_name = org_name
+        def_entity.entity.status.cloud_properties.ovdc_name = ovdc_name
+        def_entity.entity.status.cloud_properties.ovdc_network_name = cluster_spec.spec.settings.network  # noqa: E501
+        def_entity.entity.status.cloud_properties.rollback_on_failure = cluster_spec.spec.settings.rollback_on_failure  # noqa: E501
+        def_entity.entity.status.cloud_properties.ssh_key = cluster_spec.spec.settings.ssh_key  # noqa: E501
         # No need to set org context for non sysadmin users
         org_context = None
         if self.context.client.is_sysadmin():

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -6,7 +6,7 @@ import re
 import string
 import threading
 import time
-from typing import Dict, List, Union
+from typing import Dict, List
 import urllib
 
 import pkg_resources
@@ -300,7 +300,8 @@ class ClusterService(abstract_broker.AbstractBroker):
         # Get the existing defined entity for the given cluster id
         curr_entity: common_models.DefEntity = self.entity_svc.get_entity(cluster_id)  # noqa: E501
         cluster_name: str = curr_entity.name
-        current_spec = self.construct_cluster_spec_from_entity_status(curr_entity.entity.status)  # noqa: E501
+        current_spec = def_utils.construct_cluster_spec_from_entity_status(
+            curr_entity.entity.status, def_constants.RDESchemaVersions.RDE_2_X)  # noqa: E501
         curr_worker_count: int = current_spec.workers.count
         curr_nfs_count: int = current_spec.nfs.count
         state: str = curr_entity.state
@@ -333,7 +334,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                 f"valid state to be resized. Please contact the administrator")
 
         # Record telemetry details
-        telemetry_data: common_models.DefEntity = common_models.DefEntity(id=cluster_id, entity=cluster_spec)  # noqa: E501
+        telemetry_data: common_models.DefEntity = common_models.DefEntity(entityType=def_utils.get_registered_def_entity_type().id, id=cluster_id, entity=cluster_spec)  # noqa: E501
         telemetry_handler.record_user_action_details(
             cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY,
             cse_params={
@@ -432,9 +433,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                 telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
             }
         )
-
-        return self._get_cluster_upgrade_plan(curr_entity.entity.spec.k8_distribution.template_name, # noqa: E501
-                                              curr_entity.entity.spec.k8_distribution.template_revision) # noqa: E501
+        return self._get_cluster_upgrade_plan(curr_entity.entity.status.cloud_properties.k8_distribution.template_name,  # noqa: E501
+                                              curr_entity.entity.status.cloud_properties.k8_distribution.template_revision)  # noqa: E501
 
     def upgrade_cluster(self, cluster_id: str,
                         upgrade_spec: rde_2_0_0.NativeEntity):
@@ -466,8 +466,8 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         # check that the specified template is a valid upgrade target
         template = {}
-        valid_templates = self._get_cluster_upgrade_plan(curr_entity.entity.spec.k8_distribution.template_name, # noqa: E501
-                                                         curr_entity.entity.spec.k8_distribution.template_revision) # noqa: E501
+        valid_templates = self._get_cluster_upgrade_plan(curr_entity.entity.status.cloud_properties.k8_distribution.template_name, # noqa: E501
+                                                         curr_entity.entity.status.cloud_properties.k8_distribution.template_revision) # noqa: E501
 
         for t in valid_templates:
             if (t[LocalTemplateKey.NAME], str(t[LocalTemplateKey.REVISION])) == (new_template_name, str(new_template_revision)): # noqa: E501
@@ -917,7 +917,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             curr_entity: common_models.DefEntity = self.entity_svc.get_entity(
                 cluster_id)
             cluster_name: str = curr_entity.name
-            current_spec = self.construct_cluster_spec_from_entity_status(curr_entity.entity.status)  # noqa: E501
+            current_spec = def_utils.construct_cluster_spec_from_entity_status(
+                curr_entity.entity.status, def_constants.RDESchemaVersions.RDE_2_X)  # noqa: E501
             curr_worker_count: int = current_spec.workers.count
             curr_nfs_count: int = current_spec.nfs.count
             template_name = current_spec.k8_distribution.template_name  # noqa: E501
@@ -1029,7 +1030,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             curr_entity: common_models.DefEntity = self.entity_svc.get_entity(cluster_id)  # noqa: E501
             vapp_href = curr_entity.externalId
             cluster_name = curr_entity.entity.metadata.cluster_name
-            current_spec = self.construct_cluster_spec_from_entity_status(curr_entity.entity.status)  # noqa: E501
+            current_spec = def_utils.construct_cluster_spec_from_entity_status(
+                curr_entity.entity.status, def_constants.RDESchemaVersions.RDE_2_X)  # noqa: E501
             org_name = curr_entity.entity.metadata.org_name
             ovdc_name = curr_entity.entity.metadata.ovdc_name
             curr_worker_count: int = current_spec.workers.count
@@ -1366,8 +1368,9 @@ class ClusterService(abstract_broker.AbstractBroker):
             self.context.client.get_task_monitor().wait_for_status(task)
 
             # update defined entity of the cluster
-            curr_entity.entity.status.cloud_properties.k8_distribution.template_name = template[LocalTemplateKey.NAME]  # noqa: E501
-            curr_entity.entity.status.cloud_properties.k8_distribution.template_revision = int(template[LocalTemplateKey.REVISION])  # noqa: E501
+            curr_entity.entity.status.cloud_properties.k8_distribution = \
+                rde_2_0_0.Distribution(template_name=template[LocalTemplateKey.NAME],  # noqa: E501
+                                       template_revision=int(template[LocalTemplateKey.REVISION]))  # noqa: E501
             curr_entity.entity.status.cni = \
                 _create_k8s_software_string(template[LocalTemplateKey.CNI],
                                             template[LocalTemplateKey.CNI_VERSION]) # noqa: E501
@@ -1652,44 +1655,6 @@ class ClusterService(abstract_broker.AbstractBroker):
                 stack_trace=stack_trace
             )
 
-    @staticmethod
-    def construct_cluster_spec_from_entity_status(entity_status: Union[rde_2_0_0.Status, dict]) -> rde_2_0_0.ClusterSpec:  # noqa: E501
-        """Construct cluster specification from entity status using rde_2_0_0 model.
-
-        :param rde_2_0_0.Status entity_status: Entity Status as defined in rde_2_0_0  # noqa: E501
-        :return: Cluster Specification as defined in rde_2_0_0 model
-        """
-        cluster_spec = rde_2_0_0.ClusterSpec()
-        if isinstance(entity_status, dict):
-            entity_status = rde_2_0_0.Status(**entity_status)
-
-        cluster_spec.control_plane.count = 1
-        cluster_spec.control_plane.sizing_class = entity_status.nodes.control_plane.sizing_class  # noqa: E501
-        cluster_spec.control_plane.storage_profile = entity_status.nodes.control_plane.storage_profile  # noqa: E501
-
-        cluster_spec.workers.count = len(entity_status.nodes.workers)  # noqa: E501
-        if cluster_spec.workers.count == 0:
-            cluster_spec.workers.sizing_class = None
-            cluster_spec.workers.storage_profile = '*'
-        else:
-            cluster_spec.workers.sizing_class = entity_status.nodes.workers[0].sizing_class  # noqa: E501
-            cluster_spec.workers.storage_profile = entity_status.nodes.workers[0].storage_profile  # noqa: E501
-
-        cluster_spec.nfs.count = len(entity_status.nodes.nfs)
-        if cluster_spec.nfs.count == 0:
-            cluster_spec.nfs.sizing_class = None
-            cluster_spec.nfs.storage_profile = '*'
-        else:
-            cluster_spec.nfs.sizing_class = entity_status.nodes.nfs[0].sizing_class  # noqa: E501
-            cluster_spec.nfs.storage_profile = entity_status.nodes.nfs[0].storage_profile  # noqa: E501
-
-        cluster_spec.k8_distribution.template_name = entity_status.cloud_properties.k8_distribution.template_name  # noqa: E501
-        cluster_spec.k8_distribution.template_revision = entity_status.cloud_properties.k8_distribution.template_revision  # noqa: E501
-        cluster_spec.settings.network = entity_status.cloud_properties.ovdc_network_name  # noqa: E501
-        cluster_spec.settings.ssh_key = entity_status.cloud_properties.ssh_key  # noqa: E501
-        cluster_spec.settings.rollback_on_failure = entity_status.cloud_properties.rollback_on_failure  # noqa: E501
-        return cluster_spec
-
 
 def _get_nodes_details(sysadmin_client, vapp):
     """Get the details of the nodes given a vapp.
@@ -1727,6 +1692,7 @@ def _get_nodes_details(sysadmin_client, vapp):
                 policy_name = vm.ComputePolicy.VmSizingPolicy.get('name')
                 sizing_class = compute_policy_manager.\
                     get_cse_policy_display_name(policy_name)
+            storage_profile = None
             if hasattr(vm, 'StorageProfile'):
                 storage_profile: str = vm.StorageProfile.get('name')
             if vm_name.startswith(NodeType.CONTROL_PLANE):

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -301,7 +301,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         curr_entity: common_models.DefEntity = self.entity_svc.get_entity(cluster_id)  # noqa: E501
         cluster_name: str = curr_entity.name
         current_spec = def_utils.construct_cluster_spec_from_entity_status(
-            curr_entity.entity.status, "2.0.0")  # noqa: E501
+            curr_entity.entity.status, server_utils.get_rde_version_in_use())  # noqa: E501
         curr_worker_count: int = current_spec.workers.count
         curr_nfs_count: int = current_spec.nfs.count
         state: str = curr_entity.state
@@ -918,7 +918,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                 cluster_id)
             cluster_name: str = curr_entity.name
             current_spec = def_utils.construct_cluster_spec_from_entity_status(
-                curr_entity.entity.status, "2.0.0")  # noqa: E501
+                curr_entity.entity.status, server_utils.get_rde_version_in_use())  # noqa: E501
             curr_worker_count: int = current_spec.workers.count
             curr_nfs_count: int = current_spec.nfs.count
             template_name = current_spec.k8_distribution.template_name  # noqa: E501
@@ -1031,7 +1031,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             vapp_href = curr_entity.externalId
             cluster_name = curr_entity.entity.metadata.cluster_name
             current_spec = def_utils.construct_cluster_spec_from_entity_status(
-                curr_entity.entity.status, "2.0.0")  # noqa: E501
+                curr_entity.entity.status, server_utils.get_rde_version_in_use())  # noqa: E501
             org_name = curr_entity.entity.metadata.org_name
             ovdc_name = curr_entity.entity.metadata.ovdc_name
             curr_worker_count: int = current_spec.workers.count

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -300,8 +300,9 @@ class ClusterService(abstract_broker.AbstractBroker):
         # Get the existing defined entity for the given cluster id
         curr_entity: common_models.DefEntity = self.entity_svc.get_entity(cluster_id)  # noqa: E501
         cluster_name: str = curr_entity.name
-        curr_worker_count: int = curr_entity.entity.spec.workers.count
-        curr_nfs_count: int = curr_entity.entity.spec.nfs.count
+        current_spec = self.construct_cluster_spec_from_entity_status(curr_entity.entity.status)  # noqa: E501
+        curr_worker_count: int = current_spec.workers.count
+        curr_nfs_count: int = current_spec.nfs.count
         state: str = curr_entity.state
         phase: DefEntityPhase = DefEntityPhase.from_phase(
             curr_entity.entity.status.phase)
@@ -916,10 +917,11 @@ class ClusterService(abstract_broker.AbstractBroker):
             curr_entity: common_models.DefEntity = self.entity_svc.get_entity(
                 cluster_id)
             cluster_name: str = curr_entity.name
-            curr_worker_count: int = curr_entity.entity.spec.workers.count
-            curr_nfs_count: int = curr_entity.entity.spec.nfs.count
-            template_name = curr_entity.entity.spec.k8_distribution.template_name  # noqa: E501
-            template_revision = curr_entity.entity.spec.k8_distribution.template_revision  # noqa: E501
+            current_spec = self.construct_cluster_spec_from_entity_status(curr_entity.entity.status)  # noqa: E501
+            curr_worker_count: int = current_spec.workers.count
+            curr_nfs_count: int = current_spec.nfs.count
+            template_name = current_spec.k8_distribution.template_name  # noqa: E501
+            template_revision = current_spec.k8_distribution.template_revision  # noqa: E501
 
             desired_worker_count: int = cluster_spec.spec.workers.count
             desired_nfs_count: int = cluster_spec.spec.nfs.count
@@ -1027,22 +1029,23 @@ class ClusterService(abstract_broker.AbstractBroker):
             curr_entity: common_models.DefEntity = self.entity_svc.get_entity(cluster_id)  # noqa: E501
             vapp_href = curr_entity.externalId
             cluster_name = curr_entity.entity.metadata.cluster_name
+            current_spec = self.construct_cluster_spec_from_entity_status(curr_entity.entity.status)  # noqa: E501
             org_name = curr_entity.entity.metadata.org_name
             ovdc_name = curr_entity.entity.metadata.ovdc_name
-            curr_worker_count: int = curr_entity.entity.spec.workers.count
-            curr_nfs_count: int = curr_entity.entity.spec.nfs.count
+            curr_worker_count: int = current_spec.workers.count
+            curr_nfs_count: int = current_spec.nfs.count
 
             # use the same settings with which cluster was originally created
             # viz., template, storage_profile, and network among others.
-            worker_storage_profile = curr_entity.entity.spec.workers.storage_profile  # noqa: E501
-            worker_sizing_class = curr_entity.entity.spec.workers.sizing_class
-            nfs_storage_profile = curr_entity.entity.spec.nfs.storage_profile
-            nfs_sizing_class = curr_entity.entity.spec.nfs.sizing_class
-            network_name = curr_entity.entity.spec.settings.network
-            ssh_key = curr_entity.entity.spec.settings.ssh_key
-            rollback = cluster_spec.spec.settings.rollback_on_failure
-            template_name = curr_entity.entity.spec.k8_distribution.template_name  # noqa: E501
-            template_revision = curr_entity.entity.spec.k8_distribution.template_revision  # noqa: E501
+            worker_storage_profile = current_spec.workers.storage_profile # noqa: E501
+            worker_sizing_class = current_spec.workers.sizing_class
+            nfs_storage_profile = current_spec.nfs.storage_profile
+            nfs_sizing_class = current_spec.nfs.sizing_class
+            network_name = current_spec.settings.network
+            ssh_key = current_spec.settings.ssh_key
+            rollback = current_spec.settings.rollback_on_failure
+            template_name = current_spec.k8_distribution.template_name  # noqa: E501
+            template_revision = current_spec.k8_distribution.template_revision  # noqa: E501
             template = _get_template(template_name, template_revision)
 
             # compute the values of workers and nfs to be added or removed
@@ -1363,10 +1366,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             self.context.client.get_task_monitor().wait_for_status(task)
 
             # update defined entity of the cluster
-            curr_entity.entity.spec.k8_distribution.template_name = \
-                template[LocalTemplateKey.NAME]
-            curr_entity.entity.spec.k8_distribution.template_revision = \
-                int(template[LocalTemplateKey.REVISION])
+            curr_entity.entity.status.cloud_properties.k8_distribution.template_name = template[LocalTemplateKey.NAME]  # noqa: E501
+            curr_entity.entity.status.cloud_properties.k8_distribution.template_revision = int(template[LocalTemplateKey.REVISION])  # noqa: E501
             curr_entity.entity.status.cni = \
                 _create_k8s_software_string(template[LocalTemplateKey.CNI],
                                             template[LocalTemplateKey.CNI_VERSION]) # noqa: E501
@@ -1585,9 +1586,6 @@ class ClusterService(abstract_broker.AbstractBroker):
         curr_nodes_status = _get_nodes_details(
             self.context.sysadmin_client, vapp)
         if curr_nodes_status:
-            curr_entity.entity.spec.workers.count = len(
-                curr_nodes_status.workers)
-            curr_entity.entity.spec.nfs.count = len(curr_nodes_status.nfs)
             curr_entity.entity.status.nodes = curr_nodes_status
         return self.entity_svc.update_entity(cluster_id, curr_entity)
 
@@ -1654,6 +1652,44 @@ class ClusterService(abstract_broker.AbstractBroker):
                 stack_trace=stack_trace
             )
 
+    @staticmethod
+    def construct_cluster_spec_from_entity_status(entity_status: Union[rde_2_0_0.Status, dict]) -> rde_2_0_0.ClusterSpec:  # noqa: E501
+        """Construct cluster specification from entity status using rde_2_0_0 model.
+
+        :param rde_2_0_0.Status entity_status: Entity Status as defined in rde_2_0_0  # noqa: E501
+        :return: Cluster Specification as defined in rde_2_0_0 model
+        """
+        cluster_spec = rde_2_0_0.ClusterSpec()
+        if isinstance(entity_status, dict):
+            entity_status = rde_2_0_0.Status(**entity_status)
+
+        cluster_spec.control_plane.count = 1
+        cluster_spec.control_plane.sizing_class = entity_status.nodes.control_plane.sizing_class  # noqa: E501
+        cluster_spec.control_plane.storage_profile = entity_status.nodes.control_plane.storage_profile  # noqa: E501
+
+        cluster_spec.workers.count = len(entity_status.nodes.workers)  # noqa: E501
+        if cluster_spec.workers.count == 0:
+            cluster_spec.workers.sizing_class = None
+            cluster_spec.workers.storage_profile = '*'
+        else:
+            cluster_spec.workers.sizing_class = entity_status.nodes.workers[0].sizing_class  # noqa: E501
+            cluster_spec.workers.storage_profile = entity_status.nodes.workers[0].storage_profile  # noqa: E501
+
+        cluster_spec.nfs.count = len(entity_status.nodes.nfs)
+        if cluster_spec.nfs.count == 0:
+            cluster_spec.nfs.sizing_class = None
+            cluster_spec.nfs.storage_profile = '*'
+        else:
+            cluster_spec.nfs.sizing_class = entity_status.nodes.nfs[0].sizing_class  # noqa: E501
+            cluster_spec.nfs.storage_profile = entity_status.nodes.nfs[0].storage_profile  # noqa: E501
+
+        cluster_spec.k8_distribution.template_name = entity_status.cloud_properties.k8_distribution.template_name  # noqa: E501
+        cluster_spec.k8_distribution.template_revision = entity_status.cloud_properties.k8_distribution.template_revision  # noqa: E501
+        cluster_spec.settings.network = entity_status.cloud_properties.ovdc_network_name  # noqa: E501
+        cluster_spec.settings.ssh_key = entity_status.cloud_properties.ssh_key  # noqa: E501
+        cluster_spec.settings.rollback_on_failure = entity_status.cloud_properties.rollback_on_failure  # noqa: E501
+        return cluster_spec
+
 
 def _get_nodes_details(sysadmin_client, vapp):
     """Get the details of the nodes given a vapp.
@@ -1673,6 +1709,7 @@ def _get_nodes_details(sysadmin_client, vapp):
         workers = []
         nfs_nodes = []
         for vm in vms:
+            vcd_utils.to_dict(vm)
             # skip processing vms in 'unresolved' state.
             if int(vm.get('status')) == 0:
                 continue
@@ -1690,13 +1727,17 @@ def _get_nodes_details(sysadmin_client, vapp):
                 policy_name = vm.ComputePolicy.VmSizingPolicy.get('name')
                 sizing_class = compute_policy_manager.\
                     get_cse_policy_display_name(policy_name)
+            if hasattr(vm, 'StorageProfile'):
+                storage_profile: str = vm.StorageProfile.get('name')
             if vm_name.startswith(NodeType.CONTROL_PLANE):
                 control_plane = rde_2_0_0.Node(name=vm_name, ip=ip,
-                                               sizing_class=sizing_class)
+                                               sizing_class=sizing_class,
+                                               storage_profile=storage_profile)
             elif vm_name.startswith(NodeType.WORKER):
                 workers.append(
                     rde_2_0_0.Node(name=vm_name, ip=ip,
-                                   sizing_class=sizing_class))
+                                   sizing_class=sizing_class,
+                                   storage_profile=storage_profile))
             elif vm_name.startswith(NodeType.NFS):
                 exports = None
                 try:
@@ -1710,6 +1751,7 @@ def _get_nodes_details(sysadmin_client, vapp):
                                  exc_info=True)
                 nfs_nodes.append(rde_2_0_0.NfsNode(name=vm_name, ip=ip,
                                                    sizing_class=sizing_class,
+                                                   storage_profile=storage_profile,  # noqa: E501
                                                    exports=exports))
         return rde_2_0_0.Nodes(control_plane=control_plane, workers=workers,
                                nfs=nfs_nodes)
@@ -2267,42 +2309,3 @@ def _create_k8s_software_string(software_name: str, software_version: str) -> st
     :rtype: str
     """
     return f"{software_name} {software_version}"
-
-
-def _construct_cluster_spec_from_entity_status(entity_status: Union[rde_2_0_0.Status, dict]) -> rde_2_0_0.ClusterSpec:  # noqa: E501
-    """Construct cluster specification from entity status using rde_2_0_0 model.
-
-    :param rde_2_0_0.Status entity_status: Entity Status as defined in rde_2_0_0  # noqa: E501
-    :return: Cluster Specification as defined in rde_2_0_0 model
-    """
-    cluster_spec = rde_2_0_0.ClusterSpec()
-    if isinstance(entity_status, dict):
-        entity_status = rde_2_0_0.Status(**entity_status)
-        print(entity_status)
-
-    cluster_spec.control_plane.count = 1
-    cluster_spec.control_plane.sizing_class = entity_status.nodes.control_plane.sizing_class  # noqa: E501
-    cluster_spec.control_plane.storage_profile = entity_status.nodes.control_plane.storage_profile  # noqa: E501
-    cluster_spec.workers.count = entity_status.nodes.workers.count()  # noqa: E501
-
-    if entity_status.nodes.workers.count() == 0:
-        cluster_spec.workers.sizing_class = None
-        cluster_spec.workers.storage_profile = '*'
-    else:
-        cluster_spec.workers.sizing_class = entity_status.nodes.workers[0].sizing_class  # noqa: E501
-        cluster_spec.workers.storage_profile = entity_status.nodes.workers[0].storage_profile  # noqa: E501
-
-    cluster_spec.nfs.count = entity_status.nodes.nfs.count()
-    if entity_status.nodes.nfs.count() == 0:
-        cluster_spec.nfs.sizing_class = None
-        cluster_spec.nfs.storage_profile = '*'
-    else:
-        cluster_spec.nfs.sizing_class = entity_status.nodes.nfs[0].sizing_class
-        cluster_spec.nfs.storage_profile = entity_status.nodes.nfs[0].storage_profile  # noqa: E501
-
-    cluster_spec.k8_distribution.template_name = entity_status.cloud_properties.k8_distribution.template_name  # noqa: E501
-    cluster_spec.k8_distribution.template_revision = entity_status.cloud_properties.k8_distribution.template_revision  # noqa: E501
-    cluster_spec.settings.network = entity_status.cloud_properties.ovdc_network_name  # noqa: E501
-    cluster_spec.settings.ssh_key = entity_status.cloud_properties.ssh_key  # noqa: E501
-    cluster_spec.settings.rollback_on_failure = entity_status.cloud_properties.rollback_on_failure  # noqa: E501
-    return cluster_spec

--- a/container_service_extension/rde/entity_service.py
+++ b/container_service_extension/rde/entity_service.py
@@ -336,7 +336,7 @@ class DefEntityService():
                                        f"{entity_id}/{CloudApiResource.ENTITY_RESOLVE}")  # noqa: E501
         msg = response_body[def_constants.DEF_ERROR_MESSAGE_KEY]
         del response_body[def_constants.DEF_ERROR_MESSAGE_KEY]
-        entity = DefEntity(**response_body)
+        entity = DefEntity(entityType=self.get_entity(entity_id).id, **response_body)  # noqa: E501
         # TODO: Just record the error message; revisit after HTTP response code
         # is good enough to decide if exception should be thrown or not
         if entity.state != def_constants.DEF_RESOLVED_STATE:

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -49,7 +49,7 @@ class Distribution:
 
 @dataclass()
 class Settings:
-    network: str = None
+    network: str
     ssh_key: str = None
     rollback_on_failure: bool = True
 
@@ -86,7 +86,7 @@ class CloudProperties:
     ovdc_name: str = None
     ovdc_network_name: str = None
     k8_distribution: Distribution = None
-    ssh_key: str = None
+    ssh_key: str = None  # TODO contemplate the need to keep this attribute
     rollback_on_failure: bool = True
 
     def __init__(self, org_name: str = None, ovdc_name: str = None, ovdc_network_name: str = None,  # noqa: E501
@@ -137,17 +137,17 @@ class ClusterSpec:
     them into the expected class instances.
     """
 
-    control_plane: ControlPlane = None
-    workers: Workers = None
-    nfs: Nfs = None
-    k8_distribution: Distribution = None
-    settings: Settings = None
+    control_plane: ControlPlane
+    workers: Workers
+    nfs: Nfs
+    k8_distribution: Distribution
+    settings: Settings
 
-    def __init__(self, settings: Settings = None, k8_distribution: Distribution = None,  # noqa: E501
+    def __init__(self, settings: Settings, k8_distribution: Distribution = None,  # noqa: E501
                  control_plane: ControlPlane = None, workers: Workers = None,
                  nfs: Nfs = None, **kwargs):
         self.settings = Settings(**settings) \
-            if isinstance(settings, dict) else settings or Settings()
+            if isinstance(settings, dict) else settings
         self.control_plane = ControlPlane(**control_plane) \
             if isinstance(control_plane, dict) else control_plane or ControlPlane()  # noqa: E501
         self.workers = Workers(**workers) \

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -42,14 +42,14 @@ class Distribution:
     template_name: str = ""
     template_revision: int = 0
 
-    def __init__(self, template_name: str, template_revision: int, **kwargs):
+    def __init__(self, template_name: str = '', template_revision: int = 0, **kwargs):  # noqa: E501
         self.template_name = template_name
         self.template_revision = template_revision
 
 
 @dataclass()
 class Settings:
-    network: str
+    network: str = None
     ssh_key: str = None
     rollback_on_failure: bool = True
 
@@ -89,9 +89,9 @@ class CloudProperties:
     ssh_key: str = None
     rollback_on_failure: bool = True
 
-    def __init__(self, org_name: str, ovdc_name: int, ovdc_network_name: str,
-                 k8_distribution: Distribution, ssh_key: str,
-                 rollback_on_failure: bool, **kwargs):
+    def __init__(self, org_name: str = None, ovdc_name: str = None, ovdc_network_name: str = None,  # noqa: E501
+                 k8_distribution: Distribution = None, ssh_key: str = None,
+                 rollback_on_failure: bool = True, **kwargs):
         self.org_name = org_name
         self.ovdc_name = ovdc_name
         self.ovdc_network_name = ovdc_network_name
@@ -126,7 +126,7 @@ class Status:
         self.nodes = Nodes(**nodes) if isinstance(nodes, dict) else nodes
         self.cloud_properties = CloudProperties(
             **cloud_properties) if isinstance(cloud_properties, dict) \
-            else cloud_properties
+            else cloud_properties or CloudProperties()
 
 
 @dataclass()
@@ -137,17 +137,17 @@ class ClusterSpec:
     them into the expected class instances.
     """
 
-    control_plane: ControlPlane
-    workers: Workers
-    nfs: Nfs
-    k8_distribution: Distribution
-    settings: Settings
+    control_plane: ControlPlane = None
+    workers: Workers = None
+    nfs: Nfs = None
+    k8_distribution: Distribution = None
+    settings: Settings = None
 
-    def __init__(self, settings: Settings, k8_distribution: Distribution = None,  # noqa: E501
+    def __init__(self, settings: Settings = None, k8_distribution: Distribution = None,  # noqa: E501
                  control_plane: ControlPlane = None, workers: Workers = None,
                  nfs: Nfs = None, **kwargs):
         self.settings = Settings(**settings) \
-            if isinstance(settings, dict) else settings
+            if isinstance(settings, dict) else settings or Settings()
         self.control_plane = ControlPlane(**control_plane) \
             if isinstance(control_plane, dict) else control_plane or ControlPlane()  # noqa: E501
         self.workers = Workers(**workers) \

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -3,9 +3,13 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 """Utility methods to help interaction with defined entities framework."""
+from typing import Union
+
 import container_service_extension.exception.exceptions as excptn
 from container_service_extension.lib.cloudapi.cloudapi_client import CloudApiClient  # noqa: E501
 import container_service_extension.rde.constants as def_constants
+import container_service_extension.rde.models.rde_1_0_0 as rde_1_0_0
+import container_service_extension.rde.models.rde_2_0_0 as rde_2_0_0
 
 
 def raise_error_if_def_not_supported(cloudapi_client: CloudApiClient):
@@ -55,3 +59,67 @@ def get_rde_version_by_vcd_api_version(vcd_api_version: float) -> str:
 
 def get_rde_metadata(rde_version: str) -> dict:
     return def_constants.MAP_RDE_VERSION_TO_ITS_METADATA[rde_version]
+
+
+def construct_cluster_spec_from_entity_status(entity_status: Union[rde_1_0_0.Status, rde_2_0_0.Status, dict], rde_version_in_use: str) -> Union[rde_1_0_0.ClusterSpec, rde_2_0_0.ClusterSpec]:  # noqa: E501
+    """Construct cluster specification from entity status of given rde version.
+
+    :param rde_X_X_X Status entity_status: Entity Status of rde of given version  # noqa: E501
+    :param str rde_version_in_use: which version of schema
+    :return: Cluster Specification of respective rde_version_in_use
+    :raises NotImplementedError
+    """
+    if rde_version_in_use == def_constants.RDESchemaVersions.RDE_2_X.value:
+        return construct_2_0_0_cluster_spec_from_entity_status(entity_status)
+    raise NotImplementedError(f"constructing cluster spec from entity status for {rde_version_in_use} is"  # noqa:
+                              f" not implemented ")
+
+
+def construct_2_0_0_cluster_spec_from_entity_status(entity_status: Union[rde_2_0_0.Status, dict]) -> rde_2_0_0.ClusterSpec:  # noqa:
+    """Construct cluster specification from entity status using rde_2_0_0 model.
+
+    :param rde_2_0_0.Status entity_status: Entity Status as defined in rde_2_0_0  # noqa: E501
+    :return: Cluster Specification as defined in rde_2_0_0 model
+    """
+    if isinstance(entity_status, dict):
+        entity_status = rde_2_0_0.Status(**entity_status)
+
+    control_plane = rde_2_0_0.ControlPlane(
+        sizing_class=entity_status.nodes.control_plane.sizing_class,
+        storage_profile=entity_status.nodes.control_plane.storage_profile,
+        count=1)
+
+    workers_count = len(entity_status.nodes.workers)
+    if workers_count == 0:
+        workers = rde_2_0_0.Workers(sizing_class=None, storage_profile='*',
+                                    count=workers_count)
+    else:
+        workers = rde_2_0_0.Workers(
+            sizing_class=entity_status.nodes.workers[0].sizing_class,
+            storage_profile=entity_status.nodes.workers[0].storage_profile,
+            count=workers_count)
+
+    nfs_count = len(entity_status.nodes.nfs)
+    if nfs_count == 0:
+        nfs = rde_2_0_0.Nfs(sizing_class=None, storage_profile='*',
+                            count=nfs_count)
+    else:
+        nfs = rde_2_0_0.Nfs(
+            sizing_class=entity_status.nodes.nfs[0].sizing_class,  # noqa: E501
+            storage_profile=entity_status.nodes.nfs[
+                0].storage_profile)
+
+    k8_distribution = rde_2_0_0.Distribution(
+        template_name=entity_status.cloud_properties.k8_distribution.template_name,  # noqa: E501
+        template_revision=entity_status.cloud_properties.k8_distribution.template_revision)  # noqa: E501
+
+    settings = rde_2_0_0.Settings(
+        network=entity_status.cloud_properties.ovdc_network_name,
+        ssh_key=entity_status.cloud_properties.ssh_key,
+        rollback_on_failure=entity_status.cloud_properties.rollback_on_failure)  # noqa: E501
+
+    return rde_2_0_0.ClusterSpec(settings=settings,
+                                 k8_distribution=k8_distribution,
+                                 control_plane=control_plane,
+                                 workers=workers,
+                                 nfs=nfs)

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -69,7 +69,8 @@ def construct_cluster_spec_from_entity_status(entity_status: Union[rde_1_0_0.Sta
     :return: Cluster Specification of respective rde_version_in_use
     :raises NotImplementedError
     """
-    if rde_version_in_use == def_constants.RDESchemaVersions.RDE_2_X.value:
+    # TODO: Refactor this multiple if to rde_version -> handler pattern
+    if rde_version_in_use == '2.0.0':
         return construct_2_0_0_cluster_spec_from_entity_status(entity_status)
     raise NotImplementedError(f"constructing cluster spec from entity status for {rde_version_in_use} is"  # noqa:
                               f" not implemented ")

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -61,7 +61,7 @@ def get_rde_metadata(rde_version: str) -> dict:
     return def_constants.MAP_RDE_VERSION_TO_ITS_METADATA[rde_version]
 
 
-def construct_cluster_spec_from_entity_status(entity_status: Union[rde_1_0_0.Status, rde_2_0_0.Status, dict], rde_version_in_use: str) -> Union[rde_1_0_0.ClusterSpec, rde_2_0_0.ClusterSpec]:  # noqa: E501
+def construct_cluster_spec_from_entity_status(entity_status: Union[rde_1_0_0.Status, rde_2_0_0.Status], rde_version_in_use: str) -> Union[rde_1_0_0.ClusterSpec, rde_2_0_0.ClusterSpec]:  # noqa: E501
     """Construct cluster specification from entity status of given rde version.
 
     :param rde_X_X_X Status entity_status: Entity Status of rde of given version  # noqa: E501
@@ -71,20 +71,18 @@ def construct_cluster_spec_from_entity_status(entity_status: Union[rde_1_0_0.Sta
     """
     # TODO: Refactor this multiple if to rde_version -> handler pattern
     if rde_version_in_use == '2.0.0':
-        return construct_2_0_0_cluster_spec_from_entity_status(entity_status)
+        return construct_2_x_cluster_spec_from_entity_status(entity_status)
     raise NotImplementedError(f"constructing cluster spec from entity status for {rde_version_in_use} is"  # noqa:
                               f" not implemented ")
 
 
-def construct_2_0_0_cluster_spec_from_entity_status(entity_status: Union[rde_2_0_0.Status, dict]) -> rde_2_0_0.ClusterSpec:  # noqa:
+def construct_2_x_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Status) -> rde_2_0_0.ClusterSpec:  # noqa:
     """Construct cluster specification from entity status using rde_2_0_0 model.
 
     :param rde_2_0_0.Status entity_status: Entity Status as defined in rde_2_0_0  # noqa: E501
     :return: Cluster Specification as defined in rde_2_0_0 model
     """
-    if isinstance(entity_status, dict):
-        entity_status = rde_2_0_0.Status(**entity_status)
-
+    # Currently only single control-plane is supported.
     control_plane = rde_2_0_0.ControlPlane(
         sizing_class=entity_status.nodes.control_plane.sizing_class,
         storage_profile=entity_status.nodes.control_plane.storage_profile,

--- a/cse_def_schema/schema_2_0_0.json
+++ b/cse_def_schema/schema_2_0_0.json
@@ -250,7 +250,7 @@
                 },
                 "additionalProperties": true
             },
-            "apiversion": {
+            "api_version": {
                 "type": "string",
                 "description":"Yet to be defined."
             }


### PR DESCRIPTION
- Cluster operations get the current state from defined entity status  
- Change the rde usage to 2.0.0 in cluster_svc2.py
- Method to convert the status to Spec as part of Cluster Service (Logically more closer for this method to be here)
- Retrieves the current state from Status using Helper 
- Stops updating the spec while updating Status, 
- While updating the Status, update the newly added cloud_properties and storage_profile
- Sanity test done on cluster creation using rde 2.0.0 and cluster service 2_x
- Verified Status gets updated
- **TODO:** Get latest master code and do cluster operations
---------
![image](https://user-images.githubusercontent.com/5530442/109189991-7b4e9e80-7749-11eb-8939-be8b8cb27cd5.png)

---------------------------
![image](https://user-images.githubusercontent.com/5530442/109190074-93262280-7749-11eb-8b33-f05519839a61.png)
--------------------------------------------------------
@Anirudh9794 @sahithi @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/928)
<!-- Reviewable:end -->
