### PR TITLE
Fix `cse template list`

### DIFF
--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -1564,7 +1564,7 @@ def _get_unvalidated_config(config_file_path,
 def _get_clients_from_config(config, log_wire_file, log_wire):
     client = vcd_client.Client(
         config['vcd']['host'],
-        api_version=config['vcd']['api_version'],
+        api_version=config['vcd'].get('api_version'),
         verify_ssl_certs=config['vcd']['verify'],
         log_file=log_wire_file,
         log_requests=log_wire,


### PR DESCRIPTION
Command throws error if `api_version` key is not found in the config file. As of CSE 3.1 the key is not supported in the config file, so we must not be relying on it's presence. This PR removes the hard dependency, and uses the default value of None while creating pyvcloud client, which will choose the highest supported api version.

This problem only occurs if the config file is not validated before use. In case of validated config file, internally CSE sets the correct value of 'api_version' key in the run time config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1006)
<!-- Reviewable:end -->
