### PR TITLE
[VCDA-2318] Enabled hooks as part of Entity type registration.

### DIFF
--- a/container_service_extension/developer_guide.md
+++ b/container_service_extension/developer_guide.md
@@ -1,0 +1,84 @@
+# Check-list
+
+This is the checklist of steps to be performed at the beginning of each 
+release cycle of CSE.
+
+# Server
+
+## API versioning
+(To be updated by Aritra)
+Update the CSE server supported API version set - (file references)
+
+## API endpoints
+(To be updated by Aritra)
+Guidelines on
+- how to edit the request dispatcher maps.
+- when to add a new endpoint.
+- rules to follow to maintain backward compatibility
+
+## RDE
+RDEs offer persistence in VCD for otherwise CSE's K8 clusters. It contains two 
+parts a)the latest desired state expressed by the user b)the current state of the cluster. 
+
+Versioning terminology:
+- Runtime RDE version represents the RDE version chosen by the CSE server to 
+  represent the clusters. It varies depending on the VCD version that is configured with CSE server. 
+  For example, a)when CSE 3.1 is configured with VCD 10.2, RDE 1.0 becomes CSE 3.1's runtime RDE version.
+  b)when CSE 3.1 is configured with VCD 10.3, RDE 2.0 becomes CSE 3.1's runtime RDE version.
+- 2.X represents the latest minor version under the given major version line 
+- 2.1 literally represents the 2.1 version.
+  
+Versioning guidelines:
+- Based on the anticipated schema changes and its dependencies on VCD version, 
+  determine whether major or minor version needs to be bumped up. 
+  Use https://semver.org/ for versioning guidelines. In short, bump up the 
+  major version only when there is an addition of new required properties, deletion of 
+  existing required properties or strict dependency on features of a particular VCD version.
+- The goal must be always to provide the latest features (newer RDE versions) 
+  on older versions of VCD. When this cannot be achieved for any reason, that 
+  is an indication to bump up the major version.
+  
+Steps:
+1. Create new schema file under /cse_def_schema/schema_x_y_z.json.
+2. Update below classes and tables for the finalized RDE version. There could 
+   be more trivial constructs to be updated. Updating the below should lead you 
+   to the other constructs. Below can be found in ../rde/constants.py and ../rde/common_models.py
+   - class SchemaFile(Enum): represents the Schema file to be used for a given RDE version
+   - class EntityType(Enum): represents the Entity Type for a given RDE version
+   - class RuntimeRDEVersion(Enum): represents the RDE version to be used for a given major version line.
+   - MAP_VCD_API_VERSION_TO_RUNTIME_RDE_VERSION: dictates the RDE version to be used by the CSE server at runtime based on the VCD version it is configured with.
+   - MAP_RDE_VERSION_TO_ITS_METADATA: dictates the constructs to be registered at the time of installation and upgrade for a given RDE version.
+   - MAP_VCD_API_VERSION_TO_RDE_VERSION: Maps the RDE version introduced at a given API version
+   - MAP_INPUT_PAYLOAD_VERSION_TO_RDE_VERSION: maps the payload version string to the rde version.
+
+## CSE Install
+1. RDE schema registration - Ensure right runtime RDE version is chosen and 
+   right schema is registered - container_service_extension.installer.configure_cse._register_def_schema
+   
+## CSE Upgrade
+(To be updated by Aritra and Sakthi)
+1. RDE schema registration - Ensure right runtime RDE version is chosen and 
+   right schema is registered - container_service_extension.installer.configure_cse._register_def_schema
+2. Open new upgrade paths (references and guidelines - to be updated)
+3. Upgrade existing RDE instances to newer runtime RDE chosen by the server (references and guidelines - to be updated)
+
+## CSE start-up
+(To be updated by Aniruddha)
+1. Determine the CSE server API version at runtime.
+2. Ensure right runtime RDE version is loaded into the config variable.
+3. Ensure the templates' metadata is correctly loaded into config variable.
+    
+## Telemetry
+(To be filled by Sakthi)
+
+# CLI
+(To be updated by Aritra sen and Aniruddha)
+1. Auto-negotiate the VCD api version to be used to communicate with CSE server.
+   - Update the CSE CLI supported API version set.
+2. Dynamically compute the RDE version to use based on the CSE server side configuration.
+
+# Template management
+(To be updated by Aniruddha)
+1. Update min and max versions of CSE version in each of the template definition
+   at https://github.com/vmware/container-service-extension-templates/blob/upgrades/template_v2.yaml
+2. Ensure metadata on existing templates is updated correctly during the upgrade process.

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -283,11 +283,11 @@ def install_cse(config_file_name, config, skip_template_creation,
         INSTALL_LOGGER.info(msg)
 
         ext_type = _get_existing_extension_type(client)
-        if ext_type != server_constants.ExtensionType.NONE:
-            ext_found_msg = f"{ext_type} extension found. Use `cse upgrade` " \
-                            f"instead of 'cse install'."
-            INSTALL_LOGGER.error(ext_found_msg)
-            raise Exception(ext_found_msg)
+        # if ext_type != server_constants.ExtensionType.NONE:
+        #     ext_found_msg = f"{ext_type} extension found. Use `cse upgrade` " \
+        #                     f"instead of 'cse install'."
+        #     INSTALL_LOGGER.error(ext_found_msg)
+        #     raise Exception(ext_found_msg)
 
         # register cse def schema on VCD
         _register_def_schema(client=client, config=config,
@@ -1203,15 +1203,16 @@ def _register_def_schema(client: Client,
             rde_metadata[def_constants.RDEMetadataKey.INTERFACES]
         _register_interfaces(cloudapi_client, interfaces, msg_update_callback)
 
-        # Register Native EntityType
-        entity_type: common_models.DefEntityType = \
-            rde_metadata[def_constants.RDEMetadataKey.ENTITY_TYPE]
-        _register_native_entity_type(cloudapi_client, entity_type, msg_update_callback)  # noqa: E501
-
         # Register Behavior(s)
         behavior_metadata: Dict[str, List[Behavior]] = rde_metadata.get(
             def_constants.RDEMetadataKey.INTERFACE_TO_BEHAVIORS_MAP, {})
         _register_behaviors(cloudapi_client, behavior_metadata, msg_update_callback)  # noqa: E501
+
+        # Register Native EntityType
+        entity_type: common_models.DefEntityType = \
+            rde_metadata[def_constants.RDEMetadataKey.ENTITY_TYPE]
+        _register_native_entity_type(cloudapi_client, entity_type,
+                                     msg_update_callback)  # noqa: E501
 
         # Override Behavior(s)
         override_behavior_metadata: Dict[str, List[Behavior]] = \

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -283,11 +283,11 @@ def install_cse(config_file_name, config, skip_template_creation,
         INSTALL_LOGGER.info(msg)
 
         ext_type = _get_existing_extension_type(client)
-        # if ext_type != server_constants.ExtensionType.NONE:
-        #     ext_found_msg = f"{ext_type} extension found. Use `cse upgrade` " \
-        #                     f"instead of 'cse install'."
-        #     INSTALL_LOGGER.error(ext_found_msg)
-        #     raise Exception(ext_found_msg)
+        if ext_type != server_constants.ExtensionType.NONE:
+            ext_found_msg = f"{ext_type} extension found. Use `cse upgrade` " \
+                            f"instead of 'cse install'."
+            INSTALL_LOGGER.error(ext_found_msg)
+            raise Exception(ext_found_msg)
 
         # register cse def schema on VCD
         _register_def_schema(client=client, config=config,

--- a/container_service_extension/rde/models/common_models.py
+++ b/container_service_extension/rde/models/common_models.py
@@ -6,6 +6,7 @@ from enum import Enum
 from enum import unique
 from typing import List
 
+from dataclasses_json import dataclass_json, Undefined
 
 from container_service_extension.common.constants import shared_constants as shared_constants  # noqa: E501
 from container_service_extension.rde import utils as def_utils
@@ -44,6 +45,7 @@ class DefInterface:
             return self.id
 
 
+@dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass(frozen=True)
 class DefEntityType:
     """Represents the schema for Defined Entities."""
@@ -287,17 +289,23 @@ class EntityType(Enum):
                                              vendor=Vendor.CSE.value,
                                              nss=Nss.NATIVE_ClUSTER.value,
                                              description='')
-    NATIVE_ENTITY_TYPE_2_0_0 = DefEntityType(name='nativeClusterEntityType',
-                                             id=f"{DEF_ENTITY_TYPE_ID_PREFIX}:{Vendor.CSE.value}:{Nss.NATIVE_ClUSTER}:2.0.0",  # noqa: E501
-                                             schema=load_rde_schema(
-                                                 SchemaFile.SCHEMA_2_0_0),
-                                             interfaces=[
-                                                 K8Interface.VCD_INTERFACE.value.id,  # noqa: E501
-                                                 K8Interface.CSE_INTERFACE.value.id],  # noqa: E501
-                                             version='2.0.0',
-                                             vendor=Vendor.CSE.value,
-                                             nss=Nss.NATIVE_ClUSTER.value,
-                                             description='')
+    NATIVE_ENTITY_TYPE_2_0_0 = DefEntityType2_0(name='nativeClusterEntityType',
+                                                id=f"{DEF_ENTITY_TYPE_ID_PREFIX}:{Vendor.CSE.value}:{Nss.NATIVE_ClUSTER}:2.0.0",  # noqa: E501
+                                                schema=load_rde_schema(SchemaFile.SCHEMA_2_0_0),  # noqa: E501
+                                                interfaces=[
+                                                    K8Interface.VCD_INTERFACE.value.id,  # noqa: E501
+                                                    K8Interface.CSE_INTERFACE.value.id],  # noqa: E501
+                                                version='2.0.0',
+                                                vendor=Vendor.CSE.value,
+                                                nss=Nss.NATIVE_ClUSTER.value,
+                                                description='',
+                                                # TODO Uncomment this portion when the behavior integration is complete.  # noqa: E501
+                                                #  Uncommenting below, today (Apr 16,2021), will break the existing native api endpoints.  # noqa: E501
+                                                # hooks={
+                                                #     'PostCreate': BehaviorOperation.CREATE_CLUSTER.value.id,  # noqa: E501
+                                                #     'PostUpdate': BehaviorOperation.UPDATE_CLUSTER.value.id,  # noqa: E501
+                                                #     'PreDelete': BehaviorOperation.DELETE_CLUSTER.value.id}  # noqa: E501
+                                                )
     TKG_ENTITY_TYPE_1_0_0 = DefEntityType(name='TKG Cluster',
                                           id=f"{DEF_ENTITY_TYPE_ID_PREFIX}:{Vendor.VMWARE.value}:{Nss.TKG}:1.0.0",  # noqa: E501
                                           schema='',

--- a/container_service_extension/rde/models/common_models.py
+++ b/container_service_extension/rde/models/common_models.py
@@ -300,7 +300,7 @@ class EntityType(Enum):
                                                 nss=Nss.NATIVE_ClUSTER.value,
                                                 description='',
                                                 # TODO Uncomment this portion when the behavior integration is complete.  # noqa: E501
-                                                #  Uncommenting below, today (Apr 16,2021), will break the existing native api endpoints.  # noqa: E501
+                                                #  Uncommenting below, today(Apr 16,2021), will break the existing native api endpoints.  # noqa: E501
                                                 # hooks={
                                                 #     'PostCreate': BehaviorOperation.CREATE_CLUSTER.value.id,  # noqa: E501
                                                 #     'PostUpdate': BehaviorOperation.UPDATE_CLUSTER.value.id,  # noqa: E501

--- a/container_service_extension/rde/models/common_models.py
+++ b/container_service_extension/rde/models/common_models.py
@@ -74,6 +74,13 @@ class DefEntityType:
             return self.id
 
 
+@dataclass(frozen=True)
+class DefEntityType2_0(DefEntityType):
+    """Represents the schema for Defined Entities."""
+
+    hooks: dict = None
+
+
 @dataclass()
 class Owner:
     name: str = None

--- a/container_service_extension/rde/schema_service.py
+++ b/container_service_extension/rde/schema_service.py
@@ -159,7 +159,7 @@ class DefSchemaService():
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}",
             payload=asdict(entity_type))
-        return common_models.DefEntityType(**response_body)
+        return common_models.DefEntityType2_0(**response_body)
 
     @handle_schema_service_exception
     def get_entity_type(self, id: str) -> common_models.DefEntityType:
@@ -173,7 +173,7 @@ class DefSchemaService():
             method=cse_shared_constants.RequestMethod.GET,
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}/{id}")
-        return common_models.DefEntityType(**response_body)
+        return common_models.DefEntityType2_0(**response_body)
 
     @handle_schema_service_exception
     def list_entity_types(self):
@@ -192,7 +192,7 @@ class DefSchemaService():
                 f"page={page_num}")
             if len(response_body['values']) > 0:
                 for entityType in response_body['values']:
-                    yield common_models.DefEntityType(**entityType)
+                    yield common_models.DefEntityType2_0(**entityType)
             else:
                 break
 

--- a/container_service_extension/rde/schema_service.py
+++ b/container_service_extension/rde/schema_service.py
@@ -159,7 +159,7 @@ class DefSchemaService():
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}",
             payload=asdict(entity_type))
-        return common_models.DefEntityType2_0(**response_body)
+        return common_models.DefEntityType(**response_body)
 
     @handle_schema_service_exception
     def get_entity_type(self, id: str) -> common_models.DefEntityType:
@@ -173,7 +173,7 @@ class DefSchemaService():
             method=cse_shared_constants.RequestMethod.GET,
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}/{id}")
-        return common_models.DefEntityType2_0(**response_body)
+        return common_models.DefEntityType(**response_body)
 
     @handle_schema_service_exception
     def list_entity_types(self):
@@ -192,7 +192,7 @@ class DefSchemaService():
                 f"page={page_num}")
             if len(response_body['values']) > 0:
                 for entityType in response_body['values']:
-                    yield common_models.DefEntityType2_0(**entityType)
+                    yield common_models.DefEntityType(**entityType)
             else:
                 break
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,6 @@ vcd-cli >= 24.0.1, < 25.0.0
 
 # vsphere-guest-run 0.0.7
 vsphere-guest-run >= 0.0.7, < 1.0.0
+
+# dataclasses-json
+dataclasses-json >= 0.5.2, < 1.0.0


### PR DESCRIPTION
1. Included Hooks as part of Entity type schema (Uncommented the hooks portion, for now, to avoid breaking native API endpoints). This must be uncommented when the cluster CRUD with behaviors is fully ready.
2. Tested it.

How to test hooks on your environment:
- Please uncomment hooks in container_service_extension/rde/models/common_models.py:292
- Delete the existing Entity type and rerun the 'cse install' command.
- Create/update/delete RDE and it should hit the behavior_dispatcher.py workflow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1011)
<!-- Reviewable:end -->
