### PR TITLE
[VCDA-2559] Fix `cse cluster apply -s -n/-t/-m`

### DIFF
--- a/container_service_extension/client/cluster_commands.py
+++ b/container_service_extension/client/cluster_commands.py
@@ -530,7 +530,7 @@ Examples
     '--native',
     'k8_runtime',
     is_flag=True,
-    flag_value=shared_constants.ClusterEntityKind.NATIVE,
+    flag_value=shared_constants.ClusterEntityKind.NATIVE.value,
     help="should be used with --sample, this flag generates sample yaml for k8 runtime: native"  # noqa: E501
 )
 @click.option(
@@ -538,7 +538,7 @@ Examples
     '--tkg',
     'k8_runtime',
     is_flag=True,
-    flag_value=shared_constants.ClusterEntityKind.TKG,
+    flag_value=shared_constants.ClusterEntityKind.TKG.value,
     help="should be used with --sample, this flag generates sample yaml for k8 runtime: TKG"  # noqa: E501
 )
 @click.option(
@@ -547,7 +547,7 @@ Examples
     'k8_runtime',
     is_flag=True,
     hidden=not utils.is_environment_variable_enabled(cli_constants.ENV_CSE_TKG_PLUS_ENABLED),  # noqa: E501
-    flag_value=shared_constants.ClusterEntityKind.TKG_PLUS,
+    flag_value=shared_constants.ClusterEntityKind.TKG_PLUS.value,
     help="should be used with --sample, this flag generates sample yaml for k8 runtime: TKG+"  # noqa: E501
 )
 @click.option(
@@ -556,7 +556,7 @@ Examples
     'k8_runtime',
     is_flag=True,
     hidden=not utils.is_environment_variable_enabled(cli_constants.ENV_CSE_TKG_M_ENABLED),  # noqa: E501
-    flag_value=shared_constants.ClusterEntityKind.TKG_M,
+    flag_value=shared_constants.ClusterEntityKind.TKG_M.value,
     help="should be used with --sample, this flag generates sample yaml for k8 runtime: TKGm"  # noqa: E501
 )
 @click.option(
@@ -611,10 +611,10 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, out
                     msg += " or --tkg-m"
                 CLIENT_LOGGER.error(msg)
                 raise Exception(msg)
-            if k8_runtime == shared_constants.ClusterEntityKind.TKG_PLUS \
+            if k8_runtime == shared_constants.ClusterEntityKind.TKG_PLUS.value \
                     and not tkg_plus_env_enabled:  # noqa: E501
                 raise Exception(f"{shared_constants.ClusterEntityKind.TKG_PLUS.value} not enabled")  # noqa: E501
-            if k8_runtime == shared_constants.ClusterEntityKind.TKG_M \
+            if k8_runtime == shared_constants.ClusterEntityKind.TKG_M.value \
                     and not tkg_m_env_enabled:  # noqa: E501
                 raise Exception(f"{shared_constants.ClusterEntityKind.TKG_M.value} not enabled")  # noqa: E501
 
@@ -647,7 +647,7 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, out
         CLIENT_LOGGER.debug(result)
     except Exception as e:
         stderr(e, ctx)
-        CLIENT_LOGGER.error(str(e))
+        CLIENT_LOGGER.error(str(e), exc_info=True)
 
 
 @cluster_group.command('delete-nfs',

--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -124,10 +124,10 @@ class GroupCommandFilter(click.Group):
 
     # TODO(Make get_command hierarchy aware): Since get_command() cannot know
     # the hierarchical context of 'cmd_name', there is a possibility that
-    # there will be unintended command ommition.
-    # Example: If 'node' command is ommited in cse group, and the filter is
+    # there will be unintended command omission.
+    # Example: If 'node' command is omitted in cse group, and the filter is
     # used in pks group (which is part of cse group), then the 'node' command
-    # under pks group also will be ommitted.
+    # under pks group also will be omitted.
     def get_command(self, ctx, cmd_name):
         """Override this click method to customize.
 
@@ -163,7 +163,7 @@ class GroupCommandFilter(click.Group):
             filtered_params = [param for param in cmd.params if param.name not in unsupported_params]  # noqa: E501
             cmd.params = filtered_params
         except Exception as e:
-            CLIENT_LOGGER.debug(f'exception while filtering {cmd_name}: {e}')
-            pass
+            CLIENT_LOGGER.debug(
+                f'exception while filtering {cmd_name}: {e}', exc_info=True)
 
         return click.Group.get_command(self, ctx, cmd_name)

--- a/container_service_extension/client/sample_generator.py
+++ b/container_service_extension/client/sample_generator.py
@@ -79,9 +79,8 @@ def get_sample_cluster_configuration(output=None, k8_runtime=None):
     :return: sample cluster configuration
     :rtype: str
     """
-    if k8_runtime == shared_constants.ClusterEntityKind.TKG:
+    if k8_runtime == shared_constants.ClusterEntityKind.TKG.value:
         sample_cluster_config = SAMPLE_TKG_CLUSTER_SPEC_HELP + _get_sample_tkg_cluster_configuration()  # noqa: E501
-
     else:
         sample_cluster_config = SAMPLE_K8_CLUSTER_SPEC_HELP + _get_sample_cluster_configuration_by_k8_runtime(k8_runtime)  # noqa: E501
 
@@ -129,7 +128,7 @@ def _get_sample_cluster_configuration_by_k8_runtime(k8_runtime):
         metadata=metadata,
         spec=cluster_spec,
         status=status,
-        kind=k8_runtime.value
+        kind=k8_runtime
     )
 
     sample_cluster_config = yaml.dump(dataclasses.asdict(cluster_entity))


### PR DESCRIPTION
On windows, `cse cluster apply -s` fails with the error message "str object has no attribute value"

It seems that click converts all default values to string before passing them to the method as param.
The default value for the type of sample to generate is an Enum, which when passed into the method is getting converted to string, as a result the code downstream that tries to grab the value of the Enum object ends up calling value() on a string object and fails.

As a fix, this PR makes sure that the entire code path is designed to deal with only strings and not Enum objects.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1058)
<!-- Reviewable:end -->
