### PR TITLE
[VCDA-2151]  use server_rde_version to register rde schema in CSE install

### DIFF
--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -788,7 +788,7 @@ def _register_def_schema(client: Client,
         for interface_metadata in interfaces_metadata_list:
             try:
                 schema_svc.get_interface(interface_metadata.get_id())
-                if interface_metadata is def_constants.CommonInterfaceMetadata:
+                if interface_metadata == def_constants.CommonInterfaceMetadata:
                     msg = f"Built in kubernetes interface {interface_metadata.NAME} present"  # noqa: E501
                 else:
                     msg = f"Skipping creation of interface {interface_metadata.NAME}." \
@@ -797,10 +797,10 @@ def _register_def_schema(client: Client,
                 INSTALL_LOGGER.info(msg)
             except cse_exception.DefSchemaServiceError:
                 # If built-in interface is missing, raise an Exception.
-                if interface_metadata is def_constants.CommonInterfaceMetadata:
+                if interface_metadata == def_constants.CommonInterfaceMetadata:
                     msg = f"Built in interface {interface_metadata.NAME} not present."  # noqa: E501
                     msg_update_callback.error(msg)
-                    INSTALL_LOGGER(msg)
+                    INSTALL_LOGGER.error(msg)
                     raise
                 # Create other interfaces if not present
                 interface: common_models.DefInterface = \

--- a/container_service_extension/rde/constants.py
+++ b/container_service_extension/rde/constants.py
@@ -89,6 +89,7 @@ class NativeEntityTypeMetadata_1_0_0(str, Enum):
     VENDOR = Vendor.CSE.value
     NSS = DEF_NATIVE_ENTITY_TYPE_NSS
     VERSION = '1.0.0'
+    SCHEMA_FILE = 'schema_1_0_0.json'
     NAME = 'nativeClusterEntityType'
 
     @classmethod
@@ -117,33 +118,6 @@ class TKGEntityTypeMetadata_1_0_0(str, Enum):
     @classmethod
     def get_id(cls):
         return f"{DEF_ENTITY_TYPE_ID_PREFIX}:{cls.VENDOR}:{cls.NSS}:{cls.VERSION}"  # noqa: E501
-
-
-# TODO: Replace MAP_API_VERSION_TO_KEYS with MAP_RDE_VERSION_TO_ITS_METADATA
-MAP_API_VERSION_TO_KEYS = {
-    35.0: {
-        DefKey.INTERFACE_VENDOR: CommonInterfaceMetadata.VENDOR,
-        DefKey.INTERFACE_NSS: CommonInterfaceMetadata.NSS,
-        DefKey.INTERFACE_VERSION: CommonInterfaceMetadata.VERSION,
-        DefKey.INTERFACE_NAME: CommonInterfaceMetadata.NAME,
-        DefKey.ENTITY_TYPE_VENDOR: NativeEntityTypeMetadata_1_0_0.VENDOR,
-        DefKey.ENTITY_TYPE_NSS: NativeEntityTypeMetadata_1_0_0.NSS,
-        DefKey.ENTITY_TYPE_VERSION: NativeEntityTypeMetadata_1_0_0.VERSION,
-        DefKey.ENTITY_TYPE_NAME: NativeEntityTypeMetadata_1_0_0.NAME,
-        DefKey.ENTITY_TYPE_SCHEMA_VERSION: 'api_v35',
-    },
-    36.0: {
-        DefKey.INTERFACE_VENDOR: CommonInterfaceMetadata.VENDOR,
-        DefKey.INTERFACE_NSS: CommonInterfaceMetadata.NSS,
-        DefKey.INTERFACE_VERSION: CommonInterfaceMetadata.VERSION,
-        DefKey.INTERFACE_NAME: CommonInterfaceMetadata.NAME,
-        DefKey.ENTITY_TYPE_VENDOR: NativeEntityTypeMetadata_2_0_0.VENDOR,
-        DefKey.ENTITY_TYPE_NSS: NativeEntityTypeMetadata_2_0_0.NSS,
-        DefKey.ENTITY_TYPE_VERSION: NativeEntityTypeMetadata_2_0_0.VERSION,
-        DefKey.ENTITY_TYPE_NAME: NativeEntityTypeMetadata_2_0_0.NAME,
-        DefKey.ENTITY_TYPE_SCHEMA_VERSION: 'api_v35',
-    }
-}
 
 
 @unique

--- a/container_service_extension/rde/constants.py
+++ b/container_service_extension/rde/constants.py
@@ -43,19 +43,6 @@ DEF_NATIVE_ENTITY_TYPE_RIGHT_BUNDLE = \
     f'{Vendor.CSE.value}:{Nss.NATIVE_ClUSTER.value} Entitlement'
 
 
-@unique
-class DefKey(str, Enum):
-    INTERFACE_VENDOR = 'interface_vendor'
-    INTERFACE_NSS = 'interface_nss'
-    INTERFACE_VERSION = 'interface_version'
-    INTERFACE_NAME = 'interface_name'
-    ENTITY_TYPE_VENDOR = 'entity_type_vendor'
-    ENTITY_TYPE_NAME = 'entity_type_name'
-    ENTITY_TYPE_NSS = 'entity_type_nss'
-    ENTITY_TYPE_VERSION = 'entity_type_version'
-    ENTITY_TYPE_SCHEMA_VERSION = 'schema_version'
-
-
 # Defines the RDE version CSE server uses at runtime.
 # RDE version used by a given CSE version can differ based on the VCD
 # environment it is configured with.

--- a/cse_def_schema/api_v35/schema.json
+++ b/cse_def_schema/api_v35/schema.json
@@ -1,215 +1,260 @@
 {
-        "definitions": {
-            "node": {
-                "type": "object",
-                "required": ["name"],
-                "properties": {
-                    "name": {"type": "string"},
-                    "ip": {"type": "string"},
-                    "sizing_class": {"type": "string"}
-                },
-                "additionalproperties": true
-            }
-        },
-        "type": "object",
-        "required": [
-            "kind",
-            "spec",
-            "metadata"
-        ],
-        "properties": {
-            "kind": {
-                "enum": [
-                    "native",
-                    "TanzuKubernetesCluster",
-                    "TKG+"
-                ],
-                "type": "string",
-                "description": "The kind of the Kubernetes cluster."
+    "definitions": {
+        "node": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+                "name": {"type": "string"},
+                "ip": {"type": "string"},
+                "sizing_class": {"type": "string"},
+                "storage_profile": {"type": "string"}
             },
-            "spec": {
-                "type": "object",
-                "description": "The user specification of the desired state of the cluster.",
-                "required": [
-                    "settings"
-                ],
-                "properties": {
-                    "workers": {
-                        "type": "object",
-                        "description":"The desired worker state of the cluster. The properties \"sizing_class\" and \"storage_profile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\". Non uniform worker nodes in the clusters is not yet supported.",
-                        "required": [
-                            "count"
-                        ],
-                        "properties": {
-                            "count": {
-                                "type": "integer",
-                                "description":"Worker nodes can be scaled up and down.",
-                                "maximum": 100,
-                                "minimum": 0
-                            },
-                            "sizing_class": {
-                                "type": "string",
-                                "description":"The compute sizing policy with which worker nodes need to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc."
-                            },
-                            "storage_profile": {
-                                "type": "string",
-                                "description":"The storage-profile with which worker nodes need to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc."
-                            }
+            "additionalProperties": true
+        },
+        "k8_distribution": {
+            "type": "object",
+            "required": [
+               "template_name",
+               "template_revision"
+            ],
+            "properties": {
+               "template_name":  { "type": "string"},
+               "template_revision": { "type": "integer"}
+            },
+            "additionalProperties": true
+        }
+    },
+    "type": "object",
+    "required": [
+        "kind",
+        "spec",
+        "metadata"
+    ],
+    "properties": {
+        "kind": {
+            "enum": [
+                "native",
+                "TanzuKubernetesCluster",
+                "TKG+"
+            ],
+            "type": "string",
+            "description": "The kind of the Kubernetes cluster."
+        },
+        "spec": {
+            "type": "object",
+            "description": "The user specification of the desired state of the cluster.",
+            "required": [
+                "settings"
+            ],
+            "properties": {
+                "workers": {
+                    "type": "object",
+                    "description":"The desired worker state of the cluster. The properties \"sizing_class\" and \"storage_profile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\". Non uniform worker nodes in the clusters is not yet supported.",
+                    "required": [
+                        "count"
+                    ],
+                    "properties": {
+                        "count": {
+                            "type": "integer",
+                            "description":"Worker nodes can be scaled up and down.",
+                            "maximum": 100,
+                            "minimum": 0
+                        },
+                        "sizing_class": {
+                            "type": "string",
+                            "description":"The compute sizing policy with which worker nodes need to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc."
+                        },
+                        "storage_profile": {
+                            "type": "string",
+                            "description":"The storage-profile with which worker nodes need to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc."
                         }
                     },
-                    "control_plane": {
-                        "type": "object",
-                        "description":"The desired control-plane state of the cluster. The properties \"sizing_class\" and \"storage_profile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\".\n ",
-                        "required": [
-                            "count"
-                        ],
-                        "properties": {
-                            "count": {
-                                "type": "integer",
-                                "description":"Single control plane node is supported; More than single control plane node is not yet supported.",
-                                "maximum": 1,
-                                "minimum": 1
-                            },
-                            "sizing_class": {
-                                "type": "string",
-                                "description":"The compute sizing policy with which control-plane node needs to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc."
-                            },
-                            "storage_profile": {
-                                "type": "string",
-                                "description":"The storage-profile with which control-plane needs to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc."
-                            }
+                    "additionalProperties": true
+                },
+                "control_plane": {
+                    "type": "object",
+                    "description":"The desired control-plane state of the cluster. The properties \"sizing_class\" and \"storage_profile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\".\n ",
+                    "required": [
+                        "count"
+                    ],
+                    "properties": {
+                        "count": {
+                            "type": "integer",
+                            "description":"Single control plane node is supported; More than single control plane node is not yet supported.",
+                            "maximum": 1,
+                            "minimum": 1
+                        },
+                        "sizing_class": {
+                            "type": "string",
+                            "description":"The compute sizing policy with which control-plane node needs to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc."
+                        },
+                        "storage_profile": {
+                            "type": "string",
+                            "description":"The storage-profile with which control-plane needs to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc."
                         }
+                    },
+                    "additionalProperties": true
+                },
+                "nfs": {
+                    "type": "object",
+                    "description":"The desired nfs state of the cluster. The properties \"sizing_class\" and \"storage_profile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\".",
+                    "required": [
+                        "count"
+                    ],
+                    "properties": {
+                        "count": {
+                            "type": "integer",
+                            "description":"Nfs nodes can only be scaled-up; they cannot be scaled-down.",
+                            "maximum": 100,
+                            "minimum": 0
+                        },
+                        "sizing_class": {
+                            "type": "string",
+                            "description":"The compute sizing policy with which nfs node needs to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc."
+                        },
+                        "storage_profile": {
+                            "type": "string",
+                            "description":"The storage-profile with which nfs needs to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc."
+                        }
+                    },
+                    "additionalProperties": true
+                },
+                "settings": {
+                    "type": "object",
+                    "required": [
+                        "network"
+                    ],
+                    "properties": {
+                        "network": {
+                            "type": "string",
+                            "description":"Name of the Organization's virtual data center network"
+                        },
+                        "ssh_key": {
+                            "type": "string",
+                            "description":"The ssh key that users can use to log into the node VMs without explicitly providing passwords."
+                        },
+                        "rollback_on_failure": {
+                            "type": "boolean",
+                            "description":"On any cluster operation failure, if the value is set to true, affected node VMs will be automatically deleted."
+                        }
+                    },
+                    "additionalProperties": true
+                },
+                "k8_distribution": {
+                  "$ref": "#/definitions/k8_distribution"
+                }
+            },
+            "additionalProperties": true
+        },
+        "status": {
+            "type": "object",
+            "description":"The current status of the cluster.",
+            "required": [
+                "nodes"
+            ],
+            "properties": {
+                "phase": {
+                    "type": "string"
+                },
+                "kubernetes": {
+                    "type": "string"
+                },
+                "cni": {
+                    "type": "string"
+                },
+                "os": {
+                    "type": "string"
+                },
+                "docker_version": {
+                    "type": "string"
+                },
+                "nodes": {
+                  "type": "object",
+                  "required": [
+                    "control_plane"
+                  ],
+                  "properties": {
+                    "control_plane": {
+                      "$ref": "#/definitions/node"
+                    },
+                    "workers": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/node"
+                      },
+                      "default": []
                     },
                     "nfs": {
-                        "type": "object",
-                        "description":"The desired nfs state of the cluster. The properties \"sizing_class\" and \"storage_profile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\".",
-                        "required": [
-                            "count"
-                        ],
-                        "properties": {
-                            "count": {
-                                "type": "integer",
-                                "description":"Nfs nodes can only be scaled-up; they cannot be scaled-down.",
-                                "maximum": 100,
-                                "minimum": 0
-                            },
-                            "sizing_class": {
-                                "type": "string",
-                                "description":"The compute sizing policy with which nfs node needs to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc."
-                            },
-                            "storage_profile": {
-                                "type": "string",
-                                "description":"The storage-profile with which nfs needs to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc."
-                            }
-                        }
-                    },
-                    "settings": {
-                        "type": "object",
-                        "required": [
-                            "network"
-                        ],
-                        "properties": {
-                            "network": {
-                                "type": "string",
-                                "description":"Name of the Organization's virtual data center network"
-                            },
-                            "ssh_key": {
-                                "type": "string",
-                                "description":"The ssh key that users can use to log into the node VMs without explicitly providing passwords."
-                            },
-                            "rollback_on_failure": {
-                                "type": "boolean",
-                                "description":"On any cluster operation failure, if the value is set to true, affected node VMs will be automatically deleted."
-                            }
-                        }
-                    },
-                    "k8_distribution": {
-                        "type": "object",
-                        "required": [
-                            "template_name",
-                            "template_revision"
-                        ],
-                        "properties": {
-                            "template_name": {
-                                "type": "string"
-                            },
-                            "template_revision": {
-                                "type": "integer"
-                            }
-                        }
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/node"
+                      },
+                      "default": []
                     }
-                }
-            },
-            "status": {
-                "type": "object",
-                "description":"The current status of the cluster.",
-                "required": [
-                    "nodes"
-                ],
-                "properties": {
-                    "phase": {
-                        "type": "string"
-                    },
-                    "kubernetes": {
-                        "type": "string"
-                    },
-                    "cni": {
-                        "type": "string"
-                    },
-                    "os": {
-                        "type": "string"
-                    },
-                    "docker_version": {
-                        "type": "string"
-                    },
-                    "nodes": {
-                        "type": "object",
-                        "required": ["control_plane"],
-                        "properties": {
-                            "control_plane": {
-                                "$ref": "#/definitions/node"
-                            },
-                            "workers": {
-                                "type": "array",
-                                "items": {"$ref": "#/definitions/node"},
-                                "default": []
-                            },
-                            "nfs": {
-                                "type": "array",
-                                "items": {"$ref": "#/definitions/node"},
-                                "default": []
-                            }
-                        }
+                  },
+                  "additionalProperties": true
                 },
-                "additionalproperties": true
-            },
-            "metadata": {
-                "type": "object",
-                "required": [
-                    "org_name",
-                    "ovdc_name",
-                    "cluster_name"
-                ],
-                "properties": {
+                "cloud_properties": {
+                  "type": "object",
+                  "description": "The details specific to Cloud Director in which the cluster is hosted.",
+                  "properties": {
                     "org_name": {
-                        "type": "string",
-                        "description":"The name of the Organization in which cluster needs to be created or managed."
+                      "type": "string",
+                      "description":"The name of the Organization in which cluster needs to be created or managed."
                     },
                     "ovdc_name": {
-                        "type": "string",
-                        "description":"The name of the Organization Virtual data center in which the cluster need to be created or managed."
+                      "type": "string",
+                      "description":"The name of the Organization Virtual data center in which the cluster need to be created or managed."
                     },
-                    "cluster_name": {
-                        "type": "string",
-                        "description":"The name of the cluster."
+                    "ovdc_network_name": {
+                      "type":  "string",
+                      "description": "The name of the Organization Virtual data center network to which cluster is connected."
+                    },
+                    "k8_distribution": {
+                      "$ref": "#/definitions/k8_distribution"
+                    },
+                    "ssh_key": {
+                      "type": "string",
+                      "description":"The ssh key that users can use to log into the node VMs without explicitly providing passwords."
+                    },
+                    "rollback_on_failure": {
+                      "type": "boolean",
+                      "description":"On any cluster operation failure, if the value is set to true, affected node VMs will be automatically deleted."
                     }
+                  },
+                  "additionalProperties": true
                 }
             },
-            "apiversion": {
-                "type": "string",
-                "description":"Yet to be defined."
-            }
+            "additionalProperties": true
         },
-        "additionalproperties": false
-    }
+        "metadata": {
+            "type": "object",
+            "required": [
+                "org_name",
+                "ovdc_name",
+                "cluster_name"
+            ],
+            "properties": {
+                "org_name": {
+                    "type": "string",
+                    "description":"The name of the Organization in which cluster needs to be created or managed."
+                },
+                "ovdc_name": {
+                    "type": "string",
+                    "description":"The name of the Organization Virtual data center in which the cluster need to be created or managed."
+                },
+                "cluster_name": {
+                    "type": "string",
+                    "description":"The name of the cluster."
+                }
+            },
+            "additionalProperties": true
+        },
+        "apiversion": {
+            "type": "string",
+            "description":"Yet to be defined."
+        }
+    },
+    "additionalProperties": false
+
 }

--- a/cse_def_schema/schema_1_0_0.json
+++ b/cse_def_schema/schema_1_0_0.json
@@ -1,3 +1,260 @@
 {
-  "Read_me": "placeholder file for rde version 1.0.0 schema; yet to be moved from cse_def_schema/api_v35/schema.json."
+  "definitions": {
+      "node": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+              "name": {"type": "string"},
+              "ip": {"type": "string"},
+              "sizing_class": {"type": "string"},
+              "storage_profile": {"type": "string"}
+          },
+          "additionalProperties": true
+      },
+      "k8_distribution": {
+          "type": "object",
+          "required": [
+             "template_name",
+             "template_revision"
+          ],
+          "properties": {
+             "template_name":  { "type": "string"},
+             "template_revision": { "type": "integer"}
+          },
+          "additionalProperties": true
+      }
+  },
+  "type": "object",
+  "required": [
+      "kind",
+      "spec",
+      "metadata"
+  ],
+  "properties": {
+      "kind": {
+          "enum": [
+              "native",
+              "TanzuKubernetesCluster",
+              "TKG+"
+          ],
+          "type": "string",
+          "description": "The kind of the Kubernetes cluster."
+      },
+      "spec": {
+          "type": "object",
+          "description": "The user specification of the desired state of the cluster.",
+          "required": [
+              "settings"
+          ],
+          "properties": {
+              "workers": {
+                  "type": "object",
+                  "description":"The desired worker state of the cluster. The properties \"sizing_class\" and \"storage_profile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\". Non uniform worker nodes in the clusters is not yet supported.",
+                  "required": [
+                      "count"
+                  ],
+                  "properties": {
+                      "count": {
+                          "type": "integer",
+                          "description":"Worker nodes can be scaled up and down.",
+                          "maximum": 100,
+                          "minimum": 0
+                      },
+                      "sizing_class": {
+                          "type": "string",
+                          "description":"The compute sizing policy with which worker nodes need to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc."
+                      },
+                      "storage_profile": {
+                          "type": "string",
+                          "description":"The storage-profile with which worker nodes need to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc."
+                      }
+                  },
+                  "additionalProperties": true
+              },
+              "control_plane": {
+                  "type": "object",
+                  "description":"The desired control-plane state of the cluster. The properties \"sizing_class\" and \"storage_profile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\".\n ",
+                  "required": [
+                      "count"
+                  ],
+                  "properties": {
+                      "count": {
+                          "type": "integer",
+                          "description":"Single control plane node is supported; More than single control plane node is not yet supported.",
+                          "maximum": 1,
+                          "minimum": 1
+                      },
+                      "sizing_class": {
+                          "type": "string",
+                          "description":"The compute sizing policy with which control-plane node needs to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc."
+                      },
+                      "storage_profile": {
+                          "type": "string",
+                          "description":"The storage-profile with which control-plane needs to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc."
+                      }
+                  },
+                  "additionalProperties": true
+              },
+              "nfs": {
+                  "type": "object",
+                  "description":"The desired nfs state of the cluster. The properties \"sizing_class\" and \"storage_profile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\".",
+                  "required": [
+                      "count"
+                  ],
+                  "properties": {
+                      "count": {
+                          "type": "integer",
+                          "description":"Nfs nodes can only be scaled-up; they cannot be scaled-down.",
+                          "maximum": 100,
+                          "minimum": 0
+                      },
+                      "sizing_class": {
+                          "type": "string",
+                          "description":"The compute sizing policy with which nfs node needs to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc."
+                      },
+                      "storage_profile": {
+                          "type": "string",
+                          "description":"The storage-profile with which nfs needs to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc."
+                      }
+                  },
+                  "additionalProperties": true
+              },
+              "settings": {
+                  "type": "object",
+                  "required": [
+                      "network"
+                  ],
+                  "properties": {
+                      "network": {
+                          "type": "string",
+                          "description":"Name of the Organization's virtual data center network"
+                      },
+                      "ssh_key": {
+                          "type": "string",
+                          "description":"The ssh key that users can use to log into the node VMs without explicitly providing passwords."
+                      },
+                      "rollback_on_failure": {
+                          "type": "boolean",
+                          "description":"On any cluster operation failure, if the value is set to true, affected node VMs will be automatically deleted."
+                      }
+                  },
+                  "additionalProperties": true
+              },
+              "k8_distribution": {
+                "$ref": "#/definitions/k8_distribution"
+              }
+          },
+          "additionalProperties": true
+      },
+      "status": {
+          "type": "object",
+          "description":"The current status of the cluster.",
+          "required": [
+              "nodes"
+          ],
+          "properties": {
+              "phase": {
+                  "type": "string"
+              },
+              "kubernetes": {
+                  "type": "string"
+              },
+              "cni": {
+                  "type": "string"
+              },
+              "os": {
+                  "type": "string"
+              },
+              "docker_version": {
+                  "type": "string"
+              },
+              "nodes": {
+                "type": "object",
+                "required": [
+                  "control_plane"
+                ],
+                "properties": {
+                  "control_plane": {
+                    "$ref": "#/definitions/node"
+                  },
+                  "workers": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/node"
+                    },
+                    "default": []
+                  },
+                  "nfs": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/node"
+                    },
+                    "default": []
+                  }
+                },
+                "additionalProperties": true
+              },
+              "cloud_properties": {
+                "type": "object",
+                "description": "The details specific to Cloud Director in which the cluster is hosted.",
+                "properties": {
+                  "org_name": {
+                    "type": "string",
+                    "description":"The name of the Organization in which cluster needs to be created or managed."
+                  },
+                  "ovdc_name": {
+                    "type": "string",
+                    "description":"The name of the Organization Virtual data center in which the cluster need to be created or managed."
+                  },
+                  "ovdc_network_name": {
+                    "type":  "string",
+                    "description": "The name of the Organization Virtual data center network to which cluster is connected."
+                  },
+                  "k8_distribution": {
+                    "$ref": "#/definitions/k8_distribution"
+                  },
+                  "ssh_key": {
+                    "type": "string",
+                    "description":"The ssh key that users can use to log into the node VMs without explicitly providing passwords."
+                  },
+                  "rollback_on_failure": {
+                    "type": "boolean",
+                    "description":"On any cluster operation failure, if the value is set to true, affected node VMs will be automatically deleted."
+                  }
+                },
+                "additionalProperties": true
+              }
+          },
+          "additionalProperties": true
+      },
+      "metadata": {
+          "type": "object",
+          "required": [
+              "org_name",
+              "ovdc_name",
+              "cluster_name"
+          ],
+          "properties": {
+              "org_name": {
+                  "type": "string",
+                  "description":"The name of the Organization in which cluster needs to be created or managed."
+              },
+              "ovdc_name": {
+                  "type": "string",
+                  "description":"The name of the Organization Virtual data center in which the cluster need to be created or managed."
+              },
+              "cluster_name": {
+                  "type": "string",
+                  "description":"The name of the cluster."
+              }
+          },
+          "additionalProperties": true
+      },
+      "apiversion": {
+          "type": "string",
+          "description":"Yet to be defined."
+      }
+  },
+  "additionalProperties": false
+
 }


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Changes to use the dynamically computed `server_rde_version` to register and define interfaces

* Made changes to register array of interfaces
* Created placeholders for behavior code
* Remove the usage of MAP_API_VERSION_TO_KEYS dictionary.
* check for the presence of the required interface/ entity type before creation.

Testing done:
* Cse install to install RDE schema 1.0.0 and 2.0,0
* CSE run to dynamically load the registered schema

@sahithi @sakthisunda @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/931)
<!-- Reviewable:end -->
