### PR TITLE
[VCDA-2148] Input validator by RDE version 

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -551,6 +551,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         desired_template_revision = update_spec.spec.k8_distribution.template_revision  # noqa: E501
         if current_template_name != desired_template_name or current_template_revision != desired_template_revision:  # noqa: E501
             return self.upgrade_cluster(cluster_id, update_spec)
+        e.CseServerError("update not supported for the specified input specification")  # noqa: E501
 
     def get_cluster_acl_info(self, cluster_id, page: int, page_size: int):
         """Get cluster ACL info based on the defined entity ACL."""

--- a/container_service_extension/rde/constants.py
+++ b/container_service_extension/rde/constants.py
@@ -70,52 +70,6 @@ class RDEVersion(str, Enum):
     RDE_2_0_0 = '2.0.0'
 
 
-class CommonInterfaceMetadata(str, Enum):
-    VENDOR = Vendor.VMWARE.value
-    NSS = Nss.KUBERNETES.value
-    VERSION = '1.0.0'
-    NAME = "Kubernetes"
-
-    @classmethod
-    def get_id(cls):
-        return f"{DEF_INTERFACE_ID_PREFIX}:{cls.VENDOR}:{cls.NSS}:{cls.VERSION}"  # noqa: E501
-
-
-class NativeEntityTypeMetadata_1_0_0(str, Enum):
-    VENDOR = Vendor.CSE.value
-    NSS = DEF_NATIVE_ENTITY_TYPE_NSS
-    VERSION = '1.0.0'
-    SCHEMA_FILE = 'schema_1_0_0.json'
-    NAME = 'nativeClusterEntityType'
-
-    @classmethod
-    def get_id(cls):
-        return f"{DEF_ENTITY_TYPE_ID_PREFIX}:{cls.VENDOR}:{cls.NSS}:{cls.VERSION}"  # noqa: E501
-
-
-class NativeEntityTypeMetadata_2_0_0(str, Enum):
-    VENDOR = Vendor.CSE.value
-    NSS = DEF_NATIVE_ENTITY_TYPE_NSS
-    VERSION = '2.0.0'
-    SCHEMA_FILE = 'schema_2_0_0.json'
-    NAME = 'nativeClusterEntityType'
-
-    @classmethod
-    def get_id(cls):
-        return f"{DEF_ENTITY_TYPE_ID_PREFIX}:{cls.VENDOR}:{cls.NSS}:{cls.VERSION}"  # noqa: E501
-
-
-class TKGEntityTypeMetadata_1_0_0(str, Enum):
-    VENDOR = Vendor.VMWARE.value
-    NSS = TKG_ENTITY_TYPE_NSS
-    VERSION = '1.0.0'
-    NAME = "TKG Cluster"
-
-    @classmethod
-    def get_id(cls):
-        return f"{DEF_ENTITY_TYPE_ID_PREFIX}:{cls.VENDOR}:{cls.NSS}:{cls.VERSION}"  # noqa: E501
-
-
 @unique
 class RDEMetadataKey(str, Enum):
     ENTITY_TYPE = 'entity_type'

--- a/container_service_extension/rde/constants.py
+++ b/container_service_extension/rde/constants.py
@@ -65,6 +65,58 @@ class RuntimeRDEVersion(str, Enum):
 
 
 @unique
+class RDEVersion(str, Enum):
+    RDE_1_0_0 = '1.0.0'
+    RDE_2_0_0 = '2.0.0'
+
+
+class CommonInterfaceMetadata(str, Enum):
+    VENDOR = Vendor.VMWARE.value
+    NSS = Nss.KUBERNETES.value
+    VERSION = '1.0.0'
+    NAME = "Kubernetes"
+
+    @classmethod
+    def get_id(cls):
+        return f"{DEF_INTERFACE_ID_PREFIX}:{cls.VENDOR}:{cls.NSS}:{cls.VERSION}"  # noqa: E501
+
+
+class NativeEntityTypeMetadata_1_0_0(str, Enum):
+    VENDOR = Vendor.CSE.value
+    NSS = DEF_NATIVE_ENTITY_TYPE_NSS
+    VERSION = '1.0.0'
+    SCHEMA_FILE = 'schema_1_0_0.json'
+    NAME = 'nativeClusterEntityType'
+
+    @classmethod
+    def get_id(cls):
+        return f"{DEF_ENTITY_TYPE_ID_PREFIX}:{cls.VENDOR}:{cls.NSS}:{cls.VERSION}"  # noqa: E501
+
+
+class NativeEntityTypeMetadata_2_0_0(str, Enum):
+    VENDOR = Vendor.CSE.value
+    NSS = DEF_NATIVE_ENTITY_TYPE_NSS
+    VERSION = '2.0.0'
+    SCHEMA_FILE = 'schema_2_0_0.json'
+    NAME = 'nativeClusterEntityType'
+
+    @classmethod
+    def get_id(cls):
+        return f"{DEF_ENTITY_TYPE_ID_PREFIX}:{cls.VENDOR}:{cls.NSS}:{cls.VERSION}"  # noqa: E501
+
+
+class TKGEntityTypeMetadata_1_0_0(str, Enum):
+    VENDOR = Vendor.VMWARE.value
+    NSS = TKG_ENTITY_TYPE_NSS
+    VERSION = '1.0.0'
+    NAME = "TKG Cluster"
+
+    @classmethod
+    def get_id(cls):
+        return f"{DEF_ENTITY_TYPE_ID_PREFIX}:{cls.VENDOR}:{cls.NSS}:{cls.VERSION}"  # noqa: E501
+
+
+@unique
 class RDEMetadataKey(str, Enum):
     ENTITY_TYPE = 'entity_type'
     INTERFACES = 'interfaces'

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -32,7 +32,7 @@ class ControlPlane:
 
 @dataclass()
 class Workers:
-    sizing_class: str = None
+    sizing_class: str = "System Default"
     storage_profile: str = None
     count: int = 1
 
@@ -150,9 +150,15 @@ class ClusterSpec:
             if isinstance(settings, dict) else settings
         self.control_plane = ControlPlane(**control_plane) \
             if isinstance(control_plane, dict) else control_plane or ControlPlane()  # noqa: E501
+        if self.control_plane.sizing_class is None:
+            self.control_plane.sizing_class = "System Default"
         self.workers = Workers(**workers) \
             if isinstance(workers, dict) else workers or Workers()
+        if self.workers.sizing_class is None:
+            self.workers.sizing_class = "System Default"
         self.nfs = Nfs(**nfs) if isinstance(nfs, dict) else nfs or Nfs()
+        if self.nfs.sizing_class is None:
+            self.nfs.sizing_class = "System Default"
         self.k8_distribution = Distribution(**k8_distribution) \
             if isinstance(k8_distribution, dict) else k8_distribution or Distribution()  # noqa: E501
 

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -32,7 +32,7 @@ class ControlPlane:
 
 @dataclass()
 class Workers:
-    sizing_class: str = "System Default"
+    sizing_class: str = None
     storage_profile: str = None
     count: int = 1
 
@@ -150,15 +150,9 @@ class ClusterSpec:
             if isinstance(settings, dict) else settings
         self.control_plane = ControlPlane(**control_plane) \
             if isinstance(control_plane, dict) else control_plane or ControlPlane()  # noqa: E501
-        if self.control_plane.sizing_class is None:
-            self.control_plane.sizing_class = "System Default"
         self.workers = Workers(**workers) \
             if isinstance(workers, dict) else workers or Workers()
-        if self.workers.sizing_class is None:
-            self.workers.sizing_class = "System Default"
         self.nfs = Nfs(**nfs) if isinstance(nfs, dict) else nfs or Nfs()
-        if self.nfs.sizing_class is None:
-            self.nfs.sizing_class = "System Default"
         self.k8_distribution = Distribution(**k8_distribution) \
             if isinstance(k8_distribution, dict) else k8_distribution or Distribution()  # noqa: E501
 

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -77,7 +77,7 @@ def construct_cluster_spec_from_entity_status(entity_status: Union[rde_1_0_0.Sta
     :raises NotImplementedError
     """
     # TODO: Refactor this multiple if to rde_version -> handler pattern
-    if rde_version_in_use == '2.0.0':
+    if rde_version_in_use == def_constants.RDEVersion.RDE_2_0_0.value:
         return construct_2_x_cluster_spec_from_entity_status(entity_status)
     raise NotImplementedError(f"constructing cluster spec from entity status for {rde_version_in_use} is"  # noqa:
                               f" not implemented ")

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -97,8 +97,7 @@ def construct_2_x_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Statu
 
     workers_count = len(entity_status.nodes.workers)
     if workers_count == 0:
-        workers = rde_2_0_0.Workers(sizing_class='System Default',
-                                    storage_profile='*',
+        workers = rde_2_0_0.Workers(sizing_class=None, storage_profile=None,
                                     count=workers_count)
     else:
         workers = rde_2_0_0.Workers(
@@ -108,7 +107,7 @@ def construct_2_x_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Statu
 
     nfs_count = len(entity_status.nodes.nfs)
     if nfs_count == 0:
-        nfs = rde_2_0_0.Nfs(sizing_class='System Default', storage_profile='*',
+        nfs = rde_2_0_0.Nfs(sizing_class=None, storage_profile=None,
                             count=nfs_count)
     else:
         nfs = rde_2_0_0.Nfs(
@@ -154,5 +153,4 @@ def find_diff_fields(input_spec: dict, reference_spec: dict, exclude_fields: lis
     exclude_key_set = set(exclude_fields)
     key_set_for_validation = set(input_dict.keys()) - exclude_key_set
     return [key for key in key_set_for_validation
-            if input_dict.get(key) != reference_dict.get(key)]
-
+            if input_dict.get(key) and input_dict.get(key) != reference_dict.get(key)]  # noqa: E501

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -9,11 +9,8 @@ import json
 import math
 from typing import Union
 
-from container_service_extension.common.constants.server_constants import FlattenedClusterSpecKey  # noqa: E501
-from container_service_extension.common.constants.server_constants import VALID_UPDATE_FIELDS  # noqa: E501
 import container_service_extension.common.utils.core_utils as core_utils
 import container_service_extension.exception.exceptions as excptn
-from container_service_extension.exception.exceptions import BadRequestError
 from container_service_extension.lib.cloudapi.cloudapi_client import CloudApiClient  # noqa: E501
 import container_service_extension.rde.constants as def_constants
 import container_service_extension.rde.models.rde_1_0_0 as rde_1_0_0
@@ -100,7 +97,8 @@ def construct_2_x_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Statu
 
     workers_count = len(entity_status.nodes.workers)
     if workers_count == 0:
-        workers = rde_2_0_0.Workers(sizing_class=None, storage_profile='*',
+        workers = rde_2_0_0.Workers(sizing_class='System Default',
+                                    storage_profile='*',
                                     count=workers_count)
     else:
         workers = rde_2_0_0.Workers(
@@ -110,13 +108,13 @@ def construct_2_x_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Statu
 
     nfs_count = len(entity_status.nodes.nfs)
     if nfs_count == 0:
-        nfs = rde_2_0_0.Nfs(sizing_class=None, storage_profile='*',
+        nfs = rde_2_0_0.Nfs(sizing_class='System Default', storage_profile='*',
                             count=nfs_count)
     else:
         nfs = rde_2_0_0.Nfs(
             sizing_class=entity_status.nodes.nfs[0].sizing_class,  # noqa: E501
             storage_profile=entity_status.nodes.nfs[
-                0].storage_profile)
+                0].storage_profile, count=nfs_count)
 
     k8_distribution = rde_2_0_0.Distribution(
         template_name=entity_status.cloud_properties.k8_distribution.template_name,  # noqa: E501

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -9,7 +9,11 @@ import json
 import math
 from typing import Union
 
+from container_service_extension.common.constants.server_constants import FlattenedClusterSpecKey  # noqa: E501
+from container_service_extension.common.constants.server_constants import VALID_UPDATE_FIELDS  # noqa: E501
+import container_service_extension.common.utils.core_utils as core_utils
 import container_service_extension.exception.exceptions as excptn
+from container_service_extension.exception.exceptions import BadRequestError
 from container_service_extension.lib.cloudapi.cloudapi_client import CloudApiClient  # noqa: E501
 import container_service_extension.rde.constants as def_constants
 import container_service_extension.rde.models.rde_1_0_0 as rde_1_0_0
@@ -142,3 +146,15 @@ def load_rde_schema(schema_file: str) -> dict:
             schema_file.close()
         except Exception:
             pass
+
+
+def find_diff_fields(input_spec: dict, reference_spec: dict, exclude_fields: list = None) -> list:  # noqa: E501
+    if exclude_fields is None:
+        exclude_fields = []
+    input_dict = core_utils.flatten_dictionary(input_spec)
+    reference_dict = core_utils.flatten_dictionary(reference_spec)
+    exclude_key_set = set(exclude_fields)
+    key_set_for_validation = set(input_dict.keys()) - exclude_key_set
+    return [key for key in key_set_for_validation
+            if input_dict.get(key) != reference_dict.get(key)]
+

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -78,12 +78,12 @@ def construct_cluster_spec_from_entity_status(entity_status: Union[rde_1_0_0.Sta
     """
     # TODO: Refactor this multiple if to rde_version -> handler pattern
     if rde_version_in_use == def_constants.RDEVersion.RDE_2_0_0.value:
-        return construct_2_x_cluster_spec_from_entity_status(entity_status)
+        return construct_2_0_0_cluster_spec_from_entity_status(entity_status)
     raise NotImplementedError(f"constructing cluster spec from entity status for {rde_version_in_use} is"  # noqa:
                               f" not implemented ")
 
 
-def construct_2_x_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Status) -> rde_2_0_0.ClusterSpec:  # noqa:
+def construct_2_0_0_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Status) -> rde_2_0_0.ClusterSpec:  # noqa:
     """Construct cluster specification from entity status using rde_2_0_0 model.
 
     :param rde_2_0_0.Status entity_status: Entity Status as defined in rde_2_0_0  # noqa: E501

--- a/container_service_extension/rde/validators/abstract_validator.py
+++ b/container_service_extension/rde/validators/abstract_validator.py
@@ -1,0 +1,23 @@
+# container-service-extension
+# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import abc
+
+from container_service_extension.common.constants.server_constants import CseOperation  # noqa: E501
+
+
+class AbstractValidator(abc.ABC):
+    def __init__(self):
+        pass
+
+    @abc.abstractmethod
+    def validate(self, request_spec: dict, current_spec: dict, operation: CseOperation) -> bool:  # noqa: E501
+        """Validate the input_spec against current_spec.
+
+        :param dict request_spec: Request spec of the cluster
+        :param dict current_spec: Current status of the cluster
+        :param str operation: POST/PUT/DEL
+        :retur bool:
+        """
+        pass

--- a/container_service_extension/rde/validators/validator_factory.py
+++ b/container_service_extension/rde/validators/validator_factory.py
@@ -1,5 +1,6 @@
 import semantic_version
 
+import container_service_extension.rde.constants as rde_constants
 from container_service_extension.rde.validators.abstract_validator import AbstractValidator  # noqa: E501
 from container_service_extension.rde.validators.validator_rde_1_x import Validator_1_0_0  # noqa: E501
 from container_service_extension.rde.validators.validator_rde_2_x import Validator_2_0_0  # noqa: E501
@@ -13,7 +14,7 @@ def get_validator(rde_version_supported_api_handler: str) -> AbstractValidator:
     :rtype validator (container_service_extension.rde.validators.abstract_validator.AbstractValidator)  # noqa: E501
     """
     rde_version: semantic_version.Version = semantic_version.Version(rde_version_supported_api_handler)  # noqa: E501
-    if rde_version.major == 1:
+    if str(rde_version) == rde_constants.RDEVersion.RDE_1_0_0.value:
         return Validator_1_0_0()
-    elif rde_version.major == 2:
+    elif str(rde_version) == rde_constants.RDEVersion.RDE_2_0_0.value:
         return Validator_2_0_0()

--- a/container_service_extension/rde/validators/validator_factory.py
+++ b/container_service_extension/rde/validators/validator_factory.py
@@ -1,0 +1,19 @@
+import semantic_version
+
+from container_service_extension.rde.validators.abstract_validator import AbstractValidator  # noqa: E501
+from container_service_extension.rde.validators.validator_rde_1_x import Validator_1_0_0  # noqa: E501
+from container_service_extension.rde.validators.validator_rde_2_x import Validator_2_0_0  # noqa: E501
+
+
+def get_validator(rde_version_supported_api_handler: str) -> AbstractValidator:
+    """Get the right instance of input validator.
+
+    Factory method to return the Validator based on the RDE version in use.
+    :param str rde_version_supported_api_handler: version of rde for the api handler
+    :rtype validator (container_service_extension.rde.validators.abstract_validator.AbstractValidator)  # noqa: E501
+    """
+    rde_version: semantic_version.Version = semantic_version.Version(rde_version_supported_api_handler)  # noqa: E501
+    if rde_version.major == 1:
+        return Validator_1_0_0()
+    elif rde_version.major == 2:
+        return Validator_2_0_0()

--- a/container_service_extension/rde/validators/validator_rde_1_x.py
+++ b/container_service_extension/rde/validators/validator_rde_1_x.py
@@ -1,0 +1,22 @@
+# container-service-extension
+# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+from container_service_extension.common.constants.server_constants import CseOperation  # noqa: E501
+from container_service_extension.rde.validators.abstract_validator import AbstractValidator  # noqa: E501
+
+
+class Validator_1_0_0(AbstractValidator):
+    def __init__(self):
+        pass
+
+    def validate(self, request_spec: dict, current_status: dict, operation: CseOperation) -> bool:  # noqa: E501
+        """Validate the input_spec against current_status.
+
+        :param dict request_spec: Request spec of the cluster
+        :param dict current_status: Current status of the cluster
+        :param str operation: POST/PUT/DEL
+        :return: is validation is successful or failure
+        :rtype: bool
+        :raises NotImplementedError
+        """
+        raise NotImplementedError

--- a/container_service_extension/rde/validators/validator_rde_2_x.py
+++ b/container_service_extension/rde/validators/validator_rde_2_x.py
@@ -2,7 +2,11 @@
 # Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+
 from container_service_extension.common.constants.server_constants import CseOperation  # noqa: E501
+from container_service_extension.common.constants.server_constants import FlattenedClusterSpecKey  # noqa: E501
+from container_service_extension.common.constants.server_constants import VALID_UPDATE_FIELDS  # noqa: E501
+from container_service_extension.exception.exceptions import BadRequestError
 import container_service_extension.rde.utils as rde_utils
 from container_service_extension.rde.validators.abstract_validator import AbstractValidator  # noqa: E501
 
@@ -21,5 +25,45 @@ class Validator_2_0_0(AbstractValidator):
         :rtype: bool
         """
         if operation == CseOperation.V36_CLUSTER_UPDATE:
-            return rde_utils.validate_cluster_update_request_and_check_cluster_upgrade(request_spec, current_spec)  # noqa: E501
+            return validate_cluster_update_request_and_check_cluster_upgrade(request_spec, current_spec)  # noqa: E501
         raise NotImplementedError(f"Validator for {operation.name} not found")
+
+
+def validate_cluster_update_request_and_check_cluster_upgrade(input_spec: dict, reference_spec: dict) -> bool:  # noqa: E501
+    """Validate the desired spec with curr spec and check if upgrade operation.
+
+    :param dict input_spec: input spec
+    :param dict reference_spec: reference spec to validate the desired spec
+    :return: true if cluster operation is upgrade and false if operation is
+        resize
+    :rtype: bool
+    :raises: BadRequestError for invalid payload.
+    """
+    diff_fields = \
+        rde_utils.find_diff_fields(input_spec, reference_spec, exclude_fields=[])  # noqa: E501
+
+    # Raise exception if empty diff
+    if not diff_fields:
+        raise BadRequestError("No change in cluster specification")  # noqa: E501
+
+    # Raise exception if fields which cannot be changed are updated
+    keys_with_invalid_value = [k for k in diff_fields if k not in VALID_UPDATE_FIELDS]  # noqa: E501
+    if len(keys_with_invalid_value) > 0:
+        err_msg = f"Invalid input values found in {sorted(keys_with_invalid_value)}"  # noqa: E501
+        raise BadRequestError(err_msg)
+
+    is_resize_operation = False
+    if FlattenedClusterSpecKey.WORKERS_COUNT.value in diff_fields or \
+            FlattenedClusterSpecKey.NFS_COUNT.value in diff_fields:
+        is_resize_operation = True
+    is_upgrade_operation = False
+    if FlattenedClusterSpecKey.TEMPLATE_NAME.value in diff_fields or \
+            FlattenedClusterSpecKey.TEMPLATE_REVISION.value in diff_fields:
+        is_upgrade_operation = True
+
+    # Raise exception if resize and upgrade are performed at the same time
+    if is_resize_operation and is_upgrade_operation:
+        err_msg = "Cannot resize and upgrade the cluster at the same time"
+        raise BadRequestError(err_msg)
+
+    return is_upgrade_operation

--- a/container_service_extension/rde/validators/validator_rde_2_x.py
+++ b/container_service_extension/rde/validators/validator_rde_2_x.py
@@ -1,0 +1,25 @@
+# container-service-extension
+# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from container_service_extension.common.constants.server_constants import CseOperation  # noqa: E501
+import container_service_extension.rde.utils as rde_utils
+from container_service_extension.rde.validators.abstract_validator import AbstractValidator  # noqa: E501
+
+
+class Validator_2_0_0(AbstractValidator):
+    def __init__(self):
+        pass
+
+    def validate(self, request_spec: dict, current_spec: dict, operation: CseOperation) -> bool:  # noqa: E501
+        """Validate the input_spec against current_status of the cluster.
+
+        :param dict request_spec: Request spec of the cluster
+        :param dict current_spec: Current status of the cluster
+        :param CseOperation operation: CSE operation key
+        :return: is validation is successful or failure
+        :rtype: bool
+        """
+        if operation == CseOperation.V36_CLUSTER_UPDATE:
+            return rde_utils.validate_cluster_update_request_and_check_cluster_upgrade(request_spec, current_spec)  # noqa: E501
+        raise NotImplementedError(f"Validator for {operation.name} not found")

--- a/container_service_extension/rde/validators/validator_rde_2_x.py
+++ b/container_service_extension/rde/validators/validator_rde_2_x.py
@@ -24,6 +24,9 @@ class Validator_2_0_0(AbstractValidator):
         :return: is validation is successful or failure
         :rtype: bool
         """
+        # TODO: validators for rest of the CSE operations in V36 will be
+        #  implemented as and when v36/def_cluster_handler.py get other handler
+        #  functions
         if operation == CseOperation.V36_CLUSTER_UPDATE:
             return validate_cluster_update_request_and_check_cluster_upgrade(request_spec, current_spec)  # noqa: E501
         raise NotImplementedError(f"Validator for {operation.name} not found")

--- a/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
@@ -3,13 +3,17 @@
 # SPDX-License-Identifier: BSD-2-Clause
 from dataclasses import asdict
 
+import container_service_extension.common.constants.server_constants as server_constants  # noqa: E501
 from container_service_extension.common.constants.shared_constants import RequestKey  # noqa: E501
 import container_service_extension.common.utils.server_utils as server_utils
 import container_service_extension.lib.telemetry.constants as telemetry_constants  # noqa: E501
 import container_service_extension.lib.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
 import container_service_extension.rde.backend.cluster_service_factory as cluster_service_factory  # noqa: E501
+import container_service_extension.rde.constants as rde_constants
 from container_service_extension.rde.models.abstractNativeEntity import AbstractNativeEntity  # noqa: E501
 import container_service_extension.rde.models.rde_factory as rde_factory
+from container_service_extension.rde.utils import construct_cluster_spec_from_entity_status  # noqa: E501
+import container_service_extension.rde.validators.validator_factory as rde_validator_factory  # noqa: E501
 import container_service_extension.security.context.operation_context as ctx
 import container_service_extension.server.request_handlers.request_utils as request_utils  # noqa: E501
 
@@ -33,12 +37,19 @@ def cluster_update(data: dict, op_ctx: ctx.OperationContext):
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
     NativeEntityClass = rde_factory.get_rde_model(rde_in_use)
-    cluster_entity_spec: AbstractNativeEntity = \
+    cluster_entity: AbstractNativeEntity = \
         NativeEntityClass(**data[RequestKey.INPUT_SPEC])  # noqa: E501
     curr_entity = svc.entity_svc.get_entity(cluster_id)
-    is_upgrade_operation = \
-        request_utils.validate_cluster_update_request_and_check_cluster_upgrade(  # noqa: E501
-            asdict(cluster_entity_spec.spec), asdict(curr_entity.entity.spec))
+    cluster_entity_status = curr_entity.entity.status
+    current_entity_spec = construct_cluster_spec_from_entity_status(
+        cluster_entity_status, server_utils.get_rde_version_in_use())
+
+    is_upgrade_operation = rde_validator_factory.get_validator(
+        rde_constants.RuntimeRDEVersion.RDE_2_X).validate(
+        asdict(cluster_entity.spec),
+        asdict(current_entity_spec),
+        server_constants.CseOperation.V36_CLUSTER_UPDATE)
+
     if is_upgrade_operation:
-        return asdict(svc.upgrade_cluster(cluster_id, cluster_entity_spec))
-    return asdict(svc.resize_cluster(cluster_id, cluster_entity_spec))
+        return asdict(svc.upgrade_cluster(cluster_id, cluster_entity))
+    return asdict(svc.resize_cluster(cluster_id, cluster_entity))

--- a/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
@@ -39,17 +39,16 @@ def cluster_update(data: dict, op_ctx: ctx.OperationContext):
     NativeEntityClass = rde_factory.get_rde_model(rde_in_use)
     cluster_entity: AbstractNativeEntity = \
         NativeEntityClass(**data[RequestKey.INPUT_SPEC])  # noqa: E501
+    print(asdict(cluster_entity))
     curr_entity = svc.entity_svc.get_entity(cluster_id)
     cluster_entity_status = curr_entity.entity.status
     current_entity_spec = construct_cluster_spec_from_entity_status(
         cluster_entity_status, server_utils.get_rde_version_in_use())
 
-    is_upgrade_operation = rde_validator_factory.get_validator(
-        rde_constants.RuntimeRDEVersion.RDE_2_X).validate(
+    rde_validator_factory.get_validator(
+        rde_constants.RDEVersion.RDE_2_0_0).validate(
         asdict(cluster_entity.spec),
         asdict(current_entity_spec),
         server_constants.CseOperation.V36_CLUSTER_UPDATE)
 
-    if is_upgrade_operation:
-        return asdict(svc.upgrade_cluster(cluster_id, cluster_entity))
-    return asdict(svc.resize_cluster(cluster_id, cluster_entity))
+    return asdict(svc.update_cluster(cluster_id, cluster_entity))

--- a/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
@@ -39,7 +39,6 @@ def cluster_update(data: dict, op_ctx: ctx.OperationContext):
     NativeEntityClass = rde_factory.get_rde_model(rde_in_use)
     cluster_entity: AbstractNativeEntity = \
         NativeEntityClass(**data[RequestKey.INPUT_SPEC])  # noqa: E501
-    print(asdict(cluster_entity))
     curr_entity = svc.entity_svc.get_entity(cluster_id)
     cluster_entity_status = curr_entity.entity.status
     current_entity_spec = construct_cluster_spec_from_entity_status(


### PR DESCRIPTION
- Validator implementation by RDE version supported by API handler 
- Cluster spec validation 
- V36 cluster handler changes to use new validator
- Entity service, Cluster service fixes to get entity type 
- Tested on cluster creation and resize
- TODO: upgrade test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/934)
<!-- Reviewable:end -->
@Anirudh9794 @sahithi @rocknes 