### PR TITLE
[VCDA-2314] Skip sizing class and storage profile validation if node count is 0

### DIFF
--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -126,7 +126,7 @@ class DefEntityOperationStatus(str, Enum):
 
 
 @unique
-class FlattenedClusterSPecKey1X(Enum):
+class FlattenedClusterSpecKey1X(Enum):
     WORKERS_COUNT = 'workers.count'
     NFS_COUNT = 'nfs.count'
     TEMPLATE_NAME = 'k8_distribution.template_name'

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -126,18 +126,30 @@ class DefEntityOperationStatus(str, Enum):
 
 
 @unique
-class FlattenedClusterSpecKey(Enum):
+class FlattenedClusterSPecKey1X(Enum):
     WORKERS_COUNT = 'workers.count'
     NFS_COUNT = 'nfs.count'
     TEMPLATE_NAME = 'k8_distribution.template_name'
     TEMPLATE_REVISION = 'k8_distribution.template_revision'
-    TEMPLATE_NAME_CAMEL = 'k8Distribution.templateName'
-    TEMPLATE_REVISION_CAMEL = 'k8Distribution.templateRevision'
 
 
-VALID_UPDATE_FIELDS = [FlattenedClusterSpecKey.WORKERS_COUNT.value, FlattenedClusterSpecKey.NFS_COUNT.value,  # noqa: E501
-                       FlattenedClusterSpecKey.TEMPLATE_NAME.value, FlattenedClusterSpecKey.TEMPLATE_REVISION.value,  # noqa: E501
-                       FlattenedClusterSpecKey.TEMPLATE_NAME_CAMEL.value, FlattenedClusterSpecKey.TEMPLATE_REVISION_CAMEL.value]  # noqa: E501
+@unique
+class FlattenedClusterSpecKey2X(Enum):
+    WORKERS_COUNT = 'workers.count'
+    WORKERS_SIZING_CLASS = 'workers.sizingClass'
+    WORKERS_STORAGE_PROFILE = 'workers.storageProfile'
+    NFS_COUNT = 'nfs.count'
+    NFS_SIZING_CLASS = 'nfs.sizingClass'
+    NFS_STORAGE_PROFILE = 'nfs.storageProfile'
+    TEMPLATE_NAME = 'k8Distribution.templateName'
+    TEMPLATE_REVISION = 'k8Distribution.templateRevision'
+
+
+VALID_UPDATE_FIELDS_2X = \
+    [FlattenedClusterSpecKey2X.WORKERS_COUNT.value,
+     FlattenedClusterSpecKey2X.NFS_COUNT.value,
+     FlattenedClusterSpecKey2X.TEMPLATE_NAME.value,
+     FlattenedClusterSpecKey2X.TEMPLATE_REVISION.value]
 
 
 CLUSTER_ENTITY = 'cluster_entity'

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -43,10 +43,10 @@ class Workers:
 
 @dataclass()
 class Distribution:
-    templateName: str = ""
-    templateRevision: int = 0
+    templateName: str = None
+    templateRevision: int = None
 
-    def __init__(self, templateName: str = '', templateRevision: int = 0, **kwargs):  # noqa: E501
+    def __init__(self, templateName: str = None, templateRevision: int = None, **kwargs):  # noqa: E501
         self.templateName = templateName
         self.templateRevision = templateRevision
 

--- a/container_service_extension/rde/validators/validator_rde_2_x.py
+++ b/container_service_extension/rde/validators/validator_rde_2_x.py
@@ -5,8 +5,8 @@
 from dataclasses import asdict
 
 
-from container_service_extension.common.constants.server_constants import FlattenedClusterSpecKey  # noqa: E501
-from container_service_extension.common.constants.server_constants import VALID_UPDATE_FIELDS  # noqa: E501
+from container_service_extension.common.constants.server_constants import FlattenedClusterSpecKey2X  # noqa: E501
+from container_service_extension.common.constants.server_constants import VALID_UPDATE_FIELDS_2X  # noqa: E501
 from container_service_extension.exception.exceptions import BadRequestError
 from container_service_extension.lib.cloudapi.cloudapi_client import CloudApiClient  # noqa: E501
 from container_service_extension.rde.behaviors.behavior_model import BehaviorOperation  # noqa: E501
@@ -14,6 +14,7 @@ from container_service_extension.rde.common.entity_service import DefEntityServi
 import container_service_extension.rde.constants as rde_constants
 from container_service_extension.rde.models import rde_factory
 from container_service_extension.rde.models.abstractNativeEntity import AbstractNativeEntity  # noqa: E501
+import container_service_extension.rde.models.rde_2_0_0 as rde_2_0_0
 import container_service_extension.rde.utils as rde_utils
 from container_service_extension.rde.validators.abstract_validator import AbstractValidator  # noqa: E501
 
@@ -80,12 +81,13 @@ class Validator_2_0_0(AbstractValidator):
                 rde_utils.construct_cluster_spec_from_entity_status(
                     current_entity_status, rde_constants.RDEVersion.RDE_2_0_0.value)  # noqa: E501
         return validate_cluster_update_request_and_check_cluster_upgrade(
-            asdict(input_entity_spec),
-            asdict(current_entity_spec))
+            input_entity_spec,
+            current_entity_spec)
         raise NotImplementedError(f"Validator for {operation.name} not found")
 
 
-def validate_cluster_update_request_and_check_cluster_upgrade(input_spec: dict, reference_spec: dict) -> bool:  # noqa: E501
+def validate_cluster_update_request_and_check_cluster_upgrade(input_spec: rde_2_0_0.ClusterSpec,  # noqa: E501
+                                                              reference_spec: rde_2_0_0.ClusterSpec) -> bool:  # noqa: E501
     """Validate the desired spec with curr spec and check if upgrade operation.
 
     :param dict input_spec: input spec
@@ -95,31 +97,42 @@ def validate_cluster_update_request_and_check_cluster_upgrade(input_spec: dict, 
     :rtype: bool
     :raises: BadRequestError for invalid payload.
     """
+    exclude_fields = []
+    if reference_spec.workers.count == 0:
+        # Exclude worker nodes' sizing class and storage profile from
+        # validation if worker count is 0
+        exclude_fields.append(FlattenedClusterSpecKey2X.WORKERS_SIZING_CLASS.value)  # noqa: E501
+        exclude_fields.append(FlattenedClusterSpecKey2X.WORKERS_STORAGE_PROFILE.value)  # noqa: E501
+    if reference_spec.nfs.count == 0:
+        # Exclude nfs nodes' sizing class and storage profile from validation
+        # if nfs count is 0
+        exclude_fields.append(FlattenedClusterSpecKey2X.NFS_SIZING_CLASS.value)
+        exclude_fields.append(FlattenedClusterSpecKey2X.NFS_STORAGE_PROFILE.value)  # noqa: E501
+
+    input_spec_dict = asdict(input_spec)
+    reference_spec_dict = asdict(reference_spec)
     diff_fields = \
-        rde_utils.find_diff_fields(input_spec, reference_spec, exclude_fields=[])  # noqa: E501
+        rde_utils.find_diff_fields(input_spec_dict, reference_spec_dict, exclude_fields=exclude_fields)  # noqa: E501
 
     # Raise exception if empty diff
     if not diff_fields:
         raise BadRequestError("No change in cluster specification")  # noqa: E501
 
     # Raise exception if fields which cannot be changed are updated
-    keys_with_invalid_value = [k for k in diff_fields if k not in VALID_UPDATE_FIELDS]  # noqa: E501
+    keys_with_invalid_value = \
+        [k for k in diff_fields if k not in VALID_UPDATE_FIELDS_2X]
     if len(keys_with_invalid_value) > 0:
         err_msg = f"Invalid input values found in {sorted(keys_with_invalid_value)}"  # noqa: E501
         raise BadRequestError(err_msg)
 
     is_resize_operation = False
-    if FlattenedClusterSpecKey.WORKERS_COUNT.value in diff_fields or \
-            FlattenedClusterSpecKey.NFS_COUNT.value in diff_fields:
+    if FlattenedClusterSpecKey2X.WORKERS_COUNT.value in diff_fields or \
+            FlattenedClusterSpecKey2X.NFS_COUNT.value in diff_fields:
         is_resize_operation = True
     is_upgrade_operation = False
 
-    # TODO use a single spec key enum and do regex substitution to convert to
-    #   camel case based on RDE version in use.
-    if FlattenedClusterSpecKey.TEMPLATE_NAME.value in diff_fields or \
-            FlattenedClusterSpecKey.TEMPLATE_REVISION.value in diff_fields or \
-            FlattenedClusterSpecKey.TEMPLATE_NAME_CAMEL.value in diff_fields or \
-            FlattenedClusterSpecKey.TEMPLATE_REVISION_CAMEL.value in diff_fields:  # noqa: E501
+    if FlattenedClusterSpecKey2X.TEMPLATE_NAME.value in diff_fields or \
+            FlattenedClusterSpecKey2X.TEMPLATE_REVISION.value in diff_fields:
         is_upgrade_operation = True
 
     # Raise exception if resize and upgrade are performed at the same time

--- a/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 from dataclasses import asdict
 
-from container_service_extension.common.constants.server_constants import FlattenedClusterSPecKey1X  # noqa: E501
+from container_service_extension.common.constants.server_constants import FlattenedClusterSpecKey1X  # noqa: E501
 from container_service_extension.common.constants.server_constants import ThreadLocalData  # noqa: E501
 from container_service_extension.common.constants.shared_constants import ClusterAclKey  # noqa: E501
 from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
@@ -160,8 +160,8 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     curr_entity = svc.entity_svc.get_entity(cluster_id)
     request_utils.validate_request_payload(
         asdict(converted_native_entity.spec), asdict(curr_entity.entity.spec),
-        exclude_fields=[FlattenedClusterSPecKey1X.TEMPLATE_NAME.value,
-                        FlattenedClusterSPecKey1X.TEMPLATE_REVISION.value])
+        exclude_fields=[FlattenedClusterSpecKey1X.TEMPLATE_NAME.value,
+                        FlattenedClusterSpecKey1X.TEMPLATE_REVISION.value])
     new_rde: common_models.DefEntity = svc.upgrade_cluster(cluster_id, converted_native_entity)  # noqa: E501
     # convert the upgraded rde back to input rde version
     new_native_entity: AbstractNativeEntity = rde_utils.convert_runtime_rde_to_input_rde_version_format(  # noqa: E501

--- a/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
@@ -65,8 +65,8 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     curr_entity = svc.entity_svc.get_entity(cluster_id)
     request_utils.validate_request_payload(
         asdict(converted_native_entity.spec), asdict(curr_entity.entity.spec),
-        exclude_fields=[FlattenedClusterSPecKey1X.WORKERS_COUNT.value,
-                        FlattenedClusterSPecKey1X.NFS_COUNT.value])
+        exclude_fields=[FlattenedClusterSpecKey1X.WORKERS_COUNT.value,
+                        FlattenedClusterSpecKey1X.NFS_COUNT.value])
     new_rde: common_models.DefEntity = svc.resize_cluster(cluster_id, converted_native_entity)  # noqa: E501
     # convert the resized rde back to input rde version
     new_native_entity: AbstractNativeEntity = rde_utils.convert_runtime_rde_to_input_rde_version_format(  # noqa: E501

--- a/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 from dataclasses import asdict
 
-from container_service_extension.common.constants.server_constants import FlattenedClusterSpecKey  # noqa: E501
+from container_service_extension.common.constants.server_constants import FlattenedClusterSPecKey1X  # noqa: E501
 from container_service_extension.common.constants.server_constants import ThreadLocalData  # noqa: E501
 from container_service_extension.common.constants.shared_constants import ClusterAclKey  # noqa: E501
 from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
@@ -65,8 +65,8 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     curr_entity = svc.entity_svc.get_entity(cluster_id)
     request_utils.validate_request_payload(
         asdict(converted_native_entity.spec), asdict(curr_entity.entity.spec),
-        exclude_fields=[FlattenedClusterSpecKey.WORKERS_COUNT.value,
-                        FlattenedClusterSpecKey.NFS_COUNT.value])
+        exclude_fields=[FlattenedClusterSPecKey1X.WORKERS_COUNT.value,
+                        FlattenedClusterSPecKey1X.NFS_COUNT.value])
     new_rde: common_models.DefEntity = svc.resize_cluster(cluster_id, converted_native_entity)  # noqa: E501
     # convert the resized rde back to input rde version
     new_native_entity: AbstractNativeEntity = rde_utils.convert_runtime_rde_to_input_rde_version_format(  # noqa: E501
@@ -160,8 +160,8 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     curr_entity = svc.entity_svc.get_entity(cluster_id)
     request_utils.validate_request_payload(
         asdict(converted_native_entity.spec), asdict(curr_entity.entity.spec),
-        exclude_fields=[FlattenedClusterSpecKey.TEMPLATE_NAME.value,
-                        FlattenedClusterSpecKey.TEMPLATE_REVISION.value])
+        exclude_fields=[FlattenedClusterSPecKey1X.TEMPLATE_NAME.value,
+                        FlattenedClusterSPecKey1X.TEMPLATE_REVISION.value])
     new_rde: common_models.DefEntity = svc.upgrade_cluster(cluster_id, converted_native_entity)  # noqa: E501
     # convert the upgraded rde back to input rde version
     new_native_entity: AbstractNativeEntity = rde_utils.convert_runtime_rde_to_input_rde_version_format(  # noqa: E501


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* Set defaults for k8 template name and revision to None. This enables the user to skip validation on template name and revision by sending empty values if no change in the field is desired.
* Skip validation on workers.sizingClass, workers.storageProfile, nfs.sizingClass and nfs.storageProfile if number of workers or number of nfs nodes in the entity status is 0

@sakthisunda @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1001)
<!-- Reviewable:end -->
