### PR TITLE
[VCDA-2204] modify v36 cluster handler

### DIFF
--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -41,7 +41,8 @@ class CommandNameKey(str, Enum):
 
 # List of unsupported commands by Api Version
 UNSUPPORTED_COMMANDS_BY_VERSION = {
-    vcd_client.ApiVersion.VERSION_35.value: [GroupKey.NODE]
+    vcd_client.ApiVersion.VERSION_35.value: [GroupKey.NODE],
+    vcd_client.ApiVersion.VERSION_36.value: [GroupKey.NODE]
 }
 
 

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -318,7 +318,8 @@ class CseOperation(Enum):
     V35_NODE_INFO = ('get info of DEF node', 'NOT IMPLEMENTED')
 
     V36_CLUSTER_CREATE = ('create DEF v36 cluster', '/cse/3.0/clusters', requests.codes.accepted)  # noqa: E501
-    V36_CLUSTER_LIST = ('list DEF clusters', '/cse/3.0/cluster/%s', requests.codes.accepted)  # noqa: E501
+    V36_CLUSTER_LIST = ('list V36 DEF clusters', '/cse/3.0/clusters')  # noqa: E501
+    V36_NATIVE_CLUSTER_LIST = ('list paginated V36 DEF clusters', '/cse/3.0/nativeclusters')  # noqa: E501
     V36_CLUSTER_INFO = ('get info of DEF V36 clusters', '/cse/3.0/cluster/%s')
     V36_CLUSTER_CONFIG = ('get config of DEF V36 cluster', '/cse/3.0/cluster/%s/config')  # noqa: E501
     V36_CLUSTER_UPDATE = ('update DEF V36 cluster', '/cse/3.0/cluster/%s', requests.codes.accepted)  # noqa: E501

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -317,7 +317,12 @@ class CseOperation(Enum):
     V35_NODE_DELETE = ('delete DEF node', '/cse/3.0/cluster/%s/nfs/%s', requests.codes.accepted)  # noqa: E501
     V35_NODE_INFO = ('get info of DEF node', 'NOT IMPLEMENTED')
 
-    V36_CLUSTER_UPDATE = ('update DEF cluster', '/cse/3.0/cluster/%s', requests.codes.accepted)  # noqa: E501
+    V36_CLUSTER_LIST = ('list DEF clusters', '/cse/3.0/cluster/%s', requests.codes.accepted)  # noqa: E501
+    V36_CLUSTER_INFO = ('get info of DEF V36 clusters', '/cse/3.0/cluster/%s')
+    V36_CLUSTER_CONFIG = ('get config of DEF V36 cluster', '/cse/3.0/cluster/%s/config')  # noqa: E501
+    V36_CLUSTER_UPDATE = ('update DEF V36 cluster', '/cse/3.0/cluster/%s', requests.codes.accepted)  # noqa: E501
+    V36_CLUSTER_DELETE = ('delete DEF V36 cluster', '/cse/3.0/cluster/%s', requests.codes.accepted)  # noqa: E501
+    V36_CLUSTER_UPGRADE_PLAN = ('get supported V36 DEF cluster upgrade paths', '/cse/3.0/cluster/%s/upgrade-plan')  # noqa: E501
 
     OVDC_UPDATE = ('enable or disable ovdc for k8s', '/cse/ovdc/%s', requests.codes.accepted)  # noqa: E501
     OVDC_INFO = ('get info of ovdc', '/cse/ovdc/%s')

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -317,12 +317,16 @@ class CseOperation(Enum):
     V35_NODE_DELETE = ('delete DEF node', '/cse/3.0/cluster/%s/nfs/%s', requests.codes.accepted)  # noqa: E501
     V35_NODE_INFO = ('get info of DEF node', 'NOT IMPLEMENTED')
 
+    V36_CLUSTER_CREATE = ('create DEF v36 cluster', '/cse/3.0/clusters', requests.codes.accepted)  # noqa: E501
     V36_CLUSTER_LIST = ('list DEF clusters', '/cse/3.0/cluster/%s', requests.codes.accepted)  # noqa: E501
     V36_CLUSTER_INFO = ('get info of DEF V36 clusters', '/cse/3.0/cluster/%s')
     V36_CLUSTER_CONFIG = ('get config of DEF V36 cluster', '/cse/3.0/cluster/%s/config')  # noqa: E501
     V36_CLUSTER_UPDATE = ('update DEF V36 cluster', '/cse/3.0/cluster/%s', requests.codes.accepted)  # noqa: E501
     V36_CLUSTER_DELETE = ('delete DEF V36 cluster', '/cse/3.0/cluster/%s', requests.codes.accepted)  # noqa: E501
     V36_CLUSTER_UPGRADE_PLAN = ('get supported V36 DEF cluster upgrade paths', '/cse/3.0/cluster/%s/upgrade-plan')  # noqa: E501
+    V36_NODE_DELETE = ('delete V36 DEF node', '/cse/3.0/cluster/%s/nfs/%s', requests.codes.accepted)  # noqa: E501
+    V36_CLUSTER_ACL_LIST = ('list V36 cluster acl', '/cse/3.0/cluster/%s/acl')
+    V36_CLUSTER_ACL_UPDATE = ('update V36 cluster acl', '/cse/3.0/cluster/%s/acl', requests.codes.no_content)  # noqa: E501
 
     OVDC_UPDATE = ('enable or disable ovdc for k8s', '/cse/ovdc/%s', requests.codes.accepted)  # noqa: E501
     OVDC_INFO = ('get info of ovdc', '/cse/ovdc/%s')

--- a/container_service_extension/lib/telemetry/constants.py
+++ b/container_service_extension/lib/telemetry/constants.py
@@ -85,7 +85,12 @@ class CseOperation(Enum):
     V35_CLUSTER_ACL_UPDATE = ('cluster acl update', 'CLUSTER', 'V35_ACL_UPDATE', 'CSE_V35_CLUSTER_ACL_UPDATE')  # noqa: E501
     V35_NODE_DELETE = ('DEF nfs node delete', 'NODE', 'V35_DELETE', 'CSE_V35_NODE_DELETE')  # noqa: E501
 
+    V36_CLUSTER_CONFIG = ('DEF cluster config', 'CLUSTER', 'V36_CONFIG', 'CSE_V36_CLUSTER_CONFIG')   # noqa: E501
+    V36_CLUSTER_INFO = ('DEF cluster info', 'CLUSTER', 'V36_INFO', 'CSE_V36_CLUSTER_INFO')  # noqa: E501
+    V36_CLUSTER_LIST = ('DEF cluster list', 'CLUSTER', 'V36_LIST', 'CSE_V36_CLUSTER_LIST')  # noqa: E501
+    V36_CLUSTER_UPGRADE_PLAN = ('DEF cluster upgrade plan', 'CLUSTER', 'V36_UPGRADE_PLAN', 'CSE_V36_CLUSTER_UPGRADE_PLAN')  # noqa: E501
     V36_CLUSTER_UPDATE = ('DEF cluster update', 'CLUSTER', 'V36_APPLY', 'CSE_V36_CLUSTER_APPLY')  # noqa: E501
+    V36_CLUSTER_DELETE = ('DEF cluster delete', 'CLUSTER', 'V36_DELETE', 'CSE_V36_CLUSTER_DELETE')  # noqa: E501
 
     # Following operations do not require telemetry details. Hence the VAC
     # table name field is empty

--- a/container_service_extension/lib/telemetry/constants.py
+++ b/container_service_extension/lib/telemetry/constants.py
@@ -88,9 +88,13 @@ class CseOperation(Enum):
     V36_CLUSTER_CONFIG = ('DEF cluster config', 'CLUSTER', 'V36_CONFIG', 'CSE_V36_CLUSTER_CONFIG')   # noqa: E501
     V36_CLUSTER_INFO = ('DEF cluster info', 'CLUSTER', 'V36_INFO', 'CSE_V36_CLUSTER_INFO')  # noqa: E501
     V36_CLUSTER_LIST = ('DEF cluster list', 'CLUSTER', 'V36_LIST', 'CSE_V36_CLUSTER_LIST')  # noqa: E501
+    V36_CLUSTER_APPLY = ('DEF cluster create', 'CLUSTER', 'V36_APPLY', 'CSE_V36_CLUSTER_APPLY')  # noqa: E501
     V36_CLUSTER_UPGRADE_PLAN = ('DEF cluster upgrade plan', 'CLUSTER', 'V36_UPGRADE_PLAN', 'CSE_V36_CLUSTER_UPGRADE_PLAN')  # noqa: E501
     V36_CLUSTER_UPDATE = ('DEF cluster update', 'CLUSTER', 'V36_APPLY', 'CSE_V36_CLUSTER_APPLY')  # noqa: E501
     V36_CLUSTER_DELETE = ('DEF cluster delete', 'CLUSTER', 'V36_DELETE', 'CSE_V36_CLUSTER_DELETE')  # noqa: E501
+    V36_NODE_DELETE = ('DEF nfs node delete', 'NODE', 'V36_DELETE', 'CSE_V36_NODE_DELETE')  # noqa: E501
+    V36_CLUSTER_ACL_LIST = ('cluster acl list', 'CLUSTER', 'V36_ACL_LIST', 'CSE_V36_CLUSTER_ACL_LIST')  # noqa: E501
+    V36_CLUSTER_ACL_UPDATE = ('cluster acl update', 'CLUSTER', 'V36_ACL_UPDATE', 'CSE_V36_CLUSTER_ACL_UPDATE')  # noqa: E501
 
     # Following operations do not require telemetry details. Hence the VAC
     # table name field is empty

--- a/container_service_extension/lib/telemetry/constants.py
+++ b/container_service_extension/lib/telemetry/constants.py
@@ -90,6 +90,7 @@ class CseOperation(Enum):
     V36_CLUSTER_LIST = ('DEF cluster list', 'CLUSTER', 'V36_LIST', 'CSE_V36_CLUSTER_LIST')  # noqa: E501
     V36_CLUSTER_APPLY = ('DEF cluster create', 'CLUSTER', 'V36_APPLY', 'CSE_V36_CLUSTER_APPLY')  # noqa: E501
     V36_CLUSTER_UPGRADE_PLAN = ('DEF cluster upgrade plan', 'CLUSTER', 'V36_UPGRADE_PLAN', 'CSE_V36_CLUSTER_UPGRADE_PLAN')  # noqa: E501
+    V36_CLUSTER_UPGRADE = ('DEF cluster upgrade', 'CLUSTER', 'V36_UPGRADE', 'CSE_V36_CLUSTER_UPGRADE')  # noqa: E501
     V36_CLUSTER_UPDATE = ('DEF cluster update', 'CLUSTER', 'V36_APPLY', 'CSE_V36_CLUSTER_APPLY')  # noqa: E501
     V36_CLUSTER_DELETE = ('DEF cluster delete', 'CLUSTER', 'V36_DELETE', 'CSE_V36_CLUSTER_DELETE')  # noqa: E501
     V36_NODE_DELETE = ('DEF nfs node delete', 'NODE', 'V36_DELETE', 'CSE_V36_NODE_DELETE')  # noqa: E501

--- a/container_service_extension/lib/telemetry/payload_generator.py
+++ b/container_service_extension/lib/telemetry/payload_generator.py
@@ -809,6 +809,27 @@ def get_payload_for_v36_cluster_upgrade_plan(params):
     }
 
 
+def get_payload_for_v36_cluster_upgrade(params):
+    """Construct telemetry payload of v35 cluster upgrade.
+
+    :param dict params: defined entity instance, telemetry source_description
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    def_entity = params.get(CLUSTER_ENTITY)
+    return {
+        PayloadKey.TYPE: CseOperation.V36_CLUSTER_UPGRADE.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
+        PayloadKey.TEMPLATE_NAME: def_entity.entity.spec.k8_distribution.template_name,  # noqa: E501
+        PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision,  # noqa: E501
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
+    }
+
+
 def get_payload_for_v36_node_delete(params):
     """Construct telemetry payload of v36 cluster info.
 

--- a/container_service_extension/lib/telemetry/payload_generator.py
+++ b/container_service_extension/lib/telemetry/payload_generator.py
@@ -832,7 +832,7 @@ def get_payload_for_v36_cluster_acl_list(cluster_acl_list_info):
     page = cluster_acl_list_info[shared_constants.PaginationKey.PAGE_NUMBER]
     page_size = cluster_acl_list_info[shared_constants.PaginationKey.PAGE_SIZE]
     return {
-        PayloadKey.TYPE: CseOperation.V35_CLUSTER_ACL_LIST.telemetry_table,
+        PayloadKey.TYPE: CseOperation.V36_CLUSTER_ACL_LIST.telemetry_table,
         PayloadKey.CLUSTER_ID: uuid_hash(cluster_id),
         PayloadKey.PAGE: str(page),
         PayloadKey.PAGE_SIZE: str(page_size),
@@ -861,7 +861,7 @@ def get_payload_for_v36_cluster_acl_update(cluster_acl_update_info: dict):
         }
         filtered_acl_info.append(filtered_entry)
     return {
-        PayloadKey.TYPE: CseOperation.V35_CLUSTER_ACL_UPDATE.telemetry_table,
+        PayloadKey.TYPE: CseOperation.V36_CLUSTER_ACL_UPDATE.telemetry_table,
         PayloadKey.CLUSTER_ID: uuid_hash(cluster_id),
         PayloadKey.ACCESS_SETTING: json.dumps(filtered_acl_info),
         PayloadKey.SOURCE_ID: SourceMap.get_source_id(cluster_acl_update_info.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501

--- a/container_service_extension/lib/telemetry/payload_generator.py
+++ b/container_service_extension/lib/telemetry/payload_generator.py
@@ -690,6 +690,185 @@ def get_payload_for_v35_node_delete(params):
     }
 
 
+def get_payload_for_v36_cluster_list(params):
+    """Construct telemetry payload of v36 cluster list.
+
+    :param dict params: parameters provided to the operation
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V36_CLUSTER_LIST.telemetry_table,
+        PayloadKey.FILTER_KEYS: params.get(PayloadKey.FILTER_KEYS),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
+    }
+
+
+def get_payload_for_v36_cluster_info(params):
+    """Construct telemetry payload of v36 cluster info.
+
+    :param dict params: parameters provided to the operation
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V36_CLUSTER_INFO.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(params.get(PayloadKey.CLUSTER_ID))),  # noqa: E501
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
+    }
+
+
+def get_payload_for_v36_cluster_config(params):
+    """Construct telemetry payload of v36 cluster config.
+
+    :param dict params: defined entity instance, telemetry source_description
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    def_entity = params.get(CLUSTER_ENTITY)
+    return {
+        PayloadKey.TYPE: CseOperation.V36_CLUSTER_CONFIG.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
+        PayloadKey.TEMPLATE_NAME: def_entity.entity.spec.k8_distribution.template_name,  # noqa: E501
+        PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision,  # noqa: E501
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
+    }
+
+
+def get_payload_for_v36_cluster_apply(params):
+    """Construct telemetry payload of v36 cluster apply.
+
+    :param dict params: defined entity instance, telemetry source_description
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    def_entity = params.get(CLUSTER_ENTITY)
+    return {
+        PayloadKey.TYPE: CseOperation.V36_CLUSTER_APPLY.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
+        PayloadKey.TEMPLATE_NAME: def_entity.entity.spec.k8_distribution.template_name,  # noqa: E501
+        PayloadKey.TEMPLATE_REVISION: def_entity.entity.spec.k8_distribution.template_revision,  # noqa: E501
+        PayloadKey.NUMBER_OF_MASTER_NODES: def_entity.entity.spec.control_plane.count,  # noqa: E501
+        PayloadKey.NUMBER_OF_WORKER_NODES: def_entity.entity.spec.workers.count,  # noqa: E501
+        PayloadKey.NUMBER_OF_NFS_NODES: def_entity.entity.spec.nfs.count,  # noqa: E501
+        PayloadKey.WAS_SSH_KEY_SPECIFIED: bool(def_entity.entity.spec.settings.ssh_key),  # noqa: E501
+        PayloadKey.WAS_ROLLBACK_ENABLED: bool(def_entity.entity.spec.settings.rollback_on_failure),  # noqa: E501
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
+    }
+
+
+def get_payload_for_v36_cluster_delete(params):
+    """Construct telemetry payload of v36 cluster delete.
+
+    :param dict params: defined entity instance, telemetry source_description
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    def_entity = params.get(CLUSTER_ENTITY)
+    return {
+        PayloadKey.TYPE: CseOperation.V36_CLUSTER_DELETE.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
+    }
+
+
+def get_payload_for_v36_cluster_upgrade_plan(params):
+    """Construct telemetry payload of v36 cluster upgrade plan.
+
+    :param dict params: defined entity instance, telemetry source_description
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    def_entity = params.get(CLUSTER_ENTITY)
+    return {
+        PayloadKey.TYPE: CseOperation.V36_CLUSTER_UPGRADE_PLAN.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(def_entity.id)),  # noqa: E501
+        PayloadKey.CLUSTER_KIND: def_entity.entity.kind,
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
+    }
+
+
+def get_payload_for_v36_node_delete(params):
+    """Construct telemetry payload of v36 cluster info.
+
+    :param dict params: parameters provided to the operation
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.V36_NODE_DELETE.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(pyvcd_utils.extract_id(params.get(PayloadKey.CLUSTER_ID))),  # noqa: E501
+        PayloadKey.NODE_NAME: params.get(PayloadKey.NODE_NAME),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(params.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: params.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
+    }
+
+
+def get_payload_for_v36_cluster_acl_list(cluster_acl_list_info):
+    cluster_id = cluster_acl_list_info[RequestKey.CLUSTER_ID]
+    page = cluster_acl_list_info[shared_constants.PaginationKey.PAGE_NUMBER]
+    page_size = cluster_acl_list_info[shared_constants.PaginationKey.PAGE_SIZE]
+    return {
+        PayloadKey.TYPE: CseOperation.V35_CLUSTER_ACL_LIST.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(cluster_id),
+        PayloadKey.PAGE: str(page),
+        PayloadKey.PAGE_SIZE: str(page_size),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(cluster_acl_list_info.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: cluster_acl_list_info.get(PayloadKey.SOURCE_DESCRIPTION)   # noqa: E501
+    }
+
+
+def get_payload_for_v36_cluster_acl_update(cluster_acl_update_info: dict):
+    """Construct payload for v36 cluster acl update.
+
+    :param dict cluster_acl_update_info: a dict containing two entries:
+        1. "cluster_id" mapped to the cluster id
+        2. "update_acl_entries" mapped to a list of
+            def_models.ClusterAclEntry's
+    """
+    cluster_id = cluster_acl_update_info[RequestKey.CLUSTER_ID]
+    update_acl_entries: list = cluster_acl_update_info[ClusterAclKey.UPDATE_ACL_ENTRIES]  # noqa: E501
+
+    # Remove username from being sent
+    filtered_acl_info = []
+    for entry in update_acl_entries:
+        filtered_entry = {
+            AccessControlKey.MEMBER_ID: entry.memberId,
+            AccessControlKey.ACCESS_LEVEL_ID: entry.accessLevelId  # noqa: E501
+        }
+        filtered_acl_info.append(filtered_entry)
+    return {
+        PayloadKey.TYPE: CseOperation.V35_CLUSTER_ACL_UPDATE.telemetry_table,
+        PayloadKey.CLUSTER_ID: uuid_hash(cluster_id),
+        PayloadKey.ACCESS_SETTING: json.dumps(filtered_acl_info),
+        PayloadKey.SOURCE_ID: SourceMap.get_source_id(cluster_acl_update_info.get(PayloadKey.SOURCE_DESCRIPTION)),  # noqa: E501
+        PayloadKey.SOURCE_DESCRIPTION: cluster_acl_update_info.get(PayloadKey.SOURCE_DESCRIPTION)  # noqa: E501
+    }
+
+
 def get_payload_for_pks_list_clusters(params):
     """Construct telemetry payload of list cluster operation.
 

--- a/container_service_extension/lib/telemetry/telemetry_handler.py
+++ b/container_service_extension/lib/telemetry/telemetry_handler.py
@@ -60,6 +60,16 @@ OPERATION_TO_PAYLOAD_GENERATOR = {
     CseOperation.V35_CLUSTER_ACL_UPDATE: payload_generator.get_payload_for_v35_cluster_acl_update,  # noqa: E501
     CseOperation.V35_NODE_DELETE: payload_generator.get_payload_for_v35_node_delete,  # noqa: E501
 
+    CseOperation.V36_CLUSTER_INFO: payload_generator.get_payload_for_v36_cluster_info,  # noqa: E501
+    CseOperation.V36_CLUSTER_LIST: payload_generator.get_payload_for_v36_cluster_list,  # noqa: E501
+    CseOperation.V36_CLUSTER_CONFIG: payload_generator.get_payload_for_v36_cluster_config,  # noqa: E501
+    CseOperation.V36_CLUSTER_APPLY: payload_generator.get_payload_for_v36_cluster_apply,  # noqa: E501
+    CseOperation.V36_CLUSTER_DELETE: payload_generator.get_payload_for_v36_cluster_delete,  # noqa: E501
+    CseOperation.V36_CLUSTER_UPGRADE_PLAN: payload_generator.get_payload_for_v36_cluster_upgrade_plan,  # noqa: E501
+    CseOperation.V36_CLUSTER_ACL_LIST: payload_generator.get_payload_for_v36_cluster_acl_list,  # noqa: E501
+    CseOperation.V36_CLUSTER_ACL_UPDATE: payload_generator.get_payload_for_v36_cluster_acl_update,  # noqa: E501
+    CseOperation.V36_NODE_DELETE: payload_generator.get_payload_for_v36_node_delete,  # noqa: E501
+
     CseOperation.PKS_CLUSTER_LIST: payload_generator.get_payload_for_pks_list_clusters,  # noqa: E501
     CseOperation.PKS_CLUSTER_INFO: payload_generator.get_payload_for_pks_cluster_info,  # noqa: E501
     CseOperation.PKS_CLUSTER_CONFIG: payload_generator.get_payload_for_pks_cluster_config,  # noqa: E501

--- a/container_service_extension/lib/telemetry/telemetry_handler.py
+++ b/container_service_extension/lib/telemetry/telemetry_handler.py
@@ -66,6 +66,7 @@ OPERATION_TO_PAYLOAD_GENERATOR = {
     CseOperation.V36_CLUSTER_APPLY: payload_generator.get_payload_for_v36_cluster_apply,  # noqa: E501
     CseOperation.V36_CLUSTER_DELETE: payload_generator.get_payload_for_v36_cluster_delete,  # noqa: E501
     CseOperation.V36_CLUSTER_UPGRADE_PLAN: payload_generator.get_payload_for_v36_cluster_upgrade_plan,  # noqa: E501
+    CseOperation.V36_CLUSTER_UPGRADE: payload_generator.get_payload_for_v36_cluster_upgrade,  # noqa: E501
     CseOperation.V36_CLUSTER_ACL_LIST: payload_generator.get_payload_for_v36_cluster_acl_list,  # noqa: E501
     CseOperation.V36_CLUSTER_ACL_UPDATE: payload_generator.get_payload_for_v36_cluster_acl_update,  # noqa: E501
     CseOperation.V36_NODE_DELETE: payload_generator.get_payload_for_v36_node_delete,  # noqa: E501

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -81,7 +81,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         returning the defined entity.
         """
         telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_INFO,
+            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_INFO,
             cse_params={
                 telemetry_constants.PayloadKey.CLUSTER_ID: cluster_id,
                 telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
@@ -104,7 +104,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             filters = {}
 
         telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_LIST,
+            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_LIST,
             cse_params={
                 telemetry_constants.PayloadKey.FILTER_KEYS: ','.join(filters.keys()),  # noqa: E501
                 telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
@@ -130,7 +130,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             filters = {}
 
         telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_LIST,
+            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_LIST,
             cse_params={telemetry_constants.PayloadKey.FILTER_KEYS: ','.join(filters.keys())}  # noqa: E501
         )
 
@@ -156,7 +156,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                 f"valid state for this operation. Please contact the administrator")  # noqa: E501
 
         telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_CONFIG,
+            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_CONFIG,
             cse_params={
                 CLUSTER_ENTITY: curr_entity,
                 telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
@@ -277,7 +277,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             raise
         self.context.is_async = True
         telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY,
+            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_APPLY,
             cse_params={
                 CLUSTER_ENTITY: def_entity,
                 telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
@@ -339,7 +339,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             id=cluster_id,
             entity=cluster_spec)
         telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY,
+            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_APPLY,
             cse_params={
                 CLUSTER_ENTITY: telemetry_data,
                 telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
@@ -387,7 +387,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                 f"valid state to be deleted. Please contact administrator.")
 
         telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_DELETE,
+            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_DELETE,
             cse_params={
                 CLUSTER_ENTITY: curr_entity,
                 telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
@@ -430,7 +430,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         """
         curr_entity = self.entity_svc.get_entity(cluster_id)
         telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE_PLAN,  # noqa: E501
+            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_UPGRADE_PLAN,  # noqa: E501
             cse_params={
                 CLUSTER_ENTITY: curr_entity,
                 telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
@@ -485,7 +485,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                 f"cluster '{cluster_name}'.")
 
         telemetry_handler.record_user_action_details(
-            telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE,
+            telemetry_constants.CseOperation.V36_CLUSTER_UPGRADE,
             cse_params={
                 CLUSTER_ENTITY: curr_entity,
                 telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
@@ -562,7 +562,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
         }
         telemetry_handler.record_user_action_details(
-            telemetry_constants.CseOperation.V35_CLUSTER_ACL_LIST,
+            telemetry_constants.CseOperation.V36_CLUSTER_ACL_LIST,
             cse_params=telemetry_params)
 
         acl_svc = acl_service.ClusterACLService(cluster_id,
@@ -604,7 +604,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
         }
         telemetry_handler.record_user_action_details(
-            telemetry_constants.CseOperation.V35_CLUSTER_ACL_UPDATE,
+            telemetry_constants.CseOperation.V36_CLUSTER_ACL_UPDATE,
             cse_params=telemetry_params)
 
         # Get previous def entity acl

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -131,7 +131,10 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         telemetry_handler.record_user_action_details(
             cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_LIST,
-            cse_params={telemetry_constants.PayloadKey.FILTER_KEYS: ','.join(filters.keys())}  # noqa: E501
+            cse_params={
+                telemetry_constants.PayloadKey.FILTER_KEYS: ','.join(filters.keys()),  # noqa: E501
+                telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
+            }
         )
 
         ent_type: common_models.DefEntityType = server_utils.get_registered_def_entity_type()  # noqa: E501

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -69,10 +69,10 @@ def get_rde_metadata(rde_version: str) -> dict:
 
 
 def construct_cluster_spec_from_entity_status(entity_status: Union[rde_1_0_0.Status, rde_2_0_0.Status], rde_version: str) -> Union[rde_1_0_0.ClusterSpec, rde_2_0_0.ClusterSpec]:  # noqa: E501
-    """Construct cluster specification from entity status of given rde version.
+    """Construct cluster spec of the specified rde version from the current status of the cluster.
 
     :param rde_X_X_X Status entity_status: Entity Status of rde of given version  # noqa: E501
-    :param str rde_version: which version of schema
+    :param str rde_version: RDE version of the spec to be created from the status # noqa: E501
     :return: Cluster Specification of respective rde_version_in_use
     :raises NotImplementedError
     """

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -155,4 +155,4 @@ def find_diff_fields(input_spec: dict, reference_spec: dict, exclude_fields: lis
     exclude_key_set = set(exclude_fields)
     key_set_for_validation = set(input_dict.keys()) - exclude_key_set
     return [key for key in key_set_for_validation
-            if input_dict.get(key) and input_dict.get(key) != reference_dict.get(key)]  # noqa: E501
+            if input_dict.get(key) is not None and input_dict.get(key) != reference_dict.get(key)]  # noqa: E501

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -68,18 +68,20 @@ def get_rde_metadata(rde_version: str) -> dict:
     return MAP_RDE_VERSION_TO_ITS_METADATA[rde_version]
 
 
-def construct_cluster_spec_from_entity_status(entity_status: Union[rde_1_0_0.Status, rde_2_0_0.Status], rde_version_in_use: str) -> Union[rde_1_0_0.ClusterSpec, rde_2_0_0.ClusterSpec]:  # noqa: E501
+def construct_cluster_spec_from_entity_status(entity_status: Union[rde_1_0_0.Status, rde_2_0_0.Status], rde_version: str) -> Union[rde_1_0_0.ClusterSpec, rde_2_0_0.ClusterSpec]:  # noqa: E501
     """Construct cluster specification from entity status of given rde version.
 
     :param rde_X_X_X Status entity_status: Entity Status of rde of given version  # noqa: E501
-    :param str rde_version_in_use: which version of schema
+    :param str rde_version: which version of schema
     :return: Cluster Specification of respective rde_version_in_use
     :raises NotImplementedError
     """
     # TODO: Refactor this multiple if to rde_version -> handler pattern
-    if rde_version_in_use == def_constants.RDEVersion.RDE_2_0_0.value:
+    if rde_version == def_constants.RDEVersion.RDE_2_0_0.value:
         return construct_2_0_0_cluster_spec_from_entity_status(entity_status)
-    raise NotImplementedError(f"constructing cluster spec from entity status for {rde_version_in_use} is"  # noqa:
+    # elif rde_version == def_constants.RDEVersion.RDE_2_1_0:
+    #    return construct_2_1_0_cluster_spec_from_entity_status(entity_status)
+    raise NotImplementedError(f"constructing cluster spec from entity status for {rde_version} is"  # noqa:
                               f" not implemented ")
 
 

--- a/container_service_extension/rde/validators/abstract_validator.py
+++ b/container_service_extension/rde/validators/abstract_validator.py
@@ -5,6 +5,7 @@
 import abc
 
 from container_service_extension.common.constants.server_constants import CseOperation  # noqa: E501
+from container_service_extension.rde.models.abstractNativeEntity import AbstractNativeEntity  # noqa: E501
 
 
 class AbstractValidator(abc.ABC):
@@ -12,12 +13,13 @@ class AbstractValidator(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def validate(self, request_spec: dict, current_spec: dict, operation: CseOperation) -> bool:  # noqa: E501
+    def validate(self, input_entity: AbstractNativeEntity, current_entity: AbstractNativeEntity, operation: CseOperation) -> bool:  # noqa: E501
         """Validate the input_spec against current_spec.
 
-        :param dict request_spec: Request spec of the cluster
-        :param dict current_spec: Current status of the cluster
-        :param str operation: POST/PUT/DEL
-        :retur bool:
+        :param AbstractNativeEntity input_entity: Request spec of the cluster
+        :param AbstractNativeEntity current_entity: Current status of the cluster  # noqa: E501
+        :param CseOperation operation: CSE operation key
+        :return: is validation successful or failure
+        :rtype: bool
         """
         pass

--- a/container_service_extension/rde/validators/validator_rde_1_x.py
+++ b/container_service_extension/rde/validators/validator_rde_1_x.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 from container_service_extension.common.constants.server_constants import CseOperation  # noqa: E501
+from container_service_extension.rde.models.abstractNativeEntity import AbstractNativeEntity  # noqa: E501
 from container_service_extension.rde.validators.abstract_validator import AbstractValidator  # noqa: E501
 
 
@@ -9,13 +10,13 @@ class Validator_1_0_0(AbstractValidator):
     def __init__(self):
         pass
 
-    def validate(self, request_spec: dict, current_status: dict, operation: CseOperation) -> bool:  # noqa: E501
+    def validate(self, input_entity: AbstractNativeEntity, current_entity: AbstractNativeEntity, operation: CseOperation) -> bool:  # noqa: E501
         """Validate the input_spec against current_status.
 
-        :param dict request_spec: Request spec of the cluster
-        :param dict current_status: Current status of the cluster
-        :param str operation: POST/PUT/DEL
-        :return: is validation is successful or failure
+        :param AbstractNativeEntity input_entity: Request spec of the cluster
+        :param AbstractNativeEntity current_entity: Current status of the cluster  # noqa: E501
+        :param CseOperation operation: CSE operation key
+        :return: is validation successful or failure
         :rtype: bool
         :raises NotImplementedError
         """

--- a/container_service_extension/rde/validators/validator_rde_2_x.py
+++ b/container_service_extension/rde/validators/validator_rde_2_x.py
@@ -2,11 +2,14 @@
 # Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+from dataclasses import asdict
 
 from container_service_extension.common.constants.server_constants import CseOperation  # noqa: E501
 from container_service_extension.common.constants.server_constants import FlattenedClusterSpecKey  # noqa: E501
 from container_service_extension.common.constants.server_constants import VALID_UPDATE_FIELDS  # noqa: E501
 from container_service_extension.exception.exceptions import BadRequestError
+import container_service_extension.rde.constants as rde_constants
+from container_service_extension.rde.models.abstractNativeEntity import AbstractNativeEntity  # noqa: E501
 import container_service_extension.rde.utils as rde_utils
 from container_service_extension.rde.validators.abstract_validator import AbstractValidator  # noqa: E501
 
@@ -15,20 +18,24 @@ class Validator_2_0_0(AbstractValidator):
     def __init__(self):
         pass
 
-    def validate(self, request_spec: dict, current_spec: dict, operation: CseOperation) -> bool:  # noqa: E501
+    def validate(self, input_entity: AbstractNativeEntity, current_entity: AbstractNativeEntity, operation: CseOperation) -> bool:  # noqa: E501
         """Validate the input_spec against current_status of the cluster.
 
-        :param dict request_spec: Request spec of the cluster
-        :param dict current_spec: Current status of the cluster
+        :param dict input_entity: Request spec of the cluster
+        :param dict current_entity: Current status of the cluster
         :param CseOperation operation: CSE operation key
-        :return: is validation is successful or failure
+        :return: is validation successful or failure
         :rtype: bool
         """
         # TODO: validators for rest of the CSE operations in V36 will be
         #  implemented as and when v36/def_cluster_handler.py get other handler
         #  functions
+        input_entity_spec = input_entity.spec
+        current_entity_status = current_entity.status
+        current_entity_spec = rde_utils.\
+            construct_cluster_spec_from_entity_status(current_entity_status, rde_constants.RDEVersion.RDE_2_0_0.value)  # noqa: E501
         if operation == CseOperation.V36_CLUSTER_UPDATE:
-            return validate_cluster_update_request_and_check_cluster_upgrade(request_spec, current_spec)  # noqa: E501
+            return validate_cluster_update_request_and_check_cluster_upgrade(asdict(input_entity_spec), asdict(current_entity_spec))  # noqa: E501
         raise NotImplementedError(f"Validator for {operation.name} not found")
 
 

--- a/container_service_extension/rde/validators/validator_rde_2_x.py
+++ b/container_service_extension/rde/validators/validator_rde_2_x.py
@@ -21,8 +21,8 @@ class Validator_2_0_0(AbstractValidator):
     def validate(self, input_entity: AbstractNativeEntity, current_entity: AbstractNativeEntity, operation: CseOperation) -> bool:  # noqa: E501
         """Validate the input_spec against current_status of the cluster.
 
-        :param dict input_entity: Request spec of the cluster
-        :param dict current_entity: Current status of the cluster
+        :param AbstractNativeEntity input_entity: Request spec of the cluster
+        :param AbstractNativeEntity current_entity: Current status of the cluster  # noqa: E501
         :param CseOperation operation: CSE operation key
         :return: is validation successful or failure
         :rtype: bool

--- a/container_service_extension/server/request_dispatcher.py
+++ b/container_service_extension/server/request_dispatcher.py
@@ -437,6 +437,15 @@ CLUSTER_HANDLERS = [
                 'operation': CseOperation.V35_CLUSTER_CREATE,
                 'handler': v35_cluster_handler.cluster_create,
                 'feature_flags': ['non_legacy_api']
+            },
+            ('36.0',): {
+                'allowed_params': [],
+                'required_params': [],
+                'verify_payload': False,
+                'payload_type': '*',
+                'operation': CseOperation.V36_CLUSTER_CREATE,
+                'handler': v36_cluster_handler.cluster_create,
+                'feature_flags': ['non_legacy_api']
             }
         },
     },
@@ -556,6 +565,13 @@ CLUSTER_HANDLERS = [
                 'operation': CseOperation.V35_NODE_DELETE,
                 'handler': v35_cluster_handler.nfs_node_delete,
                 'feature_flags': ['non_legacy_api']
+            },
+            ('36.0',): {
+                'allowed_params': [],
+                'required_params': [],
+                'operation': CseOperation.V36_NODE_DELETE,
+                'handler': v36_cluster_handler.nfs_node_delete,
+                'feature_flags': ['non_legacy_api']
             }
         },
     },
@@ -568,6 +584,13 @@ CLUSTER_HANDLERS = [
                 'operation': CseOperation.V35_CLUSTER_ACL_LIST,
                 'handler': v35_cluster_handler.cluster_acl_info,
                 'feature_flags': ['non_legacy_api']
+            },
+            ('36.0',): {
+                'allowed_params': [],
+                'required_params': [],
+                'operation': CseOperation.V36_CLUSTER_ACL_LIST,
+                'handler': v36_cluster_handler.cluster_acl_info,
+                'feature_flags': ['non_legacy_api']
             }
         },
         RequestMethod.PUT: {
@@ -578,6 +601,15 @@ CLUSTER_HANDLERS = [
                 'payload_type': '*',
                 'operation': CseOperation.V35_CLUSTER_ACL_UPDATE,
                 'handler': v35_cluster_handler.cluster_acl_update,
+                'feature_flags': ['non_legacy_api']
+            },
+            ('36.0',): {
+                'allowed_params': [],
+                'required_params': [],
+                'verify_payload': False,
+                'payload_type': '*',
+                'operation': CseOperation.V36_CLUSTER_ACL_UPDATE,
+                'handler': v36_cluster_handler.cluster_acl_update,
                 'feature_flags': ['non_legacy_api']
             }
         },

--- a/container_service_extension/server/request_dispatcher.py
+++ b/container_service_extension/server/request_dispatcher.py
@@ -419,6 +419,13 @@ CLUSTER_HANDLERS = [
                 'operation': CseOperation.V35_CLUSTER_LIST,
                 'handler': v35_cluster_handler.cluster_list,
                 'feature_flags': ['non_legacy_api']
+            },
+            ('36.0',): {
+                'allowed_params': [],
+                'required_params': [],
+                'operation': CseOperation.V36_CLUSTER_LIST,
+                'handler': v36_cluster_handler.cluster_list,
+                'feature_flags': ['non_legacy_api']
             }
         },
         RequestMethod.POST: {
@@ -441,6 +448,13 @@ CLUSTER_HANDLERS = [
                 'required_params': [],
                 'operation': CseOperation.V35_CLUSTER_INFO,
                 'handler': v35_cluster_handler.cluster_info,
+                'feature_flags': ['non_legacy_api']
+            },
+            ('36.0',): {
+                'allowed_params': [],
+                'required_params': [],
+                'operation': CseOperation.V36_CLUSTER_INFO,
+                'handler': v36_cluster_handler.cluster_info,
                 'feature_flags': ['non_legacy_api']
             }
         },
@@ -471,6 +485,13 @@ CLUSTER_HANDLERS = [
                 'operation': CseOperation.V35_CLUSTER_DELETE,
                 'handler': v35_cluster_handler.cluster_delete,
                 'feature_flags': ['non_legacy_api']
+            },
+            ('36.0',): {
+                'allowed_params': [],
+                'required_params': [],
+                'operation': CseOperation.V36_CLUSTER_DELETE,
+                'handler': v36_cluster_handler.cluster_delete,
+                'feature_flags': ['non_legacy_api']
             }
         }
     },
@@ -483,6 +504,13 @@ CLUSTER_HANDLERS = [
                 'operation': CseOperation.V35_CLUSTER_CONFIG,
                 'handler': v35_cluster_handler.cluster_config,
                 'feature_flags': ['non_legacy_api']
+            },
+            ('36.0',): {
+                'allowed_params': [],
+                'required_params': [],
+                'operation': CseOperation.V36_CLUSTER_CONFIG,
+                'handler': v36_cluster_handler.cluster_config,
+                'feature_flags': ['non_legacy_api']
             }
         },
     },
@@ -494,6 +522,13 @@ CLUSTER_HANDLERS = [
                 'required_params': [],
                 'operation': CseOperation.V35_CLUSTER_UPGRADE_PLAN,
                 'handler': v35_cluster_handler.cluster_upgrade_plan,
+                'feature_flags': ['non_legacy_api']
+            },
+            ('36.0',): {
+                'allowed_params': [],
+                'required_params': [],
+                'operation': CseOperation.V36_CLUSTER_UPGRADE_PLAN,
+                'handler': v36_cluster_handler.cluster_upgrade_plan,
                 'feature_flags': ['non_legacy_api']
             }
         },

--- a/container_service_extension/server/request_dispatcher.py
+++ b/container_service_extension/server/request_dispatcher.py
@@ -450,6 +450,18 @@ CLUSTER_HANDLERS = [
         },
     },
     {
+        'url': "cse/3.0/nativeclusters",
+        RequestMethod.GET: {
+            ('36.0',): {
+                'allowed_params': ['org_name', 'ovdc_name', 'pageSize', 'page'],  # noqa: E501
+                'required_params': [],
+                'operation': CseOperation.V36_NATIVE_CLUSTER_LIST,
+                'handler': v36_cluster_handler.native_cluster_list,
+                'feature_flags': ['non_legacy_api']
+            }
+        },
+    },
+    {
         'url': f"cse/3.0/cluster/${RequestKey.CLUSTER_ID}",
         RequestMethod.GET: {
             ('35.0',): {

--- a/container_service_extension/server/request_handlers/request_utils.py
+++ b/container_service_extension/server/request_handlers/request_utils.py
@@ -134,7 +134,7 @@ def validate_request_payload(input_spec: dict, reference_spec: dict,
         raise BadRequestError(error_msg)
 
 
-def v35_api_exception_handler(func):
+def cluster_api_exception_handler(func):
     """Decorate to trap exceptions and process them.
 
     Raise errors of type KeyError, TypeError, ValueError as

--- a/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
@@ -24,7 +24,7 @@ _OPERATION_KEY = 'operation'
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY)  # noqa: E501
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster create operation.
 
@@ -44,7 +44,7 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_APPLY)  # noqa: E501
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster resize operation.
 
@@ -71,7 +71,7 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_DELETE)  # noqa: E501
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster delete operation.
 
@@ -90,7 +90,7 @@ def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_INFO)  # noqa: E501
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def cluster_info(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster info operation.
 
@@ -105,11 +105,12 @@ def cluster_info(data: dict, op_ctx: ctx.OperationContext):
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
+    print(f"cluster info v35 for:{cluster_id}")
     return asdict(svc.get_cluster_info(cluster_id))
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_CONFIG)  # noqa: E501
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster config operation.
 
@@ -125,7 +126,7 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE_PLAN)  # noqa: E501
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade-plan operation.
 
@@ -138,7 +139,7 @@ def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE)  # noqa: E501
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     """Request handler for cluster upgrade operation.
 
@@ -165,7 +166,7 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
 
 # TODO: Record telemetry in a different telemetry handler
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_UPGRADE)  # noqa: E501
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def native_cluster_list(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster list operation.
 
@@ -202,7 +203,7 @@ def native_cluster_list(data: dict, op_ctx: ctx.OperationContext):
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_ACL_LIST)  # noqa: E501
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def cluster_acl_info(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster acl list operation."""
     rde_in_use = server_utils.get_rde_version_in_use()
@@ -224,7 +225,7 @@ def cluster_acl_info(data: dict, op_ctx: ctx.OperationContext):
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_ACL_UPDATE)  # noqa: E501
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def cluster_acl_update(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster acl update operation."""
     rde_in_use = server_utils.get_rde_version_in_use()
@@ -236,7 +237,7 @@ def cluster_acl_update(data: dict, op_ctx: ctx.OperationContext):
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_LIST)  # noqa: E501
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def cluster_list(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster list operation.
 
@@ -251,7 +252,7 @@ def cluster_list(data: dict, op_ctx: ctx.OperationContext):
             svc.list_clusters(data.get(RequestKey.QUERY_PARAMS, {}))]
 
 
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def node_create(request_data, op_ctx: ctx.OperationContext):
     """Request handler for node create operation.
 
@@ -269,7 +270,7 @@ def node_create(request_data, op_ctx: ctx.OperationContext):
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V35_NODE_DELETE)  # noqa: E501
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     """Request handler for node delete operation.
 
@@ -298,7 +299,7 @@ def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     return asdict(svc.delete_nodes(cluster_id, [node_name]))
 
 
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def node_info(request_data, op_ctx: ctx.OperationContext):
     """Request handler for node info operation.
 

--- a/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
@@ -105,7 +105,6 @@ def cluster_info(data: dict, op_ctx: ctx.OperationContext):
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
-    print(f"cluster info v35 for:{cluster_id}")
     return asdict(svc.get_cluster_info(cluster_id))
 
 

--- a/container_service_extension/server/request_handlers/v35/ovdc_handler.py
+++ b/container_service_extension/server/request_handlers/v35/ovdc_handler.py
@@ -15,7 +15,7 @@ import container_service_extension.security.context.operation_context as ctx
 import container_service_extension.server.request_handlers.request_utils as request_utils  # noqa: E501
 
 
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def ovdc_update(data, operation_context: ctx.OperationContext):
     """Request handler for ovdc enable, disable operations.
 
@@ -33,7 +33,7 @@ def ovdc_update(data, operation_context: ctx.OperationContext):
 
 
 @record_user_action_telemetry(cse_operation=CseOperation.OVDC_INFO)
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def ovdc_info(data, operation_context: ctx.OperationContext):
     """Request handler for ovdc info operation.
 
@@ -46,7 +46,7 @@ def ovdc_info(data, operation_context: ctx.OperationContext):
 
 
 @record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def ovdc_list(data, operation_context: ctx.OperationContext):
     """Request handler for ovdc list operation.
 
@@ -57,7 +57,7 @@ def ovdc_list(data, operation_context: ctx.OperationContext):
 
 # TODO: Record telemetry in a different telemetry handler
 @record_user_action_telemetry(cse_operation=CseOperation.OVDC_LIST)
-@request_utils.v35_api_exception_handler
+@request_utils.cluster_api_exception_handler
 def org_vdc_list(data, operation_context: ctx.OperationContext):
     """Request handler for org vdc list operation.
 

--- a/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
@@ -42,7 +42,7 @@ def cluster_update(data: dict, op_ctx: ctx.OperationContext):
     curr_entity = svc.entity_svc.get_entity(cluster_id)
     cluster_entity_status = curr_entity.entity.status
     current_entity_spec = construct_cluster_spec_from_entity_status(
-        cluster_entity_status, server_utils.get_rde_version_in_use())
+        cluster_entity_status, rde_constants.RDEVersion.RDE_2_0_0.value)
 
     rde_validator_factory.get_validator(
         rde_constants.RDEVersion.RDE_2_0_0).validate(

--- a/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
@@ -18,9 +18,59 @@ import container_service_extension.security.context.operation_context as ctx
 import container_service_extension.server.request_handlers.request_utils as request_utils  # noqa: E501
 
 
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_LIST)  # noqa: E501
+@request_utils.cluster_api_exception_handler
+def cluster_list(data: dict, op_ctx: ctx.OperationContext):
+    """Request handler for cluster list operation.
+
+    :return: List
+    """
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
+    # response should not be paginated
+    return [asdict(def_entity) for def_entity in
+            svc.list_clusters(data.get(RequestKey.QUERY_PARAMS, {}))]
+
+
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_INFO)  # noqa: E501
+@request_utils.cluster_api_exception_handler
+def cluster_info(data: dict, op_ctx: ctx.OperationContext):
+    """Request handler for cluster info operation.
+
+    Required data: cluster_name
+    Optional data and default values: org_name=None, ovdc_name=None
+
+    (data validation handled in broker)
+
+    :return: Dict
+    """
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
+    cluster_id = data[RequestKey.CLUSTER_ID]
+    return asdict(svc.get_cluster_info(cluster_id))
+
+
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_CONFIG)  # noqa: E501
+@request_utils.cluster_api_exception_handler
+def cluster_config(data: dict, op_ctx: ctx.OperationContext):
+    """Request handler for cluster config operation.
+
+    Required data: cluster_id
+
+    :return: Dict
+    """
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
+    cluster_id = data[RequestKey.CLUSTER_ID]
+    return svc.get_cluster_config(cluster_id)
+
+
 # TODO change api exception handler.
-@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_UPDATE)  # noqa: E501
-@request_utils.v35_api_exception_handler
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_LIST)  # noqa: E501
+@request_utils.cluster_api_exception_handler
 def cluster_update(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster resize operation.
 
@@ -44,3 +94,35 @@ def cluster_update(data: dict, op_ctx: ctx.OperationContext):
         validate(cluster_entity, current_entity, server_constants.CseOperation.V36_CLUSTER_UPDATE)  # noqa: E501
 
     return asdict(svc.update_cluster(cluster_id, cluster_entity))
+
+
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_UPGRADE_PLAN)  # noqa: E501
+@request_utils.cluster_api_exception_handler
+def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
+    """Request handler for cluster upgrade-plan operation.
+
+    :return: List[Tuple(str, str)]
+    """
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
+    return svc.get_cluster_upgrade_plan(data[RequestKey.CLUSTER_ID])
+
+
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_DELETE)  # noqa: E501
+@request_utils.cluster_api_exception_handler
+def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
+    """Request handler for cluster delete operation.
+
+    Required data: cluster_name
+    Optional data and default values: org_name=None, ovdc_name=None
+
+    (data validation handled in broker)
+
+    :return: Dict
+    """
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
+    cluster_id = data[RequestKey.CLUSTER_ID]
+    return asdict(svc.delete_cluster(cluster_id))

--- a/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
@@ -17,6 +17,7 @@ import container_service_extension.lib.telemetry.telemetry_handler as telemetry_
 import container_service_extension.rde.backend.cluster_service_factory as cluster_service_factory  # noqa: E501
 import container_service_extension.rde.constants as rde_constants
 from container_service_extension.rde.models.abstractNativeEntity import AbstractNativeEntity  # noqa: E501
+import container_service_extension.rde.models.rde_2_0_0 as rde_2_0_0
 import container_service_extension.rde.models.rde_factory as rde_factory
 import container_service_extension.rde.validators.validator_factory as rde_validator_factory  # noqa: E501
 import container_service_extension.security.context.operation_context as ctx
@@ -31,6 +32,10 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     :return: Defined entity of the native cluster
     :rtype: container_service_extension.def_.models.DefEntity
     """
+    # Construct rde 2.0.0 model to ensure that this is a valid spec
+    # Any exception will be propagated to exception handler
+    rde_2_0_0.NativeEntity(**data[RequestKey.INPUT_SPEC])
+
     rde_in_use = server_utils.get_rde_version_in_use()
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)

--- a/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v36/def_cluster_handler.py
@@ -5,7 +5,12 @@ from dataclasses import asdict
 from typing import Type
 
 import container_service_extension.common.constants.server_constants as server_constants  # noqa: E501
+from container_service_extension.common.constants.shared_constants import ClusterAclKey  # noqa: E501
+from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
+from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
+from container_service_extension.common.constants.shared_constants import PaginationKey  # noqa: E501
 from container_service_extension.common.constants.shared_constants import RequestKey  # noqa: E501
+import container_service_extension.common.thread_local_data as thread_local_data  # noqa: E501
 import container_service_extension.common.utils.server_utils as server_utils
 import container_service_extension.lib.telemetry.constants as telemetry_constants  # noqa: E501
 import container_service_extension.lib.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
@@ -16,6 +21,26 @@ import container_service_extension.rde.models.rde_factory as rde_factory
 import container_service_extension.rde.validators.validator_factory as rde_validator_factory  # noqa: E501
 import container_service_extension.security.context.operation_context as ctx
 import container_service_extension.server.request_handlers.request_utils as request_utils  # noqa: E501
+
+
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_APPLY)  # noqa: E501
+@request_utils.cluster_api_exception_handler
+def cluster_create(data: dict, op_ctx: ctx.OperationContext):
+    """Request handler for cluster create operation.
+
+    :return: Defined entity of the native cluster
+    :rtype: container_service_extension.def_.models.DefEntity
+    """
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
+
+    # TODO find out the RDE version from the request spec
+    # TODO Insert RDE converters and validators
+    NativeEntityClass: Type[AbstractNativeEntity] = rde_factory.get_rde_model(rde_in_use)  # noqa: E501
+    cluster_entity_spec: AbstractNativeEntity = \
+        NativeEntityClass(**data[RequestKey.INPUT_SPEC])
+    return asdict(svc.create_cluster(cluster_entity_spec))
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_LIST)  # noqa: E501
@@ -68,8 +93,7 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     return svc.get_cluster_config(cluster_id)
 
 
-# TODO change api exception handler.
-@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_LIST)  # noqa: E501
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_APPLY)  # noqa: E501
 @request_utils.cluster_api_exception_handler
 def cluster_update(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster resize operation.
@@ -126,3 +150,67 @@ def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
         get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
     return asdict(svc.delete_cluster(cluster_id))
+
+
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_NODE_DELETE)  # noqa: E501
+@request_utils.cluster_api_exception_handler
+def nfs_node_delete(data, op_ctx: ctx.OperationContext):
+    """Request handler for node delete operation.
+
+    Required data: cluster_name, node_names_list
+    Optional data and default values: org_name=None, ovdc_name=None
+
+    (data validation handled in broker)
+
+    :return: Dict
+    """
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
+    cluster_id = data[RequestKey.CLUSTER_ID]
+    node_name = data[RequestKey.NODE_NAME]
+
+    telemetry_handler.record_user_action_details(
+        cse_operation=telemetry_constants.CseOperation.V36_NODE_DELETE,
+        cse_params={
+            telemetry_constants.PayloadKey.CLUSTER_ID: cluster_id,
+            telemetry_constants.PayloadKey.NODE_NAME: node_name,
+            telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(server_constants.ThreadLocalData.USER_AGENT)   # noqa: E501
+        }
+    )
+
+    return asdict(svc.delete_nodes(cluster_id, [node_name]))
+
+
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_ACL_LIST)  # noqa: E501
+@request_utils.cluster_api_exception_handler
+def cluster_acl_info(data: dict, op_ctx: ctx.OperationContext):
+    """Request handler for cluster acl list operation."""
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
+    cluster_id = data[RequestKey.CLUSTER_ID]
+    query = data.get(RequestKey.QUERY_PARAMS, {})
+    page = int(query.get(PaginationKey.PAGE_NUMBER, CSE_PAGINATION_FIRST_PAGE_NUMBER))  # noqa: E501
+    page_size = int(query.get(PaginationKey.PAGE_SIZE, CSE_PAGINATION_DEFAULT_PAGE_SIZE))  # noqa: E501
+    result: dict = svc.get_cluster_acl_info(cluster_id, page, page_size)
+
+    uri = data['url']
+    return server_utils.create_links_and_construct_paginated_result(
+        base_uri=uri,
+        values=result.get(PaginationKey.VALUES, []),
+        result_total=result.get(PaginationKey.RESULT_TOTAL, 0),
+        page_number=page,
+        page_size=page_size)
+
+
+@telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_ACL_UPDATE)  # noqa: E501
+@request_utils.cluster_api_exception_handler
+def cluster_acl_update(data: dict, op_ctx: ctx.OperationContext):
+    """Request handler for cluster acl update operation."""
+    rde_in_use = server_utils.get_rde_version_in_use()
+    svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
+        get_cluster_service(rde_in_use)
+    cluster_id = data[RequestKey.CLUSTER_ID]
+    update_acl_entries = data.get(RequestKey.INPUT_SPEC, {}).get(ClusterAclKey.ACCESS_SETTING)  # noqa: E501
+    svc.update_cluster_acl(cluster_id, update_acl_entries)


### PR DESCRIPTION
- Implementation of CRUD handlers for api version v36
- Update request dispatcher to register v36 cluster handlers
- Update crud handlers  in v36 api handler
- Update validator to get entity as params
- Tested CRUD operations using server_api_version:36 in profiles.yaml
- Telemetry changes and testing completed

@Anirudh9794 @sahithi @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/947)
<!-- Reviewable:end -->
