### PR TITLE
[VCDA-2435] Update the RDE schema to accommodate R1

### DIFF
--- a/container_service_extension/common/constants/shared_constants.py
+++ b/container_service_extension/common/constants/shared_constants.py
@@ -32,6 +32,7 @@ class ClusterEntityKind(Enum):
     NATIVE = 'native'
     TKG = 'TanzuKubernetesCluster'
     TKG_PLUS = 'TKG+'
+    TKGm = 'TKGm'
 
 
 # Cluster runtimes and placement policies

--- a/container_service_extension/common/constants/shared_constants.py
+++ b/container_service_extension/common/constants/shared_constants.py
@@ -32,7 +32,7 @@ class ClusterEntityKind(Enum):
     NATIVE = 'native'
     TKG = 'TanzuKubernetesCluster'
     TKG_PLUS = 'TKG+'
-    TKGm = 'TKGm'
+    TKG_M = 'TKGm'
 
 
 # Cluster runtimes and placement policies

--- a/cse_def_schema/schema_2_0_0.json
+++ b/cse_def_schema/schema_2_0_0.json
@@ -104,7 +104,7 @@
                                 "count":{
                                     "type":"integer",
                                     "description":"Worker nodes can be scaled up and down.",
-                                    "maximum":100,
+                                    "maximum":200,
                                     "minimum":0
                                 },
                                 "sizingClass":{
@@ -128,7 +128,7 @@
                                 "count":{
                                     "type":"integer",
                                     "description":"Nfs nodes can only be scaled-up; they cannot be scaled-down.",
-                                    "maximum":100,
+                                    "maximum":200,
                                     "minimum":0
                                 },
                                 "sizingClass":{

--- a/cse_def_schema/schema_2_0_0.json
+++ b/cse_def_schema/schema_2_0_0.json
@@ -146,10 +146,10 @@
                 "settings":{
                     "type":"object",
                     "required":[
-                        "network"
+                        "ovdcNetwork"
                     ],
                     "properties":{
-                        "network":{
+                        "ovdcNetwork":{
                             "type":"string",
                             "description":"Name of the Organization's virtual data center network"
                         },
@@ -160,6 +160,47 @@
                         "rollbackOnFailure":{
                             "type":"boolean",
                             "description":"On any cluster operation failure, if the value is set to true, affected node VMs will be automatically deleted."
+                        },
+                        "network": {
+                            "type": "object",
+                            "description": "The network-related settings for the cluster.",
+                            "properties": {
+                                "cni": {
+                                    "type": "object",
+                                    "description": "The CNI to use.",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "pods": {
+                                    "type": "object",
+                                    "description": "The network settings for Kubernetes pods.",
+                                    "properties": {
+                                        "cidrBlocks": {
+                                            "type": "array",
+                                            "description": "Specifies a range of IP addresses to use for Kubernetes pods.",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "services": {
+                                    "type": "object",
+                                    "description": "The network settings for Kubernetes services",
+                                    "properties": {
+                                        "cidrBlocks": {
+                                            "type": "array",
+                                            "description": "The range of IP addresses to use for Kubernetes services",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     },
                     "additionalProperties":true
@@ -265,7 +306,35 @@
                 "private": {
                     "type": "object",
                     "x-vcloud-restricted" : "private",
-                    "description": "Placeholder for the properties invisible to non-admin users."
+                    "description": "Placeholder for the properties invisible to non-admin users.",
+                    "properties": {
+                        "kubeConfig": {
+                            "type": "string",
+                            "description": "Admin kube config to access the Kubernetes cluster."
+                        },
+                        "kubeToken": {
+                            "type": "string",
+                            "description": "Kube token to join the nodes to the Kubernetes cluster."
+                        },
+                        "certificates": {
+                            "type": "string",
+                            "description": "The root certificate of the control plane."
+                        }
+                    }
+                },
+                "persistentVolumes": {
+                    "type": "array",
+                    "description": "VCD references to the list of persistent volumes.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "virtualIPs": {
+                    "type": "array",
+                    "description": "Array of virtual IPs consumed.",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             },
             "additionalProperties":true

--- a/cse_def_schema/schema_2_0_0.json
+++ b/cse_def_schema/schema_2_0_0.json
@@ -317,8 +317,11 @@
                             "description": "Kube token to join the nodes to the Kubernetes cluster."
                         },
                         "certificates": {
-                            "type": "string",
-                            "description": "The root certificate of the control plane."
+                            "type": "array",
+                            "description": "Kubernetes certificates.",
+                            "items": {
+                                "type": "string"
+                            }
                         }
                     }
                 },

--- a/cse_def_schema/schema_2_0_0.json
+++ b/cse_def_schema/schema_2_0_0.json
@@ -50,7 +50,8 @@
             "enum":[
                 "native",
                 "TanzuKubernetesCluster",
-                "TKG+"
+                "TKG+",
+                "TKGm"
             ],
             "type":"string",
             "description":"The kind of the Kubernetes cluster."


### PR DESCRIPTION
RDE 2.0 Schema changes in schema_2_0_0.json to accommodate CSE 3.1 features (CSI, CPI, TKGm integration)


Signed-off-by: sayloo <sahithi.ayloo@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1040)
<!-- Reviewable:end -->
