### PR TITLE
[VCDA-2267] Upgrading cluster RDE instead of re-creating them in cse-upgrade

### DIFF
--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -2468,11 +2468,11 @@ def _create_cluster_rde(client, cluster, kind, runtime_rde_version,
     msg_update_callback.general(msg)
 
 
-def _upgrade_cluster_rde(client, cluster, def_entity_to_upgrade,
+def _upgrade_cluster_rde(client, cluster, rde_to_upgrade,
                          runtime_rde_version, target_entity_type,
                          entity_svc, site=None, msg_update_callback=utils.NullPrinter()):  # noqa: E501
     TargetNativeEntity = get_rde_model(runtime_rde_version)
-    new_native_entity = TargetNativeEntity.from_native_entity(def_entity_to_upgrade.entity)  # noqa: E501
+    new_native_entity = TargetNativeEntity.from_native_entity(rde_to_upgrade.entity)  # noqa: E501
 
     # Adding missing fields in RDE 2.0
     # TODO: Need to find a better approach to avoid conditional logic for
@@ -2481,12 +2481,12 @@ def _upgrade_cluster_rde(client, cluster, def_entity_to_upgrade,
             semantic_version.Version(def_constants.RDEVersion.RDE_2_0_0).major:
         # RDE upgrade possible only from RDE 1.0 or RDE 2.x
         native_entity_2_x: rde_2_x.NativeEntity = new_native_entity
-        native_entity_2_x.status.uid = def_entity_to_upgrade.id
+        native_entity_2_x.status.uid = rde_to_upgrade.id
         native_entity_2_x.status.cloud_properties.site = site
         native_entity_2_x.metadata.site = site
 
     upgraded_rde: common_models.DefEntity = \
-        entity_svc.upgrade_entity(def_entity_to_upgrade.id,
+        entity_svc.upgrade_entity(rde_to_upgrade.id,
                                   new_native_entity,
                                   target_entity_type.id)
 

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -20,6 +20,7 @@ from container_service_extension.lib.cloudapi.constants import CloudApiResource
 from container_service_extension.lib.cloudapi.constants import CloudApiVersion
 from container_service_extension.logging.logger import SERVER_LOGGER as LOGGER
 import container_service_extension.rde.constants as def_constants
+from container_service_extension.rde.models.abstractNativeEntity import AbstractNativeEntity  # noqa: E501
 from container_service_extension.rde.models.common_models import DefEntity
 from container_service_extension.rde.models.common_models import DefEntityType
 from container_service_extension.rde.models.common_models import GenericClusterEntity   # noqa: E501
@@ -386,16 +387,21 @@ class DefEntityService:
         return def_constants.DEF_NATIVE_ENTITY_TYPE_NSS in response_body['entityType']  # noqa: E501
 
     @handle_entity_service_exception
-    def upgrade_entity(self, entity_id: str, target_entity_type_id: str):
+    def upgrade_entity(self, entity_id: str,
+                       upgraded_native_entity: AbstractNativeEntity,
+                       target_entity_type_id: str):
         """Upgrade entity type of the entity to the specified one.
 
         :param str entity_id: ID of the entity to upgrade
-        :param str target_entity_type_id: ID of the entity type with new
-            version
-        :return: dont know
-        :rtype: god knows
+        :param str upgraded_native_entity: dataclass representing the native
+            entity with upgraded fields.
+        :param str target_entity_type_id: target entity type version to which
+            the defined entity should be upgraded to.
+        :return: DefEntity representing the upgraded defined entity
+        :rtype: DefEntity
         """
         rde = self.get_entity(entity_id)
+        rde.entity = upgraded_native_entity
 
         # Update only the entityType property
         rde.entityType = target_entity_type_id

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -347,6 +347,7 @@ class DefEntityService:
                                        f"{entity_id}?invokeHooks={str(invoke_hooks).lower()}",  # noqa: E501
             return_response_headers=return_response_headers)
 
+    @handle_entity_service_exception
     def resolve_entity(self, entity_id: str, entity_type_id: str = None) -> DefEntity:  # noqa: E501
         """Resolve the entity.
 
@@ -383,3 +384,20 @@ class DefEntityService:
             resource_url_relative_path=f"{CloudApiResource.ENTITIES}/"
                                        f"{entity_id}")
         return def_constants.DEF_NATIVE_ENTITY_TYPE_NSS in response_body['entityType']  # noqa: E501
+
+    @handle_entity_service_exception
+    def upgrade_entity(self, entity_id: str, target_entity_type_id: str):
+        """Upgrade entity type of the entity to the specified one.
+
+        :param str entity_id: ID of the entity to upgrade
+        :param str target_entity_type_id: ID of the entity type with new
+            version
+        :return: dont know
+        :rtype: god knows
+        """
+        rde = self.get_entity(entity_id)
+
+        # Update only the entityType property
+        rde.entityType = target_entity_type_id
+
+        return self.update_entity(entity_id, rde, invoke_hooks=False)

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -213,15 +213,46 @@ class NativeEntity(AbstractNativeEntity):
             # TODO should change very much
             rde_1_x_entity: rde_1_0_0.NativeEntity = native_entity
 
+            distribution = Distribution(
+                template_name=rde_1_x_entity.spec.k8_distribution.template_name,  # noqa: E501
+                template_revision=rde_1_x_entity.spec.k8_distribution.template_revision  # noqa: E501
+            )
             # NOTE: since details for the field `site` is not present in
             # RDE 1.0, it is left empty
             cloud_properties = CloudProperties(site=None,
                                                org_name=rde_1_x_entity.metadata.org_name,  # noqa: E501
                                                virtual_data_center_name=rde_1_x_entity.metadata.ovdc_name,  # noqa: E501
                                                ovdc_network_name=rde_1_x_entity.spec.settings.network,  # noqa: E501
-                                               distribution=rde_1_x_entity.spec.k8_distribution,  # noqa: E501
+                                               distribution=distribution,
                                                ssh_key=rde_1_x_entity.spec.settings.ssh_key,  # noqa: E501
                                                rollback_on_failure=rde_1_x_entity.spec.settings.rollback_on_failure)  # noqa: E501
+            # RDE 1.0 don't have storage_profile in Node definition
+            control_plane = Node(
+                name=rde_1_x_entity.status.nodes.control_plane.name,
+                ip=rde_1_x_entity.status.nodes.control_plane.ip,
+                sizing_class=rde_1_x_entity.status.nodes.control_plane.sizing_class  # noqa: E501
+            )
+            workers = []
+            for worker in rde_1_x_entity.status.nodes.workers:
+                worker_node_2_x = Node(
+                    name=worker.name,
+                    ip=worker.ip,
+                    sizing_class=worker.sizing_class
+                )
+                workers.append(worker_node_2_x)
+            nfs_nodes = []
+            for nfs_node in rde_1_x_entity.status.nodes.nfs:
+                nfs_node_2_x = Node(
+                    name=nfs_node.name,
+                    ip=nfs_node.ip,
+                    sizing_class=nfs_node.sizing_class
+                )
+                nfs_nodes.append(nfs_node_2_x)
+            nodes = Nodes(
+                control_plane=control_plane,
+                workers=workers,
+                nfs=nfs_nodes
+            )
             # NOTE: since details for the field `uid` is not present in
             # RDE 1.0, it is left empty.
             # Proper value for `uid` should be populated after RDE is converted
@@ -232,7 +263,7 @@ class NativeEntity(AbstractNativeEntity):
                             kubernetes=rde_1_x_entity.status.kubernetes,
                             docker_version=rde_1_x_entity.status.docker_version,  # noqa: E501
                             os=rde_1_x_entity.status.os,
-                            nodes=rde_1_x_entity.status.nodes,
+                            nodes=nodes,
                             uid=None,
                             cloud_properties=cloud_properties,
                             exposed=rde_1_x_entity.status.exposed)


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

* making a call to PUT /entities/id with entityType field modified to a new entity type should upgrade the RDE to a new entity type.
* Things to note: defined entity ID will no longer contain entity type version string. Example instead of `urn:vcloud:entity:cse:nativeCluster:2.0.0:919bbbc5-3d15-4a1e-99bc-e016647ac896` it will be `urn:vcloud:entity:cse:nativeCluster:919bbbc5-3d15-4a1e-99bc-e016647ac896`. However, the entity can be accessed using former style as well.

Testing done:
* Create an RDE cluster using CSE 3.0.2 and upgrade cse. Made sure that entity upgrade is working, vapp metadata is getting updated and entity type is getting deleted successfully.

@sakthisunda @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1046)
<!-- Reviewable:end -->
