### PR TITLE
[Vcda 2462] Add behavior and handler for nfs node delete

### DIFF
--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -2411,7 +2411,7 @@ def _create_cluster_rde(client, cluster, kind, runtime_rde_version,
         # Update with the correct cluster id
         native_entity_2_x: rde_2_x.NativeEntity = def_entity.entity
         native_entity_2_x.status.uid = def_entity_id
-        native_entity_2_x.status.cloudProperties.site = site
+        native_entity_2_x.status.cloud_properties.site = site
         native_entity_2_x.metadata.site = site
 
     def_entity.externalId = cluster['vapp_href']

--- a/container_service_extension/rde/backend/cluster_service_2_x_behaviors.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_behaviors.py
@@ -64,7 +64,6 @@ CLUSTER_CREATE_IN_PROGRESS_MESSAGE = 'Create cluster in progress'
 CLUSTER_RESIZE_IN_PROGRESS_MESSAGE = 'Resize cluster in progress'
 CLUSTER_DELETE_IN_PROGRESS_MESSAGE = 'Delete cluster in progress'
 CLUSTER_UPGRADE_IN_PROGRESS_MESSAGE = 'Upgrade cluster in progress'
-NFS_NODE_DELETE_IN_PROGRESS_MESSAGE = 'NFS node delete in progress'
 
 
 class ClusterService(abstract_broker.AbstractBroker):
@@ -795,8 +794,9 @@ class ClusterService(abstract_broker.AbstractBroker):
         self.context.is_async = True
         self._monitor_delete_nodes(cluster_id=cluster_id,
                                    nodes_to_del=nodes_to_del)
+        msg = f"Deleting NFS nodes: {nodes_to_del} for cluster {curr_entity.name} ({cluster_id})"  # noqa: E501
         return self.mqtt_publisher.construct_behavior_payload(
-            message=NFS_NODE_DELETE_IN_PROGRESS_MESSAGE,
+            message=msg,
             status=BehaviorTaskStatus.RUNNING.value, progress=5)
 
     @thread_utils.run_async

--- a/container_service_extension/rde/behaviors/behavior_model.py
+++ b/container_service_extension/rde/behaviors/behavior_model.py
@@ -38,6 +38,11 @@ DELETE_CLUSTER_BEHAVIOR_INTERFACE_ID = f"{BEHAVIOR_INTERFACE_ID_PREFIX}:" \
                                        f"{DELETE_CLUSTER_BEHAVIOR_NAME}:" \
                                        f"{Vendor.CSE.value}:" \
                                        f"{Nss.KUBERNETES.value}:1.0.0"
+DELETE_NFS_NODE_BEHAVIOR_NAME = 'deleteNfsNode'
+DELETE_NFS_NODE_BEHAVIOR_ID = f"{BEHAVIOR_INTERFACE_ID_PREFIX}:" \
+                              f"{DELETE_NFS_NODE_BEHAVIOR_NAME}:" \
+                              f"{Vendor.CSE.value}:" \
+                              f"{Nss.KUBERNETES.value}:1.0.0"
 
 
 @dataclass()
@@ -107,6 +112,9 @@ class BehaviorOperation(Enum):
     GET_KUBE_CONFIG = Behavior(name=KUBE_CONFIG_BEHAVIOR_INTERFACE_NAME,
                                id=KUBE_CONFIG_BEHAVIOR_TYPE_ID,
                                ref=KUBE_CONFIG_BEHAVIOR_INTERFACE_ID)
+    DELETE_NFS_NODE = Behavior(name=DELETE_NFS_NODE_BEHAVIOR_NAME,
+                               id=DELETE_NFS_NODE_BEHAVIOR_ID,
+                               ref=DELETE_NFS_NODE_BEHAVIOR_ID)
 
 
 @unique
@@ -119,6 +127,8 @@ class BehaviorAcl(Enum):
                                           AclAccessLevelId.AccessLevelFullControl)  # noqa: E501
     KUBE_CONFIG_ACL = BehaviorAclEntry(KUBE_CONFIG_BEHAVIOR_INTERFACE_ID,
                                        AclAccessLevelId.AccessLevelReadOnly)
+    DELETE_NFS_NODE_ACL = BehaviorAclEntry(DELETE_NFS_NODE_BEHAVIOR_ID,
+                                           AclAccessLevelId.AccessLevelReadWrite)  # noqa: E501
 
 
 @dataclass()

--- a/container_service_extension/rde/behaviors/behavior_service.py
+++ b/container_service_extension/rde/behaviors/behavior_service.py
@@ -351,6 +351,11 @@ class BehaviorService:
         """
         # TODO Invocation of the behavior must return the taskID retrieved from
         #  the response headers. This is yet to be done by Extensibility team.
+        payload = None
+        if arguments:
+            payload = {
+                "arguments": arguments
+            }
         _, response_headers = self._cloudapi_client.do_request(
             method=cse_shared_constants.RequestMethod.POST,
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
@@ -359,6 +364,6 @@ class BehaviorService:
                                        f"/{CloudApiResource.BEHAVIORS}"
                                        f"/{behavior_interface_id}"
                                        f"/{CloudApiResource.BEHAVIOR_INVOCATION}",  # noqa: E501
-            payload=arguments,
+            payload=payload,
             return_response_headers=True)
         return response_headers[cse_shared_constants.HttpResponseHeader.LOCATION]  # noqa: E501

--- a/container_service_extension/rde/behaviors/behavior_service.py
+++ b/container_service_extension/rde/behaviors/behavior_service.py
@@ -334,7 +334,7 @@ class BehaviorService:
 
     @handle_behavior_service_exception
     def invoke_behavior(self, entity_id: str, behavior_interface_id: str,
-                        arguments: dict = None, return_response_headers=False):
+                        arguments: dict = None) -> str:
         """Invoke behavior on the RDE.
 
         Below is the optional sample payload for the behavior invocation.
@@ -346,11 +346,12 @@ class BehaviorService:
         :param entity_id: Id of the entity
         :param behavior_interface_id: Id of the behavior interface
         :param arguments: Arguments to the behavior
-        :param return_response_headers: should return response_headers?
+        :return: task href in the Location header
+        :rtype: str
         """
         # TODO Invocation of the behavior must return the taskID retrieved from
         #  the response headers. This is yet to be done by Extensibility team.
-        return self._cloudapi_client.do_request(
+        _, response_headers = self._cloudapi_client.do_request(
             method=cse_shared_constants.RequestMethod.POST,
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITIES}"
@@ -359,4 +360,5 @@ class BehaviorService:
                                        f"/{behavior_interface_id}"
                                        f"/{CloudApiResource.BEHAVIOR_INVOCATION}",  # noqa: E501
             payload=arguments,
-            return_response_headers=return_response_headers)
+            return_response_headers=True)
+        return response_headers[cse_shared_constants.HttpResponseHeader.LOCATION]  # noqa: E501

--- a/container_service_extension/rde/models/common_models.py
+++ b/container_service_extension/rde/models/common_models.py
@@ -365,7 +365,8 @@ MAP_RDE_VERSION_TO_ITS_METADATA = {
             K8Interface.CSE_INTERFACE.value.id:
                 [BehaviorOperation.CREATE_CLUSTER.value,
                  BehaviorOperation.UPDATE_CLUSTER.value,
-                 BehaviorOperation.DELETE_CLUSTER.value]
+                 BehaviorOperation.DELETE_CLUSTER.value,
+                 BehaviorOperation.DELETE_NFS_NODE.value]
         },
         RDEMetadataKey.ENTITY_TYPE_TO_OVERRIDABLE_BEHAVIORS_MAP: {
             EntityType.NATIVE_ENTITY_TYPE_2_0_0.value.id:
@@ -376,7 +377,8 @@ MAP_RDE_VERSION_TO_ITS_METADATA = {
                 [BehaviorAcl.CREATE_CLUSTER_ACL.value,
                  BehaviorAcl.UPDATE_CLUSTER_ACL.value,
                  BehaviorAcl.DELETE_CLUSTER_ACL.value,
-                 BehaviorAcl.KUBE_CONFIG_ACL.value]
+                 BehaviorAcl.KUBE_CONFIG_ACL.value,
+                 BehaviorAcl.DELETE_NFS_NODE_ACL.value]
         }
     }
 }

--- a/container_service_extension/security/context/behavior_request_context.py
+++ b/container_service_extension/security/context/behavior_request_context.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from dataclasses import dataclass
+from typing import Dict
 from typing import Optional
 
 from container_service_extension.mqi.consumer.mqtt_publisher import \
@@ -30,3 +31,4 @@ class RequestContext:
     op_ctx: Optional[OperationContext] = None
     user_context: Optional[BehaviorUserContext] = None
     mqtt_publisher: Optional[MQTTPublisher] = None
+    arguments: Optional[Dict[str, str]] = None

--- a/container_service_extension/server/behavior_dispatcher.py
+++ b/container_service_extension/server/behavior_dispatcher.py
@@ -20,7 +20,8 @@ MAP_BEHAVIOR_ID_TO_HANDLER_METHOD = {
     BehaviorOperation.CREATE_CLUSTER.value.id: handler.create_cluster,
     BehaviorOperation.UPDATE_CLUSTER.value.id: handler.update_cluster,
     BehaviorOperation.DELETE_CLUSTER.value.id: handler.delete_cluster,
-    BehaviorOperation.GET_KUBE_CONFIG.value.id: handler.get_kubeconfig
+    BehaviorOperation.GET_KUBE_CONFIG.value.id: handler.get_kubeconfig,
+    BehaviorOperation.DELETE_NFS_NODE.value.id: handler.nfs_node_delete
 }
 
 
@@ -38,6 +39,7 @@ def process_behavior_request(msg_json, mqtt_publisher: MQTTPublisher):
     api_version: str = payload['_metadata']['apiVersion']
     auth_token: str = payload['_metadata']['actAsToken']
     request_id: str = payload['_metadata']['requestId']
+    arguments: dict = payload['arguments']
 
     # Initializing Behavior operation context
     op_ctx = OperationContext(auth_token=auth_token, is_jwt=True, request_id=request_id)  # noqa: E501
@@ -55,7 +57,7 @@ def process_behavior_request(msg_json, mqtt_publisher: MQTTPublisher):
 
     # Invoke the handler method and return the response in the string format.
     try:
-        return MAP_BEHAVIOR_ID_TO_HANDLER_METHOD[behavior_id](behavior_ctx)  # noqa: E501
+        return MAP_BEHAVIOR_ID_TO_HANDLER_METHOD[behavior_id](behavior_ctx, **arguments)  # noqa: E501
     except CseRequestError as e:
         error_details = asdict(BehaviorError(majorErrorCode=e.status_code,
                                              minorErrorCode=e.minor_error_code,

--- a/container_service_extension/server/behavior_dispatcher.py
+++ b/container_service_extension/server/behavior_dispatcher.py
@@ -54,11 +54,12 @@ def process_behavior_request(msg_json, mqtt_publisher: MQTTPublisher):
                                   entity_type_id=entity_type_id,
                                   request_id=request_id,
                                   op_ctx=op_ctx,
-                                  mqtt_publisher=mqtt_publisher)
+                                  mqtt_publisher=mqtt_publisher,
+                                  arguments=arguments)
 
     # Invoke the handler method and return the response in the string format.
     try:
-        return MAP_BEHAVIOR_ID_TO_HANDLER_METHOD[behavior_id](behavior_ctx, **arguments)  # noqa: E501
+        return MAP_BEHAVIOR_ID_TO_HANDLER_METHOD[behavior_id](behavior_ctx)
     except CseRequestError as e:
         error_details = asdict(BehaviorError(majorErrorCode=e.status_code,
                                              minorErrorCode=e.minor_error_code,

--- a/container_service_extension/server/behavior_dispatcher.py
+++ b/container_service_extension/server/behavior_dispatcher.py
@@ -6,6 +6,7 @@ from dataclasses import asdict
 import json
 
 from container_service_extension.exception.exceptions import CseRequestError
+from container_service_extension.logging.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.mqi.consumer.mqtt_publisher import \
     MQTTPublisher
 from container_service_extension.rde.behaviors.behavior_model import \
@@ -65,6 +66,7 @@ def process_behavior_request(msg_json, mqtt_publisher: MQTTPublisher):
         payload = mqtt_publisher. \
             construct_behavior_payload(status=BehaviorTaskStatus.ERROR.value,
                                        error_details=error_details)
+        LOGGER.error(f"Error while executing handler: {error_details}", exc_info=True)  # noqa: E501
         return payload
     except Exception as e:
         error_details = asdict(BehaviorError(majorErrorCode='500',
@@ -72,5 +74,5 @@ def process_behavior_request(msg_json, mqtt_publisher: MQTTPublisher):
         payload = mqtt_publisher. \
             construct_behavior_payload(status=BehaviorTaskStatus.ERROR.value,
                                        error_details=error_details)
-
+        LOGGER.error(f"Error while executing handler: {error_details}", exc_info=True)  # noqa: E501
         return payload

--- a/container_service_extension/server/behavior_handler.py
+++ b/container_service_extension/server/behavior_handler.py
@@ -114,6 +114,7 @@ def get_kubeconfig(behavior_ctx: RequestContext, **kwargs):
     svc = cluster_service_factory.ClusterServiceFactory(behavior_ctx).get_cluster_service()  # noqa: E501
     return svc.get_cluster_config(cluster_id)
 
+
 @exception_handler
 def nfs_node_delete(behavior_ctx: RequestContext, **kwargs):
     entity_id: str = behavior_ctx.entity_id

--- a/container_service_extension/server/behavior_handler.py
+++ b/container_service_extension/server/behavior_handler.py
@@ -53,7 +53,7 @@ def exception_handler(func):
 
 
 @exception_handler
-def create_cluster(behavior_ctx: RequestContext, **kwargs):
+def create_cluster(behavior_ctx: RequestContext):
     entity_id: str = behavior_ctx.entity_id
     input_entity: dict = behavior_ctx.entity
     cloudapi_client: CloudApiClient = behavior_ctx.op_ctx.cloudapi_client
@@ -76,7 +76,7 @@ def create_cluster(behavior_ctx: RequestContext, **kwargs):
 
 
 @exception_handler
-def update_cluster(behavior_ctx: RequestContext, **kwargs):
+def update_cluster(behavior_ctx: RequestContext):
     entity_id: str = behavior_ctx.entity_id
     input_entity: dict = behavior_ctx.entity
     cloudapi_client: CloudApiClient = behavior_ctx.op_ctx.cloudapi_client
@@ -100,7 +100,7 @@ def update_cluster(behavior_ctx: RequestContext, **kwargs):
 
 
 @exception_handler
-def delete_cluster(behavior_ctx: RequestContext, **kwargs):
+def delete_cluster(behavior_ctx: RequestContext):
     entity_id: str = behavior_ctx.entity_id
 
     svc = cluster_service_factory.ClusterServiceFactory(behavior_ctx).get_cluster_service()  # noqa: E501
@@ -109,15 +109,15 @@ def delete_cluster(behavior_ctx: RequestContext, **kwargs):
 
 
 @exception_handler
-def get_kubeconfig(behavior_ctx: RequestContext, **kwargs):
+def get_kubeconfig(behavior_ctx: RequestContext):
     cluster_id: str = behavior_ctx.entity_id
     svc = cluster_service_factory.ClusterServiceFactory(behavior_ctx).get_cluster_service()  # noqa: E501
     return svc.get_cluster_config(cluster_id)
 
 
 @exception_handler
-def nfs_node_delete(behavior_ctx: RequestContext, **kwargs):
+def nfs_node_delete(behavior_ctx: RequestContext):
     entity_id: str = behavior_ctx.entity_id
-    node_to_delete: str = kwargs[RequestKey.NODE_NAME]
+    node_to_delete: str = behavior_ctx.arguments.get(RequestKey.NODE_NAME)
     svc = cluster_service_factory.ClusterServiceFactory(behavior_ctx).get_cluster_service()  # noqa: E501
     return svc.delete_nodes(entity_id, nodes_to_del=[node_to_delete])

--- a/container_service_extension/server/behavior_handler.py
+++ b/container_service_extension/server/behavior_handler.py
@@ -4,6 +4,7 @@
 
 import functools
 
+from container_service_extension.common.constants.shared_constants import RequestKey  # noqa: E501
 import container_service_extension.exception.exceptions as cse_exception
 from container_service_extension.lib.cloudapi.cloudapi_client import \
     CloudApiClient
@@ -52,7 +53,7 @@ def exception_handler(func):
 
 
 @exception_handler
-def create_cluster(behavior_ctx: RequestContext):
+def create_cluster(behavior_ctx: RequestContext, **kwargs):
     entity_id: str = behavior_ctx.entity_id
     input_entity: dict = behavior_ctx.entity
     cloudapi_client: CloudApiClient = behavior_ctx.op_ctx.cloudapi_client
@@ -75,7 +76,7 @@ def create_cluster(behavior_ctx: RequestContext):
 
 
 @exception_handler
-def update_cluster(behavior_ctx: RequestContext):
+def update_cluster(behavior_ctx: RequestContext, **kwargs):
     entity_id: str = behavior_ctx.entity_id
     input_entity: dict = behavior_ctx.entity
     cloudapi_client: CloudApiClient = behavior_ctx.op_ctx.cloudapi_client
@@ -99,7 +100,7 @@ def update_cluster(behavior_ctx: RequestContext):
 
 
 @exception_handler
-def delete_cluster(behavior_ctx: RequestContext):
+def delete_cluster(behavior_ctx: RequestContext, **kwargs):
     entity_id: str = behavior_ctx.entity_id
 
     svc = cluster_service_factory.ClusterServiceFactory(behavior_ctx).get_cluster_service()  # noqa: E501
@@ -108,7 +109,14 @@ def delete_cluster(behavior_ctx: RequestContext):
 
 
 @exception_handler
-def get_kubeconfig(behavior_ctx: RequestContext):
+def get_kubeconfig(behavior_ctx: RequestContext, **kwargs):
     cluster_id: str = behavior_ctx.entity_id
     svc = cluster_service_factory.ClusterServiceFactory(behavior_ctx).get_cluster_service()  # noqa: E501
     return svc.get_cluster_config(cluster_id)
+
+@exception_handler
+def nfs_node_delete(behavior_ctx: RequestContext, **kwargs):
+    entity_id: str = behavior_ctx.entity_id
+    node_to_delete: str = kwargs[RequestKey.NODE_NAME]
+    svc = cluster_service_factory.ClusterServiceFactory(behavior_ctx).get_cluster_service()  # noqa: E501
+    return svc.delete_nodes(entity_id, nodes_to_del=[node_to_delete])

--- a/container_service_extension/server/request_handlers/cluster_handler.py
+++ b/container_service_extension/server/request_handlers/cluster_handler.py
@@ -283,7 +283,6 @@ def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     cluster_def_entity: common_models.DefEntity = def_entity_service.get_entity(cluster_id)  # noqa: E501
     cluster_def_entity.entity.status.task_href = delete_nfs_node_task
 
-    # TODO: How to get to know what format of output the caller is expecting?
     return cluster_def_entity.to_dict()
 
 

--- a/container_service_extension/server/request_handlers/cluster_handler.py
+++ b/container_service_extension/server/request_handlers/cluster_handler.py
@@ -31,6 +31,7 @@ import container_service_extension.lib.telemetry.constants as telemetry_constant
 import container_service_extension.lib.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
 import container_service_extension.rde.backend.cluster_service_factory as cluster_service_factory  # noqa: E501
 from container_service_extension.rde.behaviors.behavior_model import BehaviorOperation  # noqa: E501
+from container_service_extension.rde.behaviors.behavior_model import DELETE_NFS_NODE_BEHAVIOR_ID  # noqa: E501
 from container_service_extension.rde.behaviors.behavior_model import KUBE_CONFIG_BEHAVIOR_INTERFACE_ID  # noqa: E501
 from container_service_extension.rde.behaviors.behavior_service import BehaviorService  # noqa: E501
 import container_service_extension.rde.common.entity_service as entity_service
@@ -168,8 +169,7 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     behavior_svc = BehaviorService(cloudapi_client=op_ctx.cloudapi_client)
     config_task_href = behavior_svc.invoke_behavior(
         entity_id=cluster_id,
-        behavior_interface_id=KUBE_CONFIG_BEHAVIOR_INTERFACE_ID,
-        return_response_headers=True)
+        behavior_interface_id=KUBE_CONFIG_BEHAVIOR_INTERFACE_ID)
     config_task = op_ctx.client.get_resource(config_task_href)
     op_ctx.client.get_task_monitor().wait_for_success(config_task)
     config_task = op_ctx.client.get_resource(config_task_href)
@@ -262,10 +262,9 @@ def nfs_node_delete(data, op_ctx: ctx.OperationContext):
 
     :return: Dict
     """
-    svc = cluster_service_factory.ClusterServiceFactory(_get_request_context(op_ctx)).get_cluster_service()  # noqa: E501
     cluster_id = data[RequestKey.CLUSTER_ID]
     node_name = data[RequestKey.NODE_NAME]
-
+    behavior_svc = BehaviorService(cloudapi_client=op_ctx.cloudapi_client)
     telemetry_handler.record_user_action_details(
         cse_operation=telemetry_constants.CseOperation.V36_NODE_DELETE,
         cse_params={
@@ -274,8 +273,18 @@ def nfs_node_delete(data, op_ctx: ctx.OperationContext):
             telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(server_constants.ThreadLocalData.USER_AGENT)   # noqa: E501
         }
     )
+    delete_nfs_node_task = behavior_svc.invoke_behavior(
+        entity_id=cluster_id,
+        behavior_interface_id=DELETE_NFS_NODE_BEHAVIOR_ID,
+        arguments={
+            RequestKey.NODE_NAME.value: node_name
+        })
+    def_entity_service = entity_service.DefEntityService(op_ctx.cloudapi_client)  # noqa: E501
+    cluster_def_entity: common_models.DefEntity = def_entity_service.get_entity(cluster_id)  # noqa: E501
+    cluster_def_entity.entity.status.task_href = delete_nfs_node_task
 
-    return svc.delete_nodes(cluster_id, [node_name]).to_dict()
+    # TODO: How to get to know what format of output the caller is expecting?
+    return cluster_def_entity.to_dict()
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_ACL_LIST)  # noqa: E501

--- a/container_service_extension/server/request_handlers/cluster_handler.py
+++ b/container_service_extension/server/request_handlers/cluster_handler.py
@@ -166,13 +166,10 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     """
     cluster_id = data[RequestKey.CLUSTER_ID]
     behavior_svc = BehaviorService(cloudapi_client=op_ctx.cloudapi_client)
-    _, headers = behavior_svc.invoke_behavior(
+    config_task_href = behavior_svc.invoke_behavior(
         entity_id=cluster_id,
         behavior_interface_id=KUBE_CONFIG_BEHAVIOR_INTERFACE_ID,
         return_response_headers=True)
-    # TODO: Use the Htttp response status code to decide which header name to use for task_href  # noqa: E501
-    # 202 - location header, 200 - xvcloud-task-location needs to be used
-    config_task_href = headers[HttpResponseHeader.LOCATION.value]
     config_task = op_ctx.client.get_resource(config_task_href)
     op_ctx.client.get_task_monitor().wait_for_success(config_task)
     config_task = op_ctx.client.get_resource(config_task_href)

--- a/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
@@ -293,9 +293,9 @@ def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     """
     rde_in_use = server_utils.get_rde_version_in_use()
     if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
-        # NOTE: cluster_handler is always expected to return RDE version
-        #   2.0.0 or more
         cluster_dict = cluster_handler.nfs_node_delete(data=data, op_ctx=op_ctx)  # noqa: E501
+        # NOTE: cluster_handler is always expected to return RDE version
+        #   2.0.0 or more. Hence a convertion to 1.0 is needed
         rde_class = rde_factory.get_rde_model(rde_in_use)
         cluster_entity: AbstractNativeEntity = rde_class.from_dict(cluster_dict['entity'])  # noqa: E501
         new_native_entity: AbstractNativeEntity = rde_utils.convert_runtime_rde_to_input_rde_version_format(  # noqa: E501

--- a/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
+++ b/container_service_extension/server/request_handlers/v35/def_cluster_handler.py
@@ -1,6 +1,7 @@
 # container-service-extension
 # Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
+import semantic_version
 
 from container_service_extension.common.constants.server_constants import FlattenedClusterSpecKey1X  # noqa: E501
 from container_service_extension.common.constants.server_constants import ThreadLocalData  # noqa: E501
@@ -19,6 +20,7 @@ from container_service_extension.rde.models.abstractNativeEntity import Abstract
 import container_service_extension.rde.models.common_models as common_models
 import container_service_extension.rde.utils as rde_utils
 import container_service_extension.security.context.operation_context as ctx
+import container_service_extension.server.request_handlers.cluster_handler as cluster_handler  # noqa: E501
 import container_service_extension.server.request_handlers.request_utils as request_utils  # noqa: E501
 
 _OPERATION_KEY = 'operation'
@@ -289,6 +291,8 @@ def nfs_node_delete(data, op_ctx: ctx.OperationContext):
     :return: Dict
     """
     rde_in_use = server_utils.get_rde_version_in_use()
+    if semantic_version.Version(rde_in_use) >= semantic_version.Version(rde_constants.RDEVersion.RDE_2_0_0.value):  # noqa: E501
+        return cluster_handler.cluster_create(data=data, op_ctx=op_ctx)
     svc = cluster_service_factory.ClusterServiceFactory(op_ctx). \
         get_cluster_service(rde_in_use)
     cluster_id = data[RequestKey.CLUSTER_ID]


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

Testing done:
- invoke behavior using `POST https://{{VCD_IP}}/cloudapi/1.0.0/entities/{{CLUSTER_ID}}/behaviors/urn:vcloud:behavior-interface:deleteNfsNode:cse:k8s:1.0.0/invocations` for valid nfs node name and invalid nfs node name

@sahithi @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1037)
<!-- Reviewable:end -->
