### PR TITLE
[VCDA-2294,VCDA-2299] Remove-Wrong-RDE-Version-Stamping-And-Convert-CSE-Version-From-Extension

### DIFF
--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -183,6 +183,8 @@ def parse_cse_extension_description(sys_admin_client, is_mqtt_extension):
         result = json.loads(description)
         result[server_constants.CSE_VERSION_KEY] = \
             semantic_version.Version(result[server_constants.CSE_VERSION_KEY])
+        result[server_constants.RDE_VERSION_IN_USE_KEY] = \
+            semantic_version.Version(result[server_constants.RDE_VERSION_IN_USE_KEY])  # noqa: E501
     except json.decoder.JSONDecodeError:
         cse_version = server_constants.UNKNOWN_CSE_VERSION
         legacy_mode = True

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -181,6 +181,8 @@ def parse_cse_extension_description(sys_admin_client, is_mqtt_extension):
     # the key legacy_mode is also mandatory
     try:
         result = json.loads(description)
+        result[server_constants.CSE_VERSION_KEY] = \
+            semantic_version.Version(result[server_constants.CSE_VERSION_KEY])
     except json.decoder.JSONDecodeError:
         cse_version = server_constants.UNKNOWN_CSE_VERSION
         legacy_mode = True
@@ -329,7 +331,7 @@ def install_cse(config_file_name, config, skip_template_creation,
 
         # Setup extension based on message bus protocol
         if server_utils.should_use_mqtt_protocol(config):
-            _register_cse_as_mqtt_extension(client, msg_update_callback)
+            _register_cse_as_mqtt_extension(client, msg_update_callback=msg_update_callback)  # noqa: E501
         else:
             # create amqp exchange if it doesn't exist
             amqp = config['amqp']
@@ -1948,10 +1950,10 @@ def _upgrade_to_cse_3_1(client, config,
         existing_ext_type = _get_existing_extension_type(client)
         if existing_ext_type == server_constants.ExtensionType.AMQP:
             _deregister_cse_amqp_extension(client)
-            _register_cse_as_mqtt_extension(client, msg_update_callback)
+            _register_cse_as_mqtt_extension(client, msg_update_callback=msg_update_callback)  # noqa: E501
         elif existing_ext_type == server_constants.ExtensionType.MQTT:
             # Remove api filters and update description
-            _update_cse_mqtt_extension(client, msg_update_callback)
+            _update_cse_mqtt_extension(client, msg_update_callback=msg_update_callback)  # noqa: E501
     else:
         # Update amqp exchange
         _create_amqp_exchange(

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -18,7 +18,6 @@ from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
-import semantic_version
 
 import container_service_extension.common.constants.server_constants as server_constants  # noqa: E501
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
@@ -109,8 +108,7 @@ def verify_version_compatibility(
 
     dikt = configure_cse.parse_cse_extension_description(
         sysadmin_client, is_mqtt_extension)
-    ext_cse_version = \
-        semantic_version.Version(dikt[server_constants.CSE_VERSION_KEY])
+    ext_cse_version = dikt[server_constants.CSE_VERSION_KEY]
     ext_in_legacy_mode = dikt[server_constants.LEGACY_MODE_KEY]
     # ext_rde_in_use = dikt[server_constants.RDE_VERSION_IN_USE_KEY]
 


### PR DESCRIPTION
- Fixed wrong RDE version stamping on CSE extension information
- Convert extracted CSE version from CSE extension to semantic_version before upgrade procedure
- Tested manually 

@Anirudh9794 @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/989)
<!-- Reviewable:end -->
