### PR TITLE
[VCDA-2195] Print template verification messages on console in CSE run

### DIFF
--- a/container_service_extension/installer/templates/local_template_manager.py
+++ b/container_service_extension/installer/templates/local_template_manager.py
@@ -106,7 +106,7 @@ def get_all_k8s_local_template_definition(client, catalog_name, org=None,
             continue
 
         if not legacy_mode:
-            # Do not load the template in legacy_mode if
+            # Do not load the template in non-legacy_mode if
             # min_cse_version and max_cse_version are not present
             # in the metadata_dict
             curr_cse_version = server_utils.get_installed_cse_version()

--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -273,8 +273,7 @@ class RemoteTemplateManager():
             if os.name != 'nt':
                 os.chmod(local_script_filepath, stat.S_IRUSR | stat.S_IWUSR)
 
-    def download_all_template_scripts(self, force_overwrite=False,
-                                      legacy_mode=False):
+    def download_all_template_scripts(self, force_overwrite=False):
         """Download all scripts for all templates mentioned in cookbook.
 
         :param bool force_overwrite: if True, will download the script even if
@@ -287,5 +286,4 @@ class RemoteTemplateManager():
             template_name = template['name']
             revision = template['revision']
             self.download_template_scripts(template_name, revision,
-                                           force_overwrite=force_overwrite,
-                                           legacy_mode=legacy_mode)
+                                           force_overwrite=force_overwrite)

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -26,7 +26,6 @@ from container_service_extension.common.constants.server_constants import CONFIG
 from container_service_extension.common.constants.server_constants import LocalTemplateKey  # noqa: E501
 from container_service_extension.common.constants.server_constants import RemoteTemplateKey  # noqa: E501
 from container_service_extension.common.constants.server_constants import SYSTEM_ORG_NAME  # noqa: E501
-from container_service_extension.common.constants.shared_constants import ClusterEntityKind  # noqa: E501
 from container_service_extension.common.constants.shared_constants import RequestMethod  # noqa: E501
 from container_service_extension.common.constants.shared_constants import SUPPORTED_VCD_API_VERSIONS  # noqa: E501
 import container_service_extension.common.utils.core_utils as utils
@@ -1031,28 +1030,18 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                 legacy_mode = config_dict['service']['legacy_mode']
 
                 local_template_definitions = \
-                    ltm.get_all_k8s_local_template_definition(
+                    ltm.get_valid_k8s_local_template_definition(
                         client=client,
                         catalog_name=catalog_name,
                         legacy_mode=legacy_mode,
+                        is_tkg_plus_enabled=is_tkg_plus_enabled,
                         org_name=org_name,
                         logger_debug=SERVER_CLI_LOGGER)
                 default_template_name = \
                     config_dict['broker']['default_template_name']
                 default_template_revision = \
                     str(config_dict['broker']['default_template_revision'])
-                api_version = float(client.get_api_version())
                 for definition in local_template_definitions:
-                    if api_version >= float(vcd_client.ApiVersion.VERSION_35.value) and \
-                            definition[LocalTemplateKey.KIND] == ClusterEntityKind.TKG_PLUS.value and \
-                            not is_tkg_plus_enabled:  # noqa: E501
-                        # TKG+ is not enabled on CSE config. Skip the template
-                        # and log the relevant information.
-                        msg = "Skipping loading template data for " \
-                              f"'{definition[LocalTemplateKey.NAME]}' as " \
-                              "TKG+ is not enabled"
-                        SERVER_CLI_LOGGER.debug(msg)
-                        continue
                     local_template = {
                         'name': definition[LocalTemplateKey.NAME],
                         'revision': int(definition[LocalTemplateKey.REVISION]),

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -18,7 +18,6 @@ from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
-import semantic_version
 
 import container_service_extension.common.constants.server_constants as server_constants  # noqa: E501
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
@@ -600,7 +599,8 @@ class Service(object, metaclass=Singleton):
             catalog_name = self.config['broker']['catalog']
             k8_templates = ltm.get_all_k8s_local_template_definition(
                 client=client, catalog_name=catalog_name, org_name=org_name,
-                legacy_mode=legacy_mode, logger_debug=logger.SERVER_LOGGER)
+                legacy_mode=legacy_mode, logger_debug=logger.SERVER_LOGGER,
+                msg_update_callback=msg_update_callback)
 
             if not k8_templates:
                 msg = "No valid K8 templates were found in catalog " \
@@ -616,23 +616,8 @@ class Service(object, metaclass=Singleton):
             default_template_revision = \
                 str(self.config['broker']['default_template_revision'])
             found_default_template = False
-            curr_cse_version = server_utils.get_installed_cse_version()
             for template in k8_templates:
                 api_version = float(client.get_api_version())
-                if legacy_mode:
-                    template_supported_cse_versions = \
-                        semantic_version.SimpleSpec(
-                            f">={template[server_constants.LocalTemplateKey.MIN_CSE_VERSION]},"  # noqa: E501
-                            f"<={template[server_constants.LocalTemplateKey.MAX_CSE_VERSION]}")  # noqa: E501
-                    if not template_supported_cse_versions.match(curr_cse_version):  # noqa: E501
-                        # Template loaded is not supported by current CSE
-                        # version
-                        msg = f"Skipping loading template data for " \
-                              f"{template[server_constants.LocalTemplateKey.NAME]}" \
-                              f" as it is not supported by CSE {curr_cse_version}"  # noqa: E501
-                        logger.SERVER_LOGGER.debug(msg)
-                        k8_templates.remove(template)
-                        continue
                 if api_version >= float(vCDApiVersion.VERSION_35.value) and \
                         template[server_constants.LocalTemplateKey.KIND] == \
                         shared_constants.ClusterEntityKind.TKG_PLUS.value and \

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -618,7 +618,7 @@ class Service(object, metaclass=Singleton):
             found_default_template = False
             for template in k8_templates:
                 api_version = float(client.get_api_version())
-                if api_version >= float(vCDApiVersion.VERSION_35.value) and \
+                if not legacy_mode and \
                         template[server_constants.LocalTemplateKey.KIND] == \
                         shared_constants.ClusterEntityKind.TKG_PLUS.value and \
                         not is_tkg_plus_enabled:


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* Load only the templates which are supported during CSE run.
* Print message on the console if template (with required metadata keys) is not valid for the given CSE version

Testing done:
* CSE run with an unsupported template
![Screen Shot 2021-03-23 at 4 23 44 PM](https://user-images.githubusercontent.com/16699642/112231552-255c0200-8bf4-11eb-8cef-23b0fa04e085.png)

@sahithi @rocknes @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/968)
<!-- Reviewable:end -->
