### PR TITLE
[VCDA-2318] Enabled hooks as part of Entity type registration

### DIFF
--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -283,11 +283,11 @@ def install_cse(config_file_name, config, skip_template_creation,
         INSTALL_LOGGER.info(msg)
 
         ext_type = _get_existing_extension_type(client)
-        if ext_type != server_constants.ExtensionType.NONE:
-            ext_found_msg = f"{ext_type} extension found. Use `cse upgrade` " \
-                            f"instead of 'cse install'."
-            INSTALL_LOGGER.error(ext_found_msg)
-            raise Exception(ext_found_msg)
+        # if ext_type != server_constants.ExtensionType.NONE:
+        #     ext_found_msg = f"{ext_type} extension found. Use `cse upgrade` " \
+        #                     f"instead of 'cse install'."
+        #     INSTALL_LOGGER.error(ext_found_msg)
+        #     raise Exception(ext_found_msg)
 
         # register cse def schema on VCD
         _register_def_schema(client=client, config=config,
@@ -1203,15 +1203,16 @@ def _register_def_schema(client: Client,
             rde_metadata[def_constants.RDEMetadataKey.INTERFACES]
         _register_interfaces(cloudapi_client, interfaces, msg_update_callback)
 
-        # Register Native EntityType
-        entity_type: common_models.DefEntityType = \
-            rde_metadata[def_constants.RDEMetadataKey.ENTITY_TYPE]
-        _register_native_entity_type(cloudapi_client, entity_type, msg_update_callback)  # noqa: E501
-
         # Register Behavior(s)
         behavior_metadata: Dict[str, List[Behavior]] = rde_metadata.get(
             def_constants.RDEMetadataKey.INTERFACE_TO_BEHAVIORS_MAP, {})
         _register_behaviors(cloudapi_client, behavior_metadata, msg_update_callback)  # noqa: E501
+
+        # Register Native EntityType
+        entity_type: common_models.DefEntityType = \
+            rde_metadata[def_constants.RDEMetadataKey.ENTITY_TYPE]
+        _register_native_entity_type(cloudapi_client, entity_type,
+                                     msg_update_callback)  # noqa: E501
 
         # Override Behavior(s)
         override_behavior_metadata: Dict[str, List[Behavior]] = \

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -283,11 +283,11 @@ def install_cse(config_file_name, config, skip_template_creation,
         INSTALL_LOGGER.info(msg)
 
         ext_type = _get_existing_extension_type(client)
-        # if ext_type != server_constants.ExtensionType.NONE:
-        #     ext_found_msg = f"{ext_type} extension found. Use `cse upgrade` " \
-        #                     f"instead of 'cse install'."
-        #     INSTALL_LOGGER.error(ext_found_msg)
-        #     raise Exception(ext_found_msg)
+        if ext_type != server_constants.ExtensionType.NONE:
+            ext_found_msg = f"{ext_type} extension found. Use `cse upgrade` " \
+                            f"instead of 'cse install'."
+            INSTALL_LOGGER.error(ext_found_msg)
+            raise Exception(ext_found_msg)
 
         # register cse def schema on VCD
         _register_def_schema(client=client, config=config,

--- a/container_service_extension/rde/models/common_models.py
+++ b/container_service_extension/rde/models/common_models.py
@@ -6,6 +6,7 @@ from enum import Enum
 from enum import unique
 from typing import List
 
+from dataclasses_json import dataclass_json, Undefined
 
 from container_service_extension.common.constants import shared_constants as shared_constants  # noqa: E501
 from container_service_extension.rde import utils as def_utils
@@ -44,6 +45,7 @@ class DefInterface:
             return self.id
 
 
+@dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass(frozen=True)
 class DefEntityType:
     """Represents the schema for Defined Entities."""
@@ -287,17 +289,23 @@ class EntityType(Enum):
                                              vendor=Vendor.CSE.value,
                                              nss=Nss.NATIVE_ClUSTER.value,
                                              description='')
-    NATIVE_ENTITY_TYPE_2_0_0 = DefEntityType(name='nativeClusterEntityType',
-                                             id=f"{DEF_ENTITY_TYPE_ID_PREFIX}:{Vendor.CSE.value}:{Nss.NATIVE_ClUSTER}:2.0.0",  # noqa: E501
-                                             schema=load_rde_schema(
-                                                 SchemaFile.SCHEMA_2_0_0),
-                                             interfaces=[
-                                                 K8Interface.VCD_INTERFACE.value.id,  # noqa: E501
-                                                 K8Interface.CSE_INTERFACE.value.id],  # noqa: E501
-                                             version='2.0.0',
-                                             vendor=Vendor.CSE.value,
-                                             nss=Nss.NATIVE_ClUSTER.value,
-                                             description='')
+    NATIVE_ENTITY_TYPE_2_0_0 = DefEntityType2_0(name='nativeClusterEntityType',
+                                                id=f"{DEF_ENTITY_TYPE_ID_PREFIX}:{Vendor.CSE.value}:{Nss.NATIVE_ClUSTER}:2.0.0",  # noqa: E501
+                                                schema=load_rde_schema(SchemaFile.SCHEMA_2_0_0),  # noqa: E501
+                                                interfaces=[
+                                                    K8Interface.VCD_INTERFACE.value.id,  # noqa: E501
+                                                    K8Interface.CSE_INTERFACE.value.id],  # noqa: E501
+                                                version='2.0.0',
+                                                vendor=Vendor.CSE.value,
+                                                nss=Nss.NATIVE_ClUSTER.value,
+                                                description='',
+                                                # TODO Uncomment this portion when the behavior integration is complete.  # noqa: E501
+                                                #  Uncommenting below, today (Apr 16,2021), will break the existing native api endpoints.  # noqa: E501
+                                                # hooks={
+                                                #     'PostCreate': BehaviorOperation.CREATE_CLUSTER.value.id,  # noqa: E501
+                                                #     'PostUpdate': BehaviorOperation.UPDATE_CLUSTER.value.id,  # noqa: E501
+                                                #     'PreDelete': BehaviorOperation.DELETE_CLUSTER.value.id}  # noqa: E501
+                                                )
     TKG_ENTITY_TYPE_1_0_0 = DefEntityType(name='TKG Cluster',
                                           id=f"{DEF_ENTITY_TYPE_ID_PREFIX}:{Vendor.VMWARE.value}:{Nss.TKG}:1.0.0",  # noqa: E501
                                           schema='',

--- a/container_service_extension/rde/models/common_models.py
+++ b/container_service_extension/rde/models/common_models.py
@@ -48,7 +48,7 @@ class DefInterface:
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass(frozen=True)
 class DefEntityType:
-    """Represents the schema for Defined Entities."""
+    """Defined Entity type schema for the apiVersion = 35.0"""
 
     name: str
     description: str
@@ -78,7 +78,7 @@ class DefEntityType:
 
 @dataclass(frozen=True)
 class DefEntityType2_0(DefEntityType):
-    """Defined Entity type schema for the apiVersion>=36.0."""
+    """Defined Entity type schema for the apiVersion = 36.0."""
 
     hooks: dict = None
 
@@ -298,7 +298,7 @@ class EntityType(Enum):
                                                 version='2.0.0',
                                                 vendor=Vendor.CSE.value,
                                                 nss=Nss.NATIVE_ClUSTER.value,
-                                                description='',
+                                                description=''
                                                 # TODO Uncomment this portion when the behavior integration is complete.  # noqa: E501
                                                 #  Uncommenting below, today (Apr 16,2021), will break the existing native api endpoints.  # noqa: E501
                                                 # hooks={

--- a/container_service_extension/rde/models/common_models.py
+++ b/container_service_extension/rde/models/common_models.py
@@ -78,7 +78,7 @@ class DefEntityType:
 
 @dataclass(frozen=True)
 class DefEntityType2_0(DefEntityType):
-    """Represents the schema for Defined Entities."""
+    """Defined Entity type schema for the apiVersion>=36.0."""
 
     hooks: dict = None
 

--- a/container_service_extension/rde/models/common_models.py
+++ b/container_service_extension/rde/models/common_models.py
@@ -48,7 +48,7 @@ class DefInterface:
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass(frozen=True)
 class DefEntityType:
-    """Defined Entity type schema for the apiVersion = 35.0"""
+    """Defined Entity type schema for the apiVersion = 35.0."""
 
     name: str
     description: str

--- a/container_service_extension/rde/models/common_models.py
+++ b/container_service_extension/rde/models/common_models.py
@@ -74,6 +74,13 @@ class DefEntityType:
             return self.id
 
 
+@dataclass(frozen=True)
+class DefEntityType2_0(DefEntityType):
+    """Represents the schema for Defined Entities."""
+
+    hooks: dict = None
+
+
 @dataclass()
 class Owner:
     name: str = None

--- a/container_service_extension/rde/schema_service.py
+++ b/container_service_extension/rde/schema_service.py
@@ -159,7 +159,7 @@ class DefSchemaService():
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}",
             payload=asdict(entity_type))
-        return common_models.DefEntityType(**response_body)
+        return common_models.DefEntityType2_0(**response_body)
 
     @handle_schema_service_exception
     def get_entity_type(self, id: str) -> common_models.DefEntityType:
@@ -173,7 +173,7 @@ class DefSchemaService():
             method=cse_shared_constants.RequestMethod.GET,
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}/{id}")
-        return common_models.DefEntityType(**response_body)
+        return common_models.DefEntityType2_0(**response_body)
 
     @handle_schema_service_exception
     def list_entity_types(self):
@@ -192,7 +192,7 @@ class DefSchemaService():
                 f"page={page_num}")
             if len(response_body['values']) > 0:
                 for entityType in response_body['values']:
-                    yield common_models.DefEntityType(**entityType)
+                    yield common_models.DefEntityType2_0(**entityType)
             else:
                 break
 

--- a/container_service_extension/rde/schema_service.py
+++ b/container_service_extension/rde/schema_service.py
@@ -159,7 +159,7 @@ class DefSchemaService():
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}",
             payload=asdict(entity_type))
-        return common_models.DefEntityType2_0(**response_body)
+        return common_models.DefEntityType(**response_body)
 
     @handle_schema_service_exception
     def get_entity_type(self, id: str) -> common_models.DefEntityType:
@@ -173,7 +173,7 @@ class DefSchemaService():
             method=cse_shared_constants.RequestMethod.GET,
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}/{id}")
-        return common_models.DefEntityType2_0(**response_body)
+        return common_models.DefEntityType(**response_body)
 
     @handle_schema_service_exception
     def list_entity_types(self):
@@ -192,7 +192,7 @@ class DefSchemaService():
                 f"page={page_num}")
             if len(response_body['values']) > 0:
                 for entityType in response_body['values']:
-                    yield common_models.DefEntityType2_0(**entityType)
+                    yield common_models.DefEntityType(**entityType)
             else:
                 break
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,6 @@ vcd-cli >= 24.0.1, < 25.0.0
 
 # vsphere-guest-run 0.0.7
 vsphere-guest-run >= 0.0.7, < 1.0.0
+
+# dataclasses-json
+dataclasses-json >= 0.5.2, < 1.0.0


### PR DESCRIPTION
1. Included Hooks as part of Entity type schema (Uncommented the hooks portion, for now, to avoid breaking native API endpoints). This must be uncommented when the cluster CRUD with behaviors is fully ready.
2. Tested it.

How to test hooks on your environment:

1. Please uncomment hooks in container_service_extension/rde/models/common_models.py:292
2. Delete the existing Entity type and rerun the 'cse install' command.
3. Create/update/delete RDE and it should hit the behavior_dispatcher.py workflow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1012)
<!-- Reviewable:end -->
