### PR TITLE
[VCDA-2472 & VCDA-2545] Use version key in template yaml instead of depending on naming

### DIFF
--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -298,7 +298,31 @@ class LocalTemplateKey(str, Enum):
 
 
 @unique
-class RemoteTemplateKey(str, Enum):
+class RemoteTemplateKeyV1(str, Enum):
+    """Enumerate the keys that define a template."""
+
+    CNI = 'cni'
+    CNI_VERSION = 'cni_version'
+    COMPUTE_POLICY = 'compute_policy'
+    CPU = 'cpu'
+    DEPRECATED = 'deprecated'
+    DESCRIPTION = 'description'
+    DOCKER_VERSION = 'docker_version'
+    KIND = 'kind'
+    KUBERNETES = 'kubernetes'
+    KUBERNETES_VERSION = 'kubernetes_version'
+    MEMORY = 'mem'
+    NAME = 'name'
+    OS = 'os'
+    REVISION = 'revision'
+    SOURCE_OVA_HREF = 'source_ova'
+    SOURCE_OVA_NAME = 'source_ova_name'
+    SOURCE_OVA_SHA256 = 'sha256_ova'
+    UPGRADE_FROM = 'upgrade_from'
+
+
+@unique
+class RemoteTemplateKeyV2(str, Enum):
     """Enumerate the keys that define a template."""
 
     CNI = 'cni'

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -220,8 +220,8 @@ class TemplateScriptFile(str, Enum):
 
     # cluster upgrade scripts
     DOCKER_UPGRADE = 'cluster-upgrade/docker-upgrade.sh'
-    CONTROL_PLANE_CNI_APPLY = 'cluster-upgrade/master-cni-apply.sh'
-    CONTROL_PLANE_K8S_UPGRADE = 'cluster-upgrade/master-k8s-upgrade.sh'
+    CONTROL_PLANE_CNI_APPLY = 'cluster-upgrade/control-plane-cni-apply.sh'
+    CONTROL_PLANE_K8S_UPGRADE = 'cluster-upgrade/control-plane-k8s-upgrade.sh'
     WORKER_K8S_UPGRADE = 'cluster-upgrade/worker-k8s-upgrade.sh'
 
 

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -280,7 +280,6 @@ class LocalTemplateKey(str, Enum):
     CATALOG_ITEM_NAME = 'catalog_item_name'
     CNI = 'cni'
     CNI_VERSION = 'cni_version'
-    COMPUTE_POLICY = 'compute_policy'
     CPU = 'cpu'
     DEPRECATED = 'deprecated'
     DESCRIPTION = 'description'

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -327,7 +327,6 @@ class RemoteTemplateKeyV2(str, Enum):
 
     CNI = 'cni'
     CNI_VERSION = 'cni_version'
-    COMPUTE_POLICY = 'compute_policy'
     CPU = 'cpu'
     DEPRECATED = 'deprecated'
     DESCRIPTION = 'description'
@@ -345,6 +344,14 @@ class RemoteTemplateKeyV2(str, Enum):
     UPGRADE_FROM = 'upgrade_from'
     MIN_CSE_VERSION = 'min_cse_version'
     MAX_CSE_VERSION = 'max_cse_version'
+
+
+@unique
+class RemoteTemplateCookbookVersion(Enum):
+    """Enumerate the remote template cookbook versions."""
+
+    Version1 = semantic_version.Version('1.0.0')
+    Version2 = semantic_version.Version('2.0.0')
 
 
 # CSE requests

--- a/container_service_extension/common/utils/server_utils.py
+++ b/container_service_extension/common/utils/server_utils.py
@@ -8,6 +8,7 @@ import math
 
 import semantic_version
 
+import container_service_extension.common.constants.server_constants as server_constants  # noqa: E501
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
 import container_service_extension.common.utils.core_utils as utils
 import container_service_extension.rde.models.common_models as common_models
@@ -105,6 +106,18 @@ def should_use_mqtt_protocol(config):
     """
     return config.get('mqtt') is not None and \
         not utils.str_to_bool(config['service'].get('legacy_mode'))
+
+
+def get_template_descriptor_keys(cookbook_version):
+    """Get template descriptor keys using the cookbook version."""
+    # if cookbook version is None, use version 1.0
+    if not cookbook_version:
+        cookbook_version = '1.0'
+    cookbook_version_to_template_descriptor_keys_map = {
+        '1.0': server_constants.RemoteTemplateKeyV1,
+        '2.0': server_constants.RemoteTemplateKeyV2
+    }
+    return cookbook_version_to_template_descriptor_keys_map[cookbook_version]
 
 
 def construct_paginated_response(values, result_total,

--- a/container_service_extension/common/utils/server_utils.py
+++ b/container_service_extension/common/utils/server_utils.py
@@ -4,6 +4,7 @@
 
 """Server utility methods used only by the CSE server."""
 
+import enum
 import math
 
 import semantic_version
@@ -108,14 +109,14 @@ def should_use_mqtt_protocol(config):
         not utils.str_to_bool(config['service'].get('legacy_mode'))
 
 
-def get_template_descriptor_keys(cookbook_version):
+def get_template_descriptor_keys(cookbook_version: str) -> enum.EnumMeta:
     """Get template descriptor keys using the cookbook version."""
     # if cookbook version is None, use version 1.0
     if not cookbook_version:
-        cookbook_version = '1.0'
+        cookbook_version = '1.0.0'
     cookbook_version_to_template_descriptor_keys_map = {
-        '1.0': server_constants.RemoteTemplateKeyV1,
-        '2.0': server_constants.RemoteTemplateKeyV2
+        '1.0.0': server_constants.RemoteTemplateKeyV1,
+        '2.0.0': server_constants.RemoteTemplateKeyV2
     }
     return cookbook_version_to_template_descriptor_keys_map[cookbook_version]
 

--- a/container_service_extension/common/utils/server_utils.py
+++ b/container_service_extension/common/utils/server_utils.py
@@ -109,7 +109,7 @@ def should_use_mqtt_protocol(config):
         not utils.str_to_bool(config['service'].get('legacy_mode'))
 
 
-def get_template_descriptor_keys(cookbook_version: str) -> enum.EnumMeta:
+def get_template_descriptor_keys(cookbook_version: semantic_version.Version) -> enum.EnumMeta:  # noqa: E501
     """Get template descriptor keys using the cookbook version."""
     # if cookbook version is None, use version 1.0
     if not cookbook_version:

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -503,7 +503,7 @@ def install_template(template_name, template_revision, config_file_name,
 
         rtm.get_filtered_remote_template_cookbook()
         remote_template_keys = server_utils.get_template_descriptor_keys(
-            str(rtm.cookbook_version))
+            rtm.cookbook_version)
 
         found_template = False
         for template in rtm.filtered_cookbook['templates']:
@@ -1503,7 +1503,7 @@ def _construct_catalog_item_name_to_template_description_map(cookbook: dict) -> 
     :rtype: dict
     """
     remote_template_keys = \
-        server_utils.get_template_descriptor_keys(cookbook['version'])
+        server_utils.get_template_descriptor_keys(semantic_version.Version(cookbook['version']))  # noqa: E501
     catalog_item_name_to_template_description = {}
     for template in cookbook['templates']:
         # For CSE 3.1, we can safely assume that all the catalog item names are
@@ -1748,7 +1748,7 @@ def _install_single_template(
         raise Exception(msg)
     localTemplateKey = server_constants.LocalTemplateKey
     remote_template_keys = server_utils.get_template_descriptor_keys(
-        str(remote_template_manager.cookbook_version))
+        remote_template_manager.cookbook_version)
     if LEGACY_MODE:
         # if legacy_mode, make use of LegacyLocalTemplateKey which
         # doesn't contain min_cse_version and max_cse_version.

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -1551,7 +1551,7 @@ def _update_metadata_for_existing_templates(client: Client, config: dict,
     rtm.get_filtered_remote_template_cookbook()
     catalog_item_to_template_description_map = \
         _construct_catalog_item_name_to_template_description_map(
-            rtm.filtered_cookbook, rtm.cookbook_version)
+            rtm.filtered_cookbook)
     # List of keys for the new template metadata. This includes
     # min_cse_version and max_cse_version
     new_metadata_key_list = [k for k in server_constants.LocalTemplateKey]

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -502,7 +502,8 @@ def install_template(template_name, template_revision, config_file_name,
             logger=INSTALL_LOGGER, msg_update_callback=msg_update_callback)
 
         rtm.get_filtered_remote_template_cookbook()
-        remote_template_keys = server_utils.get_template_descriptor_keys(rtm.cookbook_version)  # noqa: E501
+        remote_template_keys = server_utils.get_template_descriptor_keys(
+            str(rtm.cookbook_version))
 
         found_template = False
         for template in rtm.filtered_cookbook['templates']:
@@ -1747,7 +1748,7 @@ def _install_single_template(
         raise Exception(msg)
     localTemplateKey = server_constants.LocalTemplateKey
     remote_template_keys = server_utils.get_template_descriptor_keys(
-        remote_template_manager.cookbook_version)
+        str(remote_template_manager.cookbook_version))
     if LEGACY_MODE:
         # if legacy_mode, make use of LegacyLocalTemplateKey which
         # doesn't contain min_cse_version and max_cse_version.

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -502,12 +502,13 @@ def install_template(template_name, template_revision, config_file_name,
             logger=INSTALL_LOGGER, msg_update_callback=msg_update_callback)
 
         rtm.get_filtered_remote_template_cookbook()
+        remote_template_keys = server_utils.get_template_descriptor_keys(rtm.cookbook_version)  # noqa: E501
 
         found_template = False
         for template in rtm.filtered_cookbook['templates']:
-            template_name_matched = template_name in (template[server_constants.RemoteTemplateKey.NAME], '*')  # noqa: E501
+            template_name_matched = template_name in (template[remote_template_keys.NAME], '*')  # noqa: E501
             template_revision_matched = \
-                str(template_revision) in (str(template[server_constants.RemoteTemplateKey.REVISION]), '*')  # noqa: E501
+                str(template_revision) in (str(template[remote_template_keys.REVISION]), '*')  # noqa: E501
             if template_name_matched and template_revision_matched:
                 found_template = True
                 _install_single_template(
@@ -534,8 +535,8 @@ def install_template(template_name, template_revision, config_file_name,
             #   template_name is in unfiltered cookbook
             # if (template_name, template_revision) is in unfiltered cookbook
             for template in rtm.unfiltered_cookbook['templates']:
-                template_name_matched = template[server_constants.RemoteTemplateKey.NAME] == template_name  # noqa: E501
-                template_revision_matched = template_revision in (str(template[server_constants.RemoteTemplateKey.REVISION]), '*')  # noqa: E501
+                template_name_matched = template[remote_template_keys.NAME] == template_name  # noqa: E501
+                template_revision_matched = template_revision in (str(template[remote_template_keys.REVISION]), '*')  # noqa: E501
                 if template_name_matched and template_revision_matched:
                     msg = f"Template '{template_name}' at revision " \
                           f"'{template_revision}' is not supported by " \
@@ -1500,14 +1501,16 @@ def _construct_catalog_item_name_to_template_description_map(cookbook: dict) -> 
         as value
     :rtype: dict
     """
+    remote_template_keys = \
+        server_utils.get_template_descriptor_keys(cookbook['version'])
     catalog_item_name_to_template_description = {}
     for template in cookbook['templates']:
         # For CSE 3.1, we can safely assume that all the catalog item names are
         # present in template metadata as CSE 3.1 can only be upgraded from
         # CSE 3.0
         catalog_item_name = ltm.get_revisioned_template_name(
-            template[server_constants.RemoteTemplateKey.NAME],
-            template[server_constants.RemoteTemplateKey.REVISION])
+            template[remote_template_keys.NAME],
+            template[remote_template_keys.REVISION])
         catalog_item_name_to_template_description[catalog_item_name] = template
     return catalog_item_name_to_template_description
 
@@ -1548,7 +1551,7 @@ def _update_metadata_for_existing_templates(client: Client, config: dict,
     rtm.get_filtered_remote_template_cookbook()
     catalog_item_to_template_description_map = \
         _construct_catalog_item_name_to_template_description_map(
-            rtm.filtered_cookbook)
+            rtm.filtered_cookbook, rtm.cookbook_version)
     # List of keys for the new template metadata. This includes
     # min_cse_version and max_cse_version
     new_metadata_key_list = [k for k in server_constants.LocalTemplateKey]
@@ -1605,8 +1608,8 @@ def _assign_placement_policies_to_existing_templates(client: Client,
     for template in all_templates:
         kind = template.get(server_constants.LocalTemplateKey.KIND)
         catalog_item_name = ltm.get_revisioned_template_name(
-            template[server_constants.RemoteTemplateKey.NAME],
-            template[server_constants.RemoteTemplateKey.REVISION])
+            template[server_constants.LocalTemplateKey.NAME],
+            template[server_constants.LocalTemplateKey.REVISION])
         msg = f"Processing template {catalog_item_name}"
         INSTALL_LOGGER.debug(msg)
         msg_update_callback.general(msg)
@@ -1743,18 +1746,20 @@ def _install_single_template(
         msg_update_callback.error(msg)
         raise Exception(msg)
     localTemplateKey = server_constants.LocalTemplateKey
+    remote_template_keys = server_utils.get_template_descriptor_keys(
+        remote_template_manager.cookbook_version)
     if LEGACY_MODE:
         # if legacy_mode, make use of LegacyLocalTemplateKey which
         # doesn't contain min_cse_version and max_cse_version.
         localTemplateKey = server_constants.LegacyLocalTemplateKey
     templateBuildKey = server_constants.TemplateBuildKey
     remote_template_manager.download_template_scripts(
-        template_name=template[server_constants.RemoteTemplateKey.NAME],
-        revision=template[server_constants.RemoteTemplateKey.REVISION],
+        template_name=template[remote_template_keys.NAME],
+        revision=template[remote_template_keys.REVISION],
         force_overwrite=force_update)
     catalog_item_name = ltm.get_revisioned_template_name(
-        template[server_constants.RemoteTemplateKey.NAME],
-        template[server_constants.RemoteTemplateKey.REVISION])
+        template[remote_template_keys.NAME],
+        template[remote_template_keys.REVISION])
 
     # remote template data is a super set of local template data, barring
     # the key 'catalog_item_name'
@@ -1768,37 +1773,37 @@ def _install_single_template(
         raise ValueError(f"Invalid template data. Missing keys: {missing_keys}")  # noqa: E501
 
     temp_vm_name = (
-        f"{template[server_constants.RemoteTemplateKey.OS].replace('.', '')}-"
-        f"k8s{template[server_constants.RemoteTemplateKey.KUBERNETES_VERSION].replace('.', '')}-"  # noqa: E501
-        f"{template[server_constants.RemoteTemplateKey.CNI]}"
-        f"{template[server_constants.RemoteTemplateKey.CNI_VERSION].replace('.', '')}-vm"  # noqa: E501
+        f"{template[remote_template_keys.OS].replace('.', '')}-"
+        f"k8s{template[remote_template_keys.KUBERNETES_VERSION].replace('.', '')}-"  # noqa: E501
+        f"{template[remote_template_keys.CNI]}"
+        f"{template[remote_template_keys.CNI_VERSION].replace('.', '')}-vm"
     )
     build_params = {
-        templateBuildKey.TEMPLATE_NAME: template[server_constants.RemoteTemplateKey.NAME],  # noqa: E501
-        templateBuildKey.TEMPLATE_REVISION: template[server_constants.RemoteTemplateKey.REVISION],  # noqa: E501
-        templateBuildKey.SOURCE_OVA_NAME: template[server_constants.RemoteTemplateKey.SOURCE_OVA_NAME],  # noqa: E501
-        templateBuildKey.SOURCE_OVA_HREF: template[server_constants.RemoteTemplateKey.SOURCE_OVA_HREF],  # noqa: E501
-        templateBuildKey.SOURCE_OVA_SHA256: template[server_constants.RemoteTemplateKey.SOURCE_OVA_SHA256],  # noqa: E501
+        templateBuildKey.TEMPLATE_NAME: template[remote_template_keys.NAME],  # noqa: E501
+        templateBuildKey.TEMPLATE_REVISION: template[remote_template_keys.REVISION],  # noqa: E501
+        templateBuildKey.SOURCE_OVA_NAME: template[remote_template_keys.SOURCE_OVA_NAME],  # noqa: E501
+        templateBuildKey.SOURCE_OVA_HREF: template[remote_template_keys.SOURCE_OVA_HREF],  # noqa: E501
+        templateBuildKey.SOURCE_OVA_SHA256: template[remote_template_keys.SOURCE_OVA_SHA256],  # noqa: E501
         templateBuildKey.ORG_NAME: org_name,
         templateBuildKey.VDC_NAME: vdc_name,
         templateBuildKey.CATALOG_NAME: catalog_name,
         templateBuildKey.CATALOG_ITEM_NAME: catalog_item_name,
-        templateBuildKey.CATALOG_ITEM_DESCRIPTION: template[server_constants.RemoteTemplateKey.DESCRIPTION],  # noqa: E501
-        templateBuildKey.TEMP_VAPP_NAME: template[server_constants.RemoteTemplateKey.NAME] + '_temp',  # noqa: E501
+        templateBuildKey.CATALOG_ITEM_DESCRIPTION: template[remote_template_keys.DESCRIPTION],  # noqa: E501
+        templateBuildKey.TEMP_VAPP_NAME: template[remote_template_keys.NAME] + '_temp',  # noqa: E501
         templateBuildKey.TEMP_VM_NAME: temp_vm_name,
-        templateBuildKey.CPU: template[server_constants.RemoteTemplateKey.CPU],
-        templateBuildKey.MEMORY: template[server_constants.RemoteTemplateKey.MEMORY],  # noqa: E501
+        templateBuildKey.CPU: template[remote_template_keys.CPU],
+        templateBuildKey.MEMORY: template[remote_template_keys.MEMORY],  # noqa: E501
         templateBuildKey.NETWORK_NAME: network_name,
         templateBuildKey.IP_ALLOCATION_MODE: ip_allocation_mode,  # noqa: E501
         templateBuildKey.STORAGE_PROFILE: storage_profile
     }
     if not LEGACY_MODE:  # noqa: E501
         if template.get(
-                server_constants.RemoteTemplateKey.KIND) not in shared_constants.RUNTIME_DISPLAY_NAME_TO_INTERNAL_NAME_MAP:  # noqa: E501
-            raise ValueError(f"Cluster kind is {template.get(server_constants.RemoteTemplateKey.KIND)}"  # noqa: E501
+                remote_template_keys.KIND) not in shared_constants.RUNTIME_DISPLAY_NAME_TO_INTERNAL_NAME_MAP:  # noqa: E501
+            raise ValueError(f"Cluster kind is {template.get(remote_template_keys.KIND)}"  # noqa: E501
                              f" Expected { shared_constants.RUNTIME_DISPLAY_NAME_TO_INTERNAL_NAME_MAP.keys()}")  # noqa: E501
         build_params[templateBuildKey.CSE_PLACEMENT_POLICY] = \
-            shared_constants.RUNTIME_DISPLAY_NAME_TO_INTERNAL_NAME_MAP[template.get(server_constants.RemoteTemplateKey.KIND)]  # noqa: E501
+            shared_constants.RUNTIME_DISPLAY_NAME_TO_INTERNAL_NAME_MAP[template.get(remote_template_keys.KIND)]  # noqa: E501
     builder = template_builder.TemplateBuilder(client, client, build_params,
                                                ssh_key=ssh_key,
                                                logger=INSTALL_LOGGER,

--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -185,7 +185,7 @@ class RemoteTemplateManager():
                 (not self.legacy_mode and self.cookbook_version != '2.0'):
             incompatible_template_cookbook_msg = \
                 f"Template cookbook version {self.cookbook_version} is " \
-                f"incompatible with CSE executing in legacy_mode: {self.legacy_mode}"  # noqa: E501
+                f"incompatible with CSE running in legacy_mode: {self.legacy_mode}"  # noqa: E501
             self.logger.error(incompatible_template_cookbook_msg)
             self.msg_update_callback.error(incompatible_template_cookbook_msg)
             raise Exception(incompatible_template_cookbook_msg)

--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -64,7 +64,7 @@ class RemoteTemplateManager():
         self.msg_update_callback = msg_update_callback
         self.filtered_cookbook = None
         self.unfiltered_cookbook = None
-        self.cookbook_version: str = None
+        self.cookbook_version: semantic_version.Version = None
         self.scripts_directory_path: str = None
 
     def _get_base_url_from_remote_template_cookbook_url(self) -> str:

--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -142,9 +142,10 @@ class RemoteTemplateManager():
             msg += f" by CSE {current_cse_version}"
             self.logger.debug(msg)
             self.msg_update_callback.general(msg)
-        self.filtered_cookbook = {
-            'templates': supported_templates
-        }
+        self.filtered_cookbook = self.unfiltered_cookbook
+        # update templates list with only supported templates
+        self.filtered_cookbook['templates'] = supported_templates
+
         msg = "Successfully filtered unsupported templates."
         self.logger.debug(msg)
         self.msg_update_callback.general(msg)

--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -124,7 +124,7 @@ class RemoteTemplateManager():
         # Fetch current CSE version
         current_cse_version = server_utils.get_installed_cse_version()
         supported_templates = []
-        remote_template_key = server_utils.get_template_descriptor_keys(str(self.cookbook_version))  # noqa: E501
+        remote_template_key = server_utils.get_template_descriptor_keys(self.cookbook_version)  # noqa: E501
         for template_description in self.unfiltered_cookbook['templates']:
             # only include the template if the current CSE version
             # supports it
@@ -169,7 +169,7 @@ class RemoteTemplateManager():
             self.msg_update_callback.error(msg)
             raise ValueError(msg)
 
-        template_decriptor_keys = server_utils.get_template_descriptor_keys(str(self.cookbook_version))  # noqa: E501
+        template_decriptor_keys = server_utils.get_template_descriptor_keys(self.cookbook_version)  # noqa: E501
         key_set_expected = set([k.value for k in template_decriptor_keys])
 
         # Validate template yaml contents

--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -18,11 +18,6 @@ import container_service_extension.common.utils.server_utils as server_utils
 import container_service_extension.installer.templates.local_template_manager as ltm  # noqa: E501
 from container_service_extension.logging.logger import NULL_LOGGER
 
-REMOTE_TEMPLATE_COOKBOOK_V2_FILENAME = 'template_v2.yaml'
-REMOTE_TEMPLATE_COOKBOOK_FILENAME = 'template.yaml'
-REMOTE_SCRIPTS_V2_DIR = 'scripts_v2'
-REMOTE_SCRIPTS_DIR = 'scripts'
-
 
 def download_file_into_memory(url):
     """Download a file and store it in memory.

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -330,7 +330,7 @@ class NativeEntity(AbstractNativeEntity):
             )
             spec = ClusterSpec(
                 settings=Settings(
-                    network=rde_1_x_entity.spec.settings.network,
+                    ovdc_network=rde_1_x_entity.spec.settings.network,
                     ssh_key=rde_1_x_entity.spec.settings.ssh_key,
                     rollback_on_failure=rde_1_x_entity.spec.settings.rollback_on_failure),  # noqa: E501,
                 topology=topology,

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -137,7 +137,7 @@ def construct_2_0_0_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Sta
         template_revision=entity_status.cloud_properties.distribution.template_revision)  # noqa: E501
 
     settings = rde_2_0_0.Settings(
-        network=entity_status.cloud_properties.ovdc_network_name,
+        ovdc_network=entity_status.cloud_properties.ovdc_network_name,
         ssh_key=entity_status.cloud_properties.ssh_key,
         rollback_on_failure=entity_status.cloud_properties.rollback_on_failure)  # noqa: E501
 

--- a/container_service_extension/rde/validators/validator_rde_2_x.py
+++ b/container_service_extension/rde/validators/validator_rde_2_x.py
@@ -58,7 +58,11 @@ class Validator_2_0_0(AbstractValidator):
             get_rde_model(rde_version_introduced_at_api_version)
         input_entity = None
         if entity:
-            input_entity: AbstractNativeEntity = NativeEntityClass.from_dict(entity)  # noqa: E501
+            try:
+                input_entity: AbstractNativeEntity = NativeEntityClass.from_dict(entity)  # noqa: E501
+            except Exception as err:
+                msg = f"Failed to parse request body: {err}"
+                raise BadRequestError(msg)
 
         # Return True if the operation is not specified.
         if not operation:

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -1042,7 +1042,7 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                 rtm.get_filtered_remote_template_cookbook()
             remote_template_definitions = remote_template_cookbook['templates']
             remote_template_keys = server_utils.get_template_descriptor_keys(
-                str(rtm.cookbook_version))
+                rtm.cookbook_version)
             for definition in remote_template_definitions:
                 remote_template = {
                     'name': definition[remote_template_keys.NAME],

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -20,7 +20,6 @@ import yaml
 
 from container_service_extension.common.constants.server_constants import CONFIG_DECRYPTION_ERROR_MSG  # noqa: E501
 from container_service_extension.common.constants.server_constants import LocalTemplateKey  # noqa: E501
-from container_service_extension.common.constants.server_constants import RemoteTemplateKey  # noqa: E501
 from container_service_extension.common.constants.server_constants import SYSTEM_ORG_NAME  # noqa: E501
 from container_service_extension.common.constants.shared_constants import SUPPORTED_VCD_API_VERSIONS  # noqa: E501
 import container_service_extension.common.utils.core_utils as utils
@@ -1039,20 +1038,21 @@ def list_template(ctx, config_file_path, skip_config_decryption,
             remote_template_cookbook = \
                 rtm.get_filtered_remote_template_cookbook()
             remote_template_definitions = remote_template_cookbook['templates']
+            remote_template_keys = server_utils.get_template_descriptor_keys(rtm.cookbook_version)  # noqa: E501
             for definition in remote_template_definitions:
                 remote_template = {
-                    'name': definition[RemoteTemplateKey.NAME],
-                    'revision': definition[RemoteTemplateKey.REVISION],
-                    'compute_policy': definition[RemoteTemplateKey.COMPUTE_POLICY],  # noqa: E501
+                    'name': definition[remote_template_keys.NAME],
+                    'revision': definition[remote_template_keys.REVISION],
+                    'compute_policy': definition[remote_template_keys.COMPUTE_POLICY],  # noqa: E501
                     'local': 'No',
                     'remote': 'Yes',
-                    'cpu': definition[RemoteTemplateKey.CPU],
-                    'memory': definition[RemoteTemplateKey.MEMORY],
-                    'description': definition[RemoteTemplateKey.DESCRIPTION]
+                    'cpu': definition[remote_template_keys.CPU],
+                    'memory': definition[remote_template_keys.MEMORY],
+                    'description': definition[remote_template_keys.DESCRIPTION]
                 }
                 if display_option is DISPLAY_ALL:
                     remote_template['default'] = 'No'
-                remote_template['deprecated'] = 'Yes' if utils.str_to_bool(definition[RemoteTemplateKey.DEPRECATED]) else 'No'  # noqa: E501
+                remote_template['deprecated'] = 'Yes' if utils.str_to_bool(definition[remote_template_keys.DEPRECATED]) else 'No'  # noqa: E501
 
                 remote_templates.append(remote_template)
 
@@ -1065,7 +1065,7 @@ def list_template(ctx, config_file_path, skip_config_decryption,
             for local_template in local_templates:
                 found = False
                 for remote_template in remote_templates:
-                    if (local_template[LocalTemplateKey.NAME], local_template[LocalTemplateKey.REVISION]) == (remote_template[RemoteTemplateKey.NAME], remote_template[RemoteTemplateKey.REVISION]):  # noqa: E501
+                    if (local_template[LocalTemplateKey.NAME], local_template[LocalTemplateKey.REVISION]) == (remote_template[remote_template_keys.NAME], remote_template[remote_template_keys.REVISION]):  # noqa: E501
                         remote_template['compute_policy'] = \
                             local_template['compute_policy']
                         remote_template['local'] = local_template['local']
@@ -1078,7 +1078,7 @@ def list_template(ctx, config_file_path, skip_config_decryption,
             for remote_template in remote_templates:
                 found = False
                 for local_template in local_templates:
-                    if (local_template[LocalTemplateKey.NAME], local_template[LocalTemplateKey.REVISION]) == (remote_template[RemoteTemplateKey.NAME], remote_template[RemoteTemplateKey.REVISION]):  # noqa: E501
+                    if (local_template[LocalTemplateKey.NAME], local_template[LocalTemplateKey.REVISION]) == (remote_template[remote_template_keys.NAME], remote_template[remote_template_keys.REVISION]):  # noqa: E501
                         found = True
                         break
                 if not found:


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

* Template .yaml should contain a version key which will help identifying the template script structure
* Remove hard coding of script directory path. Use script_directory key in template.yaml

Testing done:
* Install CSE 3.1 using cookbook with version 1.0 -> should fail with proper error message
* Install CSE 3.1 using cookbook with version 2.0 and install a template

@rocknes @sahithi @sakthisunda @arunmk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1052)
<!-- Reviewable:end -->
