### PR TITLE
PR-Fix for RDE_RESTRICTED_FIELDS [ status ]

### DIFF
--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -71,7 +71,7 @@ class DefEntityService:
     @handle_entity_service_exception
     def create_entity(self, entity_type_id: str, entity: DefEntity,
                       tenant_org_context: str = None,
-                      delete_status_from_payload=False,
+                      delete_status_from_payload=True,
                       return_response_headers=False) -> Union[dict, Tuple[dict, dict]]:  # noqa: E501
         """Create defined entity instance of an entity type.
 

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -71,11 +71,13 @@ class DefEntityService:
     @handle_entity_service_exception
     def create_entity(self, entity_type_id: str, entity: DefEntity,
                       tenant_org_context: str = None,
+                      delete_status_from_payload=False,
                       return_response_headers=False) -> Union[dict, Tuple[dict, dict]]:  # noqa: E501
         """Create defined entity instance of an entity type.
 
         :param str entity_type_id: ID of the DefEntityType
         :param DefEntity entity: Defined entity instance
+        :param bool delete_status_from_payload: should delete status from payload?  # noqa: E501
         :param bool return_response_headers: return response headers
         :return: created entity or created entity with response headers
         :rtype: Union[dict, Tuple[dict, dict]]
@@ -83,12 +85,17 @@ class DefEntityService:
         additional_request_headers = {}
         if tenant_org_context:
             additional_request_headers['x-vmware-vcloud-tenant-context'] = tenant_org_context  # noqa: E501
+
+        payload: dict = entity.to_dict()
+        if delete_status_from_payload:
+            payload.get('entity', {}).pop('status', None)
+
         return self._cloudapi_client.do_request(
             method=RequestMethod.POST,
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
             resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}/"
                                        f"{entity_type_id}",
-            payload=entity.to_dict(),
+            payload=payload,
             additional_request_headers=additional_request_headers,
             return_response_headers=return_response_headers)
 

--- a/container_service_extension/server/request_handlers/cluster_handler.py
+++ b/container_service_extension/server/request_handlers/cluster_handler.py
@@ -79,7 +79,13 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
         org_resource = pyvcloud_utils.get_org(op_ctx.client, org_name=converted_entity.metadata.org_name)  # noqa: E501
         org_context = org_resource.href.split('/')[-1]
 
-    _, headers = def_entity_service.create_entity(entity_type_id=entity_type.id, entity=def_entity, tenant_org_context=org_context, return_response_headers=True)  # noqa: E501
+    _, headers = def_entity_service.create_entity(
+        entity_type_id=entity_type.id,
+        entity=def_entity,
+        tenant_org_context=org_context,
+        delete_status_from_payload=True,
+        return_response_headers=True)
+
     # Get the created defined entity and update the task href
     # TODO: Use the Htttp response status code to decide which header name to use for task_href  # noqa: E501
     # 202 - location header, 200 - xvcloud-task-location needs to be used

--- a/container_service_extension/server/request_handlers/cluster_handler.py
+++ b/container_service_extension/server/request_handlers/cluster_handler.py
@@ -83,7 +83,6 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
         entity_type_id=entity_type.id,
         entity=def_entity,
         tenant_org_context=org_context,
-        delete_status_from_payload=True,
         return_response_headers=True)
 
     # Get the created defined entity and update the task href


### PR DESCRIPTION

- Fixed error: RDE_RESTRICTED_FIELDS [ status ]
- Currently, cluster creation fails because the defined entity having status element is prohibited by VCD. This fix resolves by removing status element from defined entity before POSTing defined entity for cloud api endpoint. This is conditional removal required only for cluster creation.
- Tested with CSE CLI cluster creation

@Anirudh9794 @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1045)
<!-- Reviewable:end -->
