### PR TITLE
Changes to use TemplateV2.yaml

### DIFF
--- a/cluster_scripts/1_x/mstr.sh
+++ b/cluster_scripts/1_x/mstr.sh
@@ -8,9 +8,6 @@ chown $(id -u):$(id -g) /root/.kube/config
 
 export kubever=$(kubectl version --client | base64 | tr -d '\n')
 
-# BUG: This download should actually be performed by the template scripts.
-wget --no-verbose -O /root/weave.yml "https://cloud.weave.works/k8s/net?k8s-version=$kubever&v={cni_version}"
-
 kubectl apply -f /root/weave.yml
 systemctl restart kubelet
 while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done

--- a/cluster_scripts/2_x/mstr.sh
+++ b/cluster_scripts/2_x/mstr.sh
@@ -8,9 +8,6 @@ chown $(id -u):$(id -g) /root/.kube/config
 
 export kubever=$(kubectl version --client | base64 | tr -d '\n')
 
-# BUG: This download should actually be performed by the template scripts.
-wget --no-verbose -O /root/weave.yml "https://cloud.weave.works/k8s/net?k8s-version=$kubever&v={cni_version}"
-
 kubectl apply -f /root/weave.yml
 systemctl restart kubelet
 while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -227,6 +227,13 @@ class ScriptFile(str, Enum):
     WORKER_K8S_UPGRADE = 'cluster-upgrade/worker-k8s-upgrade.sh'
 
 
+TEMPLATE_SCRIPT_LIST = [ScriptFile.CUST, ScriptFile.INIT,
+                        ScriptFile.DOCKER_UPGRADE,
+                        ScriptFile.CONTROL_PLANE_CNI_APPLY,
+                        ScriptFile.CONTROL_PLANE_K8S_UPGRADE,
+                        ScriptFile.WORKER_K8S_UPGRADE]
+
+
 @unique
 class LocalTemplateKey(str, Enum):
     """Enumerate the keys that define a template."""

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -227,13 +227,6 @@ class ScriptFile(str, Enum):
     WORKER_K8S_UPGRADE = 'cluster-upgrade/worker-k8s-upgrade.sh'
 
 
-TEMPLATE_SCRIPT_LIST = [ScriptFile.CUST, ScriptFile.INIT,
-                        ScriptFile.DOCKER_UPGRADE,
-                        ScriptFile.CONTROL_PLANE_CNI_APPLY,
-                        ScriptFile.CONTROL_PLANE_K8S_UPGRADE,
-                        ScriptFile.WORKER_K8S_UPGRADE]
-
-
 @unique
 class LocalTemplateKey(str, Enum):
     """Enumerate the keys that define a template."""

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -1162,7 +1162,8 @@ def _install_all_templates(
             retain_temp_vapp=retain_temp_vapp,
             ssh_key=ssh_key,
             is_tkg_plus_enabled=server_utils.is_tkg_plus_enabled(config),
-            msg_update_callback=msg_update_callback)
+            msg_update_callback=msg_update_callback,
+            legacy_mode=config['service'].get('legacy_mode'))
 
 
 def install_template(template_name, template_revision, config_file_name,
@@ -1260,7 +1261,8 @@ def install_template(template_name, template_revision, config_file_name,
                     retain_temp_vapp=retain_temp_vapp,
                     ssh_key=ssh_key,
                     is_tkg_plus_enabled=server_utils.is_tkg_plus_enabled(config),  # noqa: E501
-                    msg_update_callback=msg_update_callback)
+                    msg_update_callback=msg_update_callback,
+                    legacy_mode=config['service'].get('legacy_mode'))
 
         if not found_template:
             msg = f"Template '{template_name}' at revision " \
@@ -1292,7 +1294,7 @@ def _install_single_template(
         client, remote_template_manager, template, org_name,
         vdc_name, catalog_name, network_name, ip_allocation_mode,
         storage_profile, force_update, retain_temp_vapp,
-        ssh_key, is_tkg_plus_enabled=False,
+        ssh_key, is_tkg_plus_enabled=False, legacy_mode=False,
         msg_update_callback=utils.NullPrinter()):
     # NOTE: For CSE 3.0, if the template is a TKG+ template
     # and `enable_tkg_plus` is set to false,
@@ -1314,7 +1316,7 @@ def _install_single_template(
     remote_template_manager.download_template_scripts(
         template_name=template[server_constants.RemoteTemplateKey.NAME],
         revision=template[server_constants.RemoteTemplateKey.REVISION],
-        force_overwrite=force_update)
+        force_overwrite=force_update, legacy_mode=legacy_mode)
     catalog_item_name = ltm.get_revisioned_template_name(
         template[server_constants.RemoteTemplateKey.NAME],
         template[server_constants.RemoteTemplateKey.REVISION])

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -1163,7 +1163,7 @@ def _install_all_templates(
             ssh_key=ssh_key,
             is_tkg_plus_enabled=server_utils.is_tkg_plus_enabled(config),
             msg_update_callback=msg_update_callback,
-            legacy_mode=config['service'].get('legacy_mode'))
+            legacy_mode=config['service']['legacy_mode'])
 
 
 def install_template(template_name, template_revision, config_file_name,

--- a/container_service_extension/installer/sample_generator.py
+++ b/container_service_extension/installer/sample_generator.py
@@ -131,7 +131,7 @@ SAMPLE_BROKER_CONFIG = {
         'storage_profile': '*',
         'default_template_name': 'my_template',
         'default_template_revision': 0,
-        'remote_template_cookbook_url': 'http://raw.githubusercontent.com/vmware/container-service-extension-templates/master/template.yaml', # noqa: E501
+        'remote_template_cookbook_url': 'http://raw.githubusercontent.com/vmware/container-service-extension-templates/upgrades/template_v2.yaml', # noqa: E501
     }
 }
 

--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -10,15 +10,14 @@ import yaml
 
 from container_service_extension.common.constants.server_constants import ScriptFile  # noqa: E501
 from container_service_extension.common.constants.server_constants import TemplateScriptFile  # noqa: E501
-from container_service_extension.common.constants.server_constants import TEMPLATE_SCRIPT_LIST  # noqa: E501
 from container_service_extension.common.utils.core_utils import download_file
 from container_service_extension.common.utils.core_utils import NullPrinter
 import container_service_extension.installer.templates.local_template_manager as ltm  # noqa: E501
 from container_service_extension.logging.logger import NULL_LOGGER
 
-REMOTE_TEMPLATE_COOKBOOK_V2_FILENAME = 'templateV2.yaml'
+REMOTE_TEMPLATE_COOKBOOK_V2_FILENAME = 'template_v2.yaml'
 REMOTE_TEMPLATE_COOKBOOK_FILENAME = 'template.yaml'
-REMOTE_SCRIPTS_V2_DIR = 'scriptsV2'
+REMOTE_SCRIPTS_V2_DIR = 'scripts_v2'
 REMOTE_SCRIPTS_DIR = 'scripts'
 
 
@@ -88,16 +87,17 @@ class RemoteTemplateManager():
         :param str script_file_name:
         """
         base_url = self._get_base_url_from_remote_template_cookbook_url()
-        revisioned_template_name = ltm.get_revisioned_template_name(template_name, revision)
+        revisioned_template_name = \
+            ltm.get_revisioned_template_name(template_name, revision)
         if legacy_mode:
             return base_url + \
                 f"/{REMOTE_SCRIPTS_DIR}" \
                 f"/{revisioned_template_name}" \
                 f"/{script_file_name}"
         return base_url + \
-                f"/{REMOTE_SCRIPTS_V2_DIR}" \
-                f"/{revisioned_template_name}" \
-                f"/{script_file_name}"
+            f"/{REMOTE_SCRIPTS_V2_DIR}" \
+            f"/{revisioned_template_name}" \
+            f"/{script_file_name}"
 
     def get_remote_template_cookbook(self):
         """Get the remote template cookbook as a dictionary.
@@ -135,8 +135,9 @@ class RemoteTemplateManager():
             scripts_to_download = ScriptFile
         for script_file in scripts_to_download:
             remote_script_url = \
-                self._get_remote_script_url(template_name, revision,
-                                            script_file, legacy_mode=legacy_mode)
+                self._get_remote_script_url(
+                    template_name, revision,
+                    script_file, legacy_mode=legacy_mode)
 
             local_script_filepath = ltm.get_script_filepath(
                 template_name, revision, script_file)

--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -9,12 +9,16 @@ import requests
 import yaml
 
 from container_service_extension.common.constants.server_constants import ScriptFile  # noqa: E501
+from container_service_extension.common.constants.server_constants import TemplateScriptFile  # noqa: E501
+from container_service_extension.common.constants.server_constants import TEMPLATE_SCRIPT_LIST  # noqa: E501
 from container_service_extension.common.utils.core_utils import download_file
 from container_service_extension.common.utils.core_utils import NullPrinter
 import container_service_extension.installer.templates.local_template_manager as ltm  # noqa: E501
 from container_service_extension.logging.logger import NULL_LOGGER
 
+REMOTE_TEMPLATE_COOKBOOK_V2_FILENAME = 'templateV2.yaml'
 REMOTE_TEMPLATE_COOKBOOK_FILENAME = 'template.yaml'
+REMOTE_SCRIPTS_V2_DIR = 'scriptsV2'
 REMOTE_SCRIPTS_DIR = 'scripts'
 
 
@@ -58,12 +62,13 @@ class RemoteTemplateManager():
 
     def _get_base_url_from_remote_template_cookbook_url(self):
         tokens = self.url.split('/')
-        if tokens[-1] == REMOTE_TEMPLATE_COOKBOOK_FILENAME:
+        if tokens[-1] in [REMOTE_TEMPLATE_COOKBOOK_V2_FILENAME,
+                          REMOTE_TEMPLATE_COOKBOOK_FILENAME]:
             return '/'.join(tokens[:-1])
         raise ValueError("Invalid url for template cookbook.")
 
     def _get_remote_script_url(self, template_name, revision,
-                               script_file_name):
+                               script_file_name, legacy_mode=False):
         """.
 
         The scripts of all templates are kept relative to templates.yaml,
@@ -83,10 +88,16 @@ class RemoteTemplateManager():
         :param str script_file_name:
         """
         base_url = self._get_base_url_from_remote_template_cookbook_url()
+        revisioned_template_name = ltm.get_revisioned_template_name(template_name, revision)
+        if legacy_mode:
+            return base_url + \
+                f"/{REMOTE_SCRIPTS_DIR}" \
+                f"/{revisioned_template_name}" \
+                f"/{script_file_name}"
         return base_url + \
-            f"/{REMOTE_SCRIPTS_DIR}" \
-            f"/{ltm.get_revisioned_template_name(template_name, revision)}" \
-            f"/{script_file_name}"
+                f"/{REMOTE_SCRIPTS_V2_DIR}" \
+                f"/{revisioned_template_name}" \
+                f"/{script_file_name}"
 
     def get_remote_template_cookbook(self):
         """Get the remote template cookbook as a dictionary.
@@ -105,7 +116,8 @@ class RemoteTemplateManager():
         return self.cookbook
 
     def download_template_scripts(self, template_name, revision,
-                                  force_overwrite=False):
+                                  force_overwrite=False,
+                                  legacy_mode=False):
         """Download all scripts of a template to local scripts folder.
 
         :param str template_name:
@@ -116,10 +128,15 @@ class RemoteTemplateManager():
         # Multiple codepaths enter into this. Hence all scripts are downloaded.
         # When vcdbroker.py id deprecated, the scripts should loop through
         # TemplateScriptFile to download scripts.
-        for script_file in ScriptFile:
+        scripts_to_download = TemplateScriptFile
+        if legacy_mode:
+            # if server configuration is indicating legacy_mode,
+            # download cluster-scripts from template repository.
+            scripts_to_download = ScriptFile
+        for script_file in scripts_to_download:
             remote_script_url = \
                 self._get_remote_script_url(template_name, revision,
-                                            script_file)
+                                            script_file, legacy_mode=legacy_mode)
 
             local_script_filepath = ltm.get_script_filepath(
                 template_name, revision, script_file)

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -514,7 +514,7 @@ class Service(object, metaclass=Singleton):
             msg_update_callback.info(msg)
             logger.SERVER_LOGGER.debug(msg)
         except cse_exception.DefSchemaServiceError as e:
-            msg = f"Error while loading defined entity schema: {e.minor_error_code}"  # noqa: E501
+            msg = f"Error while loading defined entity schema: {e.error_message}"  # noqa: E501
             msg_update_callback.error(msg)
             logger.SERVER_LOGGER.debug(msg)
             raise e


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Once the changes for https://reviewable.io/reviews/vmware/container-service-extension-templates/24#- is merged, CSE should download the cluster-scripts (mstr.sh and node.sh) only if legacy_mode is enabled.

This PR also adds logic for CSE to download from templateV2.yaml instead of template.yaml if legacy_mode is set to false.

Testing done:
* create CSE template with legacy_mode: true
* create CSE template with legacy_mode: false

@sahithi @rocknes @arunmk @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/952)
<!-- Reviewable:end -->
