### PR TITLE
[VCDA-2655] Set the RDE.status to FAILED on cluster creation failure when rollback=true

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -1008,6 +1008,12 @@ class ClusterService(abstract_broker.AbstractBroker):
                 exceptions.ClusterOperationError) as err:
             msg = f"Error creating cluster '{cluster_name}'"
             LOGGER.error(msg, exc_info=True)
+            try:
+                self._fail_operation(
+                    cluster_id, DefEntityOperation.CREATE)
+            except Exception:
+                msg = f"Failed to update defined entity status for cluster {cluster_id}"  # noqa: E501
+                LOGGER.error(f"{msg}", exc_info=True)
             if rollback:
                 msg = f"Error creating cluster '{cluster_name}'. " \
                       f"Deleting cluster (rollback=True)"
@@ -1022,15 +1028,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                     LOGGER.error(f"Failed to delete cluster '{cluster_name}'",
                                  exc_info=True)
             else:
-                # TODO: Avoid many try-except block. Check if it is a good
-                # practice
-                try:
-                    self._fail_operation(
-                        cluster_id, DefEntityOperation.CREATE)
-                except Exception:
-                    msg = f"Failed to update defined entity status for cluster {cluster_id}"  # noqa: E501
-                    LOGGER.error(f"{msg}", exc_info=True)
-
+                # TODO: Avoid many try-except block. Check if it is a good practice  # noqa: E501
                 # NOTE: sync of the defined entity should happen before call to
                 # resolving the defined entity to prevent possible missing
                 # values in the defined entity

--- a/docs/cse3_1/CLUSTER_MANAGEMENT.md
+++ b/docs/cse3_1/CLUSTER_MANAGEMENT.md
@@ -66,9 +66,11 @@ can choose to monitor the task progress manually.
 > vcd task list running
 ```
 <a name="cse30_cluster_apply"></a>
-### CSE 3.0 `Cluster apply` command
+### CSE 3.1 `Cluster apply` command
 
-1. `vcd cse cluster apply <create_cluster.yaml>` command - Takes a cluster specification file as an input and applies it to a cluster resource. The cluster resource will be created if it does not exist. 
+1. `vcd cse cluster apply <create_cluster.yaml>` command - Takes a cluster specification 
+   file as an input and applies it to a cluster resource. The cluster resource will 
+   be created if it does not exist. Note that sample file may differ from one version to another.
     * Command usage examples:
         ```sh
         vcd cse cluster apply <resize_cluster.yaml> (applies the specification on the resource specified; the cluster resource will be created if it does not exist). 
@@ -78,39 +80,41 @@ can choose to monitor the task progress manually.
     * Sample input specification file
         ```sh
         # Short description of various properties used in this sample cluster configuration
+        # apiVersion: Represents the payload version of the cluster specification. By default, \"cse.vmware.com/v2.0\" is used.
         # kind: The kind of the Kubernetes cluster.
         #
         # metadata: This is a required section
-        # metadata.cluster_name: Name of the cluster to be created or resized
-        # metadata.org_name: The name of the Organization in which cluster needs to be created or managed.
-        # metadata.ovdc_name: The name of the Organization Virtual data center in which the cluster need to be created or managed.
+        # metadata.name: Name of the cluster to be created or resized.
+        # metadata.orgName: The name of the Organization in which cluster needs to be created or managed.
+        # metadata.virtualDataCenterName: The name of the Organization Virtual data center in which the cluster need to be created or managed.
+        # metadata.site: VCD site domain name where the cluster should be deployed.
         #
         # spec: User specification of the desired state of the cluster.
-        # spec.control_plane: An optional sub-section for desired control-plane state of the cluster. The properties "sizing_class" and "storage_profile" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like "resize" and "upgrade".
-        # spec.control_plane.count: Number of control plane node(s). Only single control plane node is supported.
-        # spec.control_plane.sizing_class: The compute sizing policy with which control-plane node needs to be provisioned in a given "ovdc". The specified sizing policy is expected to be pre-published to the given ovdc.
-        # spec.control_plane.storage_profile: The storage-profile with which control-plane needs to be provisioned in a given "ovdc". The specified storage-profile is expected to be available on the given ovdc.
+        # spec.topology.controlPlane: An optional sub-section for desired control-plane state of the cluster. The properties \"sizingClass\" and \"storageProfile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\".
+        # spec.topology.controlPlane.count: Number of control plane node(s). Only single control plane node is supported.
+        # spec.topology.controlPlane.sizingClass: The compute sizing policy with which control-plane node needs to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc.
+        # spec.topology.controlPlane.storageProfile: The storage-profile with which control-plane needs to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc.
         #
-        # spec.k8_distribution: This is a required sub-section.
-        # spec.k8_distribution.template_name: Template name based on guest OS, Kubernetes version, and the Weave software version
-        # spec.k8_distribution.template_revision: revision number
+        # spec.distribution: This is a required sub-section.
+        # spec.distribution.templateName: Template name based on guest OS, Kubernetes version, and the Weave software version
+        # spec.distribution.templateRevision: revision number
         #
-        # spec.nfs: Optional sub-section for desired nfs state of the cluster. The properties "sizing_class" and "storage_profile" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like "resize" and "upgrade".
+        # spec.nfs: Optional sub-section for desired nfs state of the cluster. The properties \"sizingClass\" and \"storageProfile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\".
         # spec.nfs.count: Nfs nodes can only be scaled-up; they cannot be scaled-down. Default value is 0.
-        # spec.nfs.sizing_class: The compute sizing policy with which nfs node needs to be provisioned in a given "ovdc". The specified sizing policy is expected to be pre-published to the given ovdc.
-        # spec.nfs.storage_profile: The storage-profile with which nfs needs to be provisioned in a given "ovdc". The specified storage-profile is expected to be available on the given ovdc.
+        # spec.nfs.sizingClass: The compute sizing policy with which nfs node needs to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc.
+        # spec.nfs.storageProfile: The storage-profile with which nfs needs to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc.
         #
         # spec.settings: This is a required sub-section
-        # spec.settings.network: This value is mandatory. Name of the Organization's virtual data center network
-        # spec.settings.rollback_on_failure: Optional value that is true by default. On any cluster operation failure, if the value is set to true, affected node VMs will be automatically deleted.
-        # spec.settings.ssh_key: Optional ssh key that users can use to log into the node VMs without explicitly providing passwords.
+        # spec.settings.ovdcNetwork: This value is mandatory. Name of the Organization's virtual data center network
+        # spec.settings.rollbackOnFailure: Optional value that is true by default. On any cluster operation failure, if the value is set to true, affected node VMs will be automatically deleted.
+        # spec.settings.sshKey: Optional ssh key that users can use to log into the node VMs without explicitly providing passwords.
         #
-        # spec.workers: Optional sub-section for the desired worker state of the cluster. The properties "sizing_class" and "storage_profile" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like "resize" and "upgrade". Non uniform worker nodes in the clusters is not yet supported.
+        # spec.workers: Optional sub-section for the desired worker state of the cluster. The properties \"sizingClass\" and \"storageProfile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\". Non uniform worker nodes in the clusters is not yet supported.
         # spec.workers.count: number of worker nodes (default value:1) Worker nodes can be scaled up and down.
-        # spec.workers.sizing_class: The compute sizing policy with which worker nodes need to be provisioned in a given "ovdc". The specified sizing policy is expected to be pre-published to the given ovdc.
-        # spec.workers.storage_profile: The storage-profile with which worker nodes need to be provisioned in a given "ovdc". The specified storage-profile is expected to be available on the given ovdc.
+        # spec.workers.sizingClass: The compute sizing policy with which worker nodes need to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc.
+        # spec.workers.storageProfile: The storage-profile with which worker nodes need to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc.
         #
-        # status: Current state of the cluster in the server. This is not a required section for any of the operations.
+        # status: Current state of the cluster in the server. This is not a required section for any of the operations.\n
          
         api_version: ''
         kind: native
@@ -123,7 +127,6 @@ can choose to monitor the task progress manually.
             count: 1
             sizing_class: Large_sizing_policy_name
             storage_profile: Gold_storage_profile_name
-          expose: false
           k8_distribution:
             template_name: ubuntu-16.04_k8-1.17_weave-2.6.0
             template_revision: 2

--- a/docs/cse3_1/CLUSTER_MANAGEMENT.md
+++ b/docs/cse3_1/CLUSTER_MANAGEMENT.md
@@ -66,11 +66,9 @@ can choose to monitor the task progress manually.
 > vcd task list running
 ```
 <a name="cse30_cluster_apply"></a>
-### CSE 3.1 `Cluster apply` command
+### CSE 3.0 `Cluster apply` command
 
-1. `vcd cse cluster apply <create_cluster.yaml>` command - Takes a cluster specification 
-   file as an input and applies it to a cluster resource. The cluster resource will 
-   be created if it does not exist. Note that sample file may differ from one version to another.
+1. `vcd cse cluster apply <create_cluster.yaml>` command - Takes a cluster specification file as an input and applies it to a cluster resource. The cluster resource will be created if it does not exist. 
     * Command usage examples:
         ```sh
         vcd cse cluster apply <resize_cluster.yaml> (applies the specification on the resource specified; the cluster resource will be created if it does not exist). 
@@ -80,41 +78,39 @@ can choose to monitor the task progress manually.
     * Sample input specification file
         ```sh
         # Short description of various properties used in this sample cluster configuration
-        # apiVersion: Represents the payload version of the cluster specification. By default, \"cse.vmware.com/v2.0\" is used.
         # kind: The kind of the Kubernetes cluster.
         #
         # metadata: This is a required section
-        # metadata.name: Name of the cluster to be created or resized.
-        # metadata.orgName: The name of the Organization in which cluster needs to be created or managed.
-        # metadata.virtualDataCenterName: The name of the Organization Virtual data center in which the cluster need to be created or managed.
-        # metadata.site: VCD site domain name where the cluster should be deployed.
+        # metadata.cluster_name: Name of the cluster to be created or resized
+        # metadata.org_name: The name of the Organization in which cluster needs to be created or managed.
+        # metadata.ovdc_name: The name of the Organization Virtual data center in which the cluster need to be created or managed.
         #
         # spec: User specification of the desired state of the cluster.
-        # spec.topology.controlPlane: An optional sub-section for desired control-plane state of the cluster. The properties \"sizingClass\" and \"storageProfile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\".
-        # spec.topology.controlPlane.count: Number of control plane node(s). Only single control plane node is supported.
-        # spec.topology.controlPlane.sizingClass: The compute sizing policy with which control-plane node needs to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc.
-        # spec.topology.controlPlane.storageProfile: The storage-profile with which control-plane needs to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc.
+        # spec.control_plane: An optional sub-section for desired control-plane state of the cluster. The properties "sizing_class" and "storage_profile" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like "resize" and "upgrade".
+        # spec.control_plane.count: Number of control plane node(s). Only single control plane node is supported.
+        # spec.control_plane.sizing_class: The compute sizing policy with which control-plane node needs to be provisioned in a given "ovdc". The specified sizing policy is expected to be pre-published to the given ovdc.
+        # spec.control_plane.storage_profile: The storage-profile with which control-plane needs to be provisioned in a given "ovdc". The specified storage-profile is expected to be available on the given ovdc.
         #
-        # spec.distribution: This is a required sub-section.
-        # spec.distribution.templateName: Template name based on guest OS, Kubernetes version, and the Weave software version
-        # spec.distribution.templateRevision: revision number
+        # spec.k8_distribution: This is a required sub-section.
+        # spec.k8_distribution.template_name: Template name based on guest OS, Kubernetes version, and the Weave software version
+        # spec.k8_distribution.template_revision: revision number
         #
-        # spec.nfs: Optional sub-section for desired nfs state of the cluster. The properties \"sizingClass\" and \"storageProfile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\".
+        # spec.nfs: Optional sub-section for desired nfs state of the cluster. The properties "sizing_class" and "storage_profile" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like "resize" and "upgrade".
         # spec.nfs.count: Nfs nodes can only be scaled-up; they cannot be scaled-down. Default value is 0.
-        # spec.nfs.sizingClass: The compute sizing policy with which nfs node needs to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc.
-        # spec.nfs.storageProfile: The storage-profile with which nfs needs to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc.
+        # spec.nfs.sizing_class: The compute sizing policy with which nfs node needs to be provisioned in a given "ovdc". The specified sizing policy is expected to be pre-published to the given ovdc.
+        # spec.nfs.storage_profile: The storage-profile with which nfs needs to be provisioned in a given "ovdc". The specified storage-profile is expected to be available on the given ovdc.
         #
         # spec.settings: This is a required sub-section
-        # spec.settings.ovdcNetwork: This value is mandatory. Name of the Organization's virtual data center network
-        # spec.settings.rollbackOnFailure: Optional value that is true by default. On any cluster operation failure, if the value is set to true, affected node VMs will be automatically deleted.
-        # spec.settings.sshKey: Optional ssh key that users can use to log into the node VMs without explicitly providing passwords.
+        # spec.settings.network: This value is mandatory. Name of the Organization's virtual data center network
+        # spec.settings.rollback_on_failure: Optional value that is true by default. On any cluster operation failure, if the value is set to true, affected node VMs will be automatically deleted.
+        # spec.settings.ssh_key: Optional ssh key that users can use to log into the node VMs without explicitly providing passwords.
         #
-        # spec.workers: Optional sub-section for the desired worker state of the cluster. The properties \"sizingClass\" and \"storageProfile\" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like \"resize\" and \"upgrade\". Non uniform worker nodes in the clusters is not yet supported.
+        # spec.workers: Optional sub-section for the desired worker state of the cluster. The properties "sizing_class" and "storage_profile" can be specified only during the cluster creation phase. These properties will no longer be modifiable in further update operations like "resize" and "upgrade". Non uniform worker nodes in the clusters is not yet supported.
         # spec.workers.count: number of worker nodes (default value:1) Worker nodes can be scaled up and down.
-        # spec.workers.sizingClass: The compute sizing policy with which worker nodes need to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc.
-        # spec.workers.storageProfile: The storage-profile with which worker nodes need to be provisioned in a given \"ovdc\". The specified storage-profile is expected to be available on the given ovdc.
+        # spec.workers.sizing_class: The compute sizing policy with which worker nodes need to be provisioned in a given "ovdc". The specified sizing policy is expected to be pre-published to the given ovdc.
+        # spec.workers.storage_profile: The storage-profile with which worker nodes need to be provisioned in a given "ovdc". The specified storage-profile is expected to be available on the given ovdc.
         #
-        # status: Current state of the cluster in the server. This is not a required section for any of the operations.\n
+        # status: Current state of the cluster in the server. This is not a required section for any of the operations.
          
         api_version: ''
         kind: native
@@ -127,6 +123,7 @@ can choose to monitor the task progress manually.
             count: 1
             sizing_class: Large_sizing_policy_name
             storage_profile: Gold_storage_profile_name
+          expose: false
           k8_distribution:
             template_name: ubuntu-16.04_k8-1.17_weave-2.6.0
             template_revision: 2


### PR DESCRIPTION

RDE status.phase is not being updated to CREATE:FAILED when rollback is set to True.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1093)
<!-- Reviewable:end -->
