### PR TITLE
[VCDA-2596] CSE upgrade: Fix RDE resolution error 

### DIFF
--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -2407,7 +2407,7 @@ def _create_cluster_rde(client, cluster, kind, runtime_rde_version,
     org_resource = vcd_utils.get_org(client, org_name=cluster['org_name'])
     org_id = org_resource.href.split('/')[-1]
     def_entity = common_models.DefEntity(entity=cluster_entity, entityType=target_entity_type.id)  # noqa: E501
-    entity_svc.create_entity(target_entity_type.id, entity=def_entity, tenant_org_context=org_id)  # noqa: E501
+    entity_svc.create_entity(target_entity_type.id, entity=def_entity, tenant_org_context=org_id, delete_status_from_payload=False)  # noqa: E501
 
     def_entity = entity_svc.get_native_rde_by_name_and_rde_version(cluster['name'], runtime_rde_version)  # noqa: E501
     def_entity_id = def_entity.id


### PR DESCRIPTION
- Fixed RDE resolution error that was caused by deleting `status section` in payload while upgrading CSE 3.0.0 to CSE 3.1.0
- Retain `status section` in payload while creating RDE for upgrades as upgrades are executed by privileged user.
- Tested and verified the RDE thru CLI and postman
----------------------------------------------------------------------------------
![image](https://user-images.githubusercontent.com/5530442/122961377-332b3b80-d339-11eb-9fe1-92e5ed55f518.png)
----------------------------------------------------------------------------------
@sahithi @Anirudh9794

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1081)
<!-- Reviewable:end -->
