### PR TITLE
[VCDA-2281] Stamp rde version after install and upgrade in non legacy mode

### DIFF
--- a/container_service_extension/common/utils/core_utils.py
+++ b/container_service_extension/common/utils/core_utils.py
@@ -10,6 +10,7 @@ import pathlib
 import platform
 import stat
 import sys
+from typing import List
 import urllib
 
 import click
@@ -381,3 +382,7 @@ def extract_id_from_href(href):
     if '/' in href:
         return href.split('/')[-1]
     return href
+
+
+def get_max_api_version(api_versions: List[str]) -> float:
+    return max(float(x) for x in api_versions)

--- a/container_service_extension/common/utils/server_utils.py
+++ b/container_service_extension/common/utils/server_utils.py
@@ -47,10 +47,11 @@ def get_rde_version_in_use() -> str:
     :return: rde version
     :rtype: str
     """
-    # TODO(VCDA-2151): Uncomment after new RDE version
-    # is installed
+    # TODO: Currently in many places, this method is used with expected
+    #  return type is string. This should be changed to return semantic version
+    #  with all dependencies changed as well.
     config = get_server_runtime_config()
-    return config['service']['rde_version_in_use']
+    return str(config['service']['rde_version_in_use'])
 
 
 def get_registered_def_entity_type() -> common_models.DefEntityType:

--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -50,6 +50,7 @@ from container_service_extension.lib.telemetry.telemetry_utils import \
 from container_service_extension.lib.uaaclient.uaaclient import UaaClient
 from container_service_extension.logging.logger import NULL_LOGGER
 from container_service_extension.logging.logger import SERVER_NSXT_WIRE_LOGGER
+import container_service_extension.rde.utils as rde_utils
 from container_service_extension.security.encryption_engine import \
     get_decrypted_file_contents
 from container_service_extension.server.pks.pks_cache import Credentials
@@ -225,6 +226,11 @@ def get_validated_config(config_file_name,
     config['feature_flags']['legacy_api'] = str_to_bool(is_legacy_mode)
     config['feature_flags']['non_legacy_api'] = \
         not str_to_bool(is_legacy_mode)
+
+    max_vcd_api_version_supported = \
+        max([float(x) for x in config['service']['supported_api_versions']])  # noqa: E501
+    config['service']['rde_version_in_use'] = \
+        rde_utils.get_runtime_rde_version_by_vcd_api_version(max_vcd_api_version_supported)  # noqa: E501
 
     # Temporary work around before api version is completely removed from
     # config

--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -12,6 +12,7 @@ from pyvcloud.vcd.platform import Platform
 from pyVmomi import vim
 import requests
 from requests.exceptions import HTTPError
+import semantic_version
 from vsphere_guest_run.vsphere import VSphere
 import yaml
 
@@ -26,6 +27,7 @@ from container_service_extension.common.constants.shared_constants import \
 from container_service_extension.common.utils.core_utils import check_file_permissions  # noqa: E501
 from container_service_extension.common.utils.core_utils import check_keys_and_value_types  # noqa: E501
 from container_service_extension.common.utils.core_utils import get_duplicate_items_in_list  # noqa: E501
+from container_service_extension.common.utils.core_utils import get_max_api_version  # noqa: E501
 from container_service_extension.common.utils.core_utils import NullPrinter
 from container_service_extension.common.utils.core_utils import str_to_bool
 from container_service_extension.common.utils.server_utils import should_use_mqtt_protocol  # noqa: E501
@@ -227,10 +229,10 @@ def get_validated_config(config_file_name,
     config['feature_flags']['non_legacy_api'] = \
         not str_to_bool(is_legacy_mode)
 
-    max_vcd_api_version_supported = \
-        max([float(x) for x in config['service']['supported_api_versions']])  # noqa: E501
-    config['service']['rde_version_in_use'] = \
-        rde_utils.get_runtime_rde_version_by_vcd_api_version(max_vcd_api_version_supported)  # noqa: E501
+    max_vcd_api_version_supported = get_max_api_version(config['service']['supported_api_versions'])  # noqa: E501
+    config['service']['rde_version_in_use'] = semantic_version.Version(
+        rde_utils.get_runtime_rde_version_by_vcd_api_version(
+            max_vcd_api_version_supported))
 
     # Temporary work around before api version is completely removed from
     # config

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -335,7 +335,7 @@ def install_cse(config_file_name, config, skip_template_creation,
         if server_utils.should_use_mqtt_protocol(config):
             _register_cse_as_mqtt_extension(
                 client,
-                rde_version_in_use=config['service']['rde_version_in_use'],
+                rde_version_in_use=semantic_version.Version(config['service']['rde_version_in_use']),  # noqa: E501
                 msg_update_callback=msg_update_callback)  # noqa: E501
         else:
             # create amqp exchange if it doesn't exist
@@ -350,7 +350,7 @@ def install_cse(config_file_name, config, skip_template_creation,
                 client=client,
                 routing_key=amqp['routing_key'],
                 exchange=amqp['exchange'],
-                rde_version_in_use=config['service']['rde_version_in_use'],
+                rde_version_in_use=semantic_version.Version(config['service']['rde_version_in_use']),  # noqa: E501
                 msg_update_callback=msg_update_callback)
 
             # register rights to vCD
@@ -1874,13 +1874,13 @@ def _update_cse_extension(client, config,
             _deregister_cse_amqp_extension(client)
             _register_cse_as_mqtt_extension(
                 client,
-                rde_version_in_use=semantic_version.Version("0.0.0"),
-                msg_update_callback=msg_update_callback)
+                rde_version_in_use=semantic_version.Version(config['service']['rde_version_in_use']),  # noqa: E501
+                msg_update_callback=msg_update_callback)  # noqa: E501
         elif existing_ext_type == server_constants.ExtensionType.MQTT:
             # Remove api filters and update description
             _update_cse_mqtt_extension(
                 client,
-                rde_version_in_use=config['service']['rde_version_in_use'],
+                rde_version_in_use=semantic_version.Version(config['service']['rde_version_in_use']),  # noqa: E501
                 msg_update_callback=msg_update_callback)
     else:
         # Update amqp exchange
@@ -1898,7 +1898,7 @@ def _update_cse_extension(client, config,
             client=client,
             routing_key=config['amqp']['routing_key'],
             exchange=config['amqp']['exchange'],
-            rde_version_in_use=config['service']['rde_version_in_use'],
+            rde_version_in_use=semantic_version.Version(config['service']['rde_version_in_use']),  # noqa: E501
             msg_update_callback=msg_update_callback)
 
 

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -335,7 +335,7 @@ def install_cse(config_file_name, config, skip_template_creation,
         if server_utils.should_use_mqtt_protocol(config):
             _register_cse_as_mqtt_extension(
                 client,
-                rde_version_in_use=semantic_version.Version(config['service']['rde_version_in_use']),  # noqa: E501
+                rde_version_in_use=config['service']['rde_version_in_use'],
                 msg_update_callback=msg_update_callback)  # noqa: E501
         else:
             # create amqp exchange if it doesn't exist
@@ -350,7 +350,7 @@ def install_cse(config_file_name, config, skip_template_creation,
                 client=client,
                 routing_key=amqp['routing_key'],
                 exchange=amqp['exchange'],
-                rde_version_in_use=semantic_version.Version(config['service']['rde_version_in_use']),  # noqa: E501
+                rde_version_in_use=config['service']['rde_version_in_use'],
                 msg_update_callback=msg_update_callback)
 
             # register rights to vCD
@@ -1185,8 +1185,7 @@ def _register_def_schema(client: Client,
                                                                     logger_debug=INSTALL_LOGGER,  # noqa: E501
                                                                     logger_wire=logger_wire)  # noqa: E501
     # TODO update CSE install to create client from max_vcd_api_version
-    max_vcd_api_version_supported = \
-        max([float(x) for x in config['service']['supported_api_versions']])
+    max_vcd_api_version_supported = utils.get_max_api_version(config['service']['supported_api_versions'])   # noqa: E501
     try:
         def_utils.raise_error_if_def_not_supported(cloudapi_client)
         rde_version: str = \
@@ -1874,13 +1873,13 @@ def _update_cse_extension(client, config,
             _deregister_cse_amqp_extension(client)
             _register_cse_as_mqtt_extension(
                 client,
-                rde_version_in_use=semantic_version.Version(config['service']['rde_version_in_use']),  # noqa: E501
-                msg_update_callback=msg_update_callback)  # noqa: E501
+                rde_version_in_use=config['service']['rde_version_in_use'],
+                msg_update_callback=msg_update_callback)
         elif existing_ext_type == server_constants.ExtensionType.MQTT:
             # Remove api filters and update description
             _update_cse_mqtt_extension(
                 client,
-                rde_version_in_use=semantic_version.Version(config['service']['rde_version_in_use']),  # noqa: E501
+                rde_version_in_use=config['service']['rde_version_in_use'],
                 msg_update_callback=msg_update_callback)
     else:
         # Update amqp exchange
@@ -1898,7 +1897,7 @@ def _update_cse_extension(client, config,
             client=client,
             routing_key=config['amqp']['routing_key'],
             exchange=config['amqp']['exchange'],
-            rde_version_in_use=semantic_version.Version(config['service']['rde_version_in_use']),  # noqa: E501
+            rde_version_in_use=config['service']['rde_version_in_use'],
             msg_update_callback=msg_update_callback)
 
 
@@ -2272,8 +2271,7 @@ def _upgrade_non_legacy_clusters(
     entity_svc = def_entity_svc.DefEntityService(cloudapi_client)
     schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
 
-    max_vcd_api_version_supported = \
-        max([float(x) for x in config['service']['supported_api_versions']])
+    max_vcd_api_version_supported = utils.get_max_api_version(config['service']['supported_api_versions'])  # noqa: E501
     # TODO: get proper site information
     site = config['vcd']['host']
     runtime_rde_version: str = \
@@ -2349,8 +2347,7 @@ def _upgrade_legacy_clusters(
     entity_svc = def_entity_svc.DefEntityService(cloudapi_client)
     schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
 
-    max_vcd_api_version_supported = \
-        max([float(x) for x in config['service']['supported_api_versions']])
+    max_vcd_api_version_supported = utils.get_max_api_version(config['service']['supported_api_versions'])   # noqa: E501
     # TODO: get proper site information
     site = config['vcd']['host']
     runtime_rde_version: str = \

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -1916,8 +1916,9 @@ def _upgrade_to_cse_3_1_non_legacy(client, config,
         components were not installed correctly
     """
     is_tkg_plus_enabled = server_utils.is_tkg_plus_enabled(config=config)
+
     # This check should be done before registering def schema
-    def_entity_type_found = _def_entity_type_found(client=client)
+    def_entity_type_registered = _is_def_entity_type_registered(client=client)
 
     # Add global placement policies
     _setup_placement_policies(
@@ -1980,7 +1981,7 @@ def _upgrade_to_cse_3_1_non_legacy(client, config,
     # designed to gate cluster deployment and has no play once the cluster has
     # been deployed.
 
-    if def_entity_type_found:
+    if def_entity_type_registered:
         _upgrade_non_legacy_clusters(
             client=client,
             config=config,
@@ -2533,8 +2534,8 @@ def _print_users_in_need_of_def_rights(
         INSTALL_LOGGER.info(msg)
 
 
-def _def_entity_type_found(client):
-    """Check the presence of native entity type.
+def _is_def_entity_type_registered(client):
+    """Check the presence of native entity type of any version.
 
     :param client:
     :return: True if present else False

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -725,8 +725,6 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
                 ssh_key=ssh_key,
                 msg_update_callback=msg_update_callback)
         else:
-            # ToDo : Depending on the determined RDE version we should have
-            #  two separate upgrade paths
             _upgrade_to_cse_3_1_non_legacy(
                 client=client,
                 config=config,
@@ -1918,6 +1916,8 @@ def _upgrade_to_cse_3_1_non_legacy(client, config,
         components were not installed correctly
     """
     is_tkg_plus_enabled = server_utils.is_tkg_plus_enabled(config=config)
+    # This check should be done before registering def schema
+    def_entity_type_found = _def_entity_type_found(client=client)
 
     # Add global placement policies
     _setup_placement_policies(
@@ -1980,14 +1980,21 @@ def _upgrade_to_cse_3_1_non_legacy(client, config,
     # designed to gate cluster deployment and has no play once the cluster has
     # been deployed.
 
-    # Create DEF entity for all existing clusters (if missing)
-    _upgrade_or_create_def_entity_for_existing_clusters(
-        client=client,
-        config=config,
-        cse_clusters=clusters,
-        msg_update_callback=msg_update_callback,
-        is_tkg_plus_enabled=is_tkg_plus_enabled,
-        log_wire=log_wire)
+    if def_entity_type_found:
+        _upgrade_non_legacy_clusters(
+            client=client,
+            config=config,
+            cse_clusters=clusters,
+            msg_update_callback=msg_update_callback,
+            log_wire=log_wire)
+    else:
+        _upgrade_legacy_clusters(
+            client=client,
+            config=config,
+            cse_clusters=clusters,
+            is_tkg_plus_enabled=is_tkg_plus_enabled,
+            msg_update_callback=msg_update_callback,
+            log_wire=log_wire)
 
     # Print list of users categorized by org, who currently owns CSE clusters
     # and will need DEF entity rights.
@@ -2244,14 +2251,14 @@ def _remove_old_cse_sizing_compute_policies(
             INSTALL_LOGGER.error(msg)
 
 
-def _upgrade_or_create_def_entity_for_existing_clusters(
+def _upgrade_non_legacy_clusters(
         client,
         config,
         cse_clusters,
-        is_tkg_plus_enabled,
         msg_update_callback=utils.NullPrinter(),
         log_wire=False):
-    msg = "Making old CSE k8s clusters compatible with CSE 3.1"
+
+    msg = "Upgrading non legacy CSE k8s clusters compatible with CSE 3.1"
     msg_update_callback.info(msg)
     INSTALL_LOGGER.info(msg)
 
@@ -2301,7 +2308,57 @@ def _upgrade_or_create_def_entity_for_existing_clusters(
         except Exception as err:
             INSTALL_LOGGER.debug(str(err))
 
-        # The code below creates defined-entity for api 33/34 native clusters
+    msg = "Finished processing all clusters."
+    INSTALL_LOGGER.info(msg)
+    msg_update_callback.general(msg)
+
+    # Remove old entity types
+    msg = "Removing old native entity types"
+    INSTALL_LOGGER.info(msg)
+    msg_update_callback.general(msg)
+    try:
+        native_entity_types = _get_native_def_entity_types(client)
+        for entity_type in native_entity_types:
+            if entity_type.id != target_entity_type.id:
+                msg = f"Deleting entity type: {entity_type.id}"
+                INSTALL_LOGGER.info(msg)
+                msg_update_callback.general(msg)
+                schema_svc.delete_entity_type(entity_type.id)
+    except Exception as err:
+        INSTALL_LOGGER.debug(str(err))
+
+
+def _upgrade_legacy_clusters(
+        client,
+        config,
+        cse_clusters,
+        is_tkg_plus_enabled,
+        msg_update_callback=utils.NullPrinter(),
+        log_wire=False):
+    msg = "Upgrading legacy CSE k8s clusters compatible with CSE 3.1"
+    msg_update_callback.info(msg)
+    INSTALL_LOGGER.info(msg)
+
+    logger_wire = SERVER_CLOUDAPI_WIRE_LOGGER if log_wire else NULL_LOGGER
+    cloudapi_client = vcd_utils.get_cloudapi_client_from_vcd_client(
+        client=client,
+        logger_debug=INSTALL_LOGGER,
+        logger_wire=logger_wire)
+
+    entity_svc = def_entity_svc.DefEntityService(cloudapi_client)
+    schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
+
+    max_vcd_api_version_supported = \
+        max([float(x) for x in config['service']['supported_api_versions']])
+    # TODO: get proper site information
+    site = config['vcd']['host']
+    runtime_rde_version: str = \
+        def_utils.get_runtime_rde_version_by_vcd_api_version(max_vcd_api_version_supported)  # noqa: E501
+    rde_metadata: dict = def_utils.get_rde_metadata(runtime_rde_version)
+    entity_type_metadata = rde_metadata[def_constants.RDEMetadataKey.ENTITY_TYPE]  # noqa: E501
+    target_entity_type = schema_svc.get_entity_type(entity_type_metadata.get_id())  # noqa: E501
+
+    for cluster in cse_clusters:
         try:
             policy_name = _get_placement_policy_name_from_template_name(
                 cluster['template_name'])
@@ -2379,7 +2436,7 @@ def _create_cluster_rde(client, cluster, kind, runtime_rde_version,
             id=org_urn)
     except Exception as err:
         INSTALL_LOGGER.debug(str(err))
-        msg = "Unable to determine current owner of cluster '{cluster['name']}'. Unable to process ownership."  # noqa: E501
+        msg = f"Unable to determine current owner of cluster '{cluster['name']}'. Unable to process ownership."  # noqa: E501
         msg_update_callback.info(msg)
         INSTALL_LOGGER.info(msg)
 
@@ -2474,3 +2531,32 @@ def _print_users_in_need_of_def_rights(
         msg = msg + org_users_msg
         msg_update_callback.info(msg)
         INSTALL_LOGGER.info(msg)
+
+
+def _def_entity_type_found(client):
+    """Check the presence of native entity type.
+
+    :param client:
+    :return: True if present else False
+    :rtype: bool
+    """
+    try:
+        return True if len(_get_native_def_entity_types(client)) > 0 else False  # noqa: E501
+    except cse_exception.DefNotSupportedException:
+        return False
+
+
+def _get_native_def_entity_types(client):
+    """Get list of native entity types.
+
+    :param client:
+    :return: list of native entity types
+    :rtype: list
+    """
+    cloudapi_client = vcd_utils.get_cloudapi_client_from_vcd_client(
+        client=client,
+        logger_debug=INSTALL_LOGGER
+    )
+    schema_svc = def_schema_svc.DefSchemaService(cloudapi_client)
+    return [entity_type for entity_type in schema_svc.list_entity_types()
+            if entity_type.nss == def_constants.Nss.NATIVE_ClUSTER.value]

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -335,8 +335,8 @@ def install_cse(config_file_name, config, skip_template_creation,
         if server_utils.should_use_mqtt_protocol(config):
             _register_cse_as_mqtt_extension(
                 client,
-                rde_version_in_use=semantic_version.Version("0.0.0"),
-                msg_update_callback=msg_update_callback)
+                rde_version_in_use=config['service']['rde_version_in_use'],
+                msg_update_callback=msg_update_callback)  # noqa: E501
         else:
             # create amqp exchange if it doesn't exist
             amqp = config['amqp']
@@ -350,7 +350,7 @@ def install_cse(config_file_name, config, skip_template_creation,
                 client=client,
                 routing_key=amqp['routing_key'],
                 exchange=amqp['exchange'],
-                rde_version_in_use=semantic_version.Version("0.0.0"),
+                rde_version_in_use=config['service']['rde_version_in_use'],
                 msg_update_callback=msg_update_callback)
 
             # register rights to vCD
@@ -1882,7 +1882,7 @@ def _update_cse_extension(client, config,
             # Remove api filters and update description
             _update_cse_mqtt_extension(
                 client,
-                rde_version_in_use=semantic_version.Version("0.0.0"),
+                rde_version_in_use=config['service']['rde_version_in_use'],
                 msg_update_callback=msg_update_callback)
     else:
         # Update amqp exchange
@@ -1900,7 +1900,7 @@ def _update_cse_extension(client, config,
             client=client,
             routing_key=config['amqp']['routing_key'],
             exchange=config['amqp']['exchange'],
-            rde_version_in_use=semantic_version.Version("0.0.0"),
+            rde_version_in_use=config['service']['rde_version_in_use'],
             msg_update_callback=msg_update_callback)
 
 
@@ -2003,9 +2003,6 @@ def _upgrade_to_cse_3_1_legacy(
         msg_update_callback=utils.NullPrinter()):
     """Handle upgrade when no support from VCD for RDE.
 
-    :raises: MultipleRecordsException: (when using mqtt) if more than one
-        service with the given name and namespace are found when trying to
-        delete the amqp-based extension.
     :raises cse_exception.AmqpError: (when using AMQP) if AMQP exchange
         could not be created.
     """

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -18,6 +18,7 @@ from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
+import semantic_version
 
 import container_service_extension.common.constants.server_constants as server_constants  # noqa: E501
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -141,8 +141,8 @@ def verify_version_compatibility(
             "it in legacy mode."
 
     if not ext_in_legacy_mode and ext_rde_in_use < runtime_rde_version:
-        error_msg += f"Supported Server RDE version ({runtime_rde_version}) " \
-            f"is higher than the previously installed RDE version " \
+        error_msg += f"Installed CSE RDE version ({runtime_rde_version}) " \
+            f"is lower than the supported Server RDE version " \
             f"({ext_rde_in_use}). Upgrade CSE to update RDE."
 
     if error_msg:

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -105,12 +105,13 @@ def verify_version_compatibility(
         should_cse_run_in_legacy_mode: bool,
         is_mqtt_extension: bool):
     cse_version = server_utils.get_installed_cse_version()
+    runtime_rde_version = semantic_version.Version(server_utils.get_rde_version_in_use())  # noqa: E501
 
     dikt = configure_cse.parse_cse_extension_description(
         sysadmin_client, is_mqtt_extension)
     ext_cse_version = dikt[server_constants.CSE_VERSION_KEY]
     ext_in_legacy_mode = dikt[server_constants.LEGACY_MODE_KEY]
-    # ext_rde_in_use = dikt[server_constants.RDE_VERSION_IN_USE_KEY]
+    ext_rde_in_use = dikt[server_constants.RDE_VERSION_IN_USE_KEY]
 
     # version data doesn't exist, so installed CSE is <= 2.6.1
     if ext_cse_version == server_constants.UNKNOWN_CSE_VERSION:
@@ -139,7 +140,10 @@ def verify_version_compatibility(
             "Installed CSE is configured in non-legacy mode. Unable to run " \
             "it in legacy mode."
 
-    # ToDo : RDE version check
+    if not ext_in_legacy_mode and ext_rde_in_use < runtime_rde_version:
+        error_msg += f"Supported Server RDE version ({runtime_rde_version}) " \
+            f"is higher than the previously installed RDE version " \
+            f"({ext_rde_in_use}). Upgrade CSE to update RDE."
 
     if error_msg:
         raise cse_exception.VersionCompatibilityError(error_msg)
@@ -488,11 +492,6 @@ class Service(object, metaclass=Singleton):
                                                               logger_wire)
             raise_error_if_def_not_supported(cloudapi_client)
 
-            # set the RDE version used
-            max_vcd_api_version_supported = \
-                max([float(x) for x in self.config['service']['supported_api_versions']])  # noqa: E501
-            self.config['service']['rde_version_in_use'] = \
-                def_utils.get_runtime_rde_version_by_vcd_api_version(max_vcd_api_version_supported)  # noqa: E501
             server_rde_version = server_utils.get_rde_version_in_use()
             msg_update_callback.general(f"Using RDE version: {server_rde_version}")  # noqa: E501
 


### PR DESCRIPTION
-  Stamp rde version : install and upgrade in non-legacy mode
-  cse run : suggest to upgrade if rde version in extension < runtime rde version to upgrade to
-  Tested with install, upgrade and run command
-  This PR has extra code that is already under review: [VCDA-2285] Enable cse 3.0 legacy to cse 3.1 legacy upgrade. This is required for testing
- Remove old entity types after upgrade
- Testing completed

@Anirudh9794 @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/999)
<!-- Reviewable:end -->
