### PR TITLE
[VCDA-2563] Update TKG flags and constant names

### DIFF
--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -36,7 +36,7 @@ class Cluster:
         elif float(api_version) >= float(vcd_client.ApiVersion.VERSION_35.value):  # noqa: E501
             if k8_runtime in CSE_SERVER_RUNTIMES:
                 return DEClusterNative(client)
-            elif k8_runtime == ClusterEntityKind.TKG.value:
+            elif k8_runtime == ClusterEntityKind.TKG_S.value:
                 return DEClusterTKG(client)
             else:
                 return DECluster(client)

--- a/container_service_extension/client/cluster_commands.py
+++ b/container_service_extension/client/cluster_commands.py
@@ -155,11 +155,11 @@ Example
                             "Note that '--id' flag is applicable for API versions >= 35 only.")  # noqa: E501
 
         client = ctx.obj['client']
-        if client_utils.is_cli_for_tkg_only():
+        if client_utils.is_cli_for_tkg_s_only():
             if k8_runtime in shared_constants.CSE_SERVER_RUNTIMES:
                 # Cannot run the command as cse cli is enabled only for native
                 raise CseServerNotRunningError()
-            k8_runtime = shared_constants.ClusterEntityKind.TKG.value
+            k8_runtime = shared_constants.ClusterEntityKind.TKG_S.value
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org is None:
             org = ctx.obj['profiles'].get('org_in_use')
@@ -534,15 +534,15 @@ Examples
     help="should be used with --sample, this flag generates sample yaml for k8 runtime: native"  # noqa: E501
 )
 @click.option(
-    '-t',
-    '--tkg',
+    '-k',
+    '--tkg-s',
     'k8_runtime',
     is_flag=True,
-    flag_value=shared_constants.ClusterEntityKind.TKG.value,
-    help="should be used with --sample, this flag generates sample yaml for k8 runtime: TKG"  # noqa: E501
+    flag_value=shared_constants.ClusterEntityKind.TKG_S.value,
+    help="should be used with --sample, this flag generates sample yaml for k8 runtime: TKG service"  # noqa: E501
 )
 @click.option(
-    '-k',
+    '-p',
     '--tkg-plus',
     'k8_runtime',
     is_flag=True,
@@ -551,8 +551,8 @@ Examples
     help="should be used with --sample, this flag generates sample yaml for k8 runtime: TKG+"  # noqa: E501
 )
 @click.option(
-    '-m',
-    '--tkg-m',
+    '-t',
+    '--tkg',
     'k8_runtime',
     is_flag=True,
     hidden=not utils.is_environment_variable_enabled(cli_constants.ENV_CSE_TKG_M_ENABLED),  # noqa: E501
@@ -604,11 +604,11 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, out
             tkg_m_env_enabled = utils.is_environment_variable_enabled(cli_constants.ENV_CSE_TKG_M_ENABLED)  # noqa: E501
             if not k8_runtime:
                 console_message_printer.general_no_color(ctx.get_help())
-                msg = "with option --sample you must specify one of the options: --native or --tkg"  # noqa: E501
+                msg = "with option --sample you must specify one of the options: --native or --tkg-s"  # noqa: E501
                 if tkg_plus_env_enabled:
                     msg += " or --tkg-plus"
                 if tkg_m_env_enabled:
-                    msg += " or --tkg-m"
+                    msg += " or --tkg"
                 CLIENT_LOGGER.error(msg)
                 raise Exception(msg)
             if k8_runtime == shared_constants.ClusterEntityKind.TKG_PLUS.value \
@@ -629,13 +629,13 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, out
         k8_runtime = cluster_config.get('kind')
         if not k8_runtime:
             raise Exception("Cluster kind missing from the spec.")
-        if client_utils.is_cli_for_tkg_only():
+        if client_utils.is_cli_for_tkg_s_only():
             if k8_runtime in shared_constants.CSE_SERVER_RUNTIMES:
                 # Cannot run the command as cse cli is enabled only for native
                 raise CseServerNotRunningError()
-            k8_runtime = shared_constants.ClusterEntityKind.TKG.value
+            k8_runtime = shared_constants.ClusterEntityKind.TKG_S.value
         org_name = None
-        if k8_runtime == shared_constants.ClusterEntityKind.TKG.value:
+        if k8_runtime == shared_constants.ClusterEntityKind.TKG_S.value:
             org_name = org
             if not org:
                 org_name = ctx.obj['profiles'].get('org_in_use')
@@ -733,11 +733,11 @@ Examples
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
         client_utils.cse_restore_session(ctx)
-        if client_utils.is_cli_for_tkg_only():
+        if client_utils.is_cli_for_tkg_s_only():
             if k8_runtime in shared_constants.CSE_SERVER_RUNTIMES:
                 # Cannot run the command as cse cli is enabled only for native
                 raise CseServerNotRunningError()
-            k8_runtime = shared_constants.ClusterEntityKind.TKG.value
+            k8_runtime = shared_constants.ClusterEntityKind.TKG_S.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org_name is None:
@@ -814,11 +814,11 @@ Example
     CLIENT_LOGGER.debug(f'Executing command: {ctx.command_path}')
     try:
         client_utils.cse_restore_session(ctx)
-        if client_utils.is_cli_for_tkg_only():
+        if client_utils.is_cli_for_tkg_s_only():
             if k8_runtime in shared_constants.CSE_SERVER_RUNTIMES:
                 # Cannot run the command as cse cli is enabled only for native
                 raise CseServerNotRunningError()
-            k8_runtime = shared_constants.ClusterEntityKind.TKG.value
+            k8_runtime = shared_constants.ClusterEntityKind.TKG_S.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org_name is None:
@@ -895,11 +895,11 @@ Examples:
             raise Exception("Please specify cluster name (or) cluster Id. "
                             "Note that '--id' flag is applicable for API versions >= 35 only.")  # noqa: E501
         client_utils.cse_restore_session(ctx)
-        if client_utils.is_cli_for_tkg_only():
+        if client_utils.is_cli_for_tkg_s_only():
             if k8_runtime in shared_constants.CSE_SERVER_RUNTIMES:
                 # Cannot run the command as cse cli is enabled only for native
                 raise CseServerNotRunningError()
-            k8_runtime = shared_constants.ClusterEntityKind.TKG.value
+            k8_runtime = shared_constants.ClusterEntityKind.TKG_S.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org is None:
@@ -977,11 +977,11 @@ Example
             raise Exception("Please specify cluster name (or) cluster Id. "
                             "Note that '--id' flag is applicable for API versions >= 35 only.")  # noqa: E501
         client_utils.cse_restore_session(ctx)
-        if client_utils.is_cli_for_tkg_only():
+        if client_utils.is_cli_for_tkg_s_only():
             if k8_runtime in shared_constants.CSE_SERVER_RUNTIMES:
                 # Cannot run the command as cse cli is enabled only for native
                 raise CseServerNotRunningError()
-            k8_runtime = shared_constants.ClusterEntityKind.TKG.value
+            k8_runtime = shared_constants.ClusterEntityKind.TKG_S.value
         client = ctx.obj['client']
         cluster = Cluster(client, k8_runtime=k8_runtime)
         if not client.is_sysadmin() and org is None:

--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -143,7 +143,7 @@ class GroupCommandFilter(click.Group):
             version = client.get_api_version()
 
             # Skipping some commands when CSE server is not running
-            if client_utils.is_cli_for_tkg_only() and \
+            if client_utils.is_cli_for_tkg_s_only() and \
                 cmd_name in [*UNSUPPORTED_COMMANDS_WITH_SERVER_NOT_RUNNING_BY_VERSION.get(version, []),  # noqa: E501
                              *UNSUPPORTED_SUBCOMMANDS_WITH_SERVER_NOT_RUNNING_BY_VERSION.get(version, {}).get(self.name, [])]:  # noqa: E501
                 return None

--- a/container_service_extension/client/de_cluster.py
+++ b/container_service_extension/client/de_cluster.py
@@ -63,7 +63,7 @@ class DECluster:
         :rtype: list(dict)
         """
         clusters = []
-        if client_utils.is_cli_for_tkg_only():
+        if client_utils.is_cli_for_tkg_s_only():
             try:
                 for clusters, has_more_results in \
                         self._tkgCluster.list_tkg_clusters(vdc=vdc, org=org):
@@ -138,7 +138,7 @@ class DECluster:
         :param str cluster_name: Cluster name to search for
         :param str org: Org to filter by
         :param str vdc: VDC to filter by
-        :returns: tkg entity or native def entity with entity properties and
+        :returns: tkg-s entity or native def entity with entity properties and
             boolean indicating cluster type
         :rtype: (cluster, dict,  bool)
         """

--- a/container_service_extension/client/de_cluster_tkg.py
+++ b/container_service_extension/client/de_cluster_tkg.py
@@ -124,7 +124,7 @@ class DEClusterTKG:
                     cli_constants.CLIOutputKey.CLUSTER_NAME.value: entity.metadata.name, # noqa: E501
                     cli_constants.CLIOutputKey.VDC.value: entity.metadata.virtual_data_center_name, # noqa: E501
                     cli_constants.CLIOutputKey.ORG.value: entity_properties['org']['name'], # noqa: E501
-                    cli_constants.CLIOutputKey.K8S_RUNTIME.value: shared_constants.ClusterEntityKind.TKG.value, # noqa: E501
+                    cli_constants.CLIOutputKey.K8S_RUNTIME.value: shared_constants.ClusterEntityKind.TKG_S.value, # noqa: E501
                     cli_constants.CLIOutputKey.K8S_VERSION.value: entity.spec.distribution.version, # noqa: E501
                     cli_constants.CLIOutputKey.STATUS.value: entity.status.phase if entity.status else 'N/A',  # noqa: E501
                     cli_constants.CLIOutputKey.OWNER.value: entity_properties['owner']['name'],  # noqa: E501

--- a/container_service_extension/client/ovdc_commands.py
+++ b/container_service_extension/client/ovdc_commands.py
@@ -86,7 +86,7 @@ Example
     help="Enable OVDC for k8 runtime native"
 )
 @click.option(
-    '-t',
+    '-p',
     '--tkg-plus',
     'enable_tkg_plus',
     is_flag=True,
@@ -94,8 +94,8 @@ Example
     help="Enable OVDC for k8 runtime TKG plus"
 )
 @click.option(
-    '-m',
-    '--tkg-m',
+    '-t',
+    '--tkg',
     'enable_tkg_m',
     is_flag=True,
     hidden=not utils.is_environment_variable_enabled(cli_constants.ENV_CSE_TKG_M_ENABLED),  # noqa: E501
@@ -171,7 +171,7 @@ Example
     help="Disable OVDC for k8 runtime native cluster"
 )
 @click.option(
-    '-t',
+    '-p',
     '--tkg-plus',
     'disable_tkg_plus',
     is_flag=True,
@@ -179,8 +179,8 @@ Example
     help="Disable OVDC for k8 runtime TKG plus"
 )
 @click.option(
-    '-m',
-    '--tkg-m',
+    '-t',
+    '--tkg',
     'disable_tkg_m',
     is_flag=True,
     hidden=not utils.is_environment_variable_enabled(cli_constants.ENV_CSE_TKG_M_ENABLED),  # noqa: E501

--- a/container_service_extension/client/sample_generator.py
+++ b/container_service_extension/client/sample_generator.py
@@ -79,7 +79,7 @@ def get_sample_cluster_configuration(output=None, k8_runtime=None):
     :return: sample cluster configuration
     :rtype: str
     """
-    if k8_runtime == shared_constants.ClusterEntityKind.TKG.value:
+    if k8_runtime == shared_constants.ClusterEntityKind.TKG_S.value:
         sample_cluster_config = SAMPLE_TKG_CLUSTER_SPEC_HELP + _get_sample_tkg_cluster_configuration()  # noqa: E501
     else:
         sample_cluster_config = SAMPLE_K8_CLUSTER_SPEC_HELP + _get_sample_cluster_configuration_by_k8_runtime(k8_runtime)  # noqa: E501

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -16,22 +16,22 @@ from container_service_extension.logger import NULL_LOGGER
 from container_service_extension.shared_constants import CSE_SERVER_API_VERSION
 from container_service_extension.shared_constants import CSE_SERVER_BUSY_KEY
 
-_RESTRICT_CLI_TO_TKG_OPERATIONS = False
+_RESTRICT_CLI_TO_TKG_S_OPERATIONS = False
 
 
-def is_cli_for_tkg_only():
-    global _RESTRICT_CLI_TO_TKG_OPERATIONS
-    return _RESTRICT_CLI_TO_TKG_OPERATIONS
+def is_cli_for_tkg_s_only():
+    global _RESTRICT_CLI_TO_TKG_S_OPERATIONS
+    return _RESTRICT_CLI_TO_TKG_S_OPERATIONS
 
 
-def restrict_cli_to_tkg_operations():
-    global _RESTRICT_CLI_TO_TKG_OPERATIONS
-    _RESTRICT_CLI_TO_TKG_OPERATIONS = True
+def restrict_cli_to_tkg_s_operations():
+    global _RESTRICT_CLI_TO_TKG_S_OPERATIONS
+    _RESTRICT_CLI_TO_TKG_S_OPERATIONS = True
 
 
 def enable_cli_for_all_operations():
-    global _RESTRICT_CLI_TO_TKG_OPERATIONS
-    _RESTRICT_CLI_TO_TKG_OPERATIONS = False
+    global _RESTRICT_CLI_TO_TKG_S_OPERATIONS
+    _RESTRICT_CLI_TO_TKG_S_OPERATIONS = False
 
 
 def cse_restore_session(ctx, vdc_required=False) -> None:
@@ -72,8 +72,9 @@ def cse_restore_session(ctx, vdc_required=False) -> None:
         client.rehydrate_from_token(
             profiles.get('token'), profiles.get('is_jwt_token'))
 
-        ctx.obj = {}
-        ctx.obj['client'] = client
+        ctx.obj = {
+            'client': client
+        }
 
     _override_client(ctx)
 
@@ -97,7 +98,7 @@ def _override_client(ctx) -> None:
     is_cse_server_running = profiles.get(CSE_SERVER_RUNNING, default=True)
     cse_server_api_version = profiles.get(CSE_SERVER_API_VERSION)
     if not is_cse_server_running:
-        restrict_cli_to_tkg_operations()
+        restrict_cli_to_tkg_s_operations()
         ctx.obj['profiles'] = profiles
         return
 
@@ -114,7 +115,7 @@ def _override_client(ctx) -> None:
             # If request to CSE server times out
             profiles.set(CSE_SERVER_RUNNING, False)
             # restrict CLI for only TKG operations
-            restrict_cli_to_tkg_operations()
+            restrict_cli_to_tkg_s_operations()
             ctx.obj['profiles'] = profiles
             profiles.save()
             return
@@ -148,7 +149,7 @@ def construct_task_console_message(task_href: str) -> str:
 
 
 def swagger_object_to_dict(obj):
-    """Convert a swagger obejct to a dictionary without changing case type."""
+    """Convert a swagger object to a dictionary without changing case type."""
     # reference: https://github.com/swagger-api/swagger-codegen/issues/8948
     result = {}
     o_map = obj.attribute_map
@@ -211,7 +212,7 @@ def print_paginated_result(generator, should_print_all=False, logger=NULL_LOGGER
     :param Generator[(List[dict], int), None, None] generator: generator which
         yields a list of results and a boolean indicating if more results
         are present.
-    :param bool should_print_all: print all the results without promting the
+    :param bool should_print_all: print all the results without prompting the
         user.
     :param logger logger: logger to log the results or exceptions.
     """

--- a/container_service_extension/configure_cse.py
+++ b/container_service_extension/configure_cse.py
@@ -2180,6 +2180,8 @@ def _get_placement_policy_name_from_template_name(template_name):
     elif 'tkgm' in template_name:
         policy_name = \
             shared_constants.TKG_M_CLUSTER_RUNTIME_INTERNAL_NAME
+    # Some earlier TKG+ templates had just `tkg` in their name and
+    # not `tkgplus`
     elif 'tkg' in template_name or 'tkgplus' in template_name:
         policy_name = \
             shared_constants.TKG_PLUS_CLUSTER_RUNTIME_INTERNAL_NAME

--- a/container_service_extension/def_/models.py
+++ b/container_service_extension/def_/models.py
@@ -342,7 +342,7 @@ class GenericClusterEntity:
                  shared_constants.ClusterEntityKind.TKG_M.value]:
             self.entity = NativeEntity(**entity_dict) if isinstance(entity, dict) else entity  # noqa: E501
         elif entity_dict['kind'] == \
-                shared_constants.ClusterEntityKind.TKG.value:
+                shared_constants.ClusterEntityKind.TKG_S.value:
             self.entity = TKGEntity(**entity) if isinstance(entity, dict) else entity  # noqa: E501
         else:
             raise Exception("Invalid cluster kind")

--- a/container_service_extension/exceptions.py
+++ b/container_service_extension/exceptions.py
@@ -49,7 +49,7 @@ class CseServerNotRunningError(CseServerError):
         return "Please contact administrator, CSE server seems to be" \
                " down. CSE- CLI can now only be used to manage TKG " \
                " clusters (but not native). Once CSE server is up, please" \
-               " re-login to manage both native and tkg clusters."
+               " re-login to manage both native and tkg-s clusters."
 
 
 class CseRequestError(CseServerError):

--- a/container_service_extension/shared_constants.py
+++ b/container_service_extension/shared_constants.py
@@ -22,7 +22,7 @@ CSE_SERVER_API_VERSION = 'cse_server_api_version'
 
 class ClusterEntityKind(Enum):
     NATIVE = 'native'
-    TKG = 'TanzuKubernetesCluster'
+    TKG_S = 'TanzuKubernetesCluster'
     TKG_PLUS = 'TKG+'
     TKG_M = 'TKGm'
 


### PR DESCRIPTION
Changed the constants and methods dealing with TKG(WCP) to TKG-S. The value of the constant were left intact, only the variable names were changed.

In CSE CLI, certain flags related to TKG+, TKG(WCP) and TKGm were changed to better reflect the marketing strategy around TKG.

TKG: --tkg/-t -> --tkg-s/-k
TKG+: --tkg-plus/-t/-k -> --tkg-plus/-p
TKGm: --tkg-m/-m -> --tkg/-t

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1071)
<!-- Reviewable:end -->
