### PR TITLE
[VCDA-2557] Update help strings install upgrade template install

### DIFF
--- a/container_service_extension/client/template_commands.py
+++ b/container_service_extension/client/template_commands.py
@@ -16,6 +16,9 @@ from container_service_extension.logging.logger import CLIENT_LOGGER
 def template_group(ctx):
     """Manage native kubernetes runtime templates.
 
+Templates that are no longer compliant with CSE template cookbook
+specification will be ignored.
+
 \b
 Examples
     vcd cse template list

--- a/container_service_extension/installer/sample_generator.py
+++ b/container_service_extension/installer/sample_generator.py
@@ -332,16 +332,19 @@ def generate_sample_config(
         sample_config += yaml.safe_dump(SAMPLE_VCS_CONFIG,
                                         default_flow_style=False) + '\n'
 
-        updated_service_config = dict(SAMPLE_SERVICE_CONFIG)
         if api_version < float(ApiVersion.VERSION_35.value):
-            updated_service_config['service']['legacy_mode'] = False
-        sample_config += yaml.safe_dump(updated_service_config,
+            SAMPLE_SERVICE_CONFIG['service']['legacy_mode'] = True
+
+        sample_config += yaml.safe_dump(SAMPLE_SERVICE_CONFIG,
                                         default_flow_style=False) + '\n'
+
+        if api_version < float(ApiVersion.VERSION_35.value):
+            SAMPLE_BROKER_CONFIG['broker']['remote_template_cookbook_url'] = 'http://raw.githubusercontent.com/vmware/container-service-extension-templates/upgrades/template.yaml' # noqa: E501
 
         sample_config += yaml.safe_dump(SAMPLE_BROKER_CONFIG,
                                         default_flow_style=False) + '\n'
 
-        if updated_service_config['service']['legacy_mode']:
+        if SAMPLE_SERVICE_CONFIG['service']['legacy_mode']:
             sample_config += TEMPLATE_RULE_NOTE + '\n'
     else:
         sample_config = yaml.safe_dump(

--- a/container_service_extension/installer/sample_generator.py
+++ b/container_service_extension/installer/sample_generator.py
@@ -304,7 +304,7 @@ def generate_sample_config(
         configuration file instead of sample regular CSE configuration file.
     :param bool legacy_mode: if True to configure CSE with whose maximum
     supported api_version < 35. if False to configure CSE with whose maximum
-    supported api_version > 35
+    supported api_version >= 35
 
     :return: sample config
 

--- a/container_service_extension/installer/sample_generator.py
+++ b/container_service_extension/installer/sample_generator.py
@@ -2,11 +2,7 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-from pyvcloud.vcd.client import ApiVersion
 import yaml
-
-from container_service_extension.common.constants.server_constants import MQTT_MIN_API_VERSION  # noqa: E501
-from container_service_extension.common.constants.shared_constants import SUPPORTED_VCD_API_VERSIONS  # noqa: E501
 
 
 INSTRUCTIONS_FOR_PKS_CONFIG_FILE = "\
@@ -297,7 +293,7 @@ SAMPLE_PKS_NSXT_SERVERS_SECTION = {
 
 
 def generate_sample_config(
-        output_file_name: str, generate_pks_config: bool, api_version: str):
+        output_file_name: str, generate_pks_config: bool, legacy_mode=False):
     """Generate sample configs for cse.
 
     If output config file name is provided, config is dumped into the file.
@@ -306,21 +302,17 @@ def generate_sample_config(
         CSE configs.
     :param bool generate_pks_config: Flag to generate sample of PKS specific
         configuration file instead of sample regular CSE configuration file.
-    :param float api_version: the desired api version for the config file.
+    :param bool legacy_mode: if True to configure CSE with whose maximum
+    supported api_version < 35. if False to configure CSE with whose maximum
+    supported api_version > 35
 
     :return: sample config
 
     :rtype: dict
     """
-    api_version_str = str(api_version)
-    if api_version_str not in SUPPORTED_VCD_API_VERSIONS:
-        raise Exception(f'vCD API version {api_version} is not supported. '
-                        f'Please pick one of the following API versions: '
-                        f'{SUPPORTED_VCD_API_VERSIONS}')
-
     if not generate_pks_config:
         # Select message protocol section
-        if api_version >= MQTT_MIN_API_VERSION:
+        if not legacy_mode:
             sample_config = COMMENTED_AMQP_SECTION + '\n'
             sample_config += yaml.safe_dump(SAMPLE_MQTT_CONFIG) + '\n'
         else:
@@ -332,13 +324,13 @@ def generate_sample_config(
         sample_config += yaml.safe_dump(SAMPLE_VCS_CONFIG,
                                         default_flow_style=False) + '\n'
 
-        if api_version < float(ApiVersion.VERSION_35.value):
+        if legacy_mode:
             SAMPLE_SERVICE_CONFIG['service']['legacy_mode'] = True
 
         sample_config += yaml.safe_dump(SAMPLE_SERVICE_CONFIG,
                                         default_flow_style=False) + '\n'
 
-        if api_version < float(ApiVersion.VERSION_35.value):
+        if legacy_mode:
             SAMPLE_BROKER_CONFIG['broker']['remote_template_cookbook_url'] = 'http://raw.githubusercontent.com/vmware/container-service-extension-templates/upgrades/template.yaml' # noqa: E501
 
         sample_config += yaml.safe_dump(SAMPLE_BROKER_CONFIG,

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -571,7 +571,7 @@ def encrypt(ctx, input_file, output_file):
         sys.exit(1)
 
 
-@cli.command(short_help='Install CSE extension 3.0.0 on vCD')
+@cli.command(short_help='Install CSE extension 3.1.1 on vCD')
 @click.pass_context
 @click.option(
     '-c',
@@ -620,7 +620,14 @@ def encrypt(ctx, input_file, output_file):
 def install(ctx, config_file_path, pks_config_file_path,
             skip_config_decryption, skip_template_creation,
             retain_temp_vapp, ssh_key_file):
-    """Install CSE on vCloud Director."""
+    """Install CSE on vCloud Director.
+
+\b
+    NOTE: Validation on remote-template_cookbook-url is done based on
+    template cookbook version and legacy_mode setting in config.
+    Set legacy_mode=true to install CSE for VCD api_version < 35.
+    Set legacy_mode=false to install CSE for VCD api_version >= 35.
+    """
     # NOTE: For CSE 3.0, if `enable_tkg_plus` in config file is set to false
     # and if `cse install` is invoked without skipping template creation,
     # an Exception will be thrown if TKG+ template is present in the
@@ -762,7 +769,11 @@ def pks_configure(ctx, pks_config_file_path, skip_config_decryption):
     help='Skip decryption of CSE/PKS config file')
 def run(ctx, config_file_path, pks_config_file_path, skip_check,
         skip_config_decryption):
-    """Run CSE service."""
+    """Run CSE service.
+
+    NOTE: Validation on remote-template_cookbook-url is done based on
+          template cookbook version and legacy_mode setting in config.
+    """
     SERVER_CLI_LOGGER.debug(f"Executing command: {ctx.command_path}")
     console_message_printer = utils.ConsoleMessagePrinter()
     utils.check_python_version(console_message_printer)
@@ -809,7 +820,7 @@ def run(ctx, config_file_path, pks_config_file_path, skip_check,
 
 
 @cli.command('upgrade',
-             short_help="Upgrade CSE extension to version 3.0.0 on vCD")
+             short_help="Upgrade CSE extension to version 3.1.1 on vCD")
 @click.pass_context
 @click.option(
     '-c',
@@ -851,17 +862,24 @@ def run(ctx, config_file_path, pks_config_file_path, skip_check,
 def upgrade(ctx, config_file_path, skip_config_decryption,
             skip_template_creation, retain_temp_vapp,
             ssh_key_file):
-    """Upgrade existing CSE installation/entities to match CSE 3.1.
+    """Upgrade existing CSE installation/entities to match CSE 3.1.1.
 
 \b
-    - Add CSE / VCD API version info to VCD's extension data for CSE
+    - Add CSE, RDE version, Legacy mode info to VCD's extension data for CSE
     - Register defined entities schema of CSE k8s clusters with VCD
     - Create placement compute policies used by CSE
     - Remove old sizing compute policies created by CSE 2.6 and below
     - Install all templates from template repository linked in config file
-    - Update currently installed templates that are no longer defined in
-      CSE template repository to adhere to CSE 3.0 template requirements.
-    - Update existing CSE k8s cluster's to match CSE 3.0 k8s clusters.
+    - Currently installed templates that are no longer compliant with
+      CSE template cookbook specification will be ignored.
+    - Update existing CSE k8s cluster's to match CSE 3.1 k8s clusters.
+    - Upgrading legacy clusters would require new template creation supported
+      by CSE 3.1.1
+    - NOTE: Validation on remote-template_cookbook-url is done based on
+      template cookbook version and legacy_mode setting in config.
+      Set legacy_mode=true to upgrade CSE for VCD api_version < 35.
+      Set legacy_mode=false to upgrade CSE for VCD api_version >= 35.
+
     """
     # NOTE: For CSE 3.0, if `enable_tkg_plus` in the config is set to false,
     # an exception is thrown if
@@ -1160,6 +1178,9 @@ def install_cse_template(ctx, template_name, template_revision,
 
     Use '*' for TEMPLATE_NAME and TEMPLATE_REVISION to install
     all listed templates.
+
+    NOTE: Validation on remote-template_cookbook-url is done based on
+          template cookbook version and legacy_mode setting.
     """
     # NOTE: For CSE 3.0, if `enable_tkg_plus` flag in config is set to false,
     # Throw an error if TKG+ template creation is issued.


### PR DESCRIPTION
- Updated Help strings for CLI on install, upgrade, run, template install
- Fixed sample generation depending on api_version: location of template_cookbook_url and legacy mode 
- Manually verified
@sahithi @Anirudh9794

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1057)
<!-- Reviewable:end -->
