### PR TITLE
[VCDA-2410] Redirect v35_handler to 36_handler if runtime_rde >= 2.0

### DIFF
--- a/container_service_extension/rde/constants.py
+++ b/container_service_extension/rde/constants.py
@@ -204,4 +204,5 @@ class RDEFilterKey(Enum):
 
 class PayloadKey(str, Enum):
     PAYLOAD_VERSION = 'apiVersion'
+    PAYLOAD_VERSION_RDE_1_0 = 'api_version'
     UNKNOWN = 'unknown'

--- a/container_service_extension/rde/models/rde_1_0_0.py
+++ b/container_service_extension/rde/models/rde_1_0_0.py
@@ -224,6 +224,35 @@ class NativeEntity(AbstractNativeEntity):
                 expose=rde_2_x_entity.spec.expose
             )
 
+            control_plane = Node(
+                name=rde_2_x_entity.status.nodes.control_plane.name,
+                ip=rde_2_x_entity.status.nodes.control_plane.ip,
+                sizing_class=rde_2_x_entity.status.nodes.control_plane.sizing_class  # noqa: E501
+            )
+
+            workers = []
+            for worker_node in rde_2_x_entity.status.nodes.workers:
+                worker_node_1_x = Node(
+                    name=worker_node.name,
+                    ip=worker_node.ip,
+                    sizing_class=worker_node.sizing_class
+                )
+                workers.append(worker_node_1_x)
+
+            nfs_nodes = []
+            for nfs_node in nfs_nodes:
+                nfs_node_1_x = Node(
+                    name=nfs_node.name,
+                    ip=nfs_node.ip,
+                    sizing_class=nfs_node.sizing_class)
+                nfs_nodes.append(nfs_node_1_x)
+
+            nodes = Nodes(
+                control_plane=control_plane,
+                workers=workers,
+                nfs=nfs_nodes
+            )
+
             status = Status(
                 phase=rde_2_x_entity.status.phase,
                 cni=rde_2_x_entity.status.cni,
@@ -231,7 +260,7 @@ class NativeEntity(AbstractNativeEntity):
                 kubernetes=rde_2_x_entity.status.kubernetes,
                 docker_version=rde_2_x_entity.status.docker_version,
                 os=rde_2_x_entity.status.os,
-                nodes=rde_2_x_entity.status.nodes,
+                nodes=nodes,
                 exposed=rde_2_x_entity.status.exposed
             )
 

--- a/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
@@ -35,6 +35,10 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     :return: Defined entity of the native cluster
     :rtype: container_service_extension.def_.models.DefEntity
     """
+    rde_in_use = server_utils.get_rde_version_in_use()
+    if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        return cluster_handler.cluster_create(data=data, op_ctx=op_ctx)
+
     input_entity: dict = data[RequestKey.INPUT_SPEC]
     # Convert the input entity to runtime rde format.
     # Based on the runtime rde, call the appropriate backend method.
@@ -58,6 +62,10 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     :return: Defined entity of the native cluster
     :rtype: container_service_extension.def_.models.DefEntity
     """
+    rde_in_use = server_utils.get_rde_version_in_use()
+    if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        return cluster_handler.cluster_update(data=data, op_ctx=op_ctx)
+
     input_entity: dict = data[RequestKey.INPUT_SPEC]
     # Convert the input entity to runtime rde format.
     # Based on the runtime rde, call the appropriate backend method.
@@ -92,6 +100,9 @@ def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
     :return: Dict
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+    if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        return cluster_handler.cluster_delete(data=data, op_ctx=op_ctx)
+
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
@@ -111,6 +122,9 @@ def cluster_info(data: dict, op_ctx: ctx.OperationContext):
     :return: Dict
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+    if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        return cluster_handler.cluster_info(data=data, op_ctx=op_ctx)
+
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
@@ -127,6 +141,9 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     :return: Dict
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+    if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        return cluster_handler.cluster_config(data=data, op_ctx=op_ctx)
+
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
@@ -141,6 +158,9 @@ def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     :return: List[Tuple(str, str)]
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+    if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        return cluster_handler.cluster_upgrade_plan(data=data, op_ctx=op_ctx)
+
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
     return svc.get_cluster_upgrade_plan(data[RequestKey.CLUSTER_ID])
@@ -155,6 +175,10 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
 
     :return: Dict
     """
+    rde_in_use = server_utils.get_rde_version_in_use()
+    if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        return cluster_handler.cluster_update(data=data, op_ctx=op_ctx)
+
     input_entity: dict = data[RequestKey.INPUT_SPEC]
     # Convert the input entity to runtime rde format.
     # Based on the runtime rde, call the appropriate backend method.
@@ -183,6 +207,9 @@ def native_cluster_list(data: dict, op_ctx: ctx.OperationContext):
     :return: List
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+    if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        return cluster_handler.native_cluster_list(data=data, op_ctx=op_ctx)
+
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
     filters = data.get(RequestKey.QUERY_PARAMS, {})
@@ -217,6 +244,9 @@ def native_cluster_list(data: dict, op_ctx: ctx.OperationContext):
 def cluster_acl_info(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster acl list operation."""
     rde_in_use = server_utils.get_rde_version_in_use()
+    if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        return cluster_handler.cluster_acl_info(data=data, op_ctx=op_ctx)
+
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
@@ -239,6 +269,9 @@ def cluster_acl_info(data: dict, op_ctx: ctx.OperationContext):
 def cluster_acl_update(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster acl update operation."""
     rde_in_use = server_utils.get_rde_version_in_use()
+    if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        return cluster_handler.cluster_acl_update(data=data, op_ctx=op_ctx)
+
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]
@@ -254,6 +287,9 @@ def cluster_list(data: dict, op_ctx: ctx.OperationContext):
     :return: List
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+    if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        return cluster_handler.cluster_list(data=data, op_ctx=op_ctx)
+
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
 

--- a/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
@@ -36,13 +36,17 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     :rtype: container_service_extension.def_.models.DefEntity
     """
     rde_in_use = server_utils.get_rde_version_in_use()
-    if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
-        return cluster_handler.cluster_create(data=data, op_ctx=op_ctx)
-
     input_entity: dict = data[RequestKey.INPUT_SPEC]
-    # Convert the input entity to runtime rde format.
-    # Based on the runtime rde, call the appropriate backend method.
+    # Convert the input entity to runtime rde format
     converted_native_entity: AbstractNativeEntity = rde_utils.convert_input_rde_to_runtime_rde_format(input_entity)  # noqa: E501
+
+    # Redirect to generic handler if the backend supports RDE-2.0
+    if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        return cluster_handler.cluster_create(
+            data={RequestKey.INPUT_SPEC: converted_native_entity.to_dict()},
+            op_ctx=op_ctx)
+
+    # Based on the runtime rde, call the appropriate backend method.
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx).get_cluster_service()  # noqa: E501
     new_rde: common_models.DefEntity = svc.create_cluster(converted_native_entity)  # noqa: E501
     # convert the created rde back to input rde version
@@ -63,16 +67,18 @@ def cluster_resize(data: dict, op_ctx: ctx.OperationContext):
     :rtype: container_service_extension.def_.models.DefEntity
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+    input_entity: dict = data[RequestKey.INPUT_SPEC]
+    # Convert the input entity to runtime rde format
+    converted_native_entity: AbstractNativeEntity = rde_utils.convert_input_rde_to_runtime_rde_format(input_entity)  # noqa: E501
+
+    # Redirect to generic handler if the backend supports RDE-2.0
     if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        data[RequestKey.INPUT_SPEC] = converted_native_entity.to_dict()
         return cluster_handler.cluster_update(data=data, op_ctx=op_ctx)
 
-    input_entity: dict = data[RequestKey.INPUT_SPEC]
-    # Convert the input entity to runtime rde format.
     # Based on the runtime rde, call the appropriate backend method.
-    converted_native_entity: AbstractNativeEntity = rde_utils.convert_input_rde_to_runtime_rde_format(input_entity)  # noqa: E501
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx).get_cluster_service()  # noqa: E501
     cluster_id = data[RequestKey.CLUSTER_ID]
-
     curr_entity = svc.entity_svc.get_entity(cluster_id)
     request_utils.validate_request_payload(
         converted_native_entity.spec.to_dict(), curr_entity.entity.spec.to_dict(),  # noqa: E501
@@ -100,6 +106,7 @@ def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
     :return: Dict
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+    # Redirect to generic handler if the backend supports RDE-2.0
     if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
         return cluster_handler.cluster_delete(data=data, op_ctx=op_ctx)
 
@@ -122,6 +129,8 @@ def cluster_info(data: dict, op_ctx: ctx.OperationContext):
     :return: Dict
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+
+    # Redirect to generic handler if the backend supports RDE-2.0
     if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
         return cluster_handler.cluster_info(data=data, op_ctx=op_ctx)
 
@@ -141,6 +150,8 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     :return: Dict
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+
+    # Redirect to generic handler if the backend supports RDE-2.0
     if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
         return cluster_handler.cluster_config(data=data, op_ctx=op_ctx)
 
@@ -158,6 +169,8 @@ def cluster_upgrade_plan(data, op_ctx: ctx.OperationContext):
     :return: List[Tuple(str, str)]
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+
+    # Redirect to generic handler if the backend supports RDE-2.0
     if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
         return cluster_handler.cluster_upgrade_plan(data=data, op_ctx=op_ctx)
 
@@ -176,13 +189,16 @@ def cluster_upgrade(data, op_ctx: ctx.OperationContext):
     :return: Dict
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+    input_entity: dict = data[RequestKey.INPUT_SPEC]
+    # Convert the input entity to runtime rde format
+    converted_native_entity: AbstractNativeEntity = rde_utils.convert_input_rde_to_runtime_rde_format(input_entity)  # noqa: E501
+
+    # Redirect to generic handler if the backend supports RDE-2.0
     if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        data[RequestKey.INPUT_SPEC] = converted_native_entity.to_dict()
         return cluster_handler.cluster_update(data=data, op_ctx=op_ctx)
 
-    input_entity: dict = data[RequestKey.INPUT_SPEC]
-    # Convert the input entity to runtime rde format.
     # Based on the runtime rde, call the appropriate backend method.
-    converted_native_entity: AbstractNativeEntity = rde_utils.convert_input_rde_to_runtime_rde_format(input_entity)  # noqa: E501
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx).get_cluster_service()  # noqa: E501
     cluster_id = data[RequestKey.CLUSTER_ID]
     curr_entity = svc.entity_svc.get_entity(cluster_id)
@@ -207,6 +223,8 @@ def native_cluster_list(data: dict, op_ctx: ctx.OperationContext):
     :return: List
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+
+    # Redirect to generic handler if the backend supports RDE-2.0
     if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
         return cluster_handler.native_cluster_list(data=data, op_ctx=op_ctx)
 
@@ -244,6 +262,8 @@ def native_cluster_list(data: dict, op_ctx: ctx.OperationContext):
 def cluster_acl_info(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster acl list operation."""
     rde_in_use = server_utils.get_rde_version_in_use()
+
+    # Redirect to generic handler if the backend supports RDE-2.0
     if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
         return cluster_handler.cluster_acl_info(data=data, op_ctx=op_ctx)
 
@@ -269,6 +289,8 @@ def cluster_acl_info(data: dict, op_ctx: ctx.OperationContext):
 def cluster_acl_update(data: dict, op_ctx: ctx.OperationContext):
     """Request handler for cluster acl update operation."""
     rde_in_use = server_utils.get_rde_version_in_use()
+
+    # Redirect to generic handler if the backend supports RDE-2.0
     if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
         return cluster_handler.cluster_acl_update(data=data, op_ctx=op_ctx)
 
@@ -287,6 +309,8 @@ def cluster_list(data: dict, op_ctx: ctx.OperationContext):
     :return: List
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+
+    # Redirect to generic handler if the backend supports RDE-2.0
     if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
         return cluster_handler.cluster_list(data=data, op_ctx=op_ctx)
 


### PR DESCRIPTION
- Delegate RDE 2.0 operations to right handler 
- Currently, if any version=35.0 call is handled by v35 handler, which is default handler for RDE 1.0. When the runtime RDE supported is RDE 2.0, delegate that to RDE 2.0 handler(cluster_handler). Thus, all RDE 2.0 and above will be directly handled by cluster_service_2x_behavior handler.
- Reject payloads of RDE 2.0 in v35 handler
- Tested using Postman for cluster creation, resize, upgrade and delete
----------------

<img width="947" alt="Screen Shot 2021-05-18 at 5 46 38 PM" src="https://user-images.githubusercontent.com/5530442/118740613-29c22700-b801-11eb-98f8-e93d68019ff4.png">
<img width="945" alt="Screen Shot 2021-05-18 at 5 46 20 PM" src="https://user-images.githubusercontent.com/5530442/118740618-2c248100-b801-11eb-99f2-01110134dffa.png">
<img width="905" alt="Screen Shot 2021-05-18 at 5 45 58 PM" src="https://user-images.githubusercontent.com/5530442/118740621-2cbd1780-b801-11eb-8417-01daf6eb137a.png">
<img width="931" alt="Screen Shot 2021-05-18 at 5 45 36 PM" src="https://user-images.githubusercontent.com/5530442/118740622-2d55ae00-b801-11eb-8b39-a1899202f24f.png">
-----------------------------------

@Anirudh9794 @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1034)
<!-- Reviewable:end -->
