### PR TITLE
[VCDA-2184] Client-connect-to-vcd-using-computed-api-version

### DIFF
--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -234,6 +234,8 @@ def get_validated_config(config_file_name,
             [float(x) for x in config['service']['supported_api_versions']
                 if float(x) >= 35.0]
     config['vcd']['api_version'] = str(max(supported_api_versions_float))
+    # Update the supported versions
+    config['service']['supported_api_versions'] = supported_api_versions_float
 
     # Store telemetry instance id, url and collector id in config
     # This steps needs to be done after api_version has been computed


### PR DESCRIPTION

- Installer and upgrader to use vcd client to use computed api version 
- Remove usage of config['vcd']['version']
- In this fix vcd clients will not use api_version in vcd section. Instead, use dynamically computed version of the api.
- Pass around api version to avoid repeating max version
- Updated the supported versions in config validator that has final fitered versions based on legacy_mode flag
- Manually tested upgrader, cse check, cse template and cse install to use the computed api version

@Anirudh9794 @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/966)
<!-- Reviewable:end -->
