### PR TITLE
Fix CTOT - add legacy_mode param to download all scripts

### DIFF
--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -151,15 +151,19 @@ class RemoteTemplateManager():
             if os.name != 'nt':
                 os.chmod(local_script_filepath, stat.S_IRUSR | stat.S_IWUSR)
 
-    def download_all_template_scripts(self, force_overwrite=False):
+    def download_all_template_scripts(self, force_overwrite=False,
+                                      legacy_mode=False):
         """Download all scripts for all templates mentioned in cookbook.
 
         :param bool force_overwrite: if True, will download the script even if
             it already exists.
+        :param bool legacy_mode: If true, only template scripts will be
+            downloaded.
         """
         remote_template_cookbook = self.get_remote_template_cookbook()
         for template in remote_template_cookbook['templates']:
             template_name = template['name']
             revision = template['revision']
             self.download_template_scripts(template_name, revision,
-                                           force_overwrite=force_overwrite)
+                                           force_overwrite=force_overwrite,
+                                           legacy_mode=legacy_mode)

--- a/container_service_extension/system_test_framework/environment.py
+++ b/container_service_extension/system_test_framework/environment.py
@@ -108,7 +108,8 @@ def init_environment(config_filepath=BASE_CONFIG_FILEPATH):
         RemoteTemplateManager(config['broker']['remote_template_cookbook_url'])
     template_cookbook = rtm.get_remote_template_cookbook()
     TEMPLATE_DEFINITIONS = template_cookbook['templates']
-    rtm.download_all_template_scripts(force_overwrite=True)
+    rtm.download_all_template_scripts(force_overwrite=True,
+                                      legacy_mode=config['service']['legacy_mode'])  # noqa: E501
 
     init_test_vars(config.get('test'))
 

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -57,7 +57,7 @@ service:
   log_wire: false
   telemetry:
     enable: false
-  legacy_mode: True
+  legacy_mode: true
 
 broker:
   catalog: cse                          # public shared catalog within org where the template will be published


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

add optional parameter `legacy_mode` to `download_all_scripts` function in remote template manager

(This is an interim fix, legacy_mode will be made a class attribute for remote_template_manager in my change set for updating install and upgrade workflows)

Testing done:
* create template in VCD using `cse template instlall command`
* run cse server test and check if right scripts are downloaded

@rocknes @sahithi @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/960)
<!-- Reviewable:end -->
