### PR TITLE
[VCDA-2285] Enable cse 3.0 legacy to cse 3.1 legacy upgrade

### DIFF
--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -1994,8 +1994,8 @@ def _upgrade_to_cse_3_1_legacy(
     :raises: MultipleRecordsException: (when using mqtt) if more than one
         service with the given name and namespace are found when trying to
         delete the amqp-based extension.
-    :raises requests.exceptions.HTTPError: (when using MQTT) if the MQTT
-        components were not installed correctly
+    :raises cse_exception.AmqpError: (when using AMQP) if AMQP exchange
+        could not be created.
     """
     if skip_template_creation:
         msg = "Skipping creation of new templates and special processing of existing templates"  # noqa: E501

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -558,7 +558,7 @@ def install_template(template_name, template_revision, config_file_name,
 # CSE 3.0.x, api v33.0
 # CSE 3.0.x, api v34.0
 # CSE 3.0.x, api v35.0
-# api v33.0 and v34.0 will map to legacy_mode = False
+# api v33.0 and v34.0 will map to legacy_mode = True
 #
 # The target configurations can be
 # CSE 3.1, vCD 10.1, legacy_mode = True
@@ -712,21 +712,23 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
         if source_cse_running_in_legacy_mode != target_cse_running_in_legacy_mode and target_cse_running_in_legacy_mode:  # noqa: E501
             raise Exception(upgrade_path_not_valid_msg)
 
-        # ToDo : This is a valid path, we need to write the
-        #  upgrade path for this
         if source_cse_running_in_legacy_mode and target_cse_running_in_legacy_mode:  # noqa: E501
-            raise Exception(upgrade_path_not_valid_msg)
-
-        # ToDo : Depending on the determined RDE version we should have
-        #  two separate upgrade paths
-
-        _upgrade_to_cse_3_1(
-            client=client,
-            config=config,
-            skip_template_creation=skip_template_creation,
-            retain_temp_vapp=retain_temp_vapp,
-            msg_update_callback=msg_update_callback,
-            log_wire=log_wire)
+            _upgrade_to_cse_3_1_legacy(
+                client=client,
+                config=config,
+                skip_template_creation=skip_template_creation,
+                retain_temp_vapp=retain_temp_vapp,
+                msg_update_callback=msg_update_callback)
+        else:
+            # ToDo : Depending on the determined RDE version we should have
+            #  two separate upgrade paths
+            _upgrade_to_cse_3_1_non_legacy(
+                client=client,
+                config=config,
+                skip_template_creation=skip_template_creation,
+                retain_temp_vapp=retain_temp_vapp,
+                msg_update_callback=msg_update_callback,
+                log_wire=log_wire)
 
         record_user_action(CseOperation.SERVICE_UPGRADE,
                            status=OperationStatus.SUCCESS,
@@ -1857,10 +1859,41 @@ def _update_cse_amqp_extension(client, routing_key, exchange,
     INSTALL_LOGGER.info(msg)
 
 
-def _upgrade_to_cse_3_1(client, config,
-                        skip_template_creation, retain_temp_vapp,
-                        msg_update_callback=utils.NullPrinter(),
-                        log_wire=False):
+def _update_cse_extension(client, config,
+                          msg_update_callback=utils.NullPrinter()):
+    # update extension
+    if server_utils.should_use_mqtt_protocol(config):
+        # Caller guarantees that there is an extension present
+        existing_ext_type = _get_existing_extension_type(client)
+        if existing_ext_type == server_constants.ExtensionType.AMQP:
+            _deregister_cse_amqp_extension(client)
+            _register_cse_as_mqtt_extension(client, msg_update_callback=msg_update_callback)  # noqa: E501
+        elif existing_ext_type == server_constants.ExtensionType.MQTT:
+            # Remove api filters and update description
+            _update_cse_mqtt_extension(client, msg_update_callback=msg_update_callback)  # noqa: E501
+    else:
+        # Update amqp exchange
+        _create_amqp_exchange(
+            exchange_name=config['amqp']['exchange'],
+            host=config['amqp']['host'],
+            port=config['amqp']['port'],
+            vhost=config['amqp']['vhost'],
+            username=config['amqp']['username'],
+            password=config['amqp']['password'],
+            msg_update_callback=msg_update_callback)
+
+        # Update cse api extension (along with api end points)
+        _update_cse_amqp_extension(
+            client=client,
+            routing_key=config['amqp']['routing_key'],
+            exchange=config['amqp']['exchange'],
+            msg_update_callback=msg_update_callback)
+
+
+def _upgrade_to_cse_3_1_non_legacy(client, config,
+                                   skip_template_creation, retain_temp_vapp,
+                                   msg_update_callback=utils.NullPrinter(),
+                                   log_wire=False):
     """Handle upgrade when VCD supports RDE.
 
     :raises: MultipleRecordsException: (when using mqtt) if more than one
@@ -1945,34 +1978,39 @@ def _upgrade_to_cse_3_1(client, config,
     # and will need DEF entity rights.
     _print_users_in_need_of_def_rights(
         cse_clusters=clusters, msg_update_callback=msg_update_callback)
+    _update_cse_extension(client=client,
+                          config=config,
+                          msg_update_callback=msg_update_callback)
 
-    # update extension
-    if server_utils.should_use_mqtt_protocol(config):
-        # Caller guarantees that there is an extension present
-        existing_ext_type = _get_existing_extension_type(client)
-        if existing_ext_type == server_constants.ExtensionType.AMQP:
-            _deregister_cse_amqp_extension(client)
-            _register_cse_as_mqtt_extension(client, msg_update_callback=msg_update_callback)  # noqa: E501
-        elif existing_ext_type == server_constants.ExtensionType.MQTT:
-            # Remove api filters and update description
-            _update_cse_mqtt_extension(client, msg_update_callback=msg_update_callback)  # noqa: E501
+
+def _upgrade_to_cse_3_1_legacy(
+        client, config, skip_template_creation, retain_temp_vapp,
+        msg_update_callback=utils.NullPrinter()):
+    """Handle upgrade when no support from VCD for RDE.
+
+    :raises: MultipleRecordsException: (when using mqtt) if more than one
+        service with the given name and namespace are found when trying to
+        delete the amqp-based extension.
+    :raises requests.exceptions.HTTPError: (when using MQTT) if the MQTT
+        components were not installed correctly
+    """
+    if skip_template_creation:
+        msg = "Skipping creation of new templates and special processing of existing templates"  # noqa: E501
+        msg_update_callback.info(msg)
+        INSTALL_LOGGER.info(msg)
     else:
-        # Update amqp exchange
-        _create_amqp_exchange(
-            exchange_name=config['amqp']['exchange'],
-            host=config['amqp']['host'],
-            port=config['amqp']['port'],
-            vhost=config['amqp']['vhost'],
-            username=config['amqp']['username'],
-            password=config['amqp']['password'],
+        # Recreate all supported templates
+        _install_all_templates(
+            client=client,
+            config=config,
+            force_create=True,
+            retain_temp_vapp=retain_temp_vapp,
+            ssh_key=retain_temp_vapp,
             msg_update_callback=msg_update_callback)
 
-        # Update cse api extension (along with api end points)
-        _update_cse_amqp_extension(
-            client=client,
-            routing_key=config['amqp']['routing_key'],
-            exchange=config['amqp']['exchange'],
-            msg_update_callback=msg_update_callback)
+    _update_cse_extension(client=client,
+                          config=config,
+                          msg_update_callback=msg_update_callback)
 
 
 def _get_placement_policy_name_from_template_name(template_name):

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -875,18 +875,9 @@ def run(ctx, config_file_path, pks_config_file_path, skip_check,
     default=None,
     type=click.File('r'),
     help='Filepath of SSH public key to add to CSE k8s template vms')
-@click.option(
-    '-p',
-    '--admin-password',
-    'admin_password',
-    default=None,
-    metavar='ADMIN_PASSWORD',
-    help="New root password to set on existing CSE k8s cluster vms. If left "
-         "empty, old passwords,if present, will be retained else it will be "
-         "auto-generated")
 def upgrade(ctx, config_file_path, skip_config_decryption,
             skip_template_creation, retain_temp_vapp,
-            ssh_key_file, admin_password):
+            ssh_key_file):
     """Upgrade existing CSE installation/entities to match CSE 3.1.
 
 \b

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -18,6 +18,7 @@ from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
+import semantic_version
 
 import container_service_extension.common.constants.server_constants as server_constants  # noqa: E501
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
@@ -108,7 +109,8 @@ def verify_version_compatibility(
 
     dikt = configure_cse.parse_cse_extension_description(
         sysadmin_client, is_mqtt_extension)
-    ext_cse_version = dikt[server_constants.CSE_VERSION_KEY]
+    ext_cse_version = \
+        semantic_version.Version(dikt[server_constants.CSE_VERSION_KEY])
     ext_in_legacy_mode = dikt[server_constants.LEGACY_MODE_KEY]
     # ext_rde_in_use = dikt[server_constants.RDE_VERSION_IN_USE_KEY]
 


### PR DESCRIPTION
- Upgrade path for CSE 3.0 legacy mode to CSE 3.1 legacy mode
- Recreate templates option 
- Update CSE extension
- Removed --password option from CLI 
- Tested upgrade with CSE 3.0.1 api version (33,34) to CSE 3.1 legacy mode=true
- VCDA-2294, 2299 changes are also in this file

@Anirudh9794 @rocknes 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/993)
<!-- Reviewable:end -->
