### PR TITLE
[VCDA-2626] Run kubeadm init with --config param for TKG+

### DIFF
--- a/cluster_scripts/v1_x/control_plane.sh
+++ b/cluster_scripts/v1_x/control_plane.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 set -e
+
+tkg_plus_kind="TKG+"
+input_kind="{cluster_kind}"
+kubeadm_config_path=/root/kubeadm-defaults.conf
+
 while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
-kubeadm init --kubernetes-version=v{k8s_version} > /root/kubeadm-init.out
+# use kubeadm config if TKG plus cluster
+if [ "$input_kind" == "$tkg_plus_kind" ]; then
+    kubeadm init --config=$kubeadm_config_path > /root/kubeadm-init.out
+else
+    kubeadm init --kubernetes-version=v{k8s_version} > /root/kubeadm-init.out
+fi
+
 mkdir -p /root/.kube
 cp -f /etc/kubernetes/admin.conf /root/.kube/config
 chown $(id -u):$(id -g) /root/.kube/config

--- a/cluster_scripts/v2_x/control_plane.sh
+++ b/cluster_scripts/v2_x/control_plane.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 set -e
+
+tkg_plus_kind="TKG+"
+input_kind="{cluster_kind}"
+kubeadm_config_path=/root/kubeadm-defaults.conf
+
 while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
-kubeadm init --kubernetes-version=v{k8s_version} > /root/kubeadm-init.out
+# use kubeadm config if TKG plus cluster
+if [ "$input_kind" == "$tkg_plus_kind" ]; then
+    kubeadm init --config=$kubeadm_config_path > /root/kubeadm-init.out
+else
+    kubeadm init --kubernetes-version=v{k8s_version} > /root/kubeadm-init.out
+fi
+
 mkdir -p /root/.kube
 cp -f /etc/kubernetes/admin.conf /root/.kube/config
 chown $(id -u):$(id -g) /root/.kube/config

--- a/container_service_extension/rde/backend/cluster_service_1_x.py
+++ b/container_service_extension/rde/backend/cluster_service_1_x.py
@@ -793,6 +793,7 @@ class ClusterService(abstract_broker.AbstractBroker):
 
             _init_cluster(sysadmin_client_v35,
                           vapp,
+                          template[LocalTemplateKey.KIND],
                           template[LocalTemplateKey.KUBERNETES_VERSION],
                           template[LocalTemplateKey.CNI_VERSION],
                           expose_ip=expose_ip)
@@ -2274,14 +2275,15 @@ def _get_control_plane_ip(sysadmin_client: vcd_client.Client, vapp,
     return control_plane_ip
 
 
-def _init_cluster(sysadmin_client: vcd_client.Client, vapp, k8s_version,
-                  cni_version, expose_ip=None):
+def _init_cluster(sysadmin_client: vcd_client.Client, vapp, cluster_kind,
+                  k8s_version, cni_version, expose_ip=None):
     vcd_utils.raise_error_if_user_not_from_system_org(sysadmin_client)
 
     try:
         templated_script = get_cluster_script_file_contents(
             ClusterScriptFile.CONTROL_PLANE, ClusterScriptFile.VERSION_1_X)
         script = templated_script.format(
+            cluster_kind=cluster_kind,
             k8s_version=k8s_version,
             cni_version=cni_version)
 

--- a/container_service_extension/rde/backend/cluster_service_1_x.py
+++ b/container_service_extension/rde/backend/cluster_service_1_x.py
@@ -2619,7 +2619,7 @@ def _run_script_in_nodes(sysadmin_client: vcd_client.Client, vapp_href,
     if results[0][0] != 0:
         raise exceptions.NodeOperationError(
             "Error during node operation:\n"
-            f"{results[0][2].content.decode()}")
+            f"{results[0][2].content.decode()[-65536:]}")
 
 
 def _get_script_execution_errors(results):

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -901,6 +901,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             vapp.reload()
             _init_cluster(sysadmin_client_v36,
                           vapp,
+                          template[LocalTemplateKey.KIND],
                           template[LocalTemplateKey.KUBERNETES_VERSION],
                           template[LocalTemplateKey.CNI_VERSION])
             control_plane_ip = _get_control_plane_ip(sysadmin_client_v36, vapp)  # noqa: E501
@@ -2273,14 +2274,15 @@ def _get_control_plane_ip(sysadmin_client: vcd_client.Client, vapp):
     return control_plane_ip
 
 
-def _init_cluster(sysadmin_client: vcd_client.Client, vapp, k8s_version,
-                  cni_version):
+def _init_cluster(sysadmin_client: vcd_client.Client, vapp, cluster_kind,
+                  k8s_version, cni_version):
     vcd_utils.raise_error_if_user_not_from_system_org(sysadmin_client)
 
     try:
         templated_script = get_cluster_script_file_contents(
             ClusterScriptFile.CONTROL_PLANE, ClusterScriptFile.VERSION_2_X)
         script = templated_script.format(
+            cluster_kind=cluster_kind,
             k8s_version=k8s_version,
             cni_version=cni_version)
         node_names = _get_node_names(vapp, NodeType.CONTROL_PLANE)


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Kubeadm init needs to be invoked using --config option for TKG+ clusters.
This change is to make sure that the control-plane.sh invoke kubeadm init with --config if kind is "TKG+"

Testing done:
* Tested if kubeadm init is invoked with --config for TKG+ cluster kind.
* Tested if kubeadm init is NOT invoked with --config option for native cluster kind.

@sahithi @arunmk  @rocknes @ltimothy7 @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1082)
<!-- Reviewable:end -->
