### PR TITLE
[VCD-2663] Mark terminal state of task to be the last operation on cluster CRUD

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -343,7 +343,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                 try:
                     # TODO can reduce try - catch by raising more specific
                     # exceptions
-                    # Resolve entity state manually (PRE_CREATED --> RESOLVED)
+                    # Resolve entity state manually (PRE_CREATED --> RESOLVED/RESOLUTION_ERROR)  # noqa: E501
                     # to allow delete operation
                     self.sysadmin_entity_svc.resolve_entity(entity_id=entity_id)  # noqa: E501
                     # delete defined entity
@@ -1108,7 +1108,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             # task to ERROR
             if rollback:
                 try:
-                    # Resolve entity state manually (PRE_CREATED --> RESOLVED)
+                    # Resolve entity state manually (PRE_CREATED --> RESOLVED/RESOLUTION_ERROR)  # noqa: E501
                     # to allow delete operation
                     self.sysadmin_entity_svc.resolve_entity(entity_id=cluster_id)  # noqa: E501
                     self.sysadmin_entity_svc.delete_entity(cluster_id,


### PR DESCRIPTION
- Fixes HTTP 401 error that happens due to token expiry between RDE REST operation(s)
- Always set the VCD behavior task status to SUCCESS or ERROR as the last operation in every cluster operation
- TODO/IN PROGRESS: testing
@sahithi @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1099)
<!-- Reviewable:end -->
