### PR TITLE
[VCDA-2316] Extract out entity status updates to a separate funciton

### DIFF
--- a/container_service_extension/mqi/consumer/mqtt_publisher.py
+++ b/container_service_extension/mqi/consumer/mqtt_publisher.py
@@ -64,7 +64,7 @@ class MQTTPublisher:
         {'majorErrorCode':'500','minorErrorCode':None,'message':None}
         :param str message: Task update message
         :param str status: Status of the task to be updated.
-        :param str progress:
+        :param int progress:
 
         :return: The constructed task payload.
         :rtype: dict

--- a/container_service_extension/rde/backend/cluster_service_2_x_behaviors.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_behaviors.py
@@ -404,7 +404,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         # trigger async operation
         self.context.is_async = True
         self._monitor_resize(cluster_id=cluster_id,
-                             cluster_spec=input_native_entity)
+                             input_native_entity=input_native_entity)
         # TODO(test-resize): verify if multiple messages are not published
         #   in update_cluster()
         return self.mqtt_publisher.construct_behavior_payload(
@@ -463,8 +463,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         # NOTE: The async method will mark the task as succeeded which will
         # allow the RDE framework to delete the cluster defined entity
         self._delete_cluster_async(cluster_name=cluster_name,
-                                   org_name=org_name, ovdc_name=ovdc_name,
-                                   def_entity=curr_entity)
+                                   org_name=org_name, ovdc_name=ovdc_name)
         return self.mqtt_publisher.construct_behavior_payload(
             message=CLUSTER_DELETE_IN_PROGRESS_MESSAGE,
             status=BehaviorTaskStatus.RUNNING.value, progress='5')
@@ -1748,7 +1747,7 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         # update the cluster_rde with external_id if provided by the caller
         if external_id:
-            cluster_rde.entity.externalId = external_id
+            cluster_rde.externalId = external_id
         # Update entity status with new values
         cluster_rde.entity.status = native_entity_status
 

--- a/container_service_extension/rde/backend/cluster_service_2_x_behaviors.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_behaviors.py
@@ -60,10 +60,10 @@ import container_service_extension.server.compute_policy_manager as compute_poli
 DEFAULT_API_VERSION = vcd_client.ApiVersion.VERSION_36.value
 
 
-CLUSTER_CREATE_IN_PROGRESS_MESSAGE = 'create_cluster_in_progress'
-CLUSTER_RESIZE_IN_PROGRESS_MESSAGE = 'resize_cluster_in_progress'
-CLUSTER_DELETE_IN_PROGRESS_MESSAGE = 'delete_cluster_in_progress'
-CLUSTER_UPGRADE_IN_PROGRESS_MESSAGE = 'upgrade_cluster_in_progress'
+CLUSTER_CREATE_IN_PROGRESS_MESSAGE = 'Create cluster in progress'
+CLUSTER_RESIZE_IN_PROGRESS_MESSAGE = 'Resize cluster in progress'
+CLUSTER_DELETE_IN_PROGRESS_MESSAGE = 'Delete cluster in progress'
+CLUSTER_UPGRADE_IN_PROGRESS_MESSAGE = 'Upgrade cluster in progress'
 
 
 class ClusterService(abstract_broker.AbstractBroker):
@@ -323,6 +323,7 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         :rtype: DefEntity
         """
+        # TODO: Make use of current entity in the behavior payload
         # NOTE: It is always better to do a get on the entity to make use of
         # existing entity status. This guarantees that operations performed
         # are relevant.
@@ -404,12 +405,15 @@ class ClusterService(abstract_broker.AbstractBroker):
         self.context.is_async = True
         self._monitor_resize(cluster_id=cluster_id,
                              cluster_spec=input_native_entity)
+        # TODO(test-resize): verify if multiple messages are not published
+        #   in update_cluster()
         return self.mqtt_publisher.construct_behavior_payload(
             message=CLUSTER_RESIZE_IN_PROGRESS_MESSAGE,
             status=BehaviorTaskStatus.RUNNING.value, progress=5)
 
     def delete_cluster(self, cluster_id):
         """Start the delete cluster operation."""
+        # TODO: Make use of current entity in the behavior payload
         # Get entity required here to get the org and vdc in which the cluster
         # is present
         curr_entity: common_models.DefEntity = self.entity_svc.get_entity(
@@ -473,6 +477,7 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         :rtype: List[Dict]
         """
+        # TODO: Make use of current entity in the behavior payload
         # Get entity required here to retrieve the cluster upgrade plan
         curr_entity = self.entity_svc.get_entity(cluster_id)
         curr_native_entity: rde_2_x.NativeEntity = curr_entity.entity
@@ -501,6 +506,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         :return: Defined entity with upgrade in progress set
         :rtype: def_models.DefEntity representing the cluster
         """
+        # TODO: Make use of current entity in the behavior payload
         curr_entity = self.entity_svc.get_entity(cluster_id)
         curr_native_entity: rde_2_x.NativeEntity = curr_entity.entity
         cluster_name = curr_native_entity.metadata.name
@@ -572,6 +578,8 @@ class ClusterService(abstract_broker.AbstractBroker):
         self.context.is_async = True
         self._upgrade_cluster_async(cluster_id=cluster_id,
                                     template=template)
+        # TODO(test-upgrade): Verify if multiple messages are not published
+        #   in update_cluster()
         return self.mqtt_publisher.construct_behavior_payload(
             message=CLUSTER_UPGRADE_IN_PROGRESS_MESSAGE,
             status=BehaviorTaskStatus.RUNNING.value, progress=5)
@@ -607,7 +615,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         desired_template_revision = input_native_entity.spec.k8_distribution.template_revision  # noqa: E501
         if current_template_name != desired_template_name or current_template_revision != desired_template_revision:  # noqa: E501
             return self.upgrade_cluster(cluster_id, input_native_entity)
-        exceptions.CseServerError("update not supported for the specified input specification")  # noqa: E501
+        raise exceptions.CseServerError("update not supported for the specified input specification")  # noqa: E501
 
     def get_cluster_acl_info(self, cluster_id, page: int, page_size: int):
         """Get cluster ACL info based on the defined entity ACL."""
@@ -689,6 +697,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         """Start the delete nodes operation."""
         if nodes_to_del is None:
             nodes_to_del = []
+        # TODO: Make use of current entity in the behavior payload
         # get_entity() call needed here to get the cluster details
         curr_entity: common_models.DefEntity = self.entity_svc.get_entity(
             cluster_id)

--- a/container_service_extension/rde/backend/cluster_service_2_x_behaviors.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_behaviors.py
@@ -217,8 +217,8 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         **telemetry: Optional
 
-        :return: Defined entity of the cluster
-        :rtype: common_models.DefEntity
+        :return: dictionary representing mqtt response published
+        :rtype: dict
         """
         cluster_name = input_native_entity.metadata.name
         org_name = input_native_entity.metadata.org_name
@@ -321,7 +321,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         :return: DefEntity of the cluster with the updated operation status
         and task_href.
 
-        :rtype: DefEntity
+        :rtype: dict
         """
         # TODO: Make use of current entity in the behavior payload
         # NOTE: It is always better to do a get on the entity to make use of
@@ -503,8 +503,8 @@ class ClusterService(abstract_broker.AbstractBroker):
         :param rde_2_x.NativeEntity input_native_entity: cluster spec with new
             kubernetes distribution and revision
 
-        :return: Defined entity with upgrade in progress set
-        :rtype: def_models.DefEntity representing the cluster
+        :return: dictionary representing mqtt response published
+        :rtype: dict
         """
         # TODO: Make use of current entity in the behavior payload
         curr_entity = self.entity_svc.get_entity(cluster_id)
@@ -516,7 +516,7 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         # check if cluster is in a valid state
         phase: DefEntityPhase = DefEntityPhase.from_phase(
-            input_native_entity.status.phase)
+            curr_native_entity.status.phase)
 
         if state != def_constants.DEF_RESOLVED_STATE or phase.is_entity_busy():
             raise exceptions.CseServerError(
@@ -594,8 +594,8 @@ class ClusterService(abstract_broker.AbstractBroker):
         :param rde_2_x.NativeEntity input_native_entity: cluster spec with new
         worker/nfs node count or new kubernetes distribution and revision
 
-        :return: Defined entity with update in progress set
-        :rtype: def_models.DefEntity representing the cluster
+        :return: dictionary representing mqtt response published
+        :rtype: dict
         """
         current_spec: rde_2_x.ClusterSpec = \
             def_utils.construct_cluster_spec_from_entity_status(

--- a/container_service_extension/rde/backend/cluster_service_2_x_behaviors.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_behaviors.py
@@ -1713,7 +1713,6 @@ class ClusterService(abstract_broker.AbstractBroker):
                 cluster_id)
         if not curr_entity.externalId and not vapp:
             return curr_entity
-        vapp_id = curr_entity.externalId
         if not vapp:
             client_v36 = self.context.get_client(
                 api_version=DEFAULT_API_VERSION)

--- a/container_service_extension/rde/models/common_models.py
+++ b/container_service_extension/rde/models/common_models.py
@@ -77,10 +77,36 @@ class DefEntityType:
             return self.id
 
 
-class DefEntityType2_0(DefEntityType):
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass(frozen=True)
+class DefEntityType2_0:
     """Defined Entity type schema for the apiVersion = 36.0."""
 
+    name: str
+    description: str
+    schema: dict
+    interfaces: List[str]
+    version: str
+    id: str = None
+    externalId: Optional[str] = None
+    readonly: bool = False
+    vendor: str = Vendor.CSE.value
+    nss: str = Nss.NATIVE_CLUSTER.value
     hooks: dict = None
+
+    def get_id(self):
+        """Get or generate entity type id.
+
+        Example : "urn:vcloud:interface:cse.native:1.0.0
+
+        By no means, id generation in this method, guarantees the actual
+        entity type registration with vCD.
+        """
+        if self.id is None:
+            return def_utils.\
+                generate_entity_type_id(self.vendor, self.nss, self.version)
+        else:
+            return self.id
 
 
 @dataclass_json
@@ -303,13 +329,13 @@ class EntityType(Enum):
                                                 version='2.0.0',
                                                 vendor=Vendor.CSE.value,
                                                 nss=Nss.NATIVE_CLUSTER.value,
-                                                description=''
+                                                description='',
                                                 # TODO Uncomment this portion when the behavior integration is complete.  # noqa: E501
                                                 #  Uncommenting below, today (Apr 16,2021), will break the existing native api endpoints.  # noqa: E501
-                                                # hooks={
-                                                #     'PostCreate': BehaviorOperation.CREATE_CLUSTER.value.id,  # noqa: E501
-                                                #     'PostUpdate': BehaviorOperation.UPDATE_CLUSTER.value.id,  # noqa: E501
-                                                #     'PreDelete': BehaviorOperation.DELETE_CLUSTER.value.id}  # noqa: E501
+                                                hooks={
+                                                    'PostCreate': BehaviorOperation.CREATE_CLUSTER.value.id,  # noqa: E501
+                                                    'PostUpdate': BehaviorOperation.UPDATE_CLUSTER.value.id,  # noqa: E501
+                                                    'PreDelete': BehaviorOperation.DELETE_CLUSTER.value.id}  # noqa: E501
                                                 )
     TKG_ENTITY_TYPE_1_0_0 = DefEntityType(name='TKG Cluster',
                                           id=f"{DEF_ENTITY_TYPE_ID_PREFIX}:{Vendor.VMWARE.value}:{Nss.TKG}:1.0.0",  # noqa: E501


### PR DESCRIPTION
…unction

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Extract out entity status updates to a separate function to allow future changes to use Optimistic locking

Testing - 
* Create cluster using create cluster behaviors (TODO)
* 
@sahithi @sakthisunda @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1020)
<!-- Reviewable:end -->
