### PR TITLE
[VCDA-2647] Announce-Template-1.21.2-On-Github-Template-Announcement-Page

### DIFF
--- a/docs/cse3_0/TEMPLATE_ANNOUNCEMENTS.md
+++ b/docs/cse3_0/TEMPLATE_ANNOUNCEMENTS.md
@@ -4,7 +4,7 @@ title: Template Announcements
 ---
 # Template Announcements
 
-## Jun 30, 2021
+## Jul 2, 2021
 
 All templates currently available:
 * New templates are highlighted

--- a/docs/cse3_0/TEMPLATE_ANNOUNCEMENTS.md
+++ b/docs/cse3_0/TEMPLATE_ANNOUNCEMENTS.md
@@ -4,6 +4,24 @@ title: Template Announcements
 ---
 # Template Announcements
 
+## Jun 30, 2021
+
+All templates currently available:
+* New templates are highlighted
+* Updated template revisions are highlighted
+* Removed templates are striked out
+
+| Template Name                        | Revision | Operating System  | Kubernetes  | Weave     | Docker                  |
+|--------------------------------------|----------|-------------------|-------------|-----------|-------------------------|
+| **ubuntu-16.04_k8-1.21_weave-2.8.1** | 1        | Ubuntu-16.04      | 1.21.2      | 2.8.1     | Docker-ce 20.10.7       |
+| ubuntu-16.04_k8-1.20_weave-2.6.5     | **2**    | Ubuntu-16.04      | 1.20.6      | 2.6.5     | Docker-ce 19.03.15      |
+| ubuntu-16.04_k8-1.19_weave-2.6.5     | **2**    | Ubuntu-16.04      | 1.19.3      | 2.6.5     | Docker-ce 19.03.12      |
+| ubuntu-16.04_k8-1.18_weave-2.6.5 *   | 2        | Ubuntu-16.04      | 1.18.6      | 2.6.5     | Docker-ce 19.03.12      |
+| ~~ubuntu-16.04_k8-1.17_weave-2.6.0~~ | ~~2~~    | ~~Ubuntu 16.04~~  | ~~1.17.9~~  | ~~2.6.0~~ | ~~Docker-ce 19.03.5~~   |
+| photon-v2_k8-1.14_weave-2.5.2        | 3        | Photon OS 2.0     | 1.14.10     | 2.5.2     | Docker-ce 18.06.2-6     |
+
+Templates marked with '*' are deprecated and will be removed in future update.
+
 ## May 3, 2021
 
 All templates currently available:


### PR DESCRIPTION
- ubuntu-16.04_k8-1.21_weave-2.8.1 announcement
- 1.17 removed
- 1.18 deprecated
- updated templates with highlighted version

@goelaashima @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1091)
<!-- Reviewable:end -->
