### PR TITLE
[VCDA-2205] V35 handler - process input and use cluster service based on runtime rde version

### DIFF
--- a/container_service_extension/rde/models/rde_1_0_0.py
+++ b/container_service_extension/rde/models/rde_1_0_0.py
@@ -8,6 +8,7 @@ from typing import List
 import container_service_extension.common.constants.server_constants as server_constants  # noqa: E501
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
 from container_service_extension.rde.models.abstractNativeEntity import AbstractNativeEntity  # noqa: E501
+import container_service_extension.rde.models.rde_2_0_0 as rde_2_0_0
 
 
 @dataclass()
@@ -203,7 +204,28 @@ class NativeEntity(AbstractNativeEntity):
         :return: native entity
         :rtype: rde_1.0.0.NativeEntity
         """
-        raise NotImplementedError
+        if isinstance(native_entity, NativeEntity):
+            return native_entity
+
+        if isinstance(native_entity, rde_2_0_0.NativeEntity):
+            rde_2_x_entity: rde_2_0_0.NativeEntity = native_entity
+            status = Status(
+                phase=rde_2_x_entity.status.phase,
+                cni=rde_2_x_entity.status.cni,
+                task_href=rde_2_x_entity.status.task_href,
+                kubernetes=rde_2_x_entity.status.kubernetes,
+                docker_version=rde_2_x_entity.status.kubernetes,
+                os=rde_2_x_entity.status.os,
+                nodes=rde_2_x_entity.status.nodes
+            )
+            rde_1_entity = cls(
+                metadata=rde_2_x_entity.metadata,
+                spec=rde_2_x_entity.spec,
+                status=status,
+                kind=rde_2_x_entity.kind,
+                api_version=''
+            )
+            return rde_1_entity
 
     @classmethod
     def from_cluster_data(cls, cluster: dict, kind: str, **kwargs):

--- a/container_service_extension/rde/models/rde_1_0_0.py
+++ b/container_service_extension/rde/models/rde_1_0_0.py
@@ -209,23 +209,70 @@ class NativeEntity(AbstractNativeEntity):
 
         if isinstance(native_entity, rde_2_0_0.NativeEntity):
             rde_2_x_entity: rde_2_0_0.NativeEntity = native_entity
+
+            metadata = Metadata(
+                cluster_name=rde_2_x_entity.metadata.name,
+                org_name=rde_2_x_entity.metadata.orgName,
+                ovdc_name=rde_2_x_entity.metadata.ovdcName
+            )
+
+            settings = Settings(
+                network=rde_2_x_entity.spec.settings.network,
+                ssh_key=rde_2_x_entity.spec.settings.sshKey,
+                rollback_on_failure=rde_2_x_entity.spec.settings.rollbackOnFailure  # noqa: E501
+            )
+
+            k8_distribution = Distribution(
+                template_name=rde_2_x_entity.spec.k8Distribution.templateName,
+                template_revision=rde_2_x_entity.spec.k8Distribution.templateRevision  # noqa: E501
+            )
+
+            control_plane = ControlPlane(
+                sizing_class=rde_2_x_entity.spec.controlPlane.sizingClass,
+                storage_profile=rde_2_x_entity.spec.controlPlane.storageProfile,  # noqa: E501
+                count=rde_2_x_entity.spec.controlPlane.count
+            )
+
+            workers = Workers(
+                sizing_class=rde_2_x_entity.spec.workers.sizingClass,
+                storage_profile=rde_2_x_entity.spec.workers.storageProfile,
+                count=rde_2_x_entity.spec.workers.count
+            )
+
+            nfs = Nfs(
+                sizing_class=rde_2_x_entity.spec.nfs.sizingClass,
+                storage_profile=rde_2_x_entity.spec.nfs.storageProfile,
+                count=rde_2_x_entity.spec.nfs.count
+            )
+
+            spec = ClusterSpec(
+                settings=settings,
+                k8_distribution=k8_distribution,
+                control_plane=control_plane,
+                workers=workers,
+                nfs=nfs
+            )
+
             status = Status(
                 phase=rde_2_x_entity.status.phase,
                 cni=rde_2_x_entity.status.cni,
                 task_href=rde_2_x_entity.status.task_href,
                 kubernetes=rde_2_x_entity.status.kubernetes,
-                docker_version=rde_2_x_entity.status.kubernetes,
+                docker_version=rde_2_x_entity.status.dockerVersion,
                 os=rde_2_x_entity.status.os,
                 nodes=rde_2_x_entity.status.nodes
             )
+
             rde_1_entity = cls(
-                metadata=rde_2_x_entity.metadata,
-                spec=rde_2_x_entity.spec,
+                metadata=metadata,
+                spec=spec,
                 status=status,
                 kind=rde_2_x_entity.kind,
                 api_version=''
             )
             return rde_1_entity
+
+        return native_entity
 
     @classmethod
     def from_cluster_data(cls, cluster: dict, kind: str, **kwargs):

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -185,9 +185,18 @@ def convert_input_rde_to_runtime_rde_format(input_entity: dict):
     :rtype: AbstractNativeEntity
     """
     payload_version = input_entity.get(def_constants.PayloadKey.PAYLOAD_VERSION)  # noqa: E501
+    if payload_version:
+        input_rde_version = def_constants.MAP_INPUT_PAYLOAD_VERSION_TO_RDE_VERSION[payload_version]  # noqa: E501
+    else:
+        input_rde_version = def_constants.RDEVersion.RDE_1_0_0.value
     runtime_rde_version = server_utils.get_rde_version_in_use()
     RuntimeNativeEntityClass: Type[AbstractNativeEntity] = rde_factory.get_rde_model(runtime_rde_version)  # noqa: E501
-    InputNativeEntityClass: Type[AbstractNativeEntity] = rde_factory.get_rde_model(  # noqa: E501
-        def_constants.MAP_INPUT_PAYLOAD_VERSION_TO_RDE_VERSION[payload_version])  # noqa: E501
+    InputNativeEntityClass: Type[AbstractNativeEntity] = rde_factory.get_rde_model(input_rde_version)  # noqa: E501
     input_rde: AbstractNativeEntity = InputNativeEntityClass(**input_entity)  # noqa: E501
     return RuntimeNativeEntityClass.from_native_entity(input_rde)
+
+
+def convert_runtime_rde_to_input_rde_version_format(runtime_rde: AbstractNativeEntity, input_rde_version):  # noqa: E501
+    InputNativeEntityClass: Type[AbstractNativeEntity] = rde_factory.get_rde_model(input_rde_version)  # noqa: E501
+    output_entity = InputNativeEntityClass.from_native_entity(runtime_rde)
+    return output_entity


### PR DESCRIPTION
- Convert the input based on runtime rde version
- Cluster service based on runtime rde version
- Convert the new entity to input format before returning
- Tested with following endpoints
- Tests done on CSE 3.1, VCD 10.3
vcd cse cluster apply
POST api/cse/3.0/cluster/{cluster_id}/action/upgrade
POST api/cse/3.0/clusters
PUT api/cse/3.0/cluster/{cluster_id}
- TBD : CSE 3.1, VCD 10.2 

@Anirudh9794 @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/984)
<!-- Reviewable:end -->
