### PR TITLE
[VCDA-2193] Change CSE install and upgrade workflow to install supported templates

### DIFF
--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -244,6 +244,8 @@ class LocalTemplateKey(str, Enum):
     OS = 'os'
     REVISION = 'revision'
     UPGRADE_FROM = 'upgrade_from'
+    MIN_CSE_VERSION = 'min_cse_version'
+    MAX_CSE_VERSION = 'max_cse_version'
 
 
 @unique
@@ -268,6 +270,8 @@ class RemoteTemplateKey(str, Enum):
     SOURCE_OVA_NAME = 'source_ova_name'
     SOURCE_OVA_SHA256 = 'sha256_ova'
     UPGRADE_FROM = 'upgrade_from'
+    MIN_CSE_VERSION = 'min_cse_version'
+    MAX_CSE_VERSION = 'max_cse_version'
 
 
 # CSE requests

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -225,6 +225,31 @@ class ScriptFile(str, Enum):
 
 
 @unique
+class LegacyLocalTemplatekey(str, Enum):
+    """Enumerate the keys that define a legacy template.
+
+    All the keys for a template except min_cse_version and
+    max_cse_version.
+    """
+    CATALOG_ITEM_NAME = 'catalog_item_name'
+    CNI = 'cni'
+    CNI_VERSION = 'cni_version'
+    COMPUTE_POLICY = 'compute_policy'
+    CPU = 'cpu'
+    DEPRECATED = 'deprecated'
+    DESCRIPTION = 'description'
+    DOCKER_VERSION = 'docker_version'
+    KIND = 'kind'
+    KUBERNETES = 'kubernetes'
+    KUBERNETES_VERSION = 'kubernetes_version'
+    MEMORY = 'mem'
+    NAME = 'name'
+    OS = 'os'
+    REVISION = 'revision'
+    UPGRADE_FROM = 'upgrade_from'
+
+
+@unique
 class LocalTemplateKey(str, Enum):
     """Enumerate the keys that define a template."""
 

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -231,6 +231,7 @@ class LegacyLocalTemplatekey(str, Enum):
     All the keys for a template except min_cse_version and
     max_cse_version.
     """
+
     CATALOG_ITEM_NAME = 'catalog_item_name'
     CNI = 'cni'
     CNI_VERSION = 'cni_version'

--- a/container_service_extension/common/utils/server_utils.py
+++ b/container_service_extension/common/utils/server_utils.py
@@ -14,14 +14,13 @@ import container_service_extension.common.utils.core_utils as utils
 import container_service_extension.rde.models.common_models as common_models
 
 
-def get_installed_cse_version():
+def get_installed_cse_version() -> semantic_version.Version:
     """."""
     cse_version_raw = utils.get_cse_info()['version']
     # Cleanup version string. Strip dev version string segment.
     # e.g. convert '2.6.0.0b2.dev5' to '2.6.0'
     tokens = cse_version_raw.split('.')[:3]
-    cse_version = semantic_version.Version('.'.join(tokens))
-    return cse_version
+    return semantic_version.Version('.'.join(tokens))
 
 
 def get_server_runtime_config():

--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -397,7 +397,6 @@ def _validate_broker_config(broker_dict,
     check_keys_and_value_types(broker_dict, SAMPLE_BROKER_CONFIG['broker'],
                                location="config file 'broker' section",
                                msg_update_callback=msg_update_callback)
-
     valid_ip_allocation_modes = [
         'dhcp',
         'pool'
@@ -410,7 +409,8 @@ def _validate_broker_config(broker_dict,
     rtm = RemoteTemplateManager(remote_template_cookbook_url=broker_dict['remote_template_cookbook_url'], # noqa: E501
                                 legacy_mode=legacy_mode,
                                 logger=logger_debug)
-    remote_template_cookbook = rtm.get_remote_template_cookbook()
+
+    remote_template_cookbook = rtm.get_filtered_remote_template_cookbook()
 
     if not remote_template_cookbook:
         raise Exception("Remote template cookbook is invalid.")

--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -38,7 +38,8 @@ from container_service_extension.installer.sample_generator import \
     SAMPLE_PKS_ORGS_SECTION, SAMPLE_PKS_PVDCS_SECTION, \
     SAMPLE_PKS_SERVERS_SECTION, SAMPLE_SERVICE_CONFIG, SAMPLE_VCD_CONFIG, \
     SAMPLE_VCS_CONFIG
-from container_service_extension.installer.templates.remote_template_manager import RemoteTemplateManager  # noqa: E501
+from container_service_extension.installer.templates.remote_template_manager \
+    import RemoteTemplateManager
 from container_service_extension.lib.nsxt.dfw_manager import DFWManager
 from container_service_extension.lib.nsxt.ipset_manager import IPSetManager
 from container_service_extension.lib.nsxt.nsxt_client import NSXTClient
@@ -143,8 +144,10 @@ def get_validated_config(config_file_name,
     except requests.exceptions.ConnectionError as err:
         raise Exception(f"Cannot connect to {err.request.url}.")
 
-    _validate_broker_config(config['broker'], msg_update_callback,
-                            logger_debug)
+    _validate_broker_config(config['broker'],
+                            legacy_mode=config['service']['legacy_mode'],
+                            msg_update_callback=msg_update_callback,
+                            logger_debug=logger_debug)
     check_keys_and_value_types(config['service'],
                                SAMPLE_SERVICE_CONFIG['service'],
                                location="config file 'service' section",
@@ -374,6 +377,7 @@ def _validate_vcd_and_vcs_config(vcd_dict,
 
 
 def _validate_broker_config(broker_dict,
+                            legacy_mode=False,
                             msg_update_callback=NullPrinter(),
                             logger_debug=NULL_LOGGER):
     """Ensure that 'broker' section of config is correct.
@@ -403,7 +407,8 @@ def _validate_broker_config(broker_dict,
                          f"'{broker_dict['ip_allocation_mode']}' when it "
                          f"should be either 'dhcp' or 'pool'")
 
-    rtm = RemoteTemplateManager(remote_template_cookbook_url=broker_dict['remote_template_cookbook_url'],  # noqa: E501
+    rtm = RemoteTemplateManager(remote_template_cookbook_url=broker_dict['remote_template_cookbook_url'], # noqa: E501
+                                legacy_mode=legacy_mode,
                                 logger=logger_debug)
     remote_template_cookbook = rtm.get_remote_template_cookbook()
 

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -1137,7 +1137,6 @@ def _install_all_templates(
         logger=INSTALL_LOGGER,
         msg_update_callback=msg_update_callback)
     remote_template_cookbook = rtm.get_remote_template_cookbook()
-    msg_update_callback.info(f'{remote_template_cookbook}')
 
     # create all templates defined in cookbook
     for template in remote_template_cookbook['templates']:
@@ -1231,7 +1230,7 @@ def install_template(template_name, template_revision, config_file_name,
             remote_template_cookbook_url=config['broker']['remote_template_cookbook_url'], # noqa: E501
             legacy_mode=config['service']['legacy_mode'],
             logger=INSTALL_LOGGER, msg_update_callback=msg_update_callback)
-        # TODO no need to return as cookbook is a class variable in RTM
+
         remote_template_cookbook = rtm.get_remote_template_cookbook()
 
         found_template = False
@@ -1259,8 +1258,9 @@ def install_template(template_name, template_revision, config_file_name,
 
         if not found_template:
             msg = f"Template '{template_name}' at revision " \
-                  f"'{template_revision}' not found in remote template " \
-                  "cookbook."
+                  f"'{template_revision}' not supported by CSE " \
+                  f"{server_utils.get_installed_cse_version()} or " \
+                  f"not found in remote template cookbook."
             msg_update_callback.error(msg)
             INSTALL_LOGGER.error(msg, exc_info=True)
             raise Exception(msg)

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -73,6 +73,7 @@ API_FILTER_PATTERNS = [
 
 LEGACY_MODE = False
 
+
 def check_cse_installation(config, msg_update_callback=utils.NullPrinter()):
     """Ensure that CSE is installed on vCD according to the config file.
 
@@ -1068,7 +1069,7 @@ def _setup_placement_policies(client,
         INSTALL_LOGGER.info(msg)
 
 
-def _construct_catalog_item_name_to_template_description_map(cookbook: dict) -> dict:
+def _construct_catalog_item_name_to_template_description_map(cookbook: dict) -> dict:  # noqa: E501
     """Get a dictionary which maps catalog item name to template description.
 
     :param dict cookbook: template cookbook
@@ -1081,7 +1082,7 @@ def _construct_catalog_item_name_to_template_description_map(cookbook: dict) -> 
         # For CSE 3.1, we can safely assume that all the catalog item names are
         # present in template metadata as CSE 3.1 can only be upgraded from
         # CSE 3.0
-        catalog_item_name_to_template_description[template[server_constants.LegacyLocalTemplatekey.CATALOG_ITEM_NAME]] = template
+        catalog_item_name_to_template_description[template[server_constants.LegacyLocalTemplatekey.CATALOG_ITEM_NAME]] = template  # noqa: E501
     return catalog_item_name_to_template_description
 
 
@@ -1120,7 +1121,8 @@ def _update_metadata_for_existing_templates(client: Client, config: dict,
     # the template descriptors supported by the target CSE version.
     rtm.get_filtered_remote_template_cookbook()
     catalog_item_to_template_description_map = \
-        _construct_catalog_item_name_to_template_description_map(rtm.filtered_cookbook)
+        _construct_catalog_item_name_to_template_description_map(
+            rtm.filtered_cookbook)
     # List of keys for the new template metadata. This includes
     # min_cse_version and max_cse_version
     new_metadata_key_list = [k for k in server_constants.LocalTemplateKey]
@@ -1133,13 +1135,14 @@ def _update_metadata_for_existing_templates(client: Client, config: dict,
             # Supported template with the template name and revision found
             # Update template metadata with min_cse_version and max_cse_version
             template[server_constants.LocalTemplateKey.MIN_CSE_VERSION] = \
-                catalog_item_to_template_description_map[server_constants.RemoteTemplateKey.MIN_CSE_VERSION]
+                catalog_item_to_template_description_map[server_constants.RemoteTemplateKey.MIN_CSE_VERSION]  # noqa: E501
             template[server_constants.LocalTemplateKey.MAX_CSE_VERSION] = \
-                catalog_item_to_template_description_map[server_constants.RemoteTemplateKey.MAX_CSE_VERSION]
+                catalog_item_to_template_description_map[server_constants.RemoteTemplateKey.MAX_CSE_VERSION]  # noqa: E501
             ltm.save_metadata(client, catalog_org_name,
                               catalog_name, catalog_item_name,
-                              template, metadata_key_list=new_metadata_key_list)
-            msg = f"Successfully updated template metadata for {catalog_item_name}"
+                              template, metadata_key_list=new_metadata_key_list)  # noqa: E501
+            msg = f"Successfully updated template metadata " \
+                  f"for {catalog_item_name}"
             INSTALL_LOGGER.debug(msg)
             msg_update_callback.general(msg)
         else:
@@ -1156,7 +1159,7 @@ def _assign_placement_policies_to_existing_templates(client: Client,
                                                      all_templates: list,
                                                      is_tkg_plus_enabled: bool,
                                                      log_wire: bool = False,
-                                                     msg_update_callback=utils.NullPrinter()):
+                                                     msg_update_callback=utils.NullPrinter()):  # noqa: E501
     # NOTE: In CSE 3.0 if `enable_tkg_plus` flag in the config is set to false,
     # And there is an existing TKG+ template, throw an exception on the console
     # and fail the upgrade.
@@ -1217,7 +1220,7 @@ def _process_existing_templates(client: Client, config: dict,
     :param bool log_wire:
     :param core_utils.ConsoleMessagePrinter msg_update_callback:
     """
-    #  Load global LEGACY_MODE variable
+    # Load global LEGACY_MODE variable
     global LEGACY_MODE
 
     catalog_name = config['broker']['catalog']
@@ -1388,14 +1391,15 @@ def install_template(template_name, template_revision, config_file_name,
                     msg_update_callback=msg_update_callback)
 
         if not LEGACY_MODE and template_name != "*" and not found_template:
-            # Do not raise template unsupported exception if template name is "*"
+            # Do not raise template unsupported exception
+            #   if template name is "*"
             # Raise TemplateUnsuppotedException if -
             # if template_revision is *, check if a template with name
             #   template_name is in unfiltered cookbook
             # if (template_name, template_revision) is in unfiltered cookbook
             for template in rtm.unfiltered_cookbook['templates']:
-                template_name_matched = template[server_constants.RemoteTemplateKey.NAME] == template_name
-                template_revision_matched = template_revision in (str(template[server_constants.RemoteTemplateKey.REVISION]), '*')
+                template_name_matched = template[server_constants.RemoteTemplateKey.NAME] == template_name  # noqa: E501
+                template_revision_matched = template_revision in (str(template[server_constants.RemoteTemplateKey.REVISION]), '*')  # noqa: E501
                 if template_name_matched and template_revision_matched:
                     msg = f"Template '{template_name}' at revision " \
                           f"'{template_revision}' is not supported by " \
@@ -1871,21 +1875,6 @@ def _upgrade_to_cse_3_1(client, config, ext_vcd_api_version,
             exchange=config['amqp']['exchange'],
             target_vcd_api_version=config['vcd']['api_version'],
             msg_update_callback=msg_update_callback)
-
-
-def _update_existing_template_metadata(client, config,
-                                       logger_debug=NULL_LOGGER,
-                                       msg_update_callback=utils.NullPrinter()):
-    """Update metadata with min_cse_version and max_cse_version.
-
-    NOTE: Update the metadata only if CSE is executed in non-legacy mode.
-    """
-    if config['service']['legacy_mode']:
-        # If CSE is executed in non-legacy mode, do nothing
-        msg = "Skipping template metadata update as " \
-              "CSE is running in legacy mode"
-        return
-    all_legacy_templates = ltm.get_all_k8s_local_template_definition()
 
 
 def _get_placement_policy_name_from_template_name(template_name):

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -1136,12 +1136,13 @@ def _update_metadata_for_existing_templates(client: Client, config: dict,
             template[server_constants.LegacyLocalTemplatekey.CATALOG_ITEM_NAME]
         if catalog_item_name in catalog_item_to_template_description_map:
             # Supported template with the template name and revision found.
-            remote_template_descriptor = catalog_item_to_template_description_map[catalog_item_name]
+            remote_template_descriptor = \
+                catalog_item_to_template_description_map[catalog_item_name]
 
             # remote_template_descriptor will contain all the necessary
             # metadata keys barring the catalog_item_name.
             # Add catalog_item_name to the dict remote_template_descriptor
-            remote_template_descriptor[server_constants.LocalTemplateKey.CATALOG_ITEM_NAME] = catalog_item_name
+            remote_template_descriptor[server_constants.LocalTemplateKey.CATALOG_ITEM_NAME] = catalog_item_name  # noqa: E501
 
             # New keys to be added (min_cse_version and max_cse_version)
             # will already be in remote_template_descriptor.

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -1094,7 +1094,7 @@ def _update_metadata_for_existing_templates(client: Client, config: dict,
                                             msg_update_callback=utils.NullPrinter()):  # noqa: E501
     """Update template metadata to include new metadata keys.
 
-    Metadata update will happen when CSE is executed in non-legacy mode only
+    Metadata update will happen when CSE is configured in non-legacy mode only
     for supported templates.
     :param vcdClient.Client client:
     :param dict config: server configuration
@@ -1108,10 +1108,10 @@ def _update_metadata_for_existing_templates(client: Client, config: dict,
     catalog_org_name = config['broker']['org']
     catalog_name = config['broker']['catalog']
 
-    # Skip updating metadata if CSE is executed in legacy mode.
+    # Skip updating metadata if CSE is configured in legacy mode.
     if LEGACY_MODE:
         msg = "Skipping template metadata update as " \
-              "CSE is executed in legacy mode."
+              "CSE is configured in legacy mode."
         INSTALL_LOGGER.debug(msg)
         msg_update_callback.general(msg)
         return
@@ -1372,7 +1372,7 @@ def install_template(template_name, template_revision, config_file_name,
         # read remote template cookbook
         rtm = RemoteTemplateManager(
             remote_template_cookbook_url=config['broker']['remote_template_cookbook_url'], # noqa: E501
-            legacy_mode=config['service']['legacy_mode'],
+            legacy_mode=LEGACY_MODE,
             logger=INSTALL_LOGGER, msg_update_callback=msg_update_callback)
 
         rtm.get_filtered_remote_template_cookbook()

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -1133,8 +1133,11 @@ def _install_all_templates(
     # read remote template cookbook, download all scripts
     rtm = RemoteTemplateManager(
         remote_template_cookbook_url=config['broker']['remote_template_cookbook_url'], # noqa: E501
-        logger=INSTALL_LOGGER, msg_update_callback=msg_update_callback)
+        legacy_mode=config['service']['legacy_mode'],
+        logger=INSTALL_LOGGER,
+        msg_update_callback=msg_update_callback)
     remote_template_cookbook = rtm.get_remote_template_cookbook()
+    msg_update_callback.info(f'{remote_template_cookbook}')
 
     # create all templates defined in cookbook
     for template in remote_template_cookbook['templates']:
@@ -1152,8 +1155,7 @@ def _install_all_templates(
             retain_temp_vapp=retain_temp_vapp,
             ssh_key=ssh_key,
             is_tkg_plus_enabled=server_utils.is_tkg_plus_enabled(config),
-            msg_update_callback=msg_update_callback,
-            legacy_mode=config['service']['legacy_mode'])
+            msg_update_callback=msg_update_callback)
 
 
 def install_template(template_name, template_revision, config_file_name,
@@ -1227,7 +1229,9 @@ def install_template(template_name, template_revision, config_file_name,
         # read remote template cookbook
         rtm = RemoteTemplateManager(
             remote_template_cookbook_url=config['broker']['remote_template_cookbook_url'], # noqa: E501
+            legacy_mode=config['service']['legacy_mode'],
             logger=INSTALL_LOGGER, msg_update_callback=msg_update_callback)
+        # TODO no need to return as cookbook is a class variable in RTM
         remote_template_cookbook = rtm.get_remote_template_cookbook()
 
         found_template = False
@@ -1251,8 +1255,7 @@ def install_template(template_name, template_revision, config_file_name,
                     retain_temp_vapp=retain_temp_vapp,
                     ssh_key=ssh_key,
                     is_tkg_plus_enabled=server_utils.is_tkg_plus_enabled(config),  # noqa: E501
-                    msg_update_callback=msg_update_callback,
-                    legacy_mode=config['service'].get('legacy_mode'))
+                    msg_update_callback=msg_update_callback)
 
         if not found_template:
             msg = f"Template '{template_name}' at revision " \
@@ -1306,7 +1309,7 @@ def _install_single_template(
     remote_template_manager.download_template_scripts(
         template_name=template[server_constants.RemoteTemplateKey.NAME],
         revision=template[server_constants.RemoteTemplateKey.REVISION],
-        force_overwrite=force_update, legacy_mode=legacy_mode)
+        force_overwrite=force_update)
     catalog_item_name = ltm.get_revisioned_template_name(
         template[server_constants.RemoteTemplateKey.NAME],
         template[server_constants.RemoteTemplateKey.REVISION])

--- a/container_service_extension/installer/templates/local_template_manager.py
+++ b/container_service_extension/installer/templates/local_template_manager.py
@@ -5,17 +5,17 @@
 import ast
 import os
 import pathlib
-import semantic_version
 
 from pyvcloud.vcd.client import MetadataDomain
 from pyvcloud.vcd.client import MetadataVisibility
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.utils import metadata_to_dict
+import semantic_version
 
-import container_service_extension.common.utils.server_utils as server_utils
 from container_service_extension.common.constants.server_constants import LegacyLocalTemplatekey  # noqa: E501
 from container_service_extension.common.constants.server_constants import LocalTemplateKey  # noqa: E501
 from container_service_extension.common.utils.pyvcloud_utils import get_org
+import container_service_extension.common.utils.server_utils as server_utils
 import container_service_extension.logging.logger as logger
 
 LOCAL_SCRIPTS_DIR = '.cse_scripts'

--- a/container_service_extension/installer/templates/local_template_manager.py
+++ b/container_service_extension/installer/templates/local_template_manager.py
@@ -5,12 +5,15 @@
 import ast
 import os
 import pathlib
+import semantic_version
 
 from pyvcloud.vcd.client import MetadataDomain
 from pyvcloud.vcd.client import MetadataVisibility
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.utils import metadata_to_dict
 
+import container_service_extension.common.utils.server_utils as server_utils
+from container_service_extension.common.constants.server_constants import LegacyLocalTemplatekey  # noqa: E501
 from container_service_extension.common.constants.server_constants import LocalTemplateKey  # noqa: E501
 from container_service_extension.common.utils.pyvcloud_utils import get_org
 import container_service_extension.logging.logger as logger
@@ -44,6 +47,7 @@ def get_script_filepath(template_name, revision, script_file_name):
 
 def get_all_k8s_local_template_definition(client, catalog_name, org=None,
                                           org_name=None,
+                                          legacy_mode=False,
                                           logger_debug=logger.NULL_LOGGER):
     """Fetch all CSE k8s templates in a catalog.
 
@@ -67,6 +71,14 @@ def get_all_k8s_local_template_definition(client, catalog_name, org=None,
     catalog_item_names = [
         entry['name'] for entry in org.list_catalog_items(catalog_name)]
     templates = []
+
+    # Select the right Key enum based on legacy_mode flag
+    localTemplateKey = LocalTemplateKey
+    if legacy_mode:
+        # if template is loaded in legacy mode, make sure to avoid the keys
+        # min_cse_version and max_cse_version
+        localTemplateKey = LegacyLocalTemplatekey
+
     for item_name in catalog_item_names:
         md = org.get_all_metadata_from_catalog_item(catalog_name=catalog_name,
                                                     item_name=item_name)
@@ -75,7 +87,7 @@ def get_all_k8s_local_template_definition(client, catalog_name, org=None,
         # if catalog item doesn't have all the required metadata keys,
         # CSE should not recognize it as a template
         expected_metadata_keys = \
-            set([entry.value for entry in LocalTemplateKey])
+            set([entry.value for entry in localTemplateKey])
         missing_metadata_keys = expected_metadata_keys - metadata_dict.keys()
         num_missing_metadata_keys = len(missing_metadata_keys)
         if num_missing_metadata_keys == len(expected_metadata_keys):
@@ -90,14 +102,29 @@ def get_all_k8s_local_template_definition(client, catalog_name, org=None,
             logger_debug.debug(msg)
             continue
 
+        if not legacy_mode:
+            # Do not load the template in legacy_mode if
+            # min_cse_version and max_cse_version are not present
+            # in the metadata_dict
+            curr_cse_version = server_utils.get_installed_cse_version()
+            valid_cse_versions = semantic_version.SimpleSpec(
+                f">={metadata_dict[localTemplateKey.MIN_CSE_VERSION]},"
+                f"<={metadata_dict[localTemplateKey.MAX_CSE_VERSION]}")
+            if not valid_cse_versions.match(curr_cse_version):
+                msg = f"Catalog item '{item_name}' is not valid for CSE " \
+                      f"{curr_cse_version}"
+                logger_debug.debug(msg)
+                continue
+
         # non-string metadata is written to the dictionary as a string
         # when 'upgrade_from' metadata is empty, vcd returns it as: "['']"
         # when 'upgrade_from' metadata is not empty, vcd returns it as an array
         # coerce "['']" to the more usable empty array []
-        if isinstance(metadata_dict[LocalTemplateKey.UPGRADE_FROM], str):
-            metadata_dict[LocalTemplateKey.UPGRADE_FROM] = ast.literal_eval(metadata_dict[LocalTemplateKey.UPGRADE_FROM]) # noqa: E501
-        if metadata_dict[LocalTemplateKey.UPGRADE_FROM] == ['']:
-            metadata_dict[LocalTemplateKey.UPGRADE_FROM] = []
+        if isinstance(metadata_dict[localTemplateKey.UPGRADE_FROM], str):
+            metadata_dict[localTemplateKey.UPGRADE_FROM] = \
+                ast.literal_eval(metadata_dict[localTemplateKey.UPGRADE_FROM])
+        if metadata_dict[localTemplateKey.UPGRADE_FROM] == ['']:
+            metadata_dict[localTemplateKey.UPGRADE_FROM] = []
 
         templates.append(metadata_dict)
 
@@ -105,12 +132,13 @@ def get_all_k8s_local_template_definition(client, catalog_name, org=None,
 
 
 def save_metadata(client, org_name, catalog_name, catalog_item_name,
-                  template_data):
+                  template_data, metadata_key_list=None):
+    metadata_key_list = metadata_key_list or []
     org_resource = client.get_org_by_name(org_name=org_name)
     org = Org(client, resource=org_resource)
     org.set_multiple_metadata_on_catalog_item(
         catalog_name=catalog_name,
         item_name=catalog_item_name,
-        key_value_dict={k: template_data[k] for k in LocalTemplateKey},
+        key_value_dict={k: template_data[k] for k in metadata_key_list},
         domain=MetadataDomain.SYSTEM,
         visibility=MetadataVisibility.PRIVATE)

--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -6,12 +6,14 @@ import os
 import stat
 
 import requests
+import semantic_version
 import yaml
 
 from container_service_extension.common.constants.server_constants import ScriptFile  # noqa: E501
 from container_service_extension.common.constants.server_constants import TemplateScriptFile  # noqa: E501
 from container_service_extension.common.utils.core_utils import download_file
 from container_service_extension.common.utils.core_utils import NullPrinter
+import container_service_extension.common.utils.server_utils as server_utils
 import container_service_extension.installer.templates.local_template_manager as ltm  # noqa: E501
 from container_service_extension.logging.logger import NULL_LOGGER
 
@@ -45,15 +47,17 @@ class RemoteTemplateManager():
     Exposes methods to download template cookbook and associated scripts.
     """
 
-    def __init__(self, remote_template_cookbook_url, logger=NULL_LOGGER,
-                 msg_update_callback=NullPrinter()):
+    def __init__(self, remote_template_cookbook_url, legacy_mode: bool = False,
+                 logger=NULL_LOGGER, msg_update_callback=NullPrinter()):
         """.
 
         :param str remote_template_cookbook_url:
+        :param bool legacy_mode:
         :param logging.Logger logger: logger to log with.
         :param utils.ConsoleMessagePrinter msg_update_callback:
             Callback object.
         """
+        self.legacy_mode = legacy_mode
         self.url = remote_template_cookbook_url
         self.logger = logger
         self.msg_update_callback = msg_update_callback
@@ -66,8 +70,7 @@ class RemoteTemplateManager():
             return '/'.join(tokens[:-1])
         raise ValueError("Invalid url for template cookbook.")
 
-    def _get_remote_script_url(self, template_name, revision,
-                               script_file_name, legacy_mode=False):
+    def _get_remote_script_url(self, template_name, revision, script_file_name):
         """.
 
         The scripts of all templates are kept relative to templates.yaml,
@@ -89,7 +92,7 @@ class RemoteTemplateManager():
         base_url = self._get_base_url_from_remote_template_cookbook_url()
         revisioned_template_name = \
             ltm.get_revisioned_template_name(template_name, revision)
-        if legacy_mode:
+        if self.legacy_mode:
             return base_url + \
                 f"/{REMOTE_SCRIPTS_DIR}" \
                 f"/{revisioned_template_name}" \
@@ -99,6 +102,36 @@ class RemoteTemplateManager():
             f"/{revisioned_template_name}" \
             f"/{script_file_name}"
 
+    def _filter_unsupported_templates(self):
+        """Remove template descriptors which is not supported."""
+        # No need to filter templates if CSE is executed in legacy mode.
+        if self.legacy_mode:
+            msg = "Skipping filtering templates as CSE is being" \
+                  " executed in legacy mode"
+            self.logger.debug(msg)
+            self.msg_update_callback.general(msg)
+            return
+        # Fetch current CSE version
+        current_cse_version = server_utils.get_installed_cse_version()
+        supported_templates = []
+        for template_description in self.cookbook['templates']:
+            # only include the template if the current CSE version
+            # supports it
+            # template is supported if current CSE version is between
+            # min_cse_version and max_cse_version of the template
+            template_supported_cse_versions = semantic_version.SimpleSpec(
+                f">={template_description['min_cse_version']},<={template_description['max_cse_version']}")  # noqa: E501
+            self.msg_update_callback.general(f'template: {template_supported_cse_versions} cse: {current_cse_version}')
+            if template_supported_cse_versions.match(current_cse_version):
+                msg = f"Template {template_description['name']} is supported."
+                self.logger.debug(msg)
+                self.msg_update_callback.general(msg)
+                supported_templates.append(template_description)
+        self.cookbook['templates'] = supported_templates
+        msg = "Successfully filtered unsupported templates."
+        self.logger.debug(msg)
+        self.msg_update_callback.general(msg)
+
     def get_remote_template_cookbook(self):
         """Get the remote template cookbook as a dictionary.
 
@@ -107,21 +140,24 @@ class RemoteTemplateManager():
         :rtype: dict
         """
         if self.cookbook:
-            self.logger.debug("Re-using cached copy of template cookbook.")
+            msg = "Re-using cached copy of template cookbook."
+            self.logger.debug(msg)
+            self.msg_update_callback(msg)
         else:
             template_cookbook_as_str = download_file_into_memory(self.url)
             self.cookbook = yaml.safe_load(template_cookbook_as_str)
-            self.logger.debug("Downloaded remote template cookbook from"
-                              f" {self.url}")
+            msg = f"Downloaded remote template cookbook from {self.url}"
+            self.logger.debug(msg)
+            self.msg_update_callback.general(msg)
+            self._filter_unsupported_templates()
         return self.cookbook
 
     def download_template_scripts(self, template_name, revision,
-                                  force_overwrite=False,
-                                  legacy_mode=False):
+                                  force_overwrite=False):
         """Download all scripts of a template to local scripts folder.
 
         :param str template_name:
-        "param str revision:
+        :param str revision:
         :param bool force_overwrite: if True, will download the script even if
             it already exists.
         """
@@ -129,7 +165,7 @@ class RemoteTemplateManager():
         # When vcdbroker.py id deprecated, the scripts should loop through
         # TemplateScriptFile to download scripts.
         scripts_to_download = TemplateScriptFile
-        if legacy_mode:
+        if self.legacy_mode:
             # if server configuration is indicating legacy_mode,
             # download cluster-scripts from template repository.
             scripts_to_download = ScriptFile
@@ -137,7 +173,7 @@ class RemoteTemplateManager():
             remote_script_url = \
                 self._get_remote_script_url(
                     template_name, revision,
-                    script_file, legacy_mode=legacy_mode)
+                    script_file)
 
             local_script_filepath = ltm.get_script_filepath(
                 template_name, revision, script_file)
@@ -160,8 +196,8 @@ class RemoteTemplateManager():
         :param bool legacy_mode: If true, only template scripts will be
             downloaded.
         """
-        remote_template_cookbook = self.get_remote_template_cookbook()
-        for template in remote_template_cookbook['templates']:
+        self.get_remote_template_cookbook()
+        for template in self.cookbook['templates']:
             template_name = template['name']
             revision = template['revision']
             self.download_template_scripts(template_name, revision,

--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -107,7 +107,7 @@ class RemoteTemplateManager():
 
     def _filter_unsupported_templates(self):
         """Remove template descriptors which is not supported."""
-        # No need to filter templates if CSE is executed in legacy mode.
+        # No need to filter templates if CSE is configured in legacy mode.
         if self.legacy_mode:
             msg = "Skipping filtering templates as CSE is being" \
                   " executed in legacy mode"
@@ -145,11 +145,11 @@ class RemoteTemplateManager():
     def _validate_remote_template_cookbook(self):
         """Check if the remote template cookbook supplied is valid.
 
-        If CSE is executed in legacy mode, template descriptors in the
+        If CSE is configured in legacy mode, template descriptors in the
         remote template cookbook are not expected to have min_cse_version and
         max_cse_version.
 
-        If CSE is executed in non-legacy mode, template descriptors in the
+        If CSE is configured in non-legacy mode, template descriptors in the
         remote template cookbook should have min_cse_version and
         max_cse_version.
         """

--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -63,7 +63,6 @@ class RemoteTemplateManager():
         self.logger = logger
         self.msg_update_callback = msg_update_callback
         self.cookbook = None
-        # self.unsupported_templates = []
 
     def _get_base_url_from_remote_template_cookbook_url(self):
         tokens = self.url.split('/')

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -1012,7 +1012,6 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                                    cse_params=cse_params,
                                    telemetry_settings=config_dict['service']['telemetry'])  # noqa: E501
 
-
         local_templates = []
         if display_option in (DISPLAY_ALL, DISPLAY_DIFF, DISPLAY_LOCAL):
             client = None
@@ -1084,7 +1083,8 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                 remote_template_cookbook_url=config_dict['broker']['remote_template_cookbook_url'], # noqa: E501
                 legacy_mode=config_dict['service']['legacy_mode'],
                 logger=SERVER_CLI_LOGGER)
-            remote_template_cookbook = rtm.get_filtered_remote_template_cookbook()
+            remote_template_cookbook = \
+                rtm.get_filtered_remote_template_cookbook()
             remote_template_definitions = remote_template_cookbook['templates']
             for definition in remote_template_definitions:
                 template = {}

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -985,6 +985,7 @@ def upgrade(ctx, config_file_path, skip_config_decryption,
 def list_template(ctx, config_file_path, skip_config_decryption,
                   display_option):
     """List CSE k8s templates."""
+    # TODO(VCDA-2236) Validate legacy_mode in extension
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
     console_message_printer = utils.ConsoleMessagePrinter()
     # Not passing the console_message_printer, because we want to suppress
@@ -1011,6 +1012,7 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                                    cse_params=cse_params,
                                    telemetry_settings=config_dict['service']['telemetry'])  # noqa: E501
 
+
         local_templates = []
         if display_option in (DISPLAY_ALL, DISPLAY_DIFF, DISPLAY_LOCAL):
             client = None
@@ -1027,13 +1029,15 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                 org_name = config_dict['broker']['org']
                 catalog_name = config_dict['broker']['catalog']
                 is_tkg_plus_enabled = server_utils.is_tkg_plus_enabled(config_dict)  # noqa: E501
+                legacy_mode = config_dict['service']['legacy_mode']
+
                 local_template_definitions = \
                     ltm.get_all_k8s_local_template_definition(
                         client=client,
                         catalog_name=catalog_name,
+                        legacy_mode=legacy_mode,
                         org_name=org_name,
                         logger_debug=SERVER_CLI_LOGGER)
-
                 default_template_name = \
                     config_dict['broker']['default_template_name']
                 default_template_revision = \
@@ -1079,8 +1083,7 @@ def list_template(ctx, config_file_path, skip_config_decryption,
             rtm = RemoteTemplateManager(
                 remote_template_cookbook_url=config_dict['broker']['remote_template_cookbook_url'], # noqa: E501
                 legacy_mode=config_dict['service']['legacy_mode'],
-                logger=SERVER_CLI_LOGGER,
-                msg_update_callback=console_message_printer)
+                logger=SERVER_CLI_LOGGER)
             remote_template_cookbook = rtm.get_remote_template_cookbook()
             remote_template_definitions = remote_template_cookbook['templates']
             for definition in remote_template_definitions:
@@ -1205,6 +1208,7 @@ def install_cse_template(ctx, template_name, template_revision,
     Use '*' for TEMPLATE_NAME and TEMPLATE_REVISION to install
     all listed templates.
     """
+    # TODO(VCDA-2236) Validate legacy_mode in extension
     # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
     # Throw an error if TKG+ template creation is issued.
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -1084,7 +1084,7 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                 remote_template_cookbook_url=config_dict['broker']['remote_template_cookbook_url'], # noqa: E501
                 legacy_mode=config_dict['service']['legacy_mode'],
                 logger=SERVER_CLI_LOGGER)
-            remote_template_cookbook = rtm.get_remote_template_cookbook()
+            remote_template_cookbook = rtm.get_filtered_remote_template_cookbook()
             remote_template_definitions = remote_template_cookbook['templates']
             for definition in remote_template_definitions:
                 template = {}

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -1078,6 +1078,7 @@ def list_template(ctx, config_file_path, skip_config_decryption,
         if display_option in (DISPLAY_ALL, DISPLAY_DIFF, DISPLAY_REMOTE):
             rtm = RemoteTemplateManager(
                 remote_template_cookbook_url=config_dict['broker']['remote_template_cookbook_url'], # noqa: E501
+                legacy_mode=config_dict['service']['legacy_mode'],
                 logger=SERVER_CLI_LOGGER,
                 msg_update_callback=console_message_printer)
             remote_template_cookbook = rtm.get_remote_template_cookbook()

--- a/container_service_extension/system_test_framework/environment.py
+++ b/container_service_extension/system_test_framework/environment.py
@@ -105,11 +105,12 @@ def init_environment(config_filepath=BASE_CONFIG_FILEPATH):
     config = testutils.yaml_to_dict(config_filepath)
 
     rtm = \
-        RemoteTemplateManager(config['broker']['remote_template_cookbook_url'])
+        RemoteTemplateManager(config['broker']['remote_template_cookbook_url'],
+                              legacy_mode=config['service']['legacy_mode'])
     template_cookbook = rtm.get_remote_template_cookbook()
     TEMPLATE_DEFINITIONS = template_cookbook['templates']
-    rtm.download_all_template_scripts(force_overwrite=True,
-                                      legacy_mode=config['service']['legacy_mode'])  # noqa: E501
+    # TODO str to bool
+    rtm.download_all_template_scripts(force_overwrite=True)
 
     init_test_vars(config.get('test'))
 

--- a/container_service_extension/system_test_framework/environment.py
+++ b/container_service_extension/system_test_framework/environment.py
@@ -107,7 +107,7 @@ def init_environment(config_filepath=BASE_CONFIG_FILEPATH):
     rtm = \
         RemoteTemplateManager(config['broker']['remote_template_cookbook_url'],
                               legacy_mode=config['service']['legacy_mode'])
-    template_cookbook = rtm.get_remote_template_cookbook()
+    template_cookbook = rtm.get_filtered_remote_template_cookbook()
     TEMPLATE_DEFINITIONS = template_cookbook['templates']
     rtm.download_all_template_scripts(force_overwrite=True)
 

--- a/container_service_extension/system_test_framework/environment.py
+++ b/container_service_extension/system_test_framework/environment.py
@@ -109,7 +109,6 @@ def init_environment(config_filepath=BASE_CONFIG_FILEPATH):
                               legacy_mode=config['service']['legacy_mode'])
     template_cookbook = rtm.get_remote_template_cookbook()
     TEMPLATE_DEFINITIONS = template_cookbook['templates']
-    # TODO str to bool
     rtm.download_all_template_scripts(force_overwrite=True)
 
     init_test_vars(config.get('test'))


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

* Cache only the templates which are supported by the current CSE version if legacy_mode is false
* install and upgrade should only install templates supported by the currently running CSE.
* Template is supported if template['min_cse_version'] >= current_cse_version <= template['max_cse_version']
* Store template's min cse version and max cse version as part of template metadata

Testing done:
* Check if CSE install installs only the supported templates
* Check if correct error is thrown if user tries to install a template which is not supported.

Required:
* Should be merged after in-place tag 3.1 is created.

@rocknes @sahithi @sakthisunda @arunmk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/958)
<!-- Reviewable:end -->
