### PR TITLE
[VCDA-2614] Fix accessing entity details array using 'entityDetails' key

### DIFF
--- a/container_service_extension/client/de_cluster_tkg.py
+++ b/container_service_extension/client/de_cluster_tkg.py
@@ -148,7 +148,7 @@ class DEClusterTKG:
         tkg_def_entities = []
         if response:
             tkg_entities = response[0]
-            tkg_def_entities = response[3]
+            tkg_def_entities = response[3]['entityDetails']
         if len(tkg_entities) == 0:
             raise cse_exceptions.ClusterNotFoundError(
                 f"TKG cluster with name '{name}' not found.")


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

entity details for list entities from TKG swagger client should be accessed using key 'entityDetails'

Testing done
* `vcd cse cluster config`
* `vcd cse cluster apply`
* `vcd cse cluster delete`

@rocknes @sahithi @ltimothy7 @arunmk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1073)
<!-- Reviewable:end -->
