### PR TITLE
[VCDA - 2624] Add `expose` and `exposed` field to RDE 2.0.0

### DIFF
--- a/container_service_extension/client/cluster_commands.py
+++ b/container_service_extension/client/cluster_commands.py
@@ -597,7 +597,9 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, out
         if generate_sample_config:
             if not k8_runtime:
                 console_message_printer.general_no_color(ctx.get_help())
-                msg = "with option --sample you must specify either of options: --native or --tkg or --tkg-plus"  # noqa: E501
+                msg = "with option --sample you must specify either of options: --native or --tkg"  # noqa: E501
+                if utils.is_environment_variable_enabled(cli_constants.ENV_CSE_TKG_PLUS_ENABLED):  # noqa: E501
+                    msg += " or --tkg-plus"
                 CLIENT_LOGGER.error(msg)
                 raise Exception(msg)
             elif k8_runtime == shared_constants.ClusterEntityKind.TKG_PLUS \
@@ -644,7 +646,7 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, out
         CLIENT_LOGGER.debug(result)
     except Exception as e:
         stderr(e, ctx)
-        CLIENT_LOGGER.error(str(e))
+        CLIENT_LOGGER.error(str(e), exec_info=True)
 
 
 @cluster_group.command('delete-nfs',

--- a/container_service_extension/client/sample_generator.py
+++ b/container_service_extension/client/sample_generator.py
@@ -93,7 +93,7 @@ def get_sample_cluster_configuration(output=None, k8_runtime=None, server_rde_in
 
 def _get_sample_cluster_configuration_by_k8_runtime(k8_runtime, server_rde_in_use):  # noqa: E501
     NativeEntityClass = rde_factory.get_rde_model(server_rde_in_use)
-    return NativeEntityClass.get_sample_native_cluster_specification(k8_runtime)  # noqa: E501
+    return NativeEntityClass.get_sample_native_cluster_specification(k8_runtime.value)  # noqa: E501
 
 
 def _get_sample_tkg_cluster_configuration():

--- a/container_service_extension/rde/backend/cluster_service_1_x.py
+++ b/container_service_extension/rde/backend/cluster_service_1_x.py
@@ -2475,7 +2475,7 @@ def _expose_cluster(client: vcd_client.Client, org_name: str, ovdc_name: str,
         client, org_name, ovdc_name, network_name)
     expose_ip = nsxt_gateway_svc.get_available_ip()
     if not expose_ip:
-        raise Exception(f'No available ips found for cluster {cluster_name} ({cluster_id})') # noqa: E501
+        raise Exception(f'No available ips found for cluster {cluster_name} ({cluster_id})')  # noqa: E501
     try:
         dnat_rule_name = _form_expose_dnat_rule_name(cluster_name, cluster_id)
         nsxt_gateway_svc.add_dnat_rule(

--- a/container_service_extension/rde/models/rde_1_0_0.py
+++ b/container_service_extension/rde/models/rde_1_0_0.py
@@ -188,7 +188,7 @@ class NativeEntity(AbstractNativeEntity):
             )
 
             settings = Settings(
-                network=rde_2_x_entity.spec.settings.network,
+                network=rde_2_x_entity.spec.settings.ovdc_network,
                 ssh_key=rde_2_x_entity.spec.settings.ssh_key,
                 rollback_on_failure=rde_2_x_entity.spec.settings.rollback_on_failure  # noqa: E501
             )
@@ -242,7 +242,7 @@ class NativeEntity(AbstractNativeEntity):
 
             nfs_nodes = []
             for nfs_node in nfs_nodes:
-                nfs_node_1_x = Node(
+                nfs_node_1_x = NfsNode(
                     name=nfs_node.name,
                     ip=nfs_node.ip,
                     sizing_class=nfs_node.sizing_class)
@@ -326,7 +326,7 @@ class NativeEntity(AbstractNativeEntity):
                     server_constants.DefEntityOperation.CREATE,
                     server_constants.DefEntityOperationStatus.SUCCEEDED)
                 ),
-                kubernetes=f"{cluster['kubernetes']} {cluster['kubernetes_version']}", # noqa: E501
+                kubernetes=f"{cluster['kubernetes']} {cluster['kubernetes_version']}",  # noqa: E501
                 cni=f"{cluster['cni']} {cluster['cni_version']}",
                 os=cluster['os'],
                 docker_version=cluster['docker_version'],

--- a/container_service_extension/rde/models/rde_1_0_0.py
+++ b/container_service_extension/rde/models/rde_1_0_0.py
@@ -245,7 +245,8 @@ class NativeEntity(AbstractNativeEntity):
                 nfs_node_1_x = NfsNode(
                     name=nfs_node.name,
                     ip=nfs_node.ip,
-                    sizing_class=nfs_node.sizing_class)
+                    sizing_class=nfs_node.sizing_class
+                )
                 nfs_nodes.append(nfs_node_1_x)
 
             nodes = Nodes(
@@ -288,17 +289,22 @@ class NativeEntity(AbstractNativeEntity):
         worker_nodes = []
         for item in cluster['nodes']:
             worker_nodes.append(
-                Node(name=item['name'], ip=item['ipAddress']))
+                Node(name=item['name'], ip=item['ipAddress'])
+            )
         nfs_nodes = []
         for item in cluster['nfs_nodes']:
-            nfs_nodes.append(NfsNode(
-                name=item['name'],
-                ip=item['ipAddress'],
-                exports=item['exports']))
+            nfs_nodes.append(
+                NfsNode(
+                    name=item['name'],
+                    ip=item['ipAddress'],
+                    exports=item['exports']
+                )
+            )
 
         k8_distribution = Distribution(
             template_name=cluster['template_name'],
-            template_revision=int(cluster['template_revision']))
+            template_revision=int(cluster['template_revision'])
+        )
 
         cluster_entity = cls(
             kind=kind,
@@ -333,7 +339,8 @@ class NativeEntity(AbstractNativeEntity):
                 nodes=Nodes(
                     control_plane=Node(
                         name=cluster['master_nodes'][0]['name'],
-                        ip=cluster['master_nodes'][0]['ipAddress']),
+                        ip=cluster['master_nodes'][0]['ipAddress']
+                    ),
                     workers=worker_nodes,
                     nfs=nfs_nodes
                 )

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -358,7 +358,7 @@ class NativeEntity(AbstractNativeEntity):
                 distribution=Distribution(
                     template_name=rde_1_x_entity.spec.k8_distribution.template_name,  # noqa: E501
                     template_revision=rde_1_x_entity.spec.k8_distribution.template_revision  # noqa: E501
-                ),
+                )
             )
             rde_2_entity = cls(
                 metadata=metadata,

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -95,6 +95,7 @@ class Network:
     cni: Optional[Cni] = None
     pods: Optional[Pods] = None
     services: Optional[Services] = None
+    expose: bool = False
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL)
@@ -103,7 +104,7 @@ class Settings:
     ovdc_network: str
     ssh_key: Optional[str] = None
     rollback_on_failure: bool = True
-    network: Optional[Network] = None
+    network: Network = Network()
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL)
@@ -146,6 +147,7 @@ class CloudProperties:
     ssh_key: Optional[str] = None
 
     rollback_on_failure: bool = True
+    exposed: bool = False
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL)
@@ -168,7 +170,6 @@ class Status:
     nodes: Optional[Nodes] = None
     uid: Optional[str] = None
     cloud_properties: CloudProperties = CloudProperties()
-    exposed: bool = False
     persistent_volumes: Optional[List[str]] = None
     virtual_IPs: Optional[List[str]] = None
     private: Optional[Private] = None
@@ -186,7 +187,6 @@ class ClusterSpec:
     settings: Settings
     topology: Topology = Topology()
     distribution: Distribution = Distribution()
-    expose: bool = False
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL)
@@ -270,13 +270,15 @@ class NativeEntity(AbstractNativeEntity):
             )
             # NOTE: since details for the field `site` is not present in
             # RDE 1.0, it is left empty
-            cloud_properties = CloudProperties(site=None,
-                                               org_name=rde_1_x_entity.metadata.org_name,  # noqa: E501
-                                               virtual_data_center_name=rde_1_x_entity.metadata.ovdc_name,  # noqa: E501
-                                               ovdc_network_name=rde_1_x_entity.spec.settings.network,  # noqa: E501
-                                               distribution=distribution,
-                                               ssh_key=rde_1_x_entity.spec.settings.ssh_key,  # noqa: E501
-                                               rollback_on_failure=rde_1_x_entity.spec.settings.rollback_on_failure)  # noqa: E501
+            cloud_properties = CloudProperties(
+                site=None,
+                org_name=rde_1_x_entity.metadata.org_name,
+                virtual_data_center_name=rde_1_x_entity.metadata.ovdc_name,
+                ovdc_network_name=rde_1_x_entity.spec.settings.network,
+                distribution=distribution,
+                ssh_key=rde_1_x_entity.spec.settings.ssh_key,
+                rollback_on_failure=rde_1_x_entity.spec.settings.rollback_on_failure,  # noqa: E501
+                exposed=rde_1_x_entity.status.exposed)
             # RDE 1.0 don't have storage_profile in Node definition
             control_plane = Node(
                 name=rde_1_x_entity.status.nodes.control_plane.name,
@@ -293,7 +295,7 @@ class NativeEntity(AbstractNativeEntity):
                 workers.append(worker_node_2_x)
             nfs_nodes = []
             for nfs_node in rde_1_x_entity.status.nodes.nfs:
-                nfs_node_2_x = Node(
+                nfs_node_2_x = NfsNode(
                     name=nfs_node.name,
                     ip=nfs_node.ip,
                     sizing_class=nfs_node.sizing_class
@@ -316,8 +318,7 @@ class NativeEntity(AbstractNativeEntity):
                             os=rde_1_x_entity.status.os,
                             nodes=nodes,
                             uid=None,
-                            cloud_properties=cloud_properties,
-                            exposed=rde_1_x_entity.status.exposed)
+                            cloud_properties=cloud_properties)
             # NOTE: since details for the field `site` is not present in
             # RDE 1.0, it is left empty.
             # Proper value for `site` should be populated after RDE is
@@ -331,31 +332,41 @@ class NativeEntity(AbstractNativeEntity):
                 control_plane=ControlPlane(
                     sizing_class=rde_1_x_entity.spec.control_plane.sizing_class,  # noqa: E501
                     storage_profile=rde_1_x_entity.spec.control_plane.storage_profile,  # noqa: E501
-                    count=rde_1_x_entity.spec.control_plane.count),
+                    count=rde_1_x_entity.spec.control_plane.count
+                ),
                 workers=Workers(
                     sizing_class=rde_1_x_entity.spec.workers.sizing_class,
                     storage_profile=rde_1_x_entity.spec.workers.storage_profile,  # noqa: E501
-                    count=rde_1_x_entity.spec.workers.count),
+                    count=rde_1_x_entity.spec.workers.count
+                ),
                 nfs=Nfs(
                     sizing_class=rde_1_x_entity.spec.nfs.sizing_class,
                     storage_profile=rde_1_x_entity.spec.nfs.storage_profile,
-                    count=rde_1_x_entity.spec.nfs.count),
+                    count=rde_1_x_entity.spec.nfs.count
+                ),
             )
             spec = ClusterSpec(
                 settings=Settings(
                     ovdc_network=rde_1_x_entity.spec.settings.network,
                     ssh_key=rde_1_x_entity.spec.settings.ssh_key,
-                    rollback_on_failure=rde_1_x_entity.spec.settings.rollback_on_failure),  # noqa: E501,
+                    rollback_on_failure=rde_1_x_entity.spec.settings.rollback_on_failure,  # noqa: E501
+                    network=Network(
+                        expose=rde_1_x_entity.spec.expose
+                    )
+                ),
                 topology=topology,
                 distribution=Distribution(
                     template_name=rde_1_x_entity.spec.k8_distribution.template_name,  # noqa: E501
-                    template_revision=rde_1_x_entity.spec.k8_distribution.template_revision),  # noqa: E501
-                expose=rde_1_x_entity.spec.expose)
-            rde_2_entity = cls(metadata=metadata,
-                               spec=spec,
-                               status=status,
-                               kind=rde_1_x_entity.kind,
-                               api_version=rde_constants.PAYLOAD_VERSION_2_0)
+                    template_revision=rde_1_x_entity.spec.k8_distribution.template_revision  # noqa: E501
+                ),
+            )
+            rde_2_entity = cls(
+                metadata=metadata,
+                spec=spec,
+                status=status,
+                kind=rde_1_x_entity.kind,
+                api_version=rde_constants.PAYLOAD_VERSION_2_0
+            )
             return rde_2_entity
 
     @classmethod
@@ -383,12 +394,13 @@ class NativeEntity(AbstractNativeEntity):
             template_name=cluster['template_name'],
             template_revision=int(cluster['template_revision']))
 
-        cloud_properties = CloudProperties(site=site,
-                                           org_name=cluster['org_name'],
-                                           virtual_data_center_name=cluster['vdc_name'],  # noqa: E501
-                                           ovdc_network_name=cluster['network_name'],  # noqa: E501
-                                           distribution=k8_distribution,
-                                           ssh_key='')
+        cloud_properties = CloudProperties(
+            site=site,
+            org_name=cluster['org_name'],
+            virtual_data_center_name=cluster['vdc_name'],
+            ovdc_network_name=cluster['network_name'],
+            distribution=k8_distribution,
+            ssh_key='')
         topology = Topology(
             workers=Workers(
                 count=len(cluster['nodes']),
@@ -408,7 +420,7 @@ class NativeEntity(AbstractNativeEntity):
             spec=ClusterSpec(
                 topology=topology,
                 settings=Settings(
-                    network=cluster['network_name'],
+                    ovdc_network=cluster['network_name'],
                     ssh_key=""
                 ),
                 distribution=k8_distribution
@@ -418,7 +430,7 @@ class NativeEntity(AbstractNativeEntity):
                     server_constants.DefEntityOperation.CREATE,
                     server_constants.DefEntityOperationStatus.SUCCEEDED)
                 ),
-                kubernetes=f"{cluster['kubernetes']} {cluster['kubernetes_version']}", # noqa: E501
+                kubernetes=f"{cluster['kubernetes']} {cluster['kubernetes_version']}",  # noqa: E501
                 cni=f"{cluster['cni']} {cluster['cni_version']}",
                 os=cluster['os'],
                 docker_version=cluster['docker_version'],
@@ -533,11 +545,13 @@ class NativeEntity(AbstractNativeEntity):
         # remove status part of the entity dict
         del native_entity_dict['status']
 
-        # Hiding the network spec section for Andromeda (CSE 3.1)
-        # spec.settings.network is targeted for CSE 3.1.1 to accommodate
-        #  CNI=Antrea
+        # Hiding certain portion of the network spec section for
+        # Andromeda (CSE 3.1) spec.settings.network is targeted
+        # for CSE 3.1.1 to accommodate Antrea as CNI
         # Below line can be deleted post Andromeda (CSE 3.1)
-        del native_entity_dict['spec']['settings']['network']
+        del native_entity_dict['spec']['settings']['network']['cni']
+        del native_entity_dict['spec']['settings']['network']['pods']
+        del native_entity_dict['spec']['settings']['network']['services']
         # Hiding the cpu and memory properties from controlPlane and workers
         # for Andromeda (CSE 3.1). Below lines can be deleted once cpu and
         # memory support is added in CSE 3.1.1

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -136,10 +136,14 @@ def construct_2_0_0_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Sta
         template_name=entity_status.cloud_properties.distribution.template_name,  # noqa: E501
         template_revision=entity_status.cloud_properties.distribution.template_revision)  # noqa: E501
 
+    network_settings = rde_2_0_0.Network(
+        expose=entity_status.cloud_properties.exposed)
+
     settings = rde_2_0_0.Settings(
         ovdc_network=entity_status.cloud_properties.ovdc_network_name,
         ssh_key=entity_status.cloud_properties.ssh_key,
-        rollback_on_failure=entity_status.cloud_properties.rollback_on_failure)  # noqa: E501
+        rollback_on_failure=entity_status.cloud_properties.rollback_on_failure,  # noqa: E501
+        network=network_settings)
 
     topology = rde_2_0_0.Topology(
         control_plane=control_plane,
@@ -148,8 +152,7 @@ def construct_2_0_0_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Sta
 
     return rde_2_0_0.ClusterSpec(settings=settings,
                                  distribution=k8_distribution,
-                                 topology=topology,
-                                 expose=entity_status.exposed)
+                                 topology=topology)
 
 
 def load_rde_schema(schema_file: str) -> dict:

--- a/cse_def_schema/schema_2_0_0.json
+++ b/cse_def_schema/schema_2_0_0.json
@@ -224,6 +224,10 @@
                                             }
                                         }
                                     }
+                                },
+                                "expose": {
+                                    "type":"boolean",
+                                    "description":"Exposes a cluster beyond routed Organization VDC network scope."
                                 }
                             }
                         }
@@ -324,6 +328,10 @@
                         "site":{
                             "type":"string",
                             "description":"Fully Qualified Domain Name of the VCD site in which the cluster is deployed"
+                        },
+                        "exposed": {
+                            "type":"boolean",
+                            "description":"Set to True, if a cluster is exposed beyond routed Organization VDC network scope."
                         }
                     },
                     "additionalProperties":true


### PR DESCRIPTION
Added two new fields to RDE 2.0.0 viz. `expose` and `exposed`. Also made associated changes in the model and service files.

Testing done:
Generated a RDE 2.0.0 based cluster spec file and made sure that the new fields are part of it.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1089)
<!-- Reviewable:end -->
