### PR TITLE
[VCDA-2595] Fixed python key error on missing config legacy_mode

### DIFF
--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -153,10 +153,6 @@ def get_validated_config(config_file_name,
     except requests.exceptions.ConnectionError as err:
         raise Exception(f"Cannot connect to {err.request.url}.")
 
-    _validate_broker_config(config['broker'],
-                            legacy_mode=config['service']['legacy_mode'],
-                            msg_update_callback=msg_update_callback,
-                            logger_debug=logger_debug)
     check_keys_and_value_types(config['service'],
                                SAMPLE_SERVICE_CONFIG['service'],
                                location="config file 'service' section",
@@ -167,6 +163,11 @@ def get_validated_config(config_file_name,
                                location="config file 'service->telemetry' "
                                         "section",
                                msg_update_callback=msg_update_callback)
+
+    _validate_broker_config(config['broker'],
+                            legacy_mode=config['service']['legacy_mode'],
+                            msg_update_callback=msg_update_callback,
+                            logger_debug=logger_debug)
 
     config = _add_additional_details_to_config(
         config=config, log_wire=log_wire, log_wire_file=log_wire_file)

--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -153,6 +153,8 @@ def get_validated_config(config_file_name,
     except requests.exceptions.ConnectionError as err:
         raise Exception(f"Cannot connect to {err.request.url}.")
 
+    # Validation of service properties is done first as those properties are
+    # used in broker validation.
     check_keys_and_value_types(config['service'],
                                SAMPLE_SERVICE_CONFIG['service'],
                                location="config file 'service' section",


### PR DESCRIPTION
- CSE server commands on missing config legacy_mode raise key error. This is fixed to display the right error message as before.
- Validation of broker section uses 'legacy_mode' key and it happens before validating service section. 
   By doing service section validation first, we avoid this KeyError.
- Tested and verified

![image](https://user-images.githubusercontent.com/5530442/122808618-f6503d80-d281-11eb-9883-440ef13a6b36.png)

@sahithi @Anirudh9794

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1077)
<!-- Reviewable:end -->
