### PR TITLE
[VCDA-2479] prevent AMQP configuration with CSE 3.1 non-legacy mode and 10.3 VCD

### DIFF
--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -59,7 +59,7 @@ from container_service_extension.security.encryption_engine import \
 from container_service_extension.server.pks.pks_cache import Credentials
 
 
-_AMQP_MAX_API_VERSION = '35.0'
+_AMQP_MAX_API_VERSION_FOR_LEGACY_MODE_FALSE = '35.0'
 
 
 def get_validated_config(config_file_name,
@@ -293,7 +293,8 @@ def _raise_error_if_amqp_not_supported(is_mqtt_used, default_api_version,
     :param str default_api_version: max VCD API version used by CSE.
     :raises: AmqpError
     """
-    if not is_mqtt_used and float(default_api_version) > float(_AMQP_MAX_API_VERSION):  # noqa: E501
+    if not is_mqtt_used and float(default_api_version) > \
+            float(_AMQP_MAX_API_VERSION_FOR_LEGACY_MODE_FALSE):
         msg = f"Cannot use AMQP message bus when working with api version" \
             f" {default_api_version}. Please upgrade to MQTT."
         logger.error(msg)

--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -59,7 +59,7 @@ from container_service_extension.security.encryption_engine import \
 from container_service_extension.server.pks.pks_cache import Credentials
 
 
-_AMQP_MAX_API_VERSION_FOR_LEGACY_MODE_FALSE = '35.0'
+_MAX_API_VERSION_TO_RUN_CSE_WITH_AMQP_IN_NON_LEGACY_MODE = '35.0'
 
 
 def get_validated_config(config_file_name,
@@ -294,7 +294,7 @@ def _raise_error_if_amqp_not_supported(is_mqtt_used, default_api_version,
     :raises: AmqpError
     """
     if not is_mqtt_used and float(default_api_version) > \
-            float(_AMQP_MAX_API_VERSION_FOR_LEGACY_MODE_FALSE):
+            float(_MAX_API_VERSION_TO_RUN_CSE_WITH_AMQP_IN_NON_LEGACY_MODE):
         msg = f"Cannot use AMQP message bus when working with api version" \
             f" {default_api_version}. Please upgrade to MQTT."
         logger.error(msg)

--- a/container_service_extension/installer/sample_generator.py
+++ b/container_service_extension/installer/sample_generator.py
@@ -334,7 +334,7 @@ def generate_sample_config(
 
         updated_service_config = dict(SAMPLE_SERVICE_CONFIG)
         if api_version < float(ApiVersion.VERSION_35.value):
-            updated_service_config['service']['legacy_mode'] = True
+            updated_service_config['service']['legacy_mode'] = False
         sample_config += yaml.safe_dump(updated_service_config,
                                         default_flow_style=False) + '\n'
 


### PR DESCRIPTION
…on-legacy mode

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

As CSE 3.1 uses behaviors when configured with VCD 10.3 and behaviors can only work with MQTT, it is not possible to support AMQP with CSE 3.1 and VCD 10.3 vcd.
Changes done:
- Config validator raises error when AMQP is configured and maximum api version is 36.0

Testing done:
- Install CSE with AMQP and vcd 10.3, check for error messages
- Install CSE with MQTT and 10.3, no errors should be thrown

@rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1048)
<!-- Reviewable:end -->
