### PR TITLE
[PR] Fix double conversion of CSE version string to semantic version

### DIFF
--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -18,7 +18,6 @@ from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
-import semantic_version
 
 import container_service_extension.common.constants.server_constants as server_constants  # noqa: E501
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
@@ -109,8 +108,7 @@ def verify_version_compatibility(
 
     dikt = configure_cse.parse_cse_extension_description(
         sysadmin_client, is_mqtt_extension)
-    ext_cse_version = \
-        semantic_version.Version(dikt[server_constants.CSE_VERSION_KEY])
+    ext_cse_version = dikt[server_constants.CSE_VERSION_KEY]
     ext_in_legacy_mode = dikt[server_constants.LEGACY_MODE_KEY]
     # ext_rde_in_use = dikt[server_constants.RDE_VERSION_IN_USE_KEY]
 


### PR DESCRIPTION
- Fix double conversion of CSE version string.
- Double conversion of CSE version string to semantic version causes `cse run ` failure. 
- Replacing the wrong commit. 
- Manually verified

@Anirudh9794 @rocknes @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1002)
<!-- Reviewable:end -->
