### PR TITLE
[VCDA-2283] CLI changes to harden against RDE changes

### DIFF
--- a/container_service_extension/client/cluster_commands.py
+++ b/container_service_extension/client/cluster_commands.py
@@ -168,6 +168,7 @@ Example
         result = cluster.delete_cluster(name, cluster_id=cluster_id,
                                         org=org, vdc=vdc)
         if len(result) == 0:
+            # TODO(CLI): Update message to use vcd task wait instead
             click.secho(f"Delete cluster operation has been initiated on "
                         f"{name}, please check the status using"
                         f" 'vcd cse cluster info {name}'.", fg='yellow')
@@ -632,7 +633,7 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, out
             if not org:
                 org_name = ctx.obj['profiles'].get('org_in_use')
 
-        cluster = Cluster(client, k8_runtime=cluster_config.get('kind'))  # noqa: E501
+        cluster = Cluster(client, k8_runtime=cluster_config.get('kind'))
         result = cluster.apply(cluster_config, cluster_id=cluster_id,
                                org=org_name)
         stdout(result, ctx)
@@ -667,6 +668,7 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, out
 def delete_nfs(ctx, cluster_name, node_name, vdc, org):
     """Remove nfs node in a cluster that uses native Kubernetes provider."""
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
+    # NOTE: command is exposed only if cli is enabled for native clusters
     try:
         client_utils.cse_restore_session(ctx)
         client = ctx.obj['client']
@@ -723,6 +725,7 @@ Examples
     (Supported only for vcd api version >= 35)
     """
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
+    # NOTE: Command is exposed only if CLI is enabled for native clusters
     try:
         client_utils.cse_restore_session(ctx)
         if client_utils.is_cli_for_tkg_only():
@@ -805,6 +808,7 @@ Example
         Affected software: Docker-CE, Kubernetes, CNI
     """
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
+    # NOTE: Command is exposed only if CLI is enabled for native
     try:
         client_utils.cse_restore_session(ctx)
         if client_utils.is_cli_for_tkg_only():
@@ -980,6 +984,8 @@ Example
             k8_runtime = shared_constants.ClusterEntityKind.TKG.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
+        # Users should be explicit in their intent about the org on which the
+        # command needs to be executed.
         if not client.is_sysadmin() and org is None:
             org = ctx.obj['profiles'].get('org_in_use')
         result = cluster.get_cluster_info(name, cluster_id=cluster_id,
@@ -1079,6 +1085,7 @@ Examples:
             k8_runtime = shared_constants.ClusterEntityKind.TKG.value
 
         client = ctx.obj['client']
+        # TODO(CLI): Check regarding is sysadmin client check
         if not org:
             ctx_profiles = ctx.obj['profiles']
             org = ctx_profiles.get('org')
@@ -1171,6 +1178,7 @@ Examples:
 
         # Determine cluster type and retrieve cluster id if needed
         client = ctx.obj['client']
+        # TODO(CLI): Check regarding is sysadmin client check
         if not org:
             ctx_profiles = ctx.obj['profiles']
             org = ctx_profiles.get('org')
@@ -1252,6 +1260,7 @@ Examples:
             k8_runtime = shared_constants.ClusterEntityKind.TKG.value
 
         client = ctx.obj['client']
+        # TODO(CLI): Check regarding why sysadmin check is excluded here
         if not org:
             ctx_profiles = ctx.obj['profiles']
             org = ctx_profiles.get('org')

--- a/container_service_extension/client/cluster_commands.py
+++ b/container_service_extension/client/cluster_commands.py
@@ -604,6 +604,10 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, out
                     and not utils.is_environment_variable_enabled(cli_constants.ENV_CSE_TKG_PLUS_ENABLED):  # noqa: E501
                 raise Exception(f"{shared_constants.ClusterEntityKind.TKG_PLUS.value} not enabled")  # noqa: E501
             else:
+                # since apply command is not exposed when CSE server is not
+                # running, it is safe to get the server_rde_version from
+                # VCD API version as VCD API version will be the supported by
+                # CSE server.
                 server_rde_version = \
                     def_utils.get_runtime_rde_version_by_vcd_api_version(
                         float(client.get_api_version()))

--- a/container_service_extension/client/cse_client/api_35/native_cluster_api.py
+++ b/container_service_extension/client/cse_client/api_35/native_cluster_api.py
@@ -10,7 +10,6 @@ import pyvcloud.vcd.client as vcd_client
 from container_service_extension.client.cse_client.cse_client import CseClient
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
 import container_service_extension.rde.models.common_models as common_models
-import container_service_extension.rde.models.rde_1_0_0 as rde_1_0_0
 
 
 class NativeClusterApi(CseClient):
@@ -21,27 +20,38 @@ class NativeClusterApi(CseClient):
         self._cluster_uri = f"{self._uri}/cluster"
         self._request_page_size = 10
 
-    def create_cluster(self, cluster_entity_definition: rde_1_0_0.NativeEntity):  # noqa: E501
-        cluster_entity_dict = asdict(cluster_entity_definition)
+    def create_cluster(self, cluster_create_spec: dict):
+        """Call create native cluster CSE server endpoint.
+
+        :param dict cluster_create_spec: Cluster create specification
+        :return: defined entity object representing the response
+        :rtype: common_models.DefEntity
+        """
         uri = self._clusters_uri
         response = self.do_request(
             uri=uri,
             method=shared_constants.RequestMethod.POST,
             accept_type='application/json',
             media_type='application/json',
-            payload=cluster_entity_dict)
+            payload=cluster_create_spec)
 
         return common_models.DefEntity(**self.process_response(response))
 
-    def update_cluster_by_cluster_id(self, cluster_id, cluster_entity_definition: rde_1_0_0.NativeEntity):  # noqa: E501
-        cluster_entity_dict = asdict(cluster_entity_definition)
+    def update_cluster_by_cluster_id(self, cluster_id: str, cluster_update_spec: dict):  # noqa: E501
+        """Call update native cluster CSE server endpoint.
+
+        :param str cluster_id: ID of the cluster
+        :param dict cluster_update_spec: Update cluster specification
+        :return: defined entity object representing the response
+        :rtype: common_models.DefEntity
+        """
         uri = f"{self._cluster_uri}/{cluster_id}"
         response = self.do_request(
             uri=uri,
             method=shared_constants.RequestMethod.PUT,
             accept_type='application/json',
             media_type='application/json',
-            payload=cluster_entity_dict)
+            payload=cluster_update_spec)
 
         return common_models.DefEntity(**self.process_response(response))
 

--- a/container_service_extension/client/de_cluster.py
+++ b/container_service_extension/client/de_cluster.py
@@ -23,7 +23,7 @@ import container_service_extension.logging.logger as logger
 import container_service_extension.rde.common.entity_service as def_entity_svc
 from container_service_extension.rde.models.abstractNativeEntity import AbstractNativeEntity  # noqa: E501
 import container_service_extension.rde.models.common_models as common_models
-import container_service_extension.rde.utils as def_utils
+import container_service_extension.rde.schema_service as def_schema_svc
 
 
 DUPLICATE_CLUSTER_ERROR_MSG = "Duplicate clusters found. Please use --k8-runtime for the unique identification"  # noqa: E501
@@ -52,9 +52,9 @@ class DECluster:
                 logger_wire=logger_wire)
         self._nativeCluster = DEClusterNative(client)
         self._tkgCluster = DEClusterTKG(client)
+        schema_svc = def_schema_svc.DefSchemaService(self._cloudapi_client)
         self._server_rde_version = \
-            def_utils.get_runtime_rde_version_by_vcd_api_version(
-                float(self._cloudapi_client.get_api_version()))
+            schema_svc.get_latest_registered_schema_version()
 
     def list_clusters(self, vdc=None, org=None, **kwargs):
         """Get collection of clusters using DEF API.

--- a/container_service_extension/client/de_cluster.py
+++ b/container_service_extension/client/de_cluster.py
@@ -21,8 +21,8 @@ import container_service_extension.common.utils.pyvcloud_utils as vcd_utils
 import container_service_extension.exception.exceptions as cse_exceptions
 import container_service_extension.logging.logger as logger
 import container_service_extension.rde.common.entity_service as def_entity_svc
+from container_service_extension.rde.models.abstractNativeEntity import AbstractNativeEntity  # noqa: E501
 import container_service_extension.rde.models.common_models as common_models
-import container_service_extension.rde.models.rde_1_0_0 as rde_1_0_0
 import container_service_extension.rde.utils as def_utils
 
 
@@ -83,7 +83,8 @@ class DECluster:
                 raise e
         else:
             # display all clusters
-            filters = client_utils.construct_filters(org=org, vdc=vdc)
+            filters = client_utils.construct_filters(
+                self._server_rde_version, org=org, vdc=vdc)
             entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
             has_more_results = True
             page_number = CSE_PAGINATION_FIRST_PAGE_NUMBER
@@ -108,13 +109,13 @@ class DECluster:
                             cli_constants.CLIOutputKey.ORG.value: de.org.name, # noqa: E501
                             cli_constants.CLIOutputKey.OWNER.value: de.owner.name  # noqa: E501
                         }
-                        if type(entity) == rde_1_0_0.NativeEntity:
+                        if isinstance(entity, AbstractNativeEntity):
                             cluster[cli_constants.CLIOutputKey.VDC.value] = \
                                 entity.metadata.ovdc_name
                             cluster[cli_constants.CLIOutputKey.K8S_RUNTIME.value] = entity.kind  # noqa: E501
                             cluster[cli_constants.CLIOutputKey.K8S_VERSION.value] = entity.status.kubernetes  # noqa: E501
                             cluster[cli_constants.CLIOutputKey.STATUS.value] = entity.status.phase  # noqa: E501
-                        elif type(entity) == common_models.TKGEntity:
+                        elif isinstance(entity, common_models.TKGEntity):
                             cluster[cli_constants.CLIOutputKey.VDC.value] = \
                                 entity.metadata.virtualDataCenterName
                             cluster[cli_constants.CLIOutputKey.K8S_RUNTIME.value] = entity.kind  # noqa: E501
@@ -146,7 +147,8 @@ class DECluster:
             boolean indicating cluster type
         :rtype: (cluster, dict,  bool)
         """
-        filters = client_utils.construct_filters(org=org, vdc=vdc)
+        filters = client_utils.construct_filters(
+            self._server_rde_version, org=org, vdc=vdc)
         entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
         has_native_rights = True
         has_tkg_rights = True

--- a/container_service_extension/client/de_cluster.py
+++ b/container_service_extension/client/de_cluster.py
@@ -110,8 +110,14 @@ class DECluster:
                             cli_constants.CLIOutputKey.OWNER.value: de.owner.name  # noqa: E501
                         }
                         if isinstance(entity, AbstractNativeEntity):
-                            cluster[cli_constants.CLIOutputKey.VDC.value] = \
-                                entity.metadata.ovdc_name
+                            # TODO remove if-else logic once model classes
+                            #   start using snake_case
+                            if hasattr(entity.metadata, 'ovdc_name'):
+                                cluster[cli_constants.CLIOutputKey.VDC.value] = \
+                                    entity.metadata.ovdc_name
+                            elif hasattr(entity.metadata, 'ovdcName'):
+                                cluster[cli_constants.CLIOutputKey.VDC.value] = \
+                                    entity.metadata.ovdcName
                             cluster[cli_constants.CLIOutputKey.K8S_RUNTIME.value] = entity.kind  # noqa: E501
                             cluster[cli_constants.CLIOutputKey.K8S_VERSION.value] = entity.status.kubernetes  # noqa: E501
                             cluster[cli_constants.CLIOutputKey.STATUS.value] = entity.status.phase  # noqa: E501

--- a/container_service_extension/client/de_cluster.py
+++ b/container_service_extension/client/de_cluster.py
@@ -114,10 +114,10 @@ class DECluster:
                             #   start using snake_case
                             if hasattr(entity.metadata, 'ovdc_name'):
                                 cluster[cli_constants.CLIOutputKey.VDC.value] = \
-                                    entity.metadata.ovdc_name
+                                    entity.metadata.ovdc_name  # noqa: E501
                             elif hasattr(entity.metadata, 'ovdcName'):
                                 cluster[cli_constants.CLIOutputKey.VDC.value] = \
-                                    entity.metadata.ovdcName
+                                    entity.metadata.ovdcName  # noqa: E501
                             cluster[cli_constants.CLIOutputKey.K8S_RUNTIME.value] = entity.kind  # noqa: E501
                             cluster[cli_constants.CLIOutputKey.K8S_VERSION.value] = entity.status.kubernetes  # noqa: E501
                             cluster[cli_constants.CLIOutputKey.STATUS.value] = entity.status.phase  # noqa: E501

--- a/container_service_extension/client/de_cluster_native.py
+++ b/container_service_extension/client/de_cluster_native.py
@@ -20,7 +20,7 @@ import container_service_extension.rde.common.entity_service as def_entity_svc
 import container_service_extension.rde.constants as rde_constants
 import container_service_extension.rde.models.common_models as common_models
 import container_service_extension.rde.models.rde_1_0_0 as rde_1_0_0
-import container_service_extension.rde.utils as def_utils
+import container_service_extension.rde.schema_service as def_schema_svc
 
 
 class DEClusterNative:
@@ -43,9 +43,9 @@ class DEClusterNative:
                 logger_wire=logger_wire)
         self._native_cluster_api = NativeClusterApi(client)
         self._client = client
+        schema_service = def_schema_svc.DefSchemaService(self._cloudapi_client)
         self._server_rde_version = \
-            def_utils.get_runtime_rde_version_by_vcd_api_version(
-                float(client.get_api_version()))
+            schema_service.get_latest_registered_schema_version()
 
     def create_cluster(self, cluster_entity: rde_1_0_0.NativeEntity):
         """Create a new Kubernetes cluster.

--- a/container_service_extension/client/de_cluster_native.py
+++ b/container_service_extension/client/de_cluster_native.py
@@ -6,6 +6,7 @@ from dataclasses import asdict
 import os
 
 import pyvcloud.vcd.exceptions as vcd_exceptions
+import semantic_version
 import yaml
 
 import container_service_extension.client.constants as cli_constants
@@ -19,7 +20,6 @@ import container_service_extension.rde.common.entity_service as def_entity_svc
 import container_service_extension.rde.constants as rde_constants
 import container_service_extension.rde.models.common_models as common_models
 import container_service_extension.rde.models.rde_1_0_0 as rde_1_0_0
-import container_service_extension.rde.models.rde_factory as rde_factory
 import container_service_extension.rde.utils as def_utils
 
 
@@ -79,7 +79,8 @@ class DEClusterNative:
         """
         if cluster_id:
             return self.get_cluster_info_by_id(cluster_id)
-        filters = client_utils.construct_filters(org=org, vdc=vdc)
+        filters = client_utils.construct_filters(
+            self._server_rde_version, org=org, vdc=vdc)
         entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
         def_entity = \
             entity_svc.get_native_rde_by_name_and_rde_version(
@@ -142,7 +143,8 @@ class DEClusterNative:
         :rtype: str
         :raises ClusterNotFoundError
         """
-        filters = client_utils.construct_filters(org=org, vdc=vdc)
+        filters = client_utils.construct_filters(
+            self._server_rde_version, org=org, vdc=vdc)
         entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
         def_entity = entity_svc.get_native_rde_by_name_and_rde_version(
             cluster_name, self._server_rde_version, filters=filters)
@@ -169,6 +171,7 @@ class DEClusterNative:
         """Get cluster config for the given cluster name.
 
         :param str cluster_name: name of the cluster
+        :param str cluster_id: id of the cluster
         :param str vdc: name of vdc
         :param str org: name of org
 
@@ -198,7 +201,8 @@ class DEClusterNative:
         :return: upgrade plan info
         :rtype: dict
         """
-        filters = client_utils.construct_filters(org=org, vdc=vdc)
+        filters = client_utils.construct_filters(
+            self._server_rde_version, org=org, vdc=vdc)
         entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
         def_entity = entity_svc.get_native_rde_by_name_and_rde_version(
             cluster_name, self._server_rde_version, filters=filters)
@@ -229,7 +233,8 @@ class DEClusterNative:
         :return: string containing upgrade cluster task href
         :rtype: str
         """
-        filters = client_utils.construct_filters(org=org_name, vdc=ovdc_name)
+        filters = client_utils.construct_filters(
+            self._server_rde_version, org=org_name, vdc=ovdc_name)
         entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
         current_entity = entity_svc.get_native_rde_by_name_and_rde_version(
             cluster_name, self._server_rde_version, filters=filters)
@@ -257,21 +262,30 @@ class DEClusterNative:
         task_href = cluster_def_entity.entity.get_latest_task_href()
         return client_utils.construct_task_console_message(task_href)
 
-    def apply(self, cluster_config, cluster_id=None, **kwargs):
+    def _get_cluster_name_from_cluster_apply_specification(self, input_spec: dict):  # noqa: E501
+        """Derive cluster name from cluster apply specificaiton.
+
+        :param dict input_spec: Input specification
+        :return: cluster name
+        :rtype: str
+        """
+        # RDE version > 1.0.0 will have the cluster name under metadata.name
+        metadata: dict = input_spec.get('metadata')
+        if semantic_version.Version(self._server_rde_version) <= \
+                semantic_version.Version(rde_constants.RDEVersion.RDE_1_0_0):
+            return metadata.get('cluster_name')
+        return metadata.get('cluster_name')
+
+    def apply(self, cluster_apply_spec: dict, cluster_id: str = None, **kwargs):  # noqa: E501
         """Apply the configuration either to create or update the cluster.
 
         :param dict cluster_config: cluster configuration information
         :return: dictionary containing the apply operation task
         :rtype: dict
         """
+        cluster_name = \
+            self._get_cluster_name_from_cluster_apply_specification(cluster_apply_spec)  # noqa: E501
         entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
-        # TODO: Sikp casting into RDE model before sending API request
-        NativeEntityClass = rde_factory.get_rde_model(self._server_rde_version)
-        cluster_spec = NativeEntityClass(**cluster_config)
-        if self._server_rde_version == rde_constants.RDEVersion.RDE_1_0_0:
-            cluster_name = cluster_spec.metadata.cluster_name
-        else:
-            cluster_name = cluster_spec.metadata.name
         if cluster_id:
             # If cluster id doesn't exist, an exception will be raised
             def_entity = entity_svc.get_entity(cluster_id)
@@ -279,16 +293,19 @@ class DEClusterNative:
             def_entity = entity_svc.get_native_rde_by_name_and_rde_version(
                 cluster_name, self._server_rde_version)
         if not def_entity:
-            cluster_def_entity = self._native_cluster_api.create_cluster(cluster_spec)  # noqa: E501
+            cluster_def_entity = self._native_cluster_api.create_cluster(
+                cluster_apply_spec)
         else:
             cluster_id = def_entity.id
             cluster_def_entity = \
-                self._native_cluster_api.update_cluster_by_cluster_id(cluster_id, cluster_spec)  # noqa: E501
+                self._native_cluster_api.update_cluster_by_cluster_id(
+                    cluster_id, cluster_apply_spec)
         task_href = cluster_def_entity.entity.get_latest_task_href()
         return client_utils.construct_task_console_message(task_href)
 
     def get_cluster_id_by_name(self, cluster_name, org=None, vdc=None):
-        filters = client_utils.construct_filters(org=org, vdc=vdc)
+        filters = client_utils.construct_filters(
+            self._server_rde_version, org=org, vdc=vdc)
         entity_svc = def_entity_svc.DefEntityService(self._cloudapi_client)
         def_entity = entity_svc.get_native_rde_by_name_and_rde_version(
             cluster_name, self._server_rde_version, filters=filters)

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -9,6 +9,7 @@ from pyvcloud.vcd.client import Client
 import pyvcloud.vcd.org as vcd_org
 import pyvcloud.vcd.utils as vcd_utils
 import requests
+import semantic_version
 import six
 from vcd_cli.profiles import Profiles
 from vcd_cli.utils import stdout
@@ -184,12 +185,17 @@ def _override_client(ctx) -> None:
     ctx.obj['profiles'] = profiles
 
 
-def construct_filters(**kwargs):
+def construct_filters(server_rde_version, **kwargs):
+    # NOTE: org and vdc filters need to be camel cased if RDE version > 1.0.0
+    filter_key = def_constants.ClusterEntityFilterKey
+    if semantic_version.Version(server_rde_version) <= \
+            semantic_version.Version(def_constants.RDEVersion.RDE_1_0_0):
+        filter_key = def_constants.ClusterEntityFilterKeyV1
     filters = {}
     if kwargs.get('org'):
-        filters[def_constants.ClusterEntityFilterKey.ORG_NAME.value] = kwargs['org']  # noqa: E501
+        filters[filter_key.ORG_NAME.value] = kwargs['org']  # noqa: E501
     if kwargs.get('vdc'):
-        filters[def_constants.ClusterEntityFilterKey.OVDC_NAME.value] = kwargs['vdc']  # noqa: E501
+        filters[filter_key.OVDC_NAME.value] = kwargs['vdc']  # noqa: E501
     return filters
 
 

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -187,10 +187,10 @@ def _override_client(ctx) -> None:
 
 def construct_filters(server_rde_version, **kwargs):
     # NOTE: org and vdc filters need to be camel cased if RDE version > 1.0.0
-    filter_key = def_constants.ClusterEntityFilterKey
+    filter_key = def_constants.ClusterEntityFilterKey2X
     if semantic_version.Version(server_rde_version) <= \
             semantic_version.Version(def_constants.RDEVersion.RDE_1_0_0):
-        filter_key = def_constants.ClusterEntityFilterKeyV1
+        filter_key = def_constants.ClusterEntityFilterKey1X
     filters = {}
     if kwargs.get('org'):
         filters[filter_key.ORG_NAME.value] = kwargs['org']  # noqa: E501

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -297,7 +297,7 @@ class DefEntityService():
         """
         if not filters:
             filters = {}
-        filters[def_constants.ClusterEntityFilterKey.CLUSTER_NAME.value] = name
+        filters[def_constants.RDEFilterKey.NAME.value] = name
         native_entity_type: DefEntityType = \
             def_utils.get_rde_metadata(version)[def_constants.RDEMetadataKey.ENTITY_TYPE]  # noqa: E501
         for entity in \

--- a/container_service_extension/rde/constants.py
+++ b/container_service_extension/rde/constants.py
@@ -148,7 +148,7 @@ MAP_INPUT_PAYLOAD_VERSION_TO_RDE_VERSION = {
 }
 
 
-class ClusterEntityFilterKeyV1(Enum):
+class ClusterEntityFilterKey1X(Enum):
     """Keys to filter cluster entities in CSE (or) vCD.
 
     NOTE: Use ClusterEntityFilterKeyV1 if RDE version is <= 1.0.0
@@ -173,7 +173,7 @@ class ClusterEntityFilterKeyV1(Enum):
     PHASE = 'entity.status.phase'
 
 
-class ClusterEntityFilterKey(Enum):
+class ClusterEntityFilterKey2X(Enum):
     """Keys to filter cluster entities in CSE (or) vCD.
 
     Below Keys are commonly used filters. An entity can be filtered by any of
@@ -193,6 +193,13 @@ class ClusterEntityFilterKey(Enum):
     K8_DISTRIBUTION = 'entity.spec.k8Distribution.templateName'
     STATE = 'state'
     PHASE = 'entity.status.phase'
+
+
+class RDEFilterKey(Enum):
+    """Keys to filter RDE."""
+
+    NAME = 'name'
+    STATE = 'state'
 
 
 class PayloadKey(str, Enum):

--- a/container_service_extension/rde/constants.py
+++ b/container_service_extension/rde/constants.py
@@ -148,9 +148,11 @@ MAP_INPUT_PAYLOAD_VERSION_TO_RDE_VERSION = {
 }
 
 
-# TODO make changes to use camel case
-class ClusterEntityFilterKey(Enum):
+class ClusterEntityFilterKeyV1(Enum):
     """Keys to filter cluster entities in CSE (or) vCD.
+
+    NOTE: Use ClusterEntityFilterKeyV1 if RDE version is <= 1.0.0
+    else, use ClusterEntityFilterKey
 
     Below Keys are commonly used filters. An entity can be filtered by any of
     its properties.
@@ -167,6 +169,28 @@ class ClusterEntityFilterKey(Enum):
     OVDC_NAME = 'entity.metadata.ovdc_name'
     KIND = 'entity.kind'
     K8_DISTRIBUTION = 'entity.spec.k8_distribution.template_name'
+    STATE = 'state'
+    PHASE = 'entity.status.phase'
+
+
+class ClusterEntityFilterKey(Enum):
+    """Keys to filter cluster entities in CSE (or) vCD.
+
+    Below Keys are commonly used filters. An entity can be filtered by any of
+    its properties.
+
+    Usage examples:
+    ..api/cse/internal/clusters?entity.kind=native
+    ..api/cse/internal/clusters?entity.metadata.orgName=org1
+    ..cloudapi/1.0.0/entities?filter=entity.metadata.orgName==org1
+    """
+
+    # TODO(DEF) CLI can leverage this enum for the filter implementation.
+    CLUSTER_NAME = 'name'
+    ORG_NAME = 'entity.metadata.orgName'
+    OVDC_NAME = 'entity.metadata.ovdcName'
+    KIND = 'entity.kind'
+    K8_DISTRIBUTION = 'entity.spec.k8Distribution.templateName'
     STATE = 'state'
     PHASE = 'entity.status.phase'
 

--- a/container_service_extension/rde/models/abstractNativeEntity.py
+++ b/container_service_extension/rde/models/abstractNativeEntity.py
@@ -17,5 +17,10 @@ class AbstractNativeEntity(abc.ABC):
     def from_cluster_data(cls, cluster: dict, kind: str, **kwargs):
         pass
 
+    @classmethod
+    @abc.abstractmethod
+    def sample_native_entity(cls, k8_runtime=''):
+        pass
+
     def get_latest_task_href(self):
         pass

--- a/container_service_extension/rde/models/rde_1_0_0.py
+++ b/container_service_extension/rde/models/rde_1_0_0.py
@@ -347,3 +347,43 @@ class NativeEntity(AbstractNativeEntity):
 
     def get_latest_task_href(self):
         return self.status.task_href
+
+    @classmethod
+    def sample_native_entity(cls, k8_runtime: str = shared_constants.ClusterEntityKind.NATIVE.value):  # noqa: E501
+        metadata = Metadata('cluster_name', 'organization_name',
+                            'org_virtual_datacenter_name')
+        status = Status()
+        settings = Settings(network='ovdc_network_name', ssh_key=None)
+        k8_distribution = Distribution(
+            template_name='ubuntu-16.04_k8-1.17_weave-2.6.0',
+            template_revision=2
+        )
+        control_plane = ControlPlane(
+            count=1,
+            sizing_class='Large_sizing_policy_name',
+            storage_profile='Gold_storage_profile_name'
+        )
+        workers = Workers(
+            count=2,
+            sizing_class='Medium_sizing_policy_name',
+            storage_profile='Silver_storage_profile'
+        )
+
+        nfs = Nfs(
+            count=0,
+            sizing_class='Large_sizing_policy_name',
+            storage_profile='Platinum_storage_profile_name'
+        )
+
+        cluster_spec = ClusterSpec(
+            control_plane=control_plane,
+            k8_distribution=k8_distribution,
+            settings=settings,
+            workers=workers,
+            nfs=nfs
+        )
+
+        return NativeEntity(metadata=metadata,
+                            spec=cluster_spec,
+                            status=status,
+                            kind=k8_runtime)

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -391,3 +391,44 @@ class NativeEntity(AbstractNativeEntity):
 
     def get_latest_task_href(self):
         return self.status.taskHref
+
+    @classmethod
+    def sample_native_entity(cls, k8_runtime: str = shared_constants.ClusterEntityKind.NATIVE.value):  # noqa: E501
+        metadata = Metadata('cluster_name', 'organization_name',
+                            'org_virtual_datacenter_name', 'VCD_site')
+        status = Status()
+        settings = Settings(network='ovdc_network_name', sshKey=None)
+        k8_distribution = Distribution(
+            templateName='ubuntu-16.04_k8-1.17_weave-2.6.0',
+            templateRevision=2
+        )
+        control_plane = ControlPlane(
+            count=1,
+            sizingClass='Large_sizing_policy_name',
+            storageProfile='Gold_storage_profile_name'
+        )
+        workers = Workers(
+            count=2,
+            sizingClass='Medium_sizing_policy_name',
+            storageProfile='Silver_storage_profile'
+        )
+
+        nfs = Nfs(
+            count=0,
+            sizingClass='Large_sizing_policy_name',
+            storageProfile='Platinum_storage_profile_name'
+        )
+
+        cluster_spec = ClusterSpec(
+            controlPlane=control_plane,
+            k8Distribution=k8_distribution,
+            settings=settings,
+            workers=workers,
+            nfs=nfs
+        )
+
+        return NativeEntity(apiVersion=rde_constants.PAYLOAD_VERSION_2_0,
+                            metadata=metadata,
+                            spec=cluster_spec,
+                            status=status,
+                            kind=k8_runtime)

--- a/container_service_extension/rde/schema_service.py
+++ b/container_service_extension/rde/schema_service.py
@@ -7,6 +7,7 @@ import functools
 import json
 
 from requests.exceptions import HTTPError
+import semantic_version
 
 import container_service_extension.common.constants.shared_constants as cse_shared_constants  # noqa: E501
 import container_service_extension.exception.exceptions as cse_exceptions
@@ -194,6 +195,21 @@ class DefSchemaService():
                     yield common_models.DefEntityType(**entityType)
             else:
                 break
+
+    @handle_schema_service_exception
+    def get_latest_registered_schema_version(self) -> str:
+        """Get the latest registered schema version.
+
+        :return: string representing the latest schema version registered.
+        :rtype: str
+        """
+        max_entity_type_version = None
+        for entity_type in self.list_entity_types():
+            entity_type_version = semantic_version.Version(entity_type.version)
+            if not max_entity_type_version or \
+                    semantic_version.Version(max_entity_type_version) < entity_type_version:  # noqa: E501
+                max_entity_type_version = str(entity_type_version)
+        return max_entity_type_version
 
     @handle_schema_service_exception
     def update_entity_type(self, entity_type: common_models.DefEntityType) -> common_models.DefEntityType:  # noqa: E501

--- a/container_service_extension/rde/schema_service.py
+++ b/container_service_extension/rde/schema_service.py
@@ -203,13 +203,12 @@ class DefSchemaService():
         :return: string representing the latest schema version registered.
         :rtype: str
         """
-        max_entity_type_version = None
+        max_entity_type_version = semantic_version.Version('0.0.0')
         for entity_type in self.list_entity_types():
             entity_type_version = semantic_version.Version(entity_type.version)
-            if not max_entity_type_version or \
-                    semantic_version.Version(max_entity_type_version) < entity_type_version:  # noqa: E501
-                max_entity_type_version = str(entity_type_version)
-        return max_entity_type_version
+            if max_entity_type_version < entity_type_version:  # noqa: E501
+                max_entity_type_version = entity_type_version
+        return str(max_entity_type_version)
 
     @handle_schema_service_exception
     def update_entity_type(self, entity_type: common_models.DefEntityType) -> common_models.DefEntityType:  # noqa: E501


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* Constructing filters in entity_service.py: filters created in entity_service module supports only snake case. Make changes to change the case of the filter string based on RDE version used.
* Sample generator: Generate sample cluster-apply specification based on server-rde version in use.
* Skip converting the input yaml into NativeEntity object before calling create / update endpoints. Only responses sent from the CSE server should be converted into model objects.
* Make sure responses from cluster list populate all the required fields, even if RDE version changes.

@sahithi @sakthisunda @rocknes @ltimothy7 @arunmk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/996)
<!-- Reviewable:end -->
