### PR TITLE
Enable backend to publish messages to MQTT bus

### DIFF
--- a/container_service_extension/mqi/consumer/constants.py
+++ b/container_service_extension/mqi/consumer/constants.py
@@ -14,10 +14,6 @@ MQTT_CLIENT_ID = 'cseMQTT'
 MQTT_CONNECT_PORT = 443
 TRANSPORT_WSS = 'websockets'
 QOS_LEVEL = 2  # No duplicate messages
-# Behavior invocations are long-running synchronous tasks. Dedicated
-# thread-pool for behaviors will prevent hogging MQTT's main thread-pool
-# (MQTTConsumer._ctpe).
-BEHAVIOR_THREAD_POOL_SIZE = 64
 
 # Used by only AMQP consumer
 MAX_PROCESSING_REQUEST_CACHE_SIZE = 1000

--- a/container_service_extension/mqi/consumer/mqtt_consumer.py
+++ b/container_service_extension/mqi/consumer/mqtt_consumer.py
@@ -44,15 +44,14 @@ class MQTTConsumer:
         self._is_closing = False
 
     def process_behavior_message(self, msg_json):
-        status, payload = behavior_dispatcher.process_behavior_request(
+        payload = behavior_dispatcher.process_behavior_request(
             msg_json, self._mqtt_publisher)
         task_id: str = msg_json['headers']['taskId']
         entity_id: str = msg_json['headers']['entityId']
         response_json = self._mqtt_publisher.form_behavior_response_json(
             task_id=task_id,
             entity_id=entity_id,
-            payload=payload,
-            status=status)
+            payload=payload)
         self._mqtt_publisher.send_response(response_json)
         LOGGER.debug(f'MQTT response: {response_json}')
 

--- a/container_service_extension/mqi/consumer/mqtt_consumer.py
+++ b/container_service_extension/mqi/consumer/mqtt_consumer.py
@@ -60,7 +60,7 @@ class MQTTConsumer:
 
     def process_mqtt_message(self, msg):
         msg_json = json.loads(msg.payload.decode(self.fsencoding))
-        if msg_json['type'] == 'BEHAVIOR_INVOCATION':
+        if msg_json.get('type', None) == 'BEHAVIOR_INVOCATION':   # noqa: E501
             self.process_behavior_message(msg_json=msg_json)
         else:
             msg_json, reply_body, status_code, req_id = utils.get_response_fields(  # noqa: E501

--- a/container_service_extension/mqi/consumer/mqtt_consumer.py
+++ b/container_service_extension/mqi/consumer/mqtt_consumer.py
@@ -51,7 +51,7 @@ class MQTTConsumer:
         payload = behavior_dispatcher.process_behavior_request(
             msg_json, self._mqtt_publisher)
 
-        response_json = self._mqtt_publisher.form_behavior_response_json(
+        response_json = self._mqtt_publisher.construct_behavior_response_json(
             task_id=task_id,
             entity_id=entity_id,
             payload=payload)
@@ -73,7 +73,7 @@ class MQTTConsumer:
 
             task_path = utils.get_task_path_from_reply_body(reply_body)
             reply_body_str = json.dumps(reply_body)
-            response_json = self._mqtt_publisher.form_response_json(
+            response_json = self._mqtt_publisher.construct_response_json(
                 request_id=req_id,
                 status_code=status_code,
                 reply_body_str=reply_body_str,
@@ -87,7 +87,7 @@ class MQTTConsumer:
         request_id = payload_json["headers"]["requestId"]
         LOGGER.debug(f"Replying with 'too many requests response' for "
                      f"request_id: {request_id} and msg id: {msg.mid}")
-        response_json = self._mqtt_publisher.form_response_json(
+        response_json = self._mqtt_publisher.construct_response_json(
             request_id=request_id,
             status_code=requests.codes.too_many_requests,
             reply_body_str=constants.TOO_MANY_REQUESTS_BODY)

--- a/container_service_extension/mqi/consumer/mqtt_consumer.py
+++ b/container_service_extension/mqi/consumer/mqtt_consumer.py
@@ -51,7 +51,7 @@ class MQTTConsumer:
         response_json = self._mqtt_publisher.form_behavior_response_json(
             task_id=task_id,
             entity_id=entity_id,
-            payload=payload)
+            task_payload=payload)
         self._mqtt_publisher.send_response(response_json)
         LOGGER.debug(f'MQTT response: {response_json}')
 

--- a/container_service_extension/mqi/consumer/mqtt_consumer.py
+++ b/container_service_extension/mqi/consumer/mqtt_consumer.py
@@ -5,7 +5,6 @@
 import json
 import ssl
 import sys
-from threading import Lock
 
 import paho.mqtt.client as mqtt
 import requests
@@ -39,7 +38,6 @@ class MQTTConsumer:
         self._mqtt_client = None
         self._mqtt_publisher: MQTTPublisher = None
         self._ctpe = ConsumerThreadPoolExecutor(self.num_processors)
-        self._publish_lock = Lock()
         self._is_closing = False
 
     def process_behavior_message(self, msg_json):

--- a/container_service_extension/mqi/consumer/mqtt_publisher.py
+++ b/container_service_extension/mqi/consumer/mqtt_publisher.py
@@ -43,7 +43,7 @@ class MQTTPublisher:
 
     def form_behavior_task_payload(self, operation='Cluster operation',
                                    status='running',
-                                   progress=50, result=None,
+                                   progress=None, result=None,
                                    error_details=None):
         """Construct the (task) payload portion of the Behavior Response.
 
@@ -68,16 +68,17 @@ class MQTTPublisher:
             payload['error'] = error_details
         return payload
 
-    def form_behavior_response_json(self, task_id, entity_id, task_payload):
+    def form_behavior_response_json(self, task_id, entity_id, payload):
         """Construct the behavior response to be published onto MQTT.
 
         :param str task_id:
         :param str entity_id: Id of the entity
-        :param dict task_payload: Payload could be of type task update (or) success
+        :param dict payload: Payload could be of type task update (or) success
         (or) error payload.
         :return: Behavior response
         :rtype: dict
         """
+        status = payload['status']
         response_json = {
             "type": "BEHAVIOR_RESPONSE",
             "headers": {
@@ -85,8 +86,10 @@ class MQTTPublisher:
                 "entityId": entity_id,
                 "contentType": "application/vnd.vmware.vcloud.task+json",
             },
-            "payload": json.dumps(task_payload)
+            "payload": json.dumps(payload)
         }
+        if status == 'success':
+            del response_json['headers']['contentType']
         return response_json
 
     def send_response(self, response_json):

--- a/container_service_extension/mqi/consumer/mqtt_publisher.py
+++ b/container_service_extension/mqi/consumer/mqtt_publisher.py
@@ -6,6 +6,8 @@ import requests
 from container_service_extension.logging.logger import SERVER_LOGGER as LOGGER
 import container_service_extension.mqi.consumer.constants as constants
 import container_service_extension.mqi.consumer.utils as utils
+from container_service_extension.rde.behaviors.behavior_model import \
+    BehaviorTaskStatus
 
 
 class MQTTPublisher:

--- a/container_service_extension/mqi/consumer/mqtt_publisher.py
+++ b/container_service_extension/mqi/consumer/mqtt_publisher.py
@@ -1,0 +1,66 @@
+import json
+from threading import Lock
+
+import requests
+
+from container_service_extension.logging.logger import SERVER_LOGGER as LOGGER
+import container_service_extension.mqi.consumer.constants as constants
+import container_service_extension.mqi.consumer.utils as utils
+
+
+class MQTTPublisher:
+    def __init__(self, mqtt_client, respond_topic):
+        self.mqtt_client = mqtt_client
+        self.respond_topic = respond_topic
+        self._publish_lock = Lock()
+
+    def form_response_json(self, request_id, status_code, reply_body_str,
+                           task_path=None):
+        response_json = {
+            "type": "API_RESPONSE",
+            "headers": {
+                "requestId": request_id,
+            },
+            "httpResponse": {
+                "statusCode": status_code,
+                "headers": {
+                    "Content-Type": "application/json",
+                    "Content-Length": len(reply_body_str)
+                },
+                "body": utils.format_response_body(reply_body_str,
+                                                   self.fsencoding)
+            }
+        }
+
+        # Add location header is appropriate status code
+        if status_code in (requests.codes.created,
+                           requests.codes.accepted,
+                           requests.codes.found,
+                           requests.codes.see_other) \
+                and task_path is not None:
+            response_json['httpResponse']['headers']['Location'] = task_path
+        return response_json
+
+    def form_behavior_response_json(self, task_id, entity_id, payload, status):
+        response_json = {
+            "type": "BEHAVIOR_RESPONSE",
+            "headers": {
+                "taskId": task_id,
+                "entityId": entity_id,
+                "status": status
+            },
+            "payload": payload
+        }
+        return response_json
+
+    def send_response(self, response_json):
+        self._publish_lock.acquire()
+        try:
+            pub_ret = self.mqtt_client.publish(topic=self.respond_topic,
+                                               payload=json.dumps(
+                                                   response_json),
+                                               qos=constants.QOS_LEVEL,
+                                               retain=False)
+        finally:
+            self._publish_lock.release()
+        LOGGER.debug(f"publish return (rc, msg_id): {pub_ret}")

--- a/container_service_extension/mqi/consumer/mqtt_publisher.py
+++ b/container_service_extension/mqi/consumer/mqtt_publisher.py
@@ -41,30 +41,30 @@ class MQTTPublisher:
             response_json['httpResponse']['headers']['Location'] = task_path
         return response_json
 
-    def form_behavior_payload(self, operation='Cluster operation',
-                              status='running',
-                              progress=None, result=None,
+    def form_behavior_payload(self, message='Cluster operation',
+                              status='running', progress=None,
                               error_details=None):
         """Construct the (task) payload portion of the Behavior Response.
 
-        :param str operation: Operation string
+        :param dict error_details: Dict form of type BehaviorError
+        {'majorErrorCode':'500','minorErrorCode':None,'message':None}
+        :param str message: Task update message
         :param str status: Status of the task to be updated.
         :param str progress:
-        :param str result: Result string in the case of status=success
-        :param dict error_details: Error_details in the case of status=error
-            {'majorErrorCode':'500','minorErrorCode':None,'message':None}
+
         :return: The constructed task payload.
         :rtype: dict
         """
         payload = {
-            "operation": operation,
             "status": status
         }
-        if progress:
-            payload['progress'] = progress
-        if result:
-            payload['result'] = result
-        if error_details:
+        if status == 'running':
+            payload['operation'] = message
+            if progress:
+                payload['progress'] = progress
+        elif status == 'success':
+            payload['result'] = message
+        elif status == 'error':
             payload['error'] = error_details
         return payload
 

--- a/container_service_extension/mqi/consumer/mqtt_publisher.py
+++ b/container_service_extension/mqi/consumer/mqtt_publisher.py
@@ -41,15 +41,39 @@ class MQTTPublisher:
             response_json['httpResponse']['headers']['Location'] = task_path
         return response_json
 
-    def form_behavior_response_json(self, task_id, entity_id, payload, status):
+    def form_behavior_error_details(self, major_error_code='400',
+                                    minor_error_code=None, error_message=None):
+        return {
+            'majorErrorCode': major_error_code,
+            'minorErrorCode': minor_error_code,
+            'message': error_message
+        }
+
+    def form_behavior_response_payload(self, operation='Cluster operation',
+                                       status='running',
+                                       progress=50, result=None,
+                                       error_details=None):
+        payload = {
+            "operation": operation,
+            "status": status
+        }
+        if progress:
+            payload['progress'] = progress
+        if result:
+            payload['result'] = result
+        if error_details:
+            payload['error'] = error_details
+        return payload
+
+    def form_behavior_response_json(self, task_id, entity_id, payload):
         response_json = {
             "type": "BEHAVIOR_RESPONSE",
             "headers": {
                 "taskId": task_id,
                 "entityId": entity_id,
-                "status": status
+                "contentType": "application/vnd.vmware.vcloud.task+json",
             },
-            "payload": payload
+            "payload": json.dumps(payload)
         }
         return response_json
 

--- a/container_service_extension/mqi/consumer/mqtt_publisher.py
+++ b/container_service_extension/mqi/consumer/mqtt_publisher.py
@@ -41,10 +41,10 @@ class MQTTPublisher:
             response_json['httpResponse']['headers']['Location'] = task_path
         return response_json
 
-    def form_behavior_task_payload(self, operation='Cluster operation',
-                                   status='running',
-                                   progress=None, result=None,
-                                   error_details=None):
+    def form_behavior_payload(self, operation='Cluster operation',
+                              status='running',
+                              progress=None, result=None,
+                              error_details=None):
         """Construct the (task) payload portion of the Behavior Response.
 
         :param str operation: Operation string

--- a/container_service_extension/mqi/consumer/mqtt_publisher.py
+++ b/container_service_extension/mqi/consumer/mqtt_publisher.py
@@ -41,18 +41,21 @@ class MQTTPublisher:
             response_json['httpResponse']['headers']['Location'] = task_path
         return response_json
 
-    def form_behavior_error_details(self, major_error_code='400',
-                                    minor_error_code=None, error_message=None):
-        return {
-            'majorErrorCode': major_error_code,
-            'minorErrorCode': minor_error_code,
-            'message': error_message
-        }
+    def form_behavior_task_payload(self, operation='Cluster operation',
+                                   status='running',
+                                   progress=50, result=None,
+                                   error_details=None):
+        """Construct the (task) payload portion of the Behavior Response.
 
-    def form_behavior_response_payload(self, operation='Cluster operation',
-                                       status='running',
-                                       progress=50, result=None,
-                                       error_details=None):
+        :param str operation: Operation string
+        :param str status: Status of the task to be updated.
+        :param str progress:
+        :param str result: Result string in the case of status=success
+        :param dict error_details: Error_details in the case of status=error
+            {'majorErrorCode':'500','minorErrorCode':None,'message':None}
+        :return: The constructed task payload.
+        :rtype: dict
+        """
         payload = {
             "operation": operation,
             "status": status
@@ -65,7 +68,16 @@ class MQTTPublisher:
             payload['error'] = error_details
         return payload
 
-    def form_behavior_response_json(self, task_id, entity_id, payload):
+    def form_behavior_response_json(self, task_id, entity_id, task_payload):
+        """Construct the behavior response to be published onto MQTT.
+
+        :param str task_id:
+        :param str entity_id: Id of the entity
+        :param dict task_payload: Payload could be of type task update (or) success
+        (or) error payload.
+        :return: Behavior response
+        :rtype: dict
+        """
         response_json = {
             "type": "BEHAVIOR_RESPONSE",
             "headers": {
@@ -73,7 +85,7 @@ class MQTTPublisher:
                 "entityId": entity_id,
                 "contentType": "application/vnd.vmware.vcloud.task+json",
             },
-            "payload": json.dumps(payload)
+            "payload": json.dumps(task_payload)
         }
         return response_json
 

--- a/container_service_extension/mqi/consumer/mqtt_publisher.py
+++ b/container_service_extension/mqi/consumer/mqtt_publisher.py
@@ -44,8 +44,8 @@ class MQTTPublisher:
         return response_json
 
     def form_behavior_payload(self, message='Cluster operation',
-                              status='running', progress=None,
-                              error_details=None):
+                              status=BehaviorTaskStatus.RUNNING.value,
+                              progress=None, error_details=None):
         """Construct the (task) payload portion of the Behavior Response.
 
         :param dict error_details: Dict form of type BehaviorError

--- a/container_service_extension/rde/backend/cluster_service_2_x_temp.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_temp.py
@@ -269,7 +269,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             }
         )
         self._create_cluster_async(entity_id, input_native_entity)
-        return self.mqtt_publisher.form_behavior_payload(
+        return self.mqtt_publisher.construct_behavior_payload(
             message='create_cluster_in_progress',
             status=BehaviorTaskStatus.RUNNING.value, progress=5)
 

--- a/container_service_extension/rde/backend/cluster_service_2_x_temp.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_temp.py
@@ -51,6 +51,8 @@ import container_service_extension.rde.constants as def_constants
 import container_service_extension.rde.models.common_models as common_models
 import container_service_extension.rde.models.rde_2_0_0 as rde_2_0_0
 import container_service_extension.rde.utils as def_utils
+from container_service_extension.rde.behaviors.behavior_model import \
+    BehaviorTaskStatus
 from container_service_extension.security.context.behavior_request_context import BehaviorRequestContext  # noqa: E501
 import container_service_extension.security.context.operation_context as ctx
 import container_service_extension.server.abstract_broker as abstract_broker
@@ -269,9 +271,9 @@ class ClusterService(abstract_broker.AbstractBroker):
             }
         )
         self._create_cluster_async(entity_id, input_native_entity)
-        return self.mqtt_publisher.form_behavior_task_payload(
+        return self.mqtt_publisher.form_behavior_payload(
             operation='create_cluster_in_progress',
-            status='running', progress=5)
+            status=BehaviorTaskStatus.RUNNING.value, progress=5)
 
     def resize_cluster(self, cluster_id: str,
                        cluster_spec: rde_2_0_0.NativeEntity):

--- a/container_service_extension/rde/backend/cluster_service_2_x_temp.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_temp.py
@@ -46,13 +46,13 @@ import container_service_extension.lib.telemetry.telemetry_handler as telemetry_
 from container_service_extension.logging.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.mqi.consumer.mqtt_publisher import MQTTPublisher  # noqa: E501
 import container_service_extension.rde.acl_service as acl_service
+from container_service_extension.rde.behaviors.behavior_model import \
+    BehaviorTaskStatus
 import container_service_extension.rde.common.entity_service as def_entity_svc
 import container_service_extension.rde.constants as def_constants
 import container_service_extension.rde.models.common_models as common_models
 import container_service_extension.rde.models.rde_2_0_0 as rde_2_0_0
 import container_service_extension.rde.utils as def_utils
-from container_service_extension.rde.behaviors.behavior_model import \
-    BehaviorTaskStatus
 from container_service_extension.security.context.behavior_request_context import BehaviorRequestContext  # noqa: E501
 import container_service_extension.security.context.operation_context as ctx
 import container_service_extension.server.abstract_broker as abstract_broker

--- a/container_service_extension/rde/backend/cluster_service_2_x_temp.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_temp.py
@@ -63,14 +63,12 @@ class ClusterService(abstract_broker.AbstractBroker):
     """Handles cluster operations for native DEF based clusters."""
 
     def __init__(self, op_ctx: BehaviorRequestContext):
-        # TODO(DEF) Once all the methods are modified to use defined entities,
-        #  the param OperationContext needs to be replaced by cloudapiclient.
         self.context: ctx.OperationContext = op_ctx.op_ctx
+        self.task_id = op_ctx.task_id
+        self.entity_id = op_ctx.entity_id
         self.mqtt_publisher: MQTTPublisher = op_ctx.mqtt_publisher
-        self.behavior_task_id = op_ctx.task_id
-        self.behavior_task_href = self.context.client.get_api_uri() + f"/task/{self.behavior_task_id}"  # noqa: E501
         self.task = None
-        self.task_resource = self.context.client.get_resource(self.behavior_task_href)  # noqa: E501
+        self.task_resource = None
         self.task_update_lock = threading.Lock()
         self.entity_svc = def_entity_svc.DefEntityService(
             self.context.cloudapi_client)
@@ -272,7 +270,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         )
         self._create_cluster_async(entity_id, input_native_entity)
         return self.mqtt_publisher.form_behavior_payload(
-            operation='create_cluster_in_progress',
+            message='create_cluster_in_progress',
             status=BehaviorTaskStatus.RUNNING.value, progress=5)
 
     def resize_cluster(self, cluster_id: str,

--- a/container_service_extension/rde/behaviors/behavior_model.py
+++ b/container_service_extension/rde/behaviors/behavior_model.py
@@ -110,3 +110,10 @@ class BehaviorAcl(Enum):
                                           AclAccessLevelId.AccessLevelFullControl)  # noqa: E501
     KUBE_CONFIG_ACL = BehaviorAclEntry(KUBE_CONFIG_BEHAVIOR_INTERFACE_ID,
                                        AclAccessLevelId.AccessLevelReadOnly)
+
+
+@dataclass()
+class BehaviorError:
+    majorErrorCode: str = '400'
+    minorErrorCode: str = None
+    message: str = None

--- a/container_service_extension/rde/behaviors/behavior_model.py
+++ b/container_service_extension/rde/behaviors/behavior_model.py
@@ -110,10 +110,3 @@ class BehaviorAcl(Enum):
                                           AclAccessLevelId.AccessLevelFullControl)  # noqa: E501
     KUBE_CONFIG_ACL = BehaviorAclEntry(KUBE_CONFIG_BEHAVIOR_INTERFACE_ID,
                                        AclAccessLevelId.AccessLevelReadOnly)
-
-
-@dataclass
-class BehaviorErrorPayload():
-    majorErrorCode: str = '400'
-    minorErrorCode: str = None
-    message: str = None

--- a/container_service_extension/rde/behaviors/behavior_model.py
+++ b/container_service_extension/rde/behaviors/behavior_model.py
@@ -117,3 +117,11 @@ class BehaviorError:
     majorErrorCode: str = '400'
     minorErrorCode: str = None
     message: str = None
+
+
+@unique
+class BehaviorTaskStatus(Enum):
+    RUNNING = 'running'
+    SUCCESS = 'success'
+    ERROR = 'error'
+    ABORTED = 'aborted'

--- a/container_service_extension/security/context/behavior_request_context.py
+++ b/container_service_extension/security/context/behavior_request_context.py
@@ -4,6 +4,8 @@
 
 from dataclasses import dataclass
 
+from container_service_extension.mqi.consumer.mqtt_publisher import \
+    MQTTPublisher
 from container_service_extension.security.context.operation_context import OperationContext  # noqa: E501
 
 
@@ -26,3 +28,4 @@ class BehaviorRequestContext:
     request_id: str
     op_ctx: OperationContext
     user_context: BehaviorUserContext
+    mqtt_publisher: MQTTPublisher

--- a/container_service_extension/server/behavior_dispatcher.py
+++ b/container_service_extension/server/behavior_dispatcher.py
@@ -6,6 +6,8 @@ from dataclasses import asdict
 import json
 
 from container_service_extension.exception.exceptions import CseRequestError
+from container_service_extension.mqi.consumer.mqtt_publisher import \
+    MQTTPublisher
 from container_service_extension.rde.behaviors.behavior_model import \
     BehaviorErrorPayload, BehaviorOperation
 from container_service_extension.security.context.behavior_request_context \
@@ -22,7 +24,7 @@ MAP_BEHAVIOR_ID_TO_HANDLER_METHOD = {
 }
 
 
-def process_behavior_request(msg_json):
+def process_behavior_request(msg_json, mqtt_publisher: MQTTPublisher):
     # Extracting contents from headers
     task_id: str = msg_json['headers']['taskId']
     entity_id: str = msg_json['headers']['entityId']
@@ -48,7 +50,8 @@ def process_behavior_request(msg_json):
                                           user_context=usr_ctx,
                                           entity_type_id=entity_type_id,
                                           request_id=request_id,
-                                          op_ctx=op_ctx)
+                                          op_ctx=op_ctx,
+                                          mqtt_publisher=mqtt_publisher)
 
     # Invoke the handler method and return the response in the string format.
     try:

--- a/container_service_extension/server/behavior_dispatcher.py
+++ b/container_service_extension/server/behavior_dispatcher.py
@@ -61,14 +61,14 @@ def process_behavior_request(msg_json, mqtt_publisher: MQTTPublisher):
                                              minorErrorCode=e.minor_error_code,
                                              message=e.error_message))
         payload = mqtt_publisher. \
-            form_behavior_payload(status=BehaviorTaskStatus.ERROR.value,
-                                  error_details=error_details)
+            construct_behavior_payload(status=BehaviorTaskStatus.ERROR.value,
+                                       error_details=error_details)
         return payload
     except Exception as e:
         error_details = asdict(BehaviorError(majorErrorCode='500',
                                              message=str(e)))
         payload = mqtt_publisher. \
-            form_behavior_payload(status=BehaviorTaskStatus.ERROR.value,
-                                  error_details=error_details)
+            construct_behavior_payload(status=BehaviorTaskStatus.ERROR.value,
+                                       error_details=error_details)
 
         return payload

--- a/container_service_extension/server/behavior_dispatcher.py
+++ b/container_service_extension/server/behavior_dispatcher.py
@@ -8,7 +8,8 @@ import json
 from container_service_extension.exception.exceptions import CseRequestError
 from container_service_extension.mqi.consumer.mqtt_publisher import \
     MQTTPublisher
-from container_service_extension.rde.behaviors.behavior_model import BehaviorError, BehaviorOperation  # noqa: E501
+from container_service_extension.rde.behaviors.behavior_model import \
+    BehaviorError, BehaviorOperation, BehaviorTaskStatus  # noqa: E501
 from container_service_extension.security.context.behavior_request_context \
     import BehaviorRequestContext, BehaviorUserContext
 from container_service_extension.security.context.operation_context import OperationContext  # noqa: E501
@@ -59,17 +60,17 @@ def process_behavior_request(msg_json, mqtt_publisher: MQTTPublisher):
         error_details = asdict(BehaviorError(majorErrorCode=e.status_code,
                                              minorErrorCode=e.minor_error_code,
                                              message=e.error_message))
-        task_payload = mqtt_publisher.\
-            form_behavior_task_payload(operation=behavior_id,
-                                       status='error',
-                                       error_details=error_details)
-        return task_payload
+        payload = mqtt_publisher.\
+            form_behavior_payload(operation=behavior_id,
+                                  status=BehaviorTaskStatus.ERROR.value,
+                                  error_details=error_details)
+        return payload
     except Exception as e:
         error_details = asdict(BehaviorError(majorErrorCode='500',
                                              message=str(e)))
-        task_payload = mqtt_publisher. \
-            form_behavior_task_payload(operation=behavior_id,
-                                       status='error',
-                                       error_details=error_details)
+        payload = mqtt_publisher. \
+            form_behavior_payload(operation=behavior_id,
+                                  status=BehaviorTaskStatus.ERROR.value,
+                                  error_details=error_details)
 
-        return task_payload
+        return payload

--- a/container_service_extension/server/behavior_dispatcher.py
+++ b/container_service_extension/server/behavior_dispatcher.py
@@ -8,7 +8,7 @@ import json
 from container_service_extension.exception.exceptions import CseRequestError
 from container_service_extension.mqi.consumer.mqtt_publisher import \
     MQTTPublisher
-from container_service_extension.rde.behaviors.behavior_model import BehaviorOperation  # noqa: E501
+from container_service_extension.rde.behaviors.behavior_model import BehaviorError, BehaviorOperation  # noqa: E501
 from container_service_extension.security.context.behavior_request_context \
     import BehaviorRequestContext, BehaviorUserContext
 from container_service_extension.security.context.operation_context import OperationContext  # noqa: E501
@@ -56,14 +56,20 @@ def process_behavior_request(msg_json, mqtt_publisher: MQTTPublisher):
     try:
         return MAP_BEHAVIOR_ID_TO_HANDLER_METHOD[behavior_id](behavior_ctx)  # noqa: E501
     except CseRequestError as e:
-        error_details = mqtt_publisher.\
-            form_behavior_error_details(major_error_code=e.status_code,
-                                        minor_error_code=e.minor_error_code,
-                                        error_message=e.error_message)
-        error_payload = mqtt_publisher.form_behavior_response_payload(operation=behavior_id)
-        return error_payload
+        error_details = asdict(BehaviorError(majorErrorCode=e.status_code,
+                                             minorErrorCode=e.minor_error_code,
+                                             message=e.error_message))
+        task_payload = mqtt_publisher.\
+            form_behavior_task_payload(operation=behavior_id,
+                                       status='error',
+                                       error_details=error_details)
+        return task_payload
     except Exception as e:
-        error_payload = mqtt_publisher. \
-            form_behavior_error_details(major_error_code='500',
-                                        error_message=str(e))
-        return error_payload
+        error_details = asdict(BehaviorError(majorErrorCode='500',
+                                             message=str(e)))
+        task_payload = mqtt_publisher. \
+            form_behavior_task_payload(operation=behavior_id,
+                                       status='error',
+                                       error_details=error_details)
+
+        return task_payload

--- a/container_service_extension/server/behavior_dispatcher.py
+++ b/container_service_extension/server/behavior_dispatcher.py
@@ -60,17 +60,15 @@ def process_behavior_request(msg_json, mqtt_publisher: MQTTPublisher):
         error_details = asdict(BehaviorError(majorErrorCode=e.status_code,
                                              minorErrorCode=e.minor_error_code,
                                              message=e.error_message))
-        payload = mqtt_publisher.\
-            form_behavior_payload(operation=behavior_id,
-                                  status=BehaviorTaskStatus.ERROR.value,
+        payload = mqtt_publisher. \
+            form_behavior_payload(status=BehaviorTaskStatus.ERROR.value,
                                   error_details=error_details)
         return payload
     except Exception as e:
         error_details = asdict(BehaviorError(majorErrorCode='500',
                                              message=str(e)))
         payload = mqtt_publisher. \
-            form_behavior_payload(operation=behavior_id,
-                                  status=BehaviorTaskStatus.ERROR.value,
+            form_behavior_payload(status=BehaviorTaskStatus.ERROR.value,
                                   error_details=error_details)
 
         return payload

--- a/container_service_extension/server/behavior_handler.py
+++ b/container_service_extension/server/behavior_handler.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-# from container_service_extension.rde.behaviors.behavior_model import BehaviorErrorPayload  # noqa: E501
 import functools
 
 import container_service_extension.exception.exceptions as cse_exception

--- a/container_service_extension/server/request_handlers/cluster_handler.py
+++ b/container_service_extension/server/request_handlers/cluster_handler.py
@@ -64,9 +64,6 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     # Based on the runtime rde, call the appropriate backend method.
     converted_native_entity = rde_utils.convert_input_rde_to_runtime_rde_format(input_entity)  # noqa: E501
 
-
-    return entity_svc.create_entity(converted_native_entity)
-
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx).get_cluster_service()  # noqa: E501
     # TODO: Response RDE must be compatible with the request RDE.
     #  Conversions may be needed especially if there is a major version
@@ -179,7 +176,6 @@ def cluster_update(data: dict, op_ctx: ctx.OperationContext):
     # Based on the runtime rde, call the appropriate backend method.
     converted_native_entity = rde_utils.convert_input_rde_to_runtime_rde_format(input_entity)  # noqa: E501
 
-    return entity_svc.update_entity(converted_native_entity)
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx).get_cluster_service()  # noqa: E501
     # TODO: Response RDE must be compatible with the request RDE.
     #  Conversions may be needed especially if there is a major version

--- a/container_service_extension/server/request_handlers/cluster_handler.py
+++ b/container_service_extension/server/request_handlers/cluster_handler.py
@@ -63,6 +63,10 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     # Convert the input entity to runtime rde format.
     # Based on the runtime rde, call the appropriate backend method.
     converted_native_entity = rde_utils.convert_input_rde_to_runtime_rde_format(input_entity)  # noqa: E501
+
+
+    return entity_svc.create_entity(converted_native_entity)
+
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx).get_cluster_service()  # noqa: E501
     # TODO: Response RDE must be compatible with the request RDE.
     #  Conversions may be needed especially if there is a major version
@@ -174,6 +178,8 @@ def cluster_update(data: dict, op_ctx: ctx.OperationContext):
     # Convert the input entity to runtime rde format.
     # Based on the runtime rde, call the appropriate backend method.
     converted_native_entity = rde_utils.convert_input_rde_to_runtime_rde_format(input_entity)  # noqa: E501
+
+    return entity_svc.update_entity(converted_native_entity)
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx).get_cluster_service()  # noqa: E501
     # TODO: Response RDE must be compatible with the request RDE.
     #  Conversions may be needed especially if there is a major version

--- a/container_service_extension/server/request_handlers/cluster_handler.py
+++ b/container_service_extension/server/request_handlers/cluster_handler.py
@@ -63,7 +63,6 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     # Convert the input entity to runtime rde format.
     # Based on the runtime rde, call the appropriate backend method.
     converted_native_entity = rde_utils.convert_input_rde_to_runtime_rde_format(input_entity)  # noqa: E501
-
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx).get_cluster_service()  # noqa: E501
     # TODO: Response RDE must be compatible with the request RDE.
     #  Conversions may be needed especially if there is a major version
@@ -175,7 +174,6 @@ def cluster_update(data: dict, op_ctx: ctx.OperationContext):
     # Convert the input entity to runtime rde format.
     # Based on the runtime rde, call the appropriate backend method.
     converted_native_entity = rde_utils.convert_input_rde_to_runtime_rde_format(input_entity)  # noqa: E501
-
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx).get_cluster_service()  # noqa: E501
     # TODO: Response RDE must be compatible with the request RDE.
     #  Conversions may be needed especially if there is a major version


### PR DESCRIPTION
Enable backend to publish messages to MQTT bus.

1. Backend can now access MQTT publisher object from the BehaviorOperationContext
2. Added support to publish success, error, and update messages on behaviors via MQTT.
3. There is no longer a need for a separate thread pool for behaviors, given we can set the terminal status asynchronously now from the backend. Removed the separate thread pool dedicated for behaviors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/978)
<!-- Reviewable:end -->
