### PR TITLE
VCDA-2220: set cloud_provider=external in kubelet

### DIFF
--- a/cluster_scripts/2_x/mstr.sh
+++ b/cluster_scripts/2_x/mstr.sh
@@ -1,7 +1,37 @@
 #!/usr/bin/env bash
-set -e
-while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
+set -ex
+
+while [ `systemctl is-active docker` != 'active' ]
+do
+  echo 'waiting for docker'
+  sleep 5
+done
+
+cat << EOF > /lib/systemd/system/kubelet.service
+# This file was added by the Container Service Extension team at VMware.
+# Note: This dropin only works with kubeadm and kubelet v1.11+
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+# This is a file that "kubeadm init" and "kubeadm join" generates at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+# This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
+# the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
+EnvironmentFile=-/etc/default/kubelet
+ExecStart=
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS {cloud_provider_external_args}
+EOF
+
+systemctl daemon-reload
+systemctl restart kubelet
+while [ `systemctl is-active kubelet` != 'active' ]
+do
+  echo 'waiting for kubelet'
+  sleep 5
+done
+
 kubeadm init --kubernetes-version=v{k8s_version} > /root/kubeadm-init.out
+
 mkdir -p /root/.kube
 cp -f /etc/kubernetes/admin.conf /root/.kube/config
 chown $(id -u):$(id -g) /root/.kube/config
@@ -12,5 +42,5 @@ export kubever=$(kubectl version --client | base64 | tr -d '\n')
 wget --no-verbose -O /root/weave.yml "https://cloud.weave.works/k8s/net?k8s-version=$kubever&v={cni_version}"
 
 kubectl apply -f /root/weave.yml
-systemctl restart kubelet
-while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done
+
+exit 0

--- a/cluster_scripts/2_x/node.sh
+++ b/cluster_scripts/2_x/node.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 
 while [ `systemctl is-active docker` != 'active' ]
 do
@@ -7,5 +7,28 @@ do
   sleep 5
 done
 
+cat << EOF > /lib/systemd/system/kubelet.service
+# This file was added by the Container Service Extension team at VMware.
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+# This is a file that "kubeadm init" and "kubeadm join" generates at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+# This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
+# the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
+EnvironmentFile=-/etc/default/kubelet
+ExecStart=
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS {cloud_provider_external_args}
+EOF
+
+systemctl daemon-reload
+systemctl restart kubelet
+while [ `systemctl is-active kubelet` != 'active' ]
+do
+  echo 'waiting for kubelet'
+  sleep 5
+done
+
 kubeadm join {ip_port} --token {token} --discovery-token-ca-cert-hash {discovery_token_ca_cert_hash}
 
+exit 0

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -48,6 +48,14 @@ class Distribution:
 
 
 @dataclass()
+class VCloud:
+    cloud_provider: bool = True
+
+    def __init__(self, cloud_provider: bool = False):
+        self.cloud_provider = cloud_provider
+
+
+@dataclass()
 class Settings:
     network: str
     ssh_key: str = None
@@ -142,10 +150,11 @@ class ClusterSpec:
     nfs: Nfs
     k8_distribution: Distribution
     settings: Settings
+    vcloud: VCloud
 
     def __init__(self, settings: Settings, k8_distribution: Distribution = None,  # noqa: E501
                  control_plane: ControlPlane = None, workers: Workers = None,
-                 nfs: Nfs = None, **kwargs):
+                 nfs: Nfs = None, vcloud: VCloud = None, **kwargs):
         self.settings = Settings(**settings) \
             if isinstance(settings, dict) else settings
         self.control_plane = ControlPlane(**control_plane) \
@@ -155,6 +164,8 @@ class ClusterSpec:
         self.nfs = Nfs(**nfs) if isinstance(nfs, dict) else nfs or Nfs()
         self.k8_distribution = Distribution(**k8_distribution) \
             if isinstance(k8_distribution, dict) else k8_distribution or Distribution()  # noqa: E501
+        self.vcloud = VCloud(**vcloud) \
+            if isinstance(vcloud, dict) else vcloud or VCloud()
 
 
 @dataclass()
@@ -186,6 +197,8 @@ class NativeEntity(AbstractNativeEntity):
             "k8_distribution": {
                 "template_name": "k81.17",
                 "template_revision": 1
+            }
+            "vcloud": {
             }
         },
         "status": {

--- a/cse_def_schema/schema_2_0_0.json
+++ b/cse_def_schema/schema_2_0_0.json
@@ -95,6 +95,10 @@
                         },
                         "additionalProperties": true
                     },
+                    "vcloud": {
+                        "type": "object",
+                        "description": "Settings for vcd cloud provider"
+                    },
                     "nfs": {
                         "type": "object",
                         "description":"The desired nfs state of the cluster. The properties \"sizing_class\" and \"storage_profile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\".",


### PR DESCRIPTION
If there is a `vcloud` section, the is an extra parameter added to the kubelet service: `--cloud_provide=external`. This is done for the control plane and node scripts. There are a few extra changes around ensuring that things are up before executing scripts and cleanup of some small parts of code.

Testing was done by changing the hardcoding done in de_cluster.py.


Signed-off-by: Arun Krishnakumar <akrishnakuma@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/961)
<!-- Reviewable:end -->
