### PR TITLE
[VCDA-2407 and VCDA-2615] Fix for TKG cli and use 37-alpha when CLI is used with vcd 10.3

### DIFF
--- a/container_service_extension/client/de_cluster_tkg.py
+++ b/container_service_extension/client/de_cluster_tkg.py
@@ -52,7 +52,7 @@ class DEClusterTKG:
         max_api_version = utils.get_max_api_version(supported_api_versions)
 
         # api_version = self._client.get_api_version()
-        # use api_version 37.0.0-alpha if VCD 10.3 or above is used.
+        # use api_version 37.0.0-alpha if VCD 10.3 is used.
         if float(max_api_version) >= float(ApiVersion.VERSION_36.value):
             api_version = '37.0.0-alpha'
         self._tkg_client.set_default_header(cli_constants.TKGRequestHeaderKey.ACCEPT,  # noqa: E501

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -282,7 +282,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                 distribution=k8_distribution,
                 org_name=org_name,
                 virtual_data_center_name=ovdc_name,
-                ovdc_network_name=input_native_entity.spec.settings.ovdc_network,
+                ovdc_network_name=input_native_entity.spec.settings.ovdc_network,  # noqa: E501
                 rollback_on_failure=input_native_entity.spec.settings.rollback_on_failure,  # noqa: E501
                 ssh_key=input_native_entity.spec.settings.ssh_key
             )


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

Testing done:
- `vcd cse cluster apply`
- `vcd cse cluster config ...`
for TKG clusters

@sakthisunda @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1075)
<!-- Reviewable:end -->
