### PR TITLE
[VCDA-2601] Create subdirectory under LOCAL SCRIPTS DIR

### DIFF
--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -291,6 +291,7 @@ class LocalTemplateKey(str, Enum):
     NAME = 'name'
     OS = 'os'
     REVISION = 'revision'
+    COOKBOOK_VERSION = 'cookbook_version'
     UPGRADE_FROM = 'upgrade_from'
     MIN_CSE_VERSION = 'min_cse_version'
     MAX_CSE_VERSION = 'max_cse_version'
@@ -473,6 +474,7 @@ class TemplateBuildKey(str, Enum):
     IP_ALLOCATION_MODE = 'ip_allocation_mode'
     STORAGE_PROFILE = 'storage_profile'
     CSE_PLACEMENT_POLICY = 'cse_placement_policy'
+    REMOTE_COOKBOOK_VERSION = 'remote_template_cookbook_version'
 
 
 @unique

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -1570,6 +1570,7 @@ def _update_metadata_for_existing_templates(client: Client, config: dict,
             # metadata keys barring the catalog_item_name.
             # Add catalog_item_name to the dict remote_template_descriptor
             remote_template_descriptor[server_constants.LocalTemplateKey.CATALOG_ITEM_NAME] = catalog_item_name  # noqa: E501
+            remote_template_descriptor[server_constants.LocalTemplateKey.COOKBOOK_VERSION] = str(rtm.cookbook_version)  # noqa: E501
 
             # New keys to be added (min_cse_version and max_cse_version)
             # will already be in remote_template_descriptor.
@@ -1667,6 +1668,7 @@ def _process_existing_templates(client: Client, config: dict,
             client,
             catalog_name=catalog_name,  # noqa: E501
             org_name=org_name,
+            ignore_metadata_keys=[server_constants.LegacyLocalTemplateKey.COMPUTE_POLICY],  # noqa: E501
             legacy_mode=True,
             logger_debug=INSTALL_LOGGER)
     # update metadata with min_cse_version and max_cse_version for all
@@ -1780,7 +1782,7 @@ def _install_single_template(
         f"{template[remote_template_keys.CNI_VERSION].replace('.', '')}-vm"
     )
     build_params = {
-        templateBuildKey.TEMPLATE_NAME: template[remote_template_keys.NAME],  # noqa: E501
+        templateBuildKey.TEMPLATE_NAME: template[remote_template_keys.NAME],
         templateBuildKey.TEMPLATE_REVISION: template[remote_template_keys.REVISION],  # noqa: E501
         templateBuildKey.SOURCE_OVA_NAME: template[remote_template_keys.SOURCE_OVA_NAME],  # noqa: E501
         templateBuildKey.SOURCE_OVA_HREF: template[remote_template_keys.SOURCE_OVA_HREF],  # noqa: E501
@@ -1793,10 +1795,11 @@ def _install_single_template(
         templateBuildKey.TEMP_VAPP_NAME: template[remote_template_keys.NAME] + '_temp',  # noqa: E501
         templateBuildKey.TEMP_VM_NAME: temp_vm_name,
         templateBuildKey.CPU: template[remote_template_keys.CPU],
-        templateBuildKey.MEMORY: template[remote_template_keys.MEMORY],  # noqa: E501
+        templateBuildKey.MEMORY: template[remote_template_keys.MEMORY],
         templateBuildKey.NETWORK_NAME: network_name,
-        templateBuildKey.IP_ALLOCATION_MODE: ip_allocation_mode,  # noqa: E501
-        templateBuildKey.STORAGE_PROFILE: storage_profile
+        templateBuildKey.IP_ALLOCATION_MODE: ip_allocation_mode,
+        templateBuildKey.STORAGE_PROFILE: storage_profile,
+        templateBuildKey.REMOTE_COOKBOOK_VERSION: remote_template_manager.cookbook_version  # noqa: E501
     }
     if not LEGACY_MODE:  # noqa: E501
         if template.get(

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -1765,9 +1765,13 @@ def _install_single_template(
         template[remote_template_keys.REVISION])
 
     # remote template data is a super set of local template data, barring
-    # the key 'catalog_item_name'
+    # the key 'catalog_item_name' and 'cookbook_version' (if CSE is running in
+    #  non-legacy mode)
     template_data = dict(template)
     template_data[localTemplateKey.CATALOG_ITEM_NAME] = catalog_item_name
+    if not LEGACY_MODE:
+        template_data[localTemplateKey.COOKBOOK_VERSION] = \
+            remote_template_manager.cookbook_version
     template_metadata_keys = [k for k in localTemplateKey]
 
     missing_keys = [k for k in template_metadata_keys

--- a/container_service_extension/installer/templates/local_template_manager.py
+++ b/container_service_extension/installer/templates/local_template_manager.py
@@ -25,8 +25,8 @@ import container_service_extension.logging.logger as logger
 
 LOCAL_SCRIPTS_DIR = '.cse_scripts'
 MAP_COOKBOOK_VERSION_TO_SCRIPTS_DIR = {
-    RemoteTemplateCookbookVersion.Version1: 'v1',
-    RemoteTemplateCookbookVersion.Version2: 'v2'
+    RemoteTemplateCookbookVersion.Version1.value: 'v1',
+    RemoteTemplateCookbookVersion.Version2.value: 'v2'
 }
 
 

--- a/container_service_extension/installer/templates/local_template_manager.py
+++ b/container_service_extension/installer/templates/local_template_manager.py
@@ -14,7 +14,6 @@ import semantic_version
 
 from container_service_extension.common.constants.server_constants import LegacyLocalTemplateKey  # noqa: E501
 from container_service_extension.common.constants.server_constants import LocalTemplateKey  # noqa: E501
-from container_service_extension.common.constants.server_constants import RemoteTemplateCookbookVersion  # noqa: E501
 import container_service_extension.common.constants.shared_constants as \
     shared_constants
 import container_service_extension.common.utils.core_utils as utils
@@ -24,10 +23,6 @@ import container_service_extension.logging.logger as logger
 
 
 LOCAL_SCRIPTS_DIR = '.cse_scripts'
-MAP_COOKBOOK_VERSION_TO_SCRIPTS_DIR = {
-    RemoteTemplateCookbookVersion.Version1.value: 'v1',
-    RemoteTemplateCookbookVersion.Version2.value: 'v2'
-}
 
 
 def get_revisioned_template_name(template_name, revision):
@@ -46,7 +41,7 @@ def get_script_filepath(cookbook_version, template_name, revision, script_file_n
 
     :rtype: str
     """
-    scripts_sub_dir = MAP_COOKBOOK_VERSION_TO_SCRIPTS_DIR[cookbook_version]
+    scripts_sub_dir = str(cookbook_version)
     template_dir = pathlib.Path.home() / LOCAL_SCRIPTS_DIR / \
         scripts_sub_dir / get_revisioned_template_name(template_name, revision)
     template_dir.mkdir(parents=True, exist_ok=True)

--- a/container_service_extension/installer/templates/local_template_manager.py
+++ b/container_service_extension/installer/templates/local_template_manager.py
@@ -14,6 +14,7 @@ import semantic_version
 
 from container_service_extension.common.constants.server_constants import LegacyLocalTemplateKey  # noqa: E501
 from container_service_extension.common.constants.server_constants import LocalTemplateKey  # noqa: E501
+from container_service_extension.common.constants.server_constants import RemoteTemplateCookbookVersion  # noqa: E501
 import container_service_extension.common.constants.shared_constants as \
     shared_constants
 import container_service_extension.common.utils.core_utils as utils
@@ -21,7 +22,12 @@ from container_service_extension.common.utils.pyvcloud_utils import get_org
 import container_service_extension.common.utils.server_utils as server_utils
 import container_service_extension.logging.logger as logger
 
+
 LOCAL_SCRIPTS_DIR = '.cse_scripts'
+MAP_COOKBOOK_VERSION_TO_SCRIPTS_DIR = {
+    RemoteTemplateCookbookVersion.Version1: 'v1',
+    RemoteTemplateCookbookVersion.Version2: 'v2'
+}
 
 
 def get_revisioned_template_name(template_name, revision):
@@ -29,17 +35,20 @@ def get_revisioned_template_name(template_name, revision):
     return f"{template_name}_rev{revision}"
 
 
-def get_script_filepath(template_name, revision, script_file_name):
+def get_script_filepath(cookbook_version, template_name, revision, script_file_name):  # noqa: E501
     """Construct the absolute path to a given script.
 
+    :param semantic_version.Version cookbook_version: Remote template cookbook
+        version
     :param str template_name:
     :param str revision:
     :param str script_file_name:
 
     :rtype: str
     """
+    scripts_sub_dir = MAP_COOKBOOK_VERSION_TO_SCRIPTS_DIR[cookbook_version]
     template_dir = pathlib.Path.home() / LOCAL_SCRIPTS_DIR / \
-        get_revisioned_template_name(template_name, revision)
+        scripts_sub_dir / get_revisioned_template_name(template_name, revision)
     template_dir.mkdir(parents=True, exist_ok=True)
 
     # pathlib '/' operator does not intuitively resolve Enums with str mixin
@@ -51,6 +60,7 @@ def get_script_filepath(template_name, revision, script_file_name):
 def get_all_k8s_local_template_definition(client, catalog_name, org=None,
                                           org_name=None,
                                           legacy_mode=False,
+                                          ignore_metadata_keys=None,
                                           logger_debug=logger.NULL_LOGGER,
                                           msg_update_callback=utils.NullPrinter()):  # noqa: E501
     """Fetch all CSE k8s templates in a catalog.
@@ -66,6 +76,7 @@ def get_all_k8s_local_template_definition(client, catalog_name, org=None,
     :param str org_name: Name of the org that is hosting the catalog. Can be
         provided in lieu of param org, however param org takes precedence.
     :param bool legacy_mode: True, if CSE is running in legacy mode
+    :param List ignore_keys: List of keys to ignore
     :param logging.Logger logger_debug:
     :param utils.NullPrinter msg_update_callback:
 
@@ -73,6 +84,8 @@ def get_all_k8s_local_template_definition(client, catalog_name, org=None,
 
     :rtype: list of dicts
     """
+    if not ignore_metadata_keys:
+        ignore_metadata_keys = []
     if not org:
         org = get_org(client, org_name=org_name)
     catalog_item_names = [
@@ -96,6 +109,8 @@ def get_all_k8s_local_template_definition(client, catalog_name, org=None,
         expected_metadata_keys = \
             set([entry.value for entry in localTemplateKey])
         missing_metadata_keys = expected_metadata_keys - metadata_dict.keys()
+        # ignore keys included in the call
+        missing_metadata_keys = missing_metadata_keys - set(ignore_metadata_keys)  # noqa: E501
         num_missing_metadata_keys = len(missing_metadata_keys)
         if num_missing_metadata_keys == len(expected_metadata_keys):
             # This catalog item has no CSE related metadata, so skip it.

--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -44,11 +44,16 @@ class RemoteTemplateManager():
     """
 
     def __init__(self, remote_template_cookbook_url, legacy_mode: bool = False,
-                 logger=NULL_LOGGER, msg_update_callback=NullPrinter()):
+                 cookbook_version=None, logger=NULL_LOGGER,
+                 msg_update_callback=NullPrinter()):
         """.
 
         :param str remote_template_cookbook_url:
         :param bool legacy_mode:
+        :param semantic_version.Version cookbook_version: Use this parameter
+            to optionally set the value for cookbook_version. This value is
+            automatically filled by get_filtered_cookbook() or
+            get_unfiltered_cookbook()
         :param logging.Logger logger: logger to log with.
         :param utils.ConsoleMessagePrinter msg_update_callback:
             Callback object.
@@ -59,7 +64,7 @@ class RemoteTemplateManager():
         self.msg_update_callback = msg_update_callback
         self.filtered_cookbook = None
         self.unfiltered_cookbook = None
-        self.cookbook_version: semantic_version.Version = None
+        self.cookbook_version: semantic_version.Version = cookbook_version
         self.scripts_directory_path: str = None
 
     def _get_base_url_from_remote_template_cookbook_url(self) -> str:
@@ -279,6 +284,8 @@ class RemoteTemplateManager():
         :param bool force_overwrite: if True, will download the script even if
             it already exists.
         """
+        if not self.cookbook_version:
+            raise ValueError('Invalid value for cookbook_version')
         # Multiple codepaths enter into this. Hence all scripts are downloaded.
         # When vcdbroker.py id deprecated, the scripts should loop through
         # TemplateScriptFile to download scripts.
@@ -294,7 +301,7 @@ class RemoteTemplateManager():
                     script_file)
 
             local_script_filepath = ltm.get_script_filepath(
-                template_name, revision, script_file)
+                self.cookbook_version, template_name, revision, script_file)
             download_file(url=remote_script_url,
                           filepath=local_script_filepath,
                           force_overwrite=force_overwrite,

--- a/container_service_extension/installer/templates/template_builder.py
+++ b/container_service_extension/installer/templates/template_builder.py
@@ -134,6 +134,7 @@ class TemplateBuilder():
         self.ip_allocation_mode = build_params.get(TemplateBuildKey.IP_ALLOCATION_MODE) # noqa: E501
         self.storage_profile = build_params.get(TemplateBuildKey.STORAGE_PROFILE) # noqa: E501
         self.cse_placement_policy = build_params.get(TemplateBuildKey.CSE_PLACEMENT_POLICY) # noqa: E501
+        self.remote_cookbook_version = build_params.get(TemplateBuildKey.REMOTE_COOKBOOK_VERSION)  # noqa: E501
         self.log_wire = log_wire
 
         if self.template_name and self.template_revision and \
@@ -222,6 +223,7 @@ class TemplateBuilder():
         :rtype: str
         """
         init_script_filepath = ltm.get_script_filepath(
+            self.remote_cookbook_version,
             self.template_name,
             self.template_revision,
             TemplateScriptFile.INIT)
@@ -290,7 +292,9 @@ class TemplateBuilder():
         self.logger.info(msg)
 
         cust_script_filepath = ltm.get_script_filepath(
-            self.template_name, self.template_revision,
+            self.remote_cookbook_version,
+            self.template_name,
+            self.template_revision,
             TemplateScriptFile.CUST)
         cust_script = read_data_file(
             cust_script_filepath, logger=self.logger,

--- a/container_service_extension/rde/backend/cluster_service_1_x.py
+++ b/container_service_extension/rde/backend/cluster_service_1_x.py
@@ -1392,6 +1392,7 @@ class ClusterService(abstract_broker.AbstractBroker):
 
             template_name = template[LocalTemplateKey.NAME]
             template_revision = template[LocalTemplateKey.REVISION]
+            template_cookbook_version = semver.Version(template[LocalTemplateKey.COOKBOOK_VERSION])  # noqa: E501
 
             # semantic version doesn't allow leading zeros
             # docker's version format YY.MM.patch allows us to directly use
@@ -1418,7 +1419,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                 msg = f"Upgrading Kubernetes ({c_k8s} -> {t_k8s}) " \
                       f"in control plane node {control_plane_node_names}"
                 self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
-                filepath = ltm.get_script_filepath(template_name,
+                filepath = ltm.get_script_filepath(template_cookbook_version,
+                                                   template_name,
                                                    template_revision,
                                                    TemplateScriptFile.CONTROL_PLANE_K8S_UPGRADE)  # noqa: E501
                 script = utils.read_data_file(filepath, logger=LOGGER)
@@ -1432,7 +1434,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                                 control_plane_node_names,
                                 cluster_name=cluster_name)
 
-                filepath = ltm.get_script_filepath(template_name,
+                filepath = ltm.get_script_filepath(template_cookbook_version,
+                                                   template_name,
                                                    template_revision,
                                                    TemplateScriptFile.WORKER_K8S_UPGRADE)  # noqa: E501
                 script = utils.read_data_file(filepath, logger=LOGGER)
@@ -1471,6 +1474,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                       f"in nodes {all_node_names}"
                 self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
                 filepath = ltm.get_script_filepath(
+                    template_cookbook_version,
                     template_name,
                     template_revision,
                     TemplateScriptFile.DOCKER_UPGRADE)
@@ -1483,7 +1487,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                       f"({curr_entity.entity.status.cni} " \
                       f"-> {t_cni}) in control plane node {control_plane_node_names}"  # noqa: E501
                 self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
-                filepath = ltm.get_script_filepath(template_name,
+                filepath = ltm.get_script_filepath(template_cookbook_version,
+                                                   template_name,
                                                    template_revision,
                                                    TemplateScriptFile.CONTROL_PLANE_CNI_APPLY)  # noqa: E501
                 script = utils.read_data_file(filepath, logger=LOGGER)
@@ -2215,6 +2220,7 @@ def _add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
                 if node_type == NodeType.NFS:
                     LOGGER.debug(f"Enabling NFS server on {vm_name}")
                     script_filepath = ltm.get_script_filepath(
+                        semver.Version(template[LocalTemplateKey.COOKBOOK_VERSION]),  # noqa: E501
                         template[LocalTemplateKey.NAME],
                         template[LocalTemplateKey.REVISION],
                         TemplateScriptFile.NFSD)

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -1425,6 +1425,7 @@ class ClusterService(abstract_broker.AbstractBroker):
 
             template_name = template[LocalTemplateKey.NAME]
             template_revision = template[LocalTemplateKey.REVISION]
+            template_cookbook_version = semver.Version(template[LocalTemplateKey.COOKBOOK_VERSION])  # noqa: E501
 
             # semantic version doesn't allow leading zeros
             # docker's version format YY.MM.patch allows us to directly use
@@ -1454,7 +1455,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                 msg = f"Upgrading Kubernetes ({c_k8s} -> {t_k8s}) " \
                       f"in control plane node {control_plane_node_names}"
                 self._update_task(BehaviorTaskStatus.RUNNING, message=msg)
-                filepath = ltm.get_script_filepath(template_name,
+                filepath = ltm.get_script_filepath(template_cookbook_version,
+                                                   template_name,
                                                    template_revision,
                                                    TemplateScriptFile.CONTROL_PLANE_K8S_UPGRADE)  # noqa: E501
                 script = utils.read_data_file(filepath, logger=LOGGER)
@@ -1468,7 +1470,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                                 control_plane_node_names,
                                 cluster_name=cluster_name)
 
-                filepath = ltm.get_script_filepath(template_name,
+                filepath = ltm.get_script_filepath(template_cookbook_version,
+                                                   template_name,
                                                    template_revision,
                                                    TemplateScriptFile.WORKER_K8S_UPGRADE)  # noqa: E501
                 script = utils.read_data_file(filepath, logger=LOGGER)
@@ -1507,6 +1510,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                       f"in nodes {all_node_names}"
                 self._update_task(BehaviorTaskStatus.RUNNING, message=msg)
                 filepath = ltm.get_script_filepath(
+                    template_cookbook_version,
                     template_name,
                     template_revision,
                     TemplateScriptFile.DOCKER_UPGRADE)
@@ -1519,7 +1523,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                       f"({curr_native_entity.status.cni} " \
                       f"-> {t_cni}) in control plane node {control_plane_node_names}"  # noqa: E501
                 self._update_task(BehaviorTaskStatus.RUNNING, message=msg)
-                filepath = ltm.get_script_filepath(template_name,
+                filepath = ltm.get_script_filepath(template_cookbook_version,
+                                                   template_name,
                                                    template_revision,
                                                    TemplateScriptFile.CONTROL_PLANE_CNI_APPLY)  # noqa: E501
                 script = utils.read_data_file(filepath, logger=LOGGER)
@@ -2216,6 +2221,7 @@ def _add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
                 if node_type == NodeType.NFS:
                     LOGGER.debug(f"Enabling NFS server on {vm_name}")
                     script_filepath = ltm.get_script_filepath(
+                        semver.Version(template[LocalTemplateKey.COOKBOOK_VERSION]),  # noqa: E501
                         template[LocalTemplateKey.NAME],
                         template[LocalTemplateKey.REVISION],
                         TemplateScriptFile.NFSD)

--- a/container_service_extension/server/vcdbroker.py
+++ b/container_service_extension/server/vcdbroker.py
@@ -29,6 +29,7 @@ from container_service_extension.common.constants.server_constants import K8sPro
 from container_service_extension.common.constants.server_constants import KwargKey  # noqa: E501
 from container_service_extension.common.constants.server_constants import LocalTemplateKey  # noqa: E501
 from container_service_extension.common.constants.server_constants import NodeType  # noqa: E501
+from container_service_extension.common.constants.server_constants import RemoteTemplateCookbookVersion  # noqa: E501
 from container_service_extension.common.constants.server_constants import ScriptFile  # noqa: E501
 from container_service_extension.common.constants.server_constants import SYSTEM_ORG_NAME  # noqa: E501
 from container_service_extension.common.constants.server_constants import ThreadLocalData  # noqa: E501
@@ -1281,6 +1282,7 @@ class VcdBroker(abstract_broker.AbstractBroker):
                 LOGGER.debug(msg)
                 self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
                 filepath = ltm.get_script_filepath(
+                    RemoteTemplateCookbookVersion.Version1,
                     template_name,
                     template_revision,
                     ScriptFile.CONTROL_PLANE_K8S_UPGRADE)
@@ -1297,6 +1299,7 @@ class VcdBroker(abstract_broker.AbstractBroker):
                                 cluster_name=cluster_name)
 
                 filepath = ltm.get_script_filepath(
+                    RemoteTemplateCookbookVersion.Version1,
                     template_name,
                     template_revision,
                     ScriptFile.WORKER_K8S_UPGRADE)
@@ -1340,7 +1343,8 @@ class VcdBroker(abstract_broker.AbstractBroker):
                       f"in nodes {all_node_names}"
                 LOGGER.debug(msg)
                 self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
-                filepath = ltm.get_script_filepath(template_name,
+                filepath = ltm.get_script_filepath(RemoteTemplateCookbookVersion.Version1,  # noqa: E501
+                                                   template_name,
                                                    template_revision,
                                                    ScriptFile.DOCKER_UPGRADE)
                 script = utils.read_data_file(filepath, logger=LOGGER)
@@ -1352,7 +1356,8 @@ class VcdBroker(abstract_broker.AbstractBroker):
                       f"in control plane node {control_plane_node_names}"  # noqa: E501
                 LOGGER.debug(msg)
                 self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
-                filepath = ltm.get_script_filepath(template_name,
+                filepath = ltm.get_script_filepath(RemoteTemplateCookbookVersion.Version1,  # noqa: E501
+                                                   template_name,
                                                    template_revision,
                                                    ScriptFile.CONTROL_PLANE_CNI_APPLY)  # noqa: E501
                 script = utils.read_data_file(filepath, logger=LOGGER)
@@ -1903,6 +1908,7 @@ def _add_nodes(client, num_nodes, node_type, org, vdc, vapp,
                 if node_type == NodeType.NFS:
                     LOGGER.debug(f"Enabling NFS server on {vm_name}")
                     script_filepath = ltm.get_script_filepath(
+                        RemoteTemplateCookbookVersion.Version1,  # noqa: E501
                         template[LocalTemplateKey.NAME],
                         template[LocalTemplateKey.REVISION],
                         ScriptFile.NFSD)
@@ -1994,7 +2000,8 @@ def _init_cluster(sysadmin_client: vcd_client.Client, vapp, template_name,
     vcd_utils.raise_error_if_user_not_from_system_org(sysadmin_client)
 
     try:
-        script_filepath = ltm.get_script_filepath(template_name,
+        script_filepath = ltm.get_script_filepath(RemoteTemplateCookbookVersion.Version1,  # noqa: E501
+                                                  template_name,
                                                   template_revision,
                                                   ScriptFile.CONTROL_PLANE)
         script = utils.read_data_file(script_filepath, logger=LOGGER)
@@ -2036,7 +2043,8 @@ def _join_cluster(sysadmin_client: vcd_client.Client, vapp, template_name,
         node_names = _get_node_names(vapp, NodeType.WORKER)
         if target_nodes is not None:
             node_names = [name for name in node_names if name in target_nodes]
-        tmp_script_filepath = ltm.get_script_filepath(template_name,
+        tmp_script_filepath = ltm.get_script_filepath(RemoteTemplateCookbookVersion.Version1,  # noqa: E501
+                                                      template_name,
                                                       template_revision,
                                                       ScriptFile.NODE)
         tmp_script = utils.read_data_file(tmp_script_filepath, logger=LOGGER)

--- a/container_service_extension/server/vcdbroker.py
+++ b/container_service_extension/server/vcdbroker.py
@@ -1282,7 +1282,7 @@ class VcdBroker(abstract_broker.AbstractBroker):
                 LOGGER.debug(msg)
                 self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
                 filepath = ltm.get_script_filepath(
-                    RemoteTemplateCookbookVersion.Version1,
+                    RemoteTemplateCookbookVersion.Version1.value,
                     template_name,
                     template_revision,
                     ScriptFile.CONTROL_PLANE_K8S_UPGRADE)
@@ -1299,7 +1299,7 @@ class VcdBroker(abstract_broker.AbstractBroker):
                                 cluster_name=cluster_name)
 
                 filepath = ltm.get_script_filepath(
-                    RemoteTemplateCookbookVersion.Version1,
+                    RemoteTemplateCookbookVersion.Version1.value,
                     template_name,
                     template_revision,
                     ScriptFile.WORKER_K8S_UPGRADE)
@@ -1343,7 +1343,7 @@ class VcdBroker(abstract_broker.AbstractBroker):
                       f"in nodes {all_node_names}"
                 LOGGER.debug(msg)
                 self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
-                filepath = ltm.get_script_filepath(RemoteTemplateCookbookVersion.Version1,  # noqa: E501
+                filepath = ltm.get_script_filepath(RemoteTemplateCookbookVersion.Version1.value,  # noqa: E501
                                                    template_name,
                                                    template_revision,
                                                    ScriptFile.DOCKER_UPGRADE)
@@ -1356,7 +1356,7 @@ class VcdBroker(abstract_broker.AbstractBroker):
                       f"in control plane node {control_plane_node_names}"  # noqa: E501
                 LOGGER.debug(msg)
                 self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
-                filepath = ltm.get_script_filepath(RemoteTemplateCookbookVersion.Version1,  # noqa: E501
+                filepath = ltm.get_script_filepath(RemoteTemplateCookbookVersion.Version1.value,  # noqa: E501
                                                    template_name,
                                                    template_revision,
                                                    ScriptFile.CONTROL_PLANE_CNI_APPLY)  # noqa: E501
@@ -1908,7 +1908,7 @@ def _add_nodes(client, num_nodes, node_type, org, vdc, vapp,
                 if node_type == NodeType.NFS:
                     LOGGER.debug(f"Enabling NFS server on {vm_name}")
                     script_filepath = ltm.get_script_filepath(
-                        RemoteTemplateCookbookVersion.Version1,  # noqa: E501
+                        RemoteTemplateCookbookVersion.Version1.value,
                         template[LocalTemplateKey.NAME],
                         template[LocalTemplateKey.REVISION],
                         ScriptFile.NFSD)
@@ -2000,7 +2000,7 @@ def _init_cluster(sysadmin_client: vcd_client.Client, vapp, template_name,
     vcd_utils.raise_error_if_user_not_from_system_org(sysadmin_client)
 
     try:
-        script_filepath = ltm.get_script_filepath(RemoteTemplateCookbookVersion.Version1,  # noqa: E501
+        script_filepath = ltm.get_script_filepath(RemoteTemplateCookbookVersion.Version1.value,  # noqa: E501
                                                   template_name,
                                                   template_revision,
                                                   ScriptFile.CONTROL_PLANE)
@@ -2043,7 +2043,7 @@ def _join_cluster(sysadmin_client: vcd_client.Client, vapp, template_name,
         node_names = _get_node_names(vapp, NodeType.WORKER)
         if target_nodes is not None:
             node_names = [name for name in node_names if name in target_nodes]
-        tmp_script_filepath = ltm.get_script_filepath(RemoteTemplateCookbookVersion.Version1,  # noqa: E501
+        tmp_script_filepath = ltm.get_script_filepath(RemoteTemplateCookbookVersion.Version1.value,  # noqa: E501
                                                       template_name,
                                                       template_revision,
                                                       ScriptFile.NODE)


### PR DESCRIPTION
… key during cse upgrade

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

* Create subdirectory under LOCAL_SCRIPTS_DIR to store script cache
* Ignore compute policy key during cse upgrade as it prevents updating template metadata once again after upgrade is complete.

Testing:
* Cse upgrade to check if ignoring keys work fine
* Template install and see if proper directory is created during cluster installation.

@rocknes @sahithi @ltimothy7 @sakthisunda @arunmk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1076)
<!-- Reviewable:end -->
