### PR TITLE
[VCDA-2676] Prevent users with <= EDIT/VIEW rights on CSE:NATIVECLUSTER from updating private property of RDE Status

### DIFF
--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -274,6 +274,13 @@ class DefEntityService:
                 self._cloudapi_client.is_sys_admin:
             resource_url_relative_path += f"?invokeHooks={str(invoke_hooks).lower()}"  # noqa: E501
 
+        payload: dict = entity.to_dict()
+
+        # Prevent users with rights <= EDIT/VIEW on CSE:NATIVECLUSTER from
+        # updating "private" property of RDE "status" section
+        if not self._cloudapi_client.is_sys_admin:
+            payload.get('entity', {}).get('status', {}).pop('private', None)
+
         if is_request_async:
             # if request is async, return the task href in
             # x_vmware_vcloud_task_location header
@@ -285,7 +292,7 @@ class DefEntityService:
                 method=RequestMethod.PUT,
                 cloudapi_version=CloudApiVersion.VERSION_1_0_0,
                 resource_url_relative_path=resource_url_relative_path,
-                payload=entity.to_dict(),
+                payload=payload,
                 return_response_headers=is_request_async)
             return DefEntity(**response_body), headers[HttpResponseHeader.X_VMWARE_VCLOUD_TASK_LOCATION.value]  # noqa: E501
         else:
@@ -293,7 +300,7 @@ class DefEntityService:
                 method=RequestMethod.PUT,
                 cloudapi_version=CloudApiVersion.VERSION_1_0_0,
                 resource_url_relative_path=resource_url_relative_path,
-                payload=entity.to_dict())
+                payload=payload)
             return DefEntity(**response_body)
 
     @handle_entity_service_exception

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -278,6 +278,9 @@ class DefEntityService:
 
         # Prevent users with rights <= EDIT/VIEW on CSE:NATIVECLUSTER from
         # updating "private" property of RDE "status" section
+        # TODO: Replace sys admin check with FULL CONTROL rights check on
+        #  CSE:NATIVECLUSTER. Users with no FULL CONTROL rights cannot update
+        #  private property of entity->status.
         if not self._cloudapi_client.is_sys_admin:
             payload.get('entity', {}).get('status', {}).pop('private', None)
 


### PR DESCRIPTION
- Fixed **Error: RDE_RESTRICTED_FIELDS [ status ]** when cluster upgrade/resize.
- This fix prevents the tenant users with as few as or fewer than EDIT and VIEW rights on CSE:NATIVECLUSTER from updating **private** property of RDE **status** section


Before Fix:
![image](https://user-images.githubusercontent.com/5530442/124835216-d2ede980-df35-11eb-8c0e-2e4a580401c8.png)

After Fix:
![image](https://user-images.githubusercontent.com/5530442/124835295-f31da880-df35-11eb-94ac-0d652628b7a3.png)

![image](https://user-images.githubusercontent.com/5530442/124835323-fe70d400-df35-11eb-9ca6-a6bedf255b82.png)

@sahithi @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1103)
<!-- Reviewable:end -->
