### PR TITLE
[VCDA-2241] Test and update cluster kubeconfig for behaviors

### DIFF
--- a/container_service_extension/rde/behaviors/behavior_model.py
+++ b/container_service_extension/rde/behaviors/behavior_model.py
@@ -15,6 +15,14 @@ KUBE_CONFIG_BEHAVIOR_INTERFACE_ID = f"{BEHAVIOR_INTERFACE_ID_PREFIX}:" \
                                     f"{KUBE_CONFIG_BEHAVIOR_INTERFACE_NAME}:" \
                                     f"{Vendor.VMWARE.value}:" \
                                     f"{Nss.KUBERNETES.value}:1.0.0"
+KUBE_CONFIG_BEHAVIOR_TYPE_NAME = 'createKubeConfig'
+BEHAVIOR_TYPE_ID_PREFIX = 'urn:vcloud:behavior-type'
+KUBE_CONFIG_BEHAVIOR_TYPE_ID = f'{BEHAVIOR_TYPE_ID_PREFIX}:' \
+                               f'{KUBE_CONFIG_BEHAVIOR_TYPE_NAME}:' \
+                               f'{Vendor.CSE.value}:' \
+                               f'{Nss.NATIVE_CLUSTER.value}:2.0.0:' \
+                               f'{Vendor.VMWARE.value}:' \
+                               f'{Nss.KUBERNETES.value}:1.0.0'
 CREATE_CLUSTER_BEHAVIOR_NAME = 'createCluster'
 CREATE_CLUSTER_BEHAVIOR_INTERFACE_ID = f"{BEHAVIOR_INTERFACE_ID_PREFIX}:" \
                                        f"{CREATE_CLUSTER_BEHAVIOR_NAME}:" \
@@ -97,7 +105,7 @@ class BehaviorOperation(Enum):
                               description='Deletes native cluster',
                               id=DELETE_CLUSTER_BEHAVIOR_INTERFACE_ID)
     GET_KUBE_CONFIG = Behavior(name=KUBE_CONFIG_BEHAVIOR_INTERFACE_NAME,
-                               id=KUBE_CONFIG_BEHAVIOR_INTERFACE_ID,
+                               id=KUBE_CONFIG_BEHAVIOR_TYPE_ID,
                                ref=KUBE_CONFIG_BEHAVIOR_INTERFACE_ID)
 
 

--- a/container_service_extension/server/behavior_handler.py
+++ b/container_service_extension/server/behavior_handler.py
@@ -86,4 +86,6 @@ def delete_cluster(behavior_ctx: BehaviorRequestContext):
 
 @exception_handler
 def get_kubeconfig(behavior_ctx: BehaviorRequestContext):
-    return "Returning the kubeconfig"
+    cluster_id: str = behavior_ctx.entity_id
+    svc = cluster_service_factory.ClusterServiceFactory(behavior_ctx).get_cluster_service()  # noqa: E501
+    return svc.get_cluster_config(cluster_id)


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Modify get kube-config operation for behaviors-handler

Testing done:
* Invoke behaviors using the endpoint `https://{{VCD_IP}}/cloudapi/1.0.0/entities/{{CLUSTER_ID}}/behaviors/urn:vcloud:behavior-interface:createKubeConfig:vmware:k8s:1.0.0/invocations`
* See if result.resultContent has the kubeconfig once the task succeeds

@sahithi @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1031)
<!-- Reviewable:end -->
