### PR TITLE
[VCDA-2560] Update RDE native schema while upgrading CSE from 3.0.0/1/2 to 3.0.3

### DIFF
--- a/container_service_extension/server_cli.py
+++ b/container_service_extension/server_cli.py
@@ -1263,7 +1263,6 @@ def install_cse_template(ctx, template_name, template_revision,
             retain_temp_vapp=retain_temp_vapp,
             ssh_key=ssh_key,
             skip_config_decryption=skip_config_decryption,
-            decryption_password=password,
             msg_update_callback=console_message_printer)
     except Exception as err:
         SERVER_CLI_LOGGER.error(str(err))


### PR DESCRIPTION
While upgrading CSE 3.0.0/1/2 to CSE 3.0.3, update the registered native RDE schema to allow TKGm as a valid value for kind.

Testing done:
Installed CSE 3.0.2.
Created a native cluster
GET on /cloudapi/1.0.0/entityTypes/urn:cse:native:1.0.0 -> verified that TKGm is not an allowed value for kind
Upgraded to CSE 3.0.3 -> Checked the schema update message on console
GET on /cloudapi/1.0.0/entityTypes/urn:cse:native:1.0.0 -> verified that TKGm is an allowed value for kind
Created TKGm cluster, the RDE resolved without any issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1061)
<!-- Reviewable:end -->
