### PR TITLE
[VCDA-2322] Modified the success payload as per the new guidelines from DEF

### DIFF
--- a/container_service_extension/mqi/consumer/mqtt_publisher.py
+++ b/container_service_extension/mqi/consumer/mqtt_publisher.py
@@ -77,7 +77,7 @@ class MQTTPublisher:
             if progress:
                 payload['progress'] = progress
         elif status == 'success':
-            payload['result'] = message
+            payload['result'] = {'resultContent': message}
         elif status == 'error':
             payload['error'] = error_details
         return payload
@@ -92,7 +92,6 @@ class MQTTPublisher:
         :return: Behavior response
         :rtype: dict
         """
-        status = payload['status']
         response_json = {
             "type": "BEHAVIOR_RESPONSE",
             "headers": {
@@ -102,8 +101,6 @@ class MQTTPublisher:
             },
             "payload": json.dumps(payload)
         }
-        if status == 'success':
-            del response_json['headers']['contentType']
         return response_json
 
     def send_response(self, response_json):


### PR DESCRIPTION
1. Modified the success payload as per the new guidelines from DEF. Success payload can be sent out with the same contentType as for other status' like running and error.
2. Tested it in CSE-VCD environment with hook-based behaviors.

- (Optional) Names of reviewers using @ sign + name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1017)
<!-- Reviewable:end -->
