### PR TITLE
[VCDA-2068, 2069, 2184] Remove api version from CSE upgrade/run/install

### DIFF
--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -11,7 +11,12 @@ from enum import unique
 import requests
 import semantic_version
 
-# CSE SERVICE; default version strings for CSE api extension
+# CSE SERVICE;
+# keys for CSE info on the extension
+CSE_VERSION_KEY = 'cse_version'
+LEGACY_MODE_KEY = 'legacy_mode'
+RDE_VERSION_IN_USE_KEY = 'rde_version'
+# default version strings for CSE api extension
 UNKNOWN_CSE_VERSION = semantic_version.Version("0.0.0")
 UNKNOWN_VCD_API_VERSION = "0.0"
 
@@ -47,7 +52,7 @@ CSE_GLOBAL_PVDC_COMPUTE_POLICY_NAME = 'global'
 CSE_GLOBAL_PVDC_COMPUTE_POLICY_DESCRIPTION = \
     'global PVDC compute policy for cse'
 
-# CSE cluster Kubeconfig path
+# CSE cluster Kube Config path
 CSE_CLUSTER_KUBECONFIG_PATH = '/root/.kube/config'
 
 # MQTT constants
@@ -225,7 +230,7 @@ class ScriptFile(str, Enum):
 
 
 @unique
-class LegacyLocalTemplatekey(str, Enum):
+class LegacyLocalTemplateKey(str, Enum):
     """Enumerate the keys that define a legacy template.
 
     All the keys for a template except min_cse_version and
@@ -386,7 +391,7 @@ class CseOperation(Enum):
 
 @unique
 class ClusterMetadataKey(str, Enum):
-    BACKWARD_COMPATIBILE_TEMPLATE_NAME = 'cse.template'
+    BACKWARD_COMPATIBLE_TEMPLATE_NAME = 'cse.template'
     CLUSTER_ID = 'cse.cluster.id'
     CSE_VERSION = 'cse.version'
     CONTROL_PLANE_IP = 'cse.master.ip'

--- a/container_service_extension/common/utils/core_utils.py
+++ b/container_service_extension/common/utils/core_utils.py
@@ -33,23 +33,7 @@ _type_to_string = {
 }
 
 
-class ConsoleMessagePrinter():
-    """Callback object to print color coded message on console."""
-
-    def general_no_color(self, msg):
-        click.secho(msg)
-
-    def general(self, msg):
-        click.secho(msg, fg='green')
-
-    def info(self, msg):
-        click.secho(msg, fg='yellow')
-
-    def error(self, msg):
-        click.secho(msg, fg='red')
-
-
-class NullPrinter():
+class NullPrinter:
     """Callback object which does nothing."""
 
     def general_no_color(self, msg):
@@ -65,10 +49,26 @@ class NullPrinter():
         pass
 
 
+class ConsoleMessagePrinter(NullPrinter):
+    """Callback object to print color coded message on console."""
+
+    def general_no_color(self, msg):
+        click.secho(msg)
+
+    def general(self, msg):
+        click.secho(msg, fg='green')
+
+    def info(self, msg):
+        click.secho(msg, fg='yellow')
+
+    def error(self, msg):
+        click.secho(msg, fg='red')
+
+
 def get_cse_info():
     return {
         'product': 'CSE',
-        'description': 'Container Service Extension for VMware vCloud Director', # noqa: E501
+        'description': 'Container Service Extension for VMware vCloud Director',  # noqa: E501
         'version': pkg_resources.require('container-service-extension')[0].version,  # noqa: E501
         'python': platform.python_version()
     }
@@ -93,7 +93,7 @@ def get_duplicate_items_in_list(items):
 
     :param list items: list of items with possible duplicates.
 
-    :return: the items that occur more than once in niput list. Each duplicated
+    :return: the items that occur more than once in input list. Each duplicated
         item will be mentioned only once in the returned list.
 
     :rtype: list
@@ -158,7 +158,7 @@ def check_keys_and_value_types(dikt, ref_dict, location='dictionary',
 def check_python_version(msg_update_callback=NullPrinter()):
     """Ensure that user's Python version >= 3.7.3.
 
-    If the check fails, will exit the python interpretor with error status.
+    If the check fails, will exit the python interpreter with error status.
 
     :param utils.ConsoleMessagePrinter msg_update_callback: Callback object.
     """
@@ -178,7 +178,7 @@ def str_to_bool(s):
 
     The conversion is case insensitive.
 
-    :param val: input string
+    :param s: input string
 
     :return: True if val is 'true' otherwise False
     """
@@ -303,7 +303,6 @@ def read_data_file(filepath, logger=NULL_LOGGER,
         found.
     """
     path = pathlib.Path(filepath)
-    contents = ''
     try:
         contents = path.read_text()
     except FileNotFoundError as err:
@@ -353,7 +352,7 @@ def escape_query_filter_expression_value(value):
 
 
 def construct_filter_string(filters: dict):
-    """Construct anded filter string from the dict.
+    """Construct &-ed filter string from the dict.
 
     :param dict filters: dictionary containing key and values for the filters
     """

--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -406,7 +406,7 @@ def _validate_broker_config(broker_dict,
                          f"'{broker_dict['ip_allocation_mode']}' when it "
                          f"should be either 'dhcp' or 'pool'")
 
-    rtm = RemoteTemplateManager(remote_template_cookbook_url=broker_dict['remote_template_cookbook_url'], # noqa: E501
+    rtm = RemoteTemplateManager(remote_template_cookbook_url=broker_dict['remote_template_cookbook_url'],  # noqa: E501
                                 legacy_mode=legacy_mode,
                                 logger=logger_debug)
 
@@ -613,8 +613,9 @@ def _validate_pks_config_data_integrity(pks_config,
                     f"Unknown Node IP Block : {ip_block_id} referenced by "
                     f"NSX-T server : {nsxt_server.get('name')}.")
         if nsxt_server.get('pods_ip_block_ids'):
+            block_not_found = False
+            ip_block_id = ''
             try:
-                block_not_found = False
                 for ip_block_id in nsxt_server.get('pods_ip_block_ids'):
                     if not ipset_manager.get_ip_block_by_id(ip_block_id):
                         block_not_found = True

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -621,9 +621,11 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
 
         if ext_cse_version == server_constants.UNKNOWN_CSE_VERSION:
             msg = "Found CSE api extension registered with vCD, but " \
-                  "couldn't determine version of CSE used previously."
-            msg_update_callback.info(msg)
-            INSTALL_LOGGER.info(msg)
+                  "couldn't determine version of CSE used previously. " \
+                  "Unable to upgrade to CSE 3.1. Please first upgrade " \
+                  "CSE to 3.0."
+            msg_update_callback.error(msg)
+            INSTALL_LOGGER.error(msg)
         else:
             msg = "Found CSE api extension registered by CSE " \
                   f"'{ext_cse_version}' in " \

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -871,9 +871,9 @@ def _construct_cse_extension_description(rde_version_in_use):
     if not rde_version_in_use:
         rde_version_in_use = semantic_version.Version("0.0.0")
     dikt = {
-        server_constants.CSE_VERSION_KEY: cse_version,
+        server_constants.CSE_VERSION_KEY: str(cse_version),
         server_constants.LEGACY_MODE_KEY: LEGACY_MODE,
-        server_constants.RDE_VERSION_IN_USE_KEY: rde_version_in_use
+        server_constants.RDE_VERSION_IN_USE_KEY: str(rde_version_in_use)
     }
 
     description = json.dumps(dikt)

--- a/container_service_extension/installer/templates/local_template_manager.py
+++ b/container_service_extension/installer/templates/local_template_manager.py
@@ -12,7 +12,7 @@ from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.utils import metadata_to_dict
 import semantic_version
 
-from container_service_extension.common.constants.server_constants import LegacyLocalTemplatekey  # noqa: E501
+from container_service_extension.common.constants.server_constants import LegacyLocalTemplateKey  # noqa: E501
 from container_service_extension.common.constants.server_constants import LocalTemplateKey  # noqa: E501
 import container_service_extension.common.constants.shared_constants as \
     shared_constants
@@ -65,6 +65,9 @@ def get_all_k8s_local_template_definition(client, catalog_name, org=None,
     :param pyvcloud.vcd.Org org: Org object which hosts the catalog.
     :param str org_name: Name of the org that is hosting the catalog. Can be
         provided in lieu of param org, however param org takes precedence.
+    :param bool legacy_mode: True, if CSE is running in legacy mode
+    :param logging.Logger logger_debug:
+    :param utils.NullPrinter msg_update_callback:
 
     :return: list of dictionaries containing template data
 
@@ -81,7 +84,7 @@ def get_all_k8s_local_template_definition(client, catalog_name, org=None,
     if legacy_mode:
         # if template is loaded in legacy mode, make sure to avoid the keys
         # min_cse_version and max_cse_version
-        localTemplateKey = LegacyLocalTemplatekey
+        localTemplateKey = LegacyLocalTemplateKey
 
     for item_name in catalog_item_names:
         md = org.get_all_metadata_from_catalog_item(catalog_name=catalog_name,
@@ -102,7 +105,7 @@ def get_all_k8s_local_template_definition(client, catalog_name, org=None,
             # log relevant information.
             msg = f"Catalog item '{item_name}' missing " \
                   f"{num_missing_metadata_keys} metadata: " \
-                  f"{missing_metadata_keys}" # noqa: F841
+                  f"{missing_metadata_keys}"  # noqa: F841
             logger_debug.debug(msg)
             msg_update_callback.info(msg)
             continue
@@ -158,10 +161,11 @@ def get_valid_k8s_local_template_definition(client, catalog_name, org=None,
         provided in lieu of param org, however param org takes precedence.
     :param bool legacy_mode: boolean indicating if the server is configured
         in legacy_mode
-    :param bool is_tkg_plus_enabled: Boolean indicaing if server is configured
+    :param bool is_tkg_plus_enabled: Boolean indicating if server is configured
         to work with TKG+
-    :param logger logger_debug: logger to log the results or exceptions.
-    :param utils.ConsoleMessagePrinter msg_update_callback:
+    :param logging.Logger logger_debug: logger to log the results or
+        exceptions.
+    :param utils.NullPrinter msg_update_callback:
 
     :return: list of dictionaries containing template data
     :rtype: list of dicts

--- a/container_service_extension/logging/logger.py
+++ b/container_service_extension/logging/logger.py
@@ -59,7 +59,7 @@ CLIENT_DEBUG_LOG_FILEPATH = f"{LOGS_DIR_NAME}/cse-client-debug.log"
 CLIENT_LOGGER = logging.getLogger(CLIENT_LOGGER_NAME)
 
 CLIENT_WIRE_LOGGER_NAME = 'container_service_extension.client-wire'
-CLIENT_WIRE_LOGGER_FILEPATH = f"{LOGS_DIR_NAME}/cse-client-wire.log" # noqa: E501
+CLIENT_WIRE_LOGGER_FILEPATH = f"{LOGS_DIR_NAME}/cse-client-wire.log"  # noqa: E501
 CLIENT_WIRE_LOGGER = logging.getLogger(CLIENT_WIRE_LOGGER_NAME)
 
 # cse server cli logger and config
@@ -103,9 +103,9 @@ SERVER_PKS_WIRE_LOGGER_NAME = 'container_service_extension.server-pks-wire'
 SERVER_PKS_WIRE_LOG_FILEPATH = f"{LOGS_DIR_NAME}/pks-wire.log"
 SERVER_PKS_WIRE_LOGGER = logging.getLogger(SERVER_PKS_WIRE_LOGGER_NAME)
 
-SERVER_CLOUDAPI_WIRE_LOGGER_NAME = 'container_service_extension.server-cloudapi-wire' # noqa: E501
+SERVER_CLOUDAPI_WIRE_LOGGER_NAME = 'container_service_extension.server-cloudapi-wire'  # noqa: E501
 SERVER_CLOUDAPI_LOG_FILEPATH = f"{LOGS_DIR_NAME}/cloudapi-wire.log"
-SERVER_CLOUDAPI_WIRE_LOGGER = logging.getLogger(SERVER_CLOUDAPI_WIRE_LOGGER_NAME) # noqa: E501
+SERVER_CLOUDAPI_WIRE_LOGGER = logging.getLogger(SERVER_CLOUDAPI_WIRE_LOGGER_NAME)  # noqa: E501
 
 # NullLogger doesn't perform logging.
 NULL_LOGGER = logging.getLogger('container_service_extension.null-logger')
@@ -137,11 +137,11 @@ def configure_all_file_loggers():
                      INFO_LOG_FORMATTER, SERVER_LOGGER),
         LoggerConfig(SERVER_LOGGER_NAME, SERVER_DEBUG_LOG_FILEPATH,
                      DEBUG_LOG_FORMATTER, SERVER_LOGGER),
-        LoggerConfig(SERVER_NSXT_WIRE_LOGGER_NAME, SERVER_NSXT_WIRE_LOG_FILEPATH, # noqa: E501
+        LoggerConfig(SERVER_NSXT_WIRE_LOGGER_NAME, SERVER_NSXT_WIRE_LOG_FILEPATH,  # noqa: E501
                      DEBUG_LOG_FORMATTER, SERVER_NSXT_WIRE_LOGGER),
         LoggerConfig(SERVER_PKS_WIRE_LOGGER_NAME, SERVER_PKS_WIRE_LOG_FILEPATH,
                      DEBUG_LOG_FORMATTER, SERVER_PKS_WIRE_LOGGER),
-        LoggerConfig(SERVER_CLOUDAPI_WIRE_LOGGER_NAME, SERVER_CLOUDAPI_LOG_FILEPATH, # noqa: E501
+        LoggerConfig(SERVER_CLOUDAPI_WIRE_LOGGER_NAME, SERVER_CLOUDAPI_LOG_FILEPATH,  # noqa: E501
                      DEBUG_LOG_FORMATTER, SERVER_CLOUDAPI_WIRE_LOGGER)
     ]
 

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -887,7 +887,7 @@ def run(ctx, config_file_path, pks_config_file_path, skip_check,
 def upgrade(ctx, config_file_path, skip_config_decryption,
             skip_template_creation, retain_temp_vapp,
             ssh_key_file, admin_password):
-    """Upgrade existing CSE installation/entities to match CSE 3.0.
+    """Upgrade existing CSE installation/entities to match CSE 3.1.
 
 \b
     - Add CSE / VCD API version info to VCD's extension data for CSE
@@ -928,7 +928,7 @@ def upgrade(ctx, config_file_path, skip_config_decryption,
     try:
         config = get_validated_config(
             config_file_name=config_file_path,
-            pks_config_file_name=None,
+            pks_config_file_name='',
             skip_config_decryption=skip_config_decryption,
             decryption_password=password,
             log_wire_file=INSTALL_WIRELOG_FILEPATH,
@@ -941,7 +941,6 @@ def upgrade(ctx, config_file_path, skip_config_decryption,
             skip_template_creation=skip_template_creation,
             ssh_key=ssh_key,
             retain_temp_vapp=retain_temp_vapp,
-            admin_password=admin_password,
             msg_update_callback=console_message_printer)
 
     except Exception as err:
@@ -1239,7 +1238,6 @@ def install_cse_template(ctx, template_name, template_revision,
             retain_temp_vapp=retain_temp_vapp,
             ssh_key=ssh_key,
             skip_config_decryption=skip_config_decryption,
-            decryption_password=password,
             msg_update_callback=console_message_printer)
     except Exception as err:
         SERVER_CLI_LOGGER.error(str(err))

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -18,6 +18,7 @@ from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
+import semantic_version
 
 import container_service_extension.common.constants.server_constants as server_constants  # noqa: E501
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
@@ -108,7 +109,8 @@ def verify_version_compatibility(
 
     dikt = configure_cse.parse_cse_extension_description(
         sysadmin_client, is_mqtt_extension)
-    ext_cse_version = dikt[server_constants.CSE_VERSION_KEY]
+    ext_cse_version = \
+        semantic_version.Version(dikt[server_constants.CSE_VERSION_KEY])
     ext_in_legacy_mode = dikt[server_constants.LEGACY_MODE_KEY]
     # ext_rde_in_use = dikt[server_constants.RDE_VERSION_IN_USE_KEY]
 


### PR DESCRIPTION
Remove usage of api version from cse install/upgrade/run
Stamp legacy mode flag on CSE extension instead of the api version in use.

Testing Done:
* Installed CSE 3.0.2, upgraded to CSE 3.1 and made sure upgrade goes through successfully.
* Re-upgraded to 3.1 to ensure idempotency of the upgrade
* Ran CSE before and after the upgrade and got correct error messages

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/981)
<!-- Reviewable:end -->
