### PR TITLE
[VCDA-2640] Port cluster expose feature to Cluster Service 2.x

### DIFF
--- a/container_service_extension/client/cluster_commands.py
+++ b/container_service_extension/client/cluster_commands.py
@@ -646,7 +646,7 @@ def apply(ctx, cluster_config_file_path, generate_sample_config, k8_runtime, out
         CLIENT_LOGGER.debug(result)
     except Exception as e:
         stderr(e, ctx)
-        CLIENT_LOGGER.error(str(e), exec_info=True)
+        CLIENT_LOGGER.error(str(e), exc_info=True)
 
 
 @cluster_group.command('delete-nfs',

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -1578,15 +1578,15 @@ def _update_metadata_for_existing_templates(client: Client, config: dict,
             ltm.save_metadata(client, catalog_org_name,
                               catalog_name, catalog_item_name,
                               remote_template_descriptor, metadata_key_list=new_metadata_key_list)  # noqa: E501
-            msg = f"Successfully updated template metadata " \
+            msg = f"Successfully updated local template metadata " \
                   f"for {catalog_item_name}"
             INSTALL_LOGGER.debug(msg)
             msg_update_callback.general(msg)
         else:
             # Template not supported in the target CSE version.
             # Do not update template metadata
-            msg = f"Template {catalog_item_name} not supported, Skipping " \
-                  f"template metadata update."
+            msg = f"Local template {catalog_item_name} not supported, " \
+                  f"Skipping template metadata update."
             INSTALL_LOGGER.debug(msg)
             msg_update_callback.general(msg)
 

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -2309,10 +2309,15 @@ def _upgrade_non_legacy_clusters(
                 INSTALL_LOGGER.info(msg)
                 msg_update_callback.info(msg)
                 _upgrade_cluster_rde(
-                    client, cluster,
-                    def_entity, runtime_rde_version,
-                    target_entity_type, entity_svc,
-                    site, msg_update_callback=msg_update_callback)
+                    client=client,
+                    cluster=cluster,
+                    rde_to_upgrade=def_entity,
+                    runtime_rde_version=runtime_rde_version,
+                    target_entity_type=target_entity_type,
+                    entity_svc=entity_svc,
+                    site=site,
+                    msg_update_callback=msg_update_callback
+                )
             else:
                 msg = f"Skipping cluster '{cluster['name']}' " \
                     f"since it has already been processed."
@@ -2489,7 +2494,7 @@ def _upgrade_cluster_rde(client, cluster, rde_to_upgrade,
 
     # Adding missing fields in RDE 2.0
     # TODO: Need to find a better approach to avoid conditional logic for
-    #   filling missing properties.
+    # filling missing properties.
     if semantic_version.Version(runtime_rde_version).major == \
             semantic_version.Version(def_constants.RDEVersion.RDE_2_0_0).major:
         # RDE upgrade possible only from RDE 1.0 or RDE 2.x
@@ -2504,7 +2509,7 @@ def _upgrade_cluster_rde(client, cluster, rde_to_upgrade,
                                   target_entity_type.id)
 
     # Update cluster metadata with new cluster id. This step is still needed
-    # because the format of the entity ID has changed to ommit version string.
+    # because the format of the entity ID has changed to omit version string.
     tags = {
         server_constants.ClusterMetadataKey.CLUSTER_ID: upgraded_rde.id,
         server_constants.ClusterMetadataKey.CSE_VERSION: server_utils.get_installed_cse_version()  # noqa: E501

--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -138,7 +138,7 @@ class RemoteTemplateManager():
             template_supported_cse_versions = semantic_version.SimpleSpec(
                 f">={template_description[remote_template_key.MIN_CSE_VERSION]},"  # noqa: E501
                 f"<={template_description[remote_template_key.MAX_CSE_VERSION]}")  # noqa: E501
-            msg = f"Template {template_description['name']}"
+            msg = f"Template {template_description['name']} revision {template_description['revision']}"  # noqa: E501
             if template_supported_cse_versions.match(current_cse_version):
                 msg += " is supported"
                 supported_templates.append(template_description)

--- a/container_service_extension/rde/backend/cluster_service_1_x.py
+++ b/container_service_extension/rde/backend/cluster_service_1_x.py
@@ -1827,7 +1827,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                                       vapp: vcd_vapp.VApp):
         kubeconfig_with_exposed_ip = self.get_cluster_config(cluster_id)
         script = \
-            nw_exp_helper.form_script_to_update_kubeconfig_with_internal_ip(
+            nw_exp_helper.construct_script_to_update_kubeconfig_with_internal_ip(  # noqa: E501
                 kubeconfig_with_exposed_ip=kubeconfig_with_exposed_ip,
                 internal_ip=internal_ip
             )
@@ -2286,8 +2286,10 @@ def _init_cluster(sysadmin_client: vcd_client.Client, vapp, cluster_kind,
 
         # Expose cluster if given external ip
         if expose_ip:
-            script = nw_exp_helper.form_expose_ip_init_cluster_script(
-                script, expose_ip)
+            script = \
+                nw_exp_helper.construct_init_cluster_script_with_exposed_ip(
+                    script, expose_ip
+                )
 
         node_names = _get_node_names(vapp, NodeType.CONTROL_PLANE)
         result = _execute_script_in_nodes(sysadmin_client, vapp=vapp,

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -1930,7 +1930,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                          curr_rde: common_models.DefEntity = None,
                          vapp=None):
         """Sync the defined entity with the latest vApp status."""
-        # NOTE: This function should not be relied to update the defined entity
+        # NOTE: This function should not be used to update the defined entity
         # unless it is sure that the Vapp with the cluster-id exists
         if not curr_rde:
             curr_rde: common_models.DefEntity = \

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -2006,7 +2006,7 @@ class ClusterService(abstract_broker.AbstractBroker):
         # Form kubeconfig with internal ip
         kubeconfig_with_exposed_ip = self.get_cluster_config(cluster_id)
         script = \
-            nw_exp_helper.form_script_to_update_kubeconfig_with_internal_ip(
+            nw_exp_helper.construct_script_to_update_kubeconfig_with_internal_ip(  # noqa: E501
                 kubeconfig_with_exposed_ip=kubeconfig_with_exposed_ip,
                 internal_ip=internal_ip
             )
@@ -2474,8 +2474,10 @@ def _init_cluster(sysadmin_client: vcd_client.Client, vapp, cluster_kind,
 
         # Expose cluster if given external ip
         if expose_ip:
-            script = nw_exp_helper.form_expose_ip_init_cluster_script(
-                script, expose_ip)
+            script = \
+                nw_exp_helper.construct_init_cluster_script_with_exposed_ip(
+                    script, expose_ip
+                )
 
         node_names = _get_node_names(vapp, NodeType.CONTROL_PLANE)
         result = _execute_script_in_nodes(sysadmin_client, vapp=vapp,

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -1244,11 +1244,12 @@ class ClusterService(abstract_broker.AbstractBroker):
                         cluster_name=cluster_name,
                         cluster_id=cluster_id)
 
-                    # For pure RDE2.0 based clusters this step won't be necessary
-                    # But we might have exposed clusters that were converted from
-                    # RDE 1.0 to RDE 2.0, since those clusters would have their
-                    # control plane ip overwritten to the external ip, we need to
-                    # set it back to the true internal ip.
+                    # For pure RDE2.0 based clusters this step won't be
+                    # necessary, but we might have exposed clusters that were
+                    # converted from RDE 1.0 to RDE 2.0, since those clusters
+                    # would have their control plane ip overwritten to the
+                    # external ip, we need to set it back to the true
+                    # internal ip.
                     curr_native_entity.status.nodes.control_plane.ip = control_plane_internal_ip  # noqa: E501
 
                     curr_native_entity.status.cloud_properties.exposed = False

--- a/container_service_extension/rde/backend/common/network_expose_helper.py
+++ b/container_service_extension/rde/backend/common/network_expose_helper.py
@@ -1,0 +1,176 @@
+# container-service-extension
+# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import re
+
+import pyvcloud.vcd.client as vcd_client
+from pyvcloud.vcd.exceptions import EntityNotFoundException
+import pyvcloud.vcd.gateway as vcd_gateway
+from pyvcloud.vcd.vdc import VDC
+import pyvcloud.vcd.vdc_network as vdc_network
+
+from container_service_extension.common.constants.server_constants import CSE_CLUSTER_KUBECONFIG_PATH  # noqa: E501
+from container_service_extension.common.constants.server_constants import EXPOSE_CLUSTER_NAME_FRAGMENT  # noqa: E501
+from container_service_extension.common.constants.server_constants import IP_PORT_REGEX  # noqa: E501
+from container_service_extension.common.constants.server_constants import NETWORK_URN_PREFIX  # noqa: E501
+from container_service_extension.common.constants.server_constants import VdcNetworkInfoKey  # noqa: E501
+from container_service_extension.common.constants.shared_constants import RequestMethod  # noqa: E501
+import container_service_extension.common.utils.core_utils as utils
+import container_service_extension.common.utils.pyvcloud_utils as vcd_utils
+import container_service_extension.lib.cloudapi.constants as cloudapi_constants
+from container_service_extension.lib.nsxt.nsxt_backed_gateway_service import NsxtBackedGatewayService  # noqa: E501
+from container_service_extension.logging.logger import SERVER_LOGGER as LOGGER
+
+
+def _get_vdc_network_response(cloudapi_client, network_urn_id: str):
+    relative_path = f'{cloudapi_constants.CloudApiResource.ORG_VDC_NETWORKS}' \
+                    f'?filter=id=={network_urn_id}'
+    response = cloudapi_client.do_request(
+        method=RequestMethod.GET,
+        cloudapi_version=cloudapi_constants.CloudApiVersion.VERSION_1_0_0,
+        resource_url_relative_path=relative_path)
+    return response
+
+
+def _get_gateway_href(vdc: VDC, gateway_name):
+    edge_gateways = vdc.list_edge_gateways()
+    for gateway_dict in edge_gateways:
+        if gateway_dict['name'] == gateway_name:
+            return gateway_dict['href']
+    return None
+
+
+def _get_gateway(client: vcd_client.Client, org_name: str, ovdc_name: str,
+                 network_name: str):
+    # Check if routed org vdc network
+    cloudapi_client = vcd_utils.get_cloudapi_client_from_vcd_client(client)
+    ovdc = vcd_utils.get_vdc(client, org_name=org_name, vdc_name=ovdc_name)
+    try:
+        routed_network_resource = ovdc.get_routed_orgvdc_network(network_name)
+    except EntityNotFoundException:
+        raise Exception(f'No routed network found named: {network_name} '
+                        f'in ovdc {ovdc_name} and org {org_name}')
+    routed_vdc_network = vdc_network.VdcNetwork(
+        client=client,
+        resource=routed_network_resource)
+    network_id = utils.extract_id_from_href(routed_vdc_network.href)
+    network_urn_id = f'{NETWORK_URN_PREFIX}:{network_id}'
+    try:
+        vdc_network_response = _get_vdc_network_response(
+            cloudapi_client, network_urn_id)
+    except Exception as err:
+        LOGGER.error(f'Error when getting vdc network response when getting '
+                     f'gateway: {str(err)}')
+        return None
+    gateway_name = vdc_network_response[VdcNetworkInfoKey.VALUES][0][
+        VdcNetworkInfoKey.CONNECTION][VdcNetworkInfoKey.ROUTER_REF][
+        VdcNetworkInfoKey.NAME]
+    gateway_href = _get_gateway_href(ovdc, gateway_name)
+    gateway = vcd_gateway.Gateway(client, name=gateway_name, href=gateway_href)
+    return gateway
+
+
+def _get_nsxt_backed_gateway_service(client: vcd_client.Client, org_name: str,
+                                     ovdc_name: str, network_name: str):
+    # Check if NSX-T backed gateway
+    gateway: vcd_gateway.Gateway = _get_gateway(
+        client=client,
+        org_name=org_name,
+        ovdc_name=ovdc_name,
+        network_name=network_name)
+    if not gateway:
+        raise Exception(f'No gateway found for network: {network_name}')
+    if not gateway.is_nsxt_backed():
+        raise Exception('Gateway is not NSX-T backed for exposing cluster.')
+    return NsxtBackedGatewayService(gateway, client)
+
+
+def form_expose_ip_init_cluster_script(script: str, expose_ip: str):
+    """Form init cluster script with expose ip control plane endpoint option.
+
+    If the '--control-plane-endpoint' option is already present, this option
+    will be replaced with this option specifying the exposed ip. If this option
+    is not specified, the '--control-plane-endpoint' option will be added.
+
+    :param str script: the init cluster script
+    :param str expose_ip: the ip to expose the cluster
+
+    :return: the updated init cluster script
+    :rtype: str
+    """
+    # Get line with 'kubeadm init'
+    kubeadm_init_match: re.Match = re.search('kubeadm init .+\n', script)
+    if not kubeadm_init_match:
+        return script
+    kubeadm_init_line: str = kubeadm_init_match.group(0)
+
+    # Either add or replace the control plane endpoint option
+    expose_control_plane_endpoint_option = f'--control-plane-endpoint=\"{expose_ip}:6443\"'  # noqa: E501
+    expose_kubeadm_init_line = re.sub(
+        f'--control-plane-endpoint={IP_PORT_REGEX}',
+        expose_control_plane_endpoint_option,
+        kubeadm_init_line)
+    if kubeadm_init_line == expose_kubeadm_init_line:  # no option was replaced
+        expose_kubeadm_init_line = kubeadm_init_line.replace(
+            'kubeadm init',
+            f'kubeadm init --control-plane-endpoint=\"{expose_ip}:6443\"')
+
+    # Replace current kubeadm init line with line containing expose_ip
+    return script.replace(kubeadm_init_line, expose_kubeadm_init_line)
+
+
+def form_expose_dnat_rule_name(cluster_name: str, cluster_id: str):
+    """Form dnat rule name for expose cluster.
+
+    Dnat rule name includes cluster name to show users the cluster rule
+    corresponds to. The cluster id is used to make the rule unique
+    """
+    return f"{cluster_name}_{cluster_id}_{EXPOSE_CLUSTER_NAME_FRAGMENT}"
+
+
+def form_script_to_update_kubeconfig_with_internal_ip(
+        kubeconfig_with_exposed_ip: dict, internal_ip: str):
+    kubeconfig_with_internal_ip = re.sub(
+        pattern=IP_PORT_REGEX,
+        repl=f'{internal_ip}:6443',
+        string=str(kubeconfig_with_exposed_ip)
+    )
+
+    script = f"#!/usr/bin/env bash\n" \
+             f"echo \'{kubeconfig_with_internal_ip}\' > " \
+             f"{CSE_CLUSTER_KUBECONFIG_PATH}\n"
+    return script
+
+
+def expose_cluster(client: vcd_client.Client, org_name: str, ovdc_name: str,
+                   network_name: str, cluster_name: str, cluster_id: str,
+                   internal_ip: str):
+    # Auto reserve ip and add dnat rule
+    nsxt_gateway_svc = _get_nsxt_backed_gateway_service(
+        client, org_name, ovdc_name, network_name)
+    expose_ip = nsxt_gateway_svc.get_available_ip()
+    if not expose_ip:
+        raise Exception(f'No available ips found for cluster {cluster_name} ({cluster_id})')  # noqa: E501
+    try:
+        dnat_rule_name = form_expose_dnat_rule_name(cluster_name, cluster_id)
+        nsxt_gateway_svc.add_dnat_rule(
+            name=dnat_rule_name,
+            internal_address=internal_ip,
+            external_address=expose_ip)
+    except Exception as err:
+        raise Exception(f'Unable to add dnat rule with error: {str(err)}')
+    return expose_ip
+
+
+def handle_delete_expose_dnat_rule(client: vcd_client.Client,
+                                   org_name: str,
+                                   ovdc_name: str,
+                                   network_name: str,
+                                   cluster_name: str,
+                                   cluster_id: str):
+    nsxt_gateway_svc = _get_nsxt_backed_gateway_service(
+        client, org_name, ovdc_name, network_name)
+    expose_dnat_rule_name = form_expose_dnat_rule_name(cluster_name,
+                                                       cluster_id)
+    nsxt_gateway_svc.delete_dnat_rule(expose_dnat_rule_name)

--- a/container_service_extension/rde/models/rde_1_0_0.py
+++ b/container_service_extension/rde/models/rde_1_0_0.py
@@ -258,9 +258,15 @@ class NativeEntity(AbstractNativeEntity):
                 expose=rde_2_x_entity.spec.settings.network.expose
             )
 
+            if rde_2_x_entity.status.cloud_properties.exposed:
+                control_plane_ip = rde_2_x_entity.status.external_ip
+            else:
+                control_plane_ip = \
+                    rde_2_x_entity.status.nodes.control_plane.ip
+
             control_plane = Node(
                 name=rde_2_x_entity.status.nodes.control_plane.name,
-                ip=rde_2_x_entity.status.nodes.control_plane.ip,
+                ip=control_plane_ip,
                 sizing_class=rde_2_x_entity.status.nodes.control_plane.sizing_class  # noqa: E501
             )
 

--- a/container_service_extension/rde/models/rde_1_0_0.py
+++ b/container_service_extension/rde/models/rde_1_0_0.py
@@ -136,6 +136,11 @@ class NativeEntity(AbstractNativeEntity):
                 "sizing_class": "Large",
                 "storage_profile": "Any"
             },
+            "nfs": {
+                "count": 1,
+                "sizing_class": "small",
+                "storage_profile": "Any"
+            },
             "settings": {
                 "network": "net",
                 "ssh_key": null,
@@ -144,13 +149,41 @@ class NativeEntity(AbstractNativeEntity):
             "k8_distribution": {
                 "template_name": "k81.17",
                 "template_revision": 1
-            }
+            },
+            "expose": False
         },
         "status": {
-            "id": null,
             "cni": null,
+            "docker_version": null,
+            "exposed": False,
+            "kubernetes": null,
+            "nodes": {
+                "workers": [
+                    {
+                        "name": "node-abcd",
+                        "ip": "10.0.0.2",
+                        "sizing_class": "small",
+                    }
+                ],
+                "control_plane": [
+                    {
+                        "name": "mstr-xyzv",
+                        "ip": "10.0.0.3",
+                        "sizing_class": "Large",
+                    }
+                ],
+                "nfs": [
+                    {
+                        "name": "nfsd-uvwx",
+                        "ip": "10.0.0.4",
+                        "sizing_class": "small",
+                        "exports": "/usr/share/abc, /usr/share/xyz"
+                    }
+                ]
+            },
+            "os": null,
             "phase": null,
-            "master_ip": "10.150.23.45"
+            "task_href" : null
         },
         "metadata": {
             "org_name": "org1",
@@ -222,7 +255,7 @@ class NativeEntity(AbstractNativeEntity):
                 control_plane=control_plane,
                 workers=workers,
                 nfs=nfs,
-                expose=rde_2_x_entity.spec.expose
+                expose=rde_2_x_entity.spec.settings.network.expose
             )
 
             control_plane = Node(
@@ -241,11 +274,12 @@ class NativeEntity(AbstractNativeEntity):
                 workers.append(worker_node_1_x)
 
             nfs_nodes = []
-            for nfs_node in nfs_nodes:
+            for nfs_node in rde_2_x_entity.status.nodes.nfs:
                 nfs_node_1_x = NfsNode(
                     name=nfs_node.name,
                     ip=nfs_node.ip,
-                    sizing_class=nfs_node.sizing_class
+                    sizing_class=nfs_node.sizing_class,
+                    exports=str(nfs_node.exports)
                 )
                 nfs_nodes.append(nfs_node_1_x)
 
@@ -263,7 +297,7 @@ class NativeEntity(AbstractNativeEntity):
                 docker_version=rde_2_x_entity.status.docker_version,
                 os=rde_2_x_entity.status.os,
                 nodes=nodes,
-                exposed=rde_2_x_entity.status.exposed
+                exposed=rde_2_x_entity.status.cloud_properties.exposed
             )
 
             rde_1_entity = cls(

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -216,9 +216,12 @@ class NativeEntity(AbstractNativeEntity):
                 },
             }
             "settings": {
-                "network": "net",
+                "ovdc_network": "net",
                 "sshKey": null,
                 "rollbackOnFailure": true
+                "network" : {
+                    "expose" : false
+                }
             },
             "distribution": {
                 "templateName": "k81.17",

--- a/cse_def_schema/schema_2_0_0.json
+++ b/cse_def_schema/schema_2_0_0.json
@@ -267,7 +267,7 @@
                 "external_ip": {
                     "type": "string",
                     "description": "External IP of the cluster if it is exposed."
-                }
+                },
                 "nodes":{
                     "type":"object",
                     "required":[

--- a/cse_def_schema/schema_2_0_0.json
+++ b/cse_def_schema/schema_2_0_0.json
@@ -264,6 +264,10 @@
                 "dockerVersion":{
                     "type":"string"
                 },
+                "external_ip": {
+                    "type": "string",
+                    "description": "External IP of the cluster if it is exposed."
+                }
                 "nodes":{
                     "type":"object",
                     "required":[


### PR DESCRIPTION
Port `cluster expose` feature from cluster_service_1_x.py to cluster_serivce_2_x.py.

Add new field `external_ip` for RDE 2.0.0. Add associated logic to retain the internal control plane ip while exposing the cluster.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1094)
<!-- Reviewable:end -->
