### PR TITLE
[VCDA-2667] Fix CSE install/upgrade to show better message around template creation/update

### DIFF
--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -143,7 +143,7 @@ class FlattenedClusterSpecKey2X(Enum):
     NFS_STORAGE_PROFILE = 'topology.nfs.storageProfile'
     TEMPLATE_NAME = 'distribution.templateName'
     TEMPLATE_REVISION = 'distribution.templateRevision'
-    EXPOSE = 'expose'
+    EXPOSE = 'settings.network.expose'
 
 
 VALID_UPDATE_FIELDS_2X = \

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -317,7 +317,10 @@ def install_cse(config_file_name, config, skip_template_creation,
             logger=INSTALL_LOGGER, msg_update_callback=msg_update_callback)
 
         if skip_template_creation:
-            msg = "Skipping creation of templates."
+            msg = "Skipping creation of templates.\nPlease note, CSE server " \
+                  "startup needs at least one valid template.\nPlease " \
+                  "create CSE K8s template(s) using the command " \
+                  "`cse template install`."
             msg_update_callback.info(msg)
             INSTALL_LOGGER.info(msg)
         else:
@@ -1584,6 +1587,11 @@ def _update_metadata_for_existing_templates(client: Client, config: dict,
         # that all the templates have catalog_item_name in their metadata
         catalog_item_name = \
             template[server_constants.LegacyLocalTemplateKey.CATALOG_ITEM_NAME]
+        template_name = \
+            template[server_constants.LegacyLocalTemplateKey.NAME]
+        template_revision = \
+            template[server_constants.LegacyLocalTemplateKey.REVISION]
+
         if catalog_item_name in catalog_item_to_template_description_map:
             # Supported template with the template name and revision found.
             remote_template_descriptor = \
@@ -1601,15 +1609,17 @@ def _update_metadata_for_existing_templates(client: Client, config: dict,
             ltm.save_metadata(client, catalog_org_name,
                               catalog_name, catalog_item_name,
                               remote_template_descriptor, metadata_key_list=new_metadata_key_list)  # noqa: E501
-            msg = f"Successfully updated local template metadata " \
-                  f"for {catalog_item_name}"
+            msg = f"Successfully updated metadata " \
+                  f"of local template : {template_name} revision " \
+                  f"{template_revision}."
             INSTALL_LOGGER.debug(msg)
             msg_update_callback.general(msg)
         else:
             # Template not supported in the target CSE version.
             # Do not update template metadata
-            msg = f"Local template {catalog_item_name} not supported, " \
-                  f"Skipping template metadata update."
+            msg = f"Local template {template_name} revision " \
+                  f"{template_revision} not supported. Skipping template " \
+                  "metadata update."
             INSTALL_LOGGER.debug(msg)
             msg_update_callback.general(msg)
 
@@ -1975,7 +1985,11 @@ def _upgrade_to_cse_3_1_non_legacy(client, config,
         log_wire=log_wire)
 
     if skip_template_creation:
-        msg = "Skipping creation of templates."
+        msg = "Skipping creation of templates.\nPlease note, CSE server " \
+              "startup needs at least one valid template.\nPlease " \
+              "create CSE K8s template(s) using the command " \
+              "`cse template install`.\n" \
+              "Processing existing templates.\n"
         msg_update_callback.info(msg)
         INSTALL_LOGGER.info(msg)
         _process_existing_templates(
@@ -2054,7 +2068,11 @@ def _upgrade_to_cse_3_1_legacy(
         could not be created.
     """
     if skip_template_creation:
-        msg = "Skipping creation of new templates and special processing of existing templates"  # noqa: E501
+        msg = "Skipping creation of new templates and special processing " \
+              "of existing templates.\nPlease note, CSE server " \
+              "startup needs at least one valid template.\nPlease create " \
+              "CSE K8s template(s) using the command " \
+              "`cse template install`."
         msg_update_callback.info(msg)
         INSTALL_LOGGER.info(msg)
     else:

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -317,10 +317,9 @@ def install_cse(config_file_name, config, skip_template_creation,
             logger=INSTALL_LOGGER, msg_update_callback=msg_update_callback)
 
         if skip_template_creation:
-            msg = "Skipping creation of templates.\nPlease note, CSE server " \
-                  "startup needs at least one valid template.\nPlease " \
-                  "create CSE K8s template(s) using the command " \
-                  "`cse template install`."
+            msg = """Skipping creation of templates.
+Please note, CSE server startup needs at least one valid template.
+Please create CSE K8s template(s) using the command `cse template install`."""
             msg_update_callback.info(msg)
             INSTALL_LOGGER.info(msg)
         else:
@@ -1337,7 +1336,7 @@ def _register_behaviors(cloudapi_client,
             try:
                 behavior_svc.get_behavior_on_interface_by_id(behavior.id, interface_id)  # noqa: E501
                 msg = f"Skipping creation of behavior '{behavior.id}' on " \
-                      f"interface '{interface_id}'.Behavior already found.\n"
+                      f"interface '{interface_id}'.Behavior already found."
                 msg_update_callback.general(msg.rstrip())
                 INSTALL_LOGGER.info(msg)
             except cse_exception.BehaviorServiceError:
@@ -2038,10 +2037,9 @@ def _upgrade_to_cse_3_1_non_legacy(client, config,
         log_wire=log_wire)
 
     if skip_template_creation:
-        msg = "Skipping creation of templates.\nPlease note, CSE server " \
-              "startup needs at least one valid template.\nPlease " \
-              "create CSE K8s template(s) using the command " \
-              "`cse template install`."
+        msg = """Skipping creation of templates.
+Please note, CSE server startup needs at least one valid template.
+Please create CSE K8s template(s) using the command `cse template install`."""
         msg_update_callback.info(msg)
         INSTALL_LOGGER.info(msg)
         _process_existing_templates(
@@ -2121,11 +2119,9 @@ def _upgrade_to_cse_3_1_legacy(
         could not be created.
     """
     if skip_template_creation:
-        msg = "Skipping creation of new templates and special processing " \
-              "of existing templates.\nPlease note, CSE server " \
-              "startup needs at least one valid template.\nPlease create " \
-              "CSE K8s template(s) using the command " \
-              "`cse template install`."
+        msg = """Skipping creation of new templates and special processing of existing templates.
+Please note, CSE server startup needs at least one valid template.
+Please create CSE K8s template(s) using the command `cse template install`."""  # noqa: E501
         msg_update_callback.info(msg)
         INSTALL_LOGGER.info(msg)
     else:

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -1595,7 +1595,7 @@ def _update_metadata_for_existing_templates(client: Client, config: dict,
         if catalog_item_name in catalog_item_to_template_description_map:
             # Supported template with the template name and revision found.
             remote_template_descriptor = \
-                catalog_item_to_template_description_map[catalog_item_name]
+                catalog_item_to_template_description_map[catalog_item_name].copy()  # noqa: E501
 
             # remote_template_descriptor will contain all the necessary
             # metadata keys barring the catalog_item_name.
@@ -1606,22 +1606,25 @@ def _update_metadata_for_existing_templates(client: Client, config: dict,
             # New keys to be added (min_cse_version and max_cse_version)
             # will already be in remote_template_descriptor.
             # Update template metadata.
-            ltm.save_metadata(client, catalog_org_name,
-                              catalog_name, catalog_item_name,
-                              remote_template_descriptor, metadata_key_list=new_metadata_key_list)  # noqa: E501
+            ltm.save_metadata(
+                client,
+                catalog_org_name,
+                catalog_name,
+                catalog_item_name,
+                remote_template_descriptor,
+                metadata_key_list=new_metadata_key_list
+            )
             msg = f"Successfully updated metadata " \
                   f"of local template : {template_name} revision " \
                   f"{template_revision}."
-            INSTALL_LOGGER.debug(msg)
-            msg_update_callback.general(msg)
         else:
             # Template not supported in the target CSE version.
             # Do not update template metadata
             msg = f"Local template {template_name} revision " \
                   f"{template_revision} not supported. Skipping template " \
                   "metadata update."
-            INSTALL_LOGGER.debug(msg)
-            msg_update_callback.general(msg)
+        INSTALL_LOGGER.debug(msg)
+        msg_update_callback.general(msg)
 
 
 def _assign_placement_policies_to_existing_templates(client: Client,
@@ -1633,26 +1636,29 @@ def _assign_placement_policies_to_existing_templates(client: Client,
     # NOTE: In CSE 3.0 if `enable_tkg_plus` flag in the config is set to false,
     # And there is an existing TKG+ template, throw an exception on the console
     # and fail the upgrade.
-    msg = 'Assigning placement policies to existing templates.'
+    msg = "Assigning placement policies to existing templates."
     INSTALL_LOGGER.debug(msg)
-    msg_update_callback.general(msg)
+    msg_update_callback.info(msg)
 
     catalog_name = config['broker']['catalog']
     org_name = config['broker']['org']
 
     for template in all_templates:
         kind = template.get(server_constants.LocalTemplateKey.KIND)
+        template_name = template[server_constants.LocalTemplateKey.NAME]
+        template_revision = template[server_constants.LocalTemplateKey.REVISION]  # noqa: E501
         catalog_item_name = ltm.get_revisioned_template_name(
-            template[server_constants.LocalTemplateKey.NAME],
-            template[server_constants.LocalTemplateKey.REVISION])
-        msg = f"Processing template {catalog_item_name}"
+            template_name,
+            template_revision
+        )
+        msg = f"Processing template {template_name} revision {template_revision}"  # noqa: E501
         INSTALL_LOGGER.debug(msg)
-        msg_update_callback.general(msg)
+        msg_update_callback.info(msg)
         if not kind:
             # skip processing the template if kind value is not present
-            msg = f"Skipping processing of template {catalog_item_name}. Template kind not found"  # noqa: E501
+            msg = f"Skipping processing of template {template_name} revision {template_revision}. Template kind not found"  # noqa: E501
             INSTALL_LOGGER.debug(msg)
-            msg_update_callback.general(msg)
+            msg_update_callback.info(msg)
             continue
         if kind == shared_constants.ClusterEntityKind.TKG_PLUS.value and \
                 not is_tkg_plus_enabled:
@@ -1704,6 +1710,10 @@ def _process_existing_templates(client: Client, config: dict,
             ignore_metadata_keys=[server_constants.LegacyLocalTemplateKey.COMPUTE_POLICY],  # noqa: E501
             legacy_mode=True,
             logger_debug=INSTALL_LOGGER)
+
+    msg = "Processing existing templates."
+    INSTALL_LOGGER.info(msg)
+    msg_update_callback.info(msg)
     # update metadata with min_cse_version and max_cse_version for all
     # legacy templates supported in the target CSE version
     _update_metadata_for_existing_templates(
@@ -1966,9 +1976,6 @@ def _upgrade_to_cse_3_1_non_legacy(client, config,
     """
     is_tkg_plus_enabled = server_utils.is_tkg_plus_enabled(config=config)
 
-    # This check should be done before registering def schema
-    def_entity_type_registered = _is_def_entity_type_registered(client=client)
-
     # Add global placement policies
     _setup_placement_policies(
         client=client,
@@ -1988,8 +1995,7 @@ def _upgrade_to_cse_3_1_non_legacy(client, config,
         msg = "Skipping creation of templates.\nPlease note, CSE server " \
               "startup needs at least one valid template.\nPlease " \
               "create CSE K8s template(s) using the command " \
-              "`cse template install`.\n" \
-              "Processing existing templates.\n"
+              "`cse template install`."
         msg_update_callback.info(msg)
         INSTALL_LOGGER.info(msg)
         _process_existing_templates(
@@ -2034,15 +2040,16 @@ def _upgrade_to_cse_3_1_non_legacy(client, config,
     # designed to gate cluster deployment and has no play once the cluster has
     # been deployed.
 
+    def_entity_type_registered = _is_def_entity_type_registered(client=client)
     if def_entity_type_registered:
-        _upgrade_non_legacy_clusters(
+        _process_non_legacy_clusters(
             client=client,
             config=config,
             cse_clusters=clusters,
             msg_update_callback=msg_update_callback,
             log_wire=log_wire)
     else:
-        _upgrade_legacy_clusters(
+        _process_legacy_clusters(
             client=client,
             config=config,
             cse_clusters=clusters,
@@ -2311,14 +2318,14 @@ def _remove_old_cse_sizing_compute_policies(
             INSTALL_LOGGER.error(msg)
 
 
-def _upgrade_non_legacy_clusters(
+def _process_non_legacy_clusters(
         client,
         config,
         cse_clusters,
         msg_update_callback=utils.NullPrinter(),
         log_wire=False):
 
-    msg = "Upgrading non legacy CSE k8s clusters compatible with CSE 3.1"
+    msg = "Processing existing CSE k8s clusters"
     msg_update_callback.info(msg)
     INSTALL_LOGGER.info(msg)
 
@@ -2348,7 +2355,7 @@ def _upgrade_non_legacy_clusters(
             def_entity = entity_svc.get_entity(cluster_id)
             source_rde_version = def_entity.entityType.split(":")[-1]
             if semantic_version.Version(source_rde_version) < semantic_version.Version(runtime_rde_version):  # noqa: E501
-                msg = f"Upgrading {def_entity.name} from {source_rde_version} to {runtime_rde_version}"  # noqa: E501
+                msg = f"Updating {def_entity.name} RDE from {source_rde_version} to {runtime_rde_version}"  # noqa: E501
                 INSTALL_LOGGER.info(msg)
                 msg_update_callback.info(msg)
                 _upgrade_cluster_rde(
@@ -2363,10 +2370,10 @@ def _upgrade_non_legacy_clusters(
                 )
             else:
                 msg = f"Skipping cluster '{cluster['name']}' " \
-                    f"since it has already been processed."
+                      f"since it has already been processed."
                 INSTALL_LOGGER.info(msg)
                 msg_update_callback.info(msg)
-            continue
+                continue
         except Exception as err:
             INSTALL_LOGGER.error(str(err), exc_info=True)
             msg_update_callback.error(f"Failed to upgrade cluster '{cluster['name']}'")  # noqa: E501
@@ -2392,14 +2399,14 @@ def _upgrade_non_legacy_clusters(
         msg_update_callback.error("Failed to delete old entity types")
 
 
-def _upgrade_legacy_clusters(
+def _process_legacy_clusters(
         client,
         config,
         cse_clusters,
         is_tkg_plus_enabled,
         msg_update_callback=utils.NullPrinter(),
         log_wire=False):
-    msg = "Upgrading legacy CSE k8s clusters compatible with CSE 3.1"
+    msg = "Processing CSE k8s clusters"
     msg_update_callback.info(msg)
     INSTALL_LOGGER.info(msg)
 
@@ -2420,6 +2427,10 @@ def _upgrade_legacy_clusters(
     target_entity_type = schema_svc.get_entity_type(entity_type_metadata.get_id())  # noqa: E501
 
     for cluster in cse_clusters:
+        msg = f"Processing cluster '{cluster['name']}'"
+        INSTALL_LOGGER.info(msg)
+        msg_update_callback.info(msg)
+
         try:
             policy_name = _get_placement_policy_name_from_template_name(
                 cluster['template_name'])
@@ -2447,7 +2458,12 @@ def _upgrade_legacy_clusters(
             client, cluster,
             kind, runtime_rde_version,
             target_entity_type, entity_svc,
-            site, msg_update_callback=msg_update_callback)  # noqa: E501
+            site, msg_update_callback=msg_update_callback
+        )
+
+        msg = f"Finished processing cluster '{cluster['name']}'"
+        INSTALL_LOGGER.info(msg)
+        msg_update_callback.general(msg)
 
     msg = "Finished processing all clusters."
     INSTALL_LOGGER.info(msg)
@@ -2521,10 +2537,6 @@ def _create_cluster_rde(client, cluster, kind, runtime_rde_version,
     client.get_task_monitor().wait_for_status(task)
 
     msg = f"Updated metadata of cluster '{cluster['name']}'"
-    INSTALL_LOGGER.info(msg)
-    msg_update_callback.general(msg)
-
-    msg = f"Finished processing cluster '{cluster['name']}'"
     INSTALL_LOGGER.info(msg)
     msg_update_callback.general(msg)
 

--- a/container_service_extension/installer/templates/template_builder.py
+++ b/container_service_extension/installer/templates/template_builder.py
@@ -23,7 +23,7 @@ from container_service_extension.common.utils.vsphere_utils import vgr_callback
 from container_service_extension.common.utils.vsphere_utils import wait_until_tools_ready  # noqa: E501
 import container_service_extension.installer.templates.local_template_manager as ltm  # noqa: E501
 from container_service_extension.logging.logger import NULL_LOGGER
-import container_service_extension.server.compute_policy_manager as compute_policy_manager # noqa: E501
+import container_service_extension.server.compute_policy_manager as compute_policy_manager  # noqa: E501
 
 
 # used for creating temp vapp
@@ -34,9 +34,8 @@ TEMP_VAPP_FENCE_MODE = FenceMode.BRIDGED.value
 def assign_placement_policy_to_template(client, cse_placement_policy,
                                         catalog_name, catalog_item_name,
                                         org_name, logger=NULL_LOGGER,
-                                        log_wire=False, msg_update_callback=NullPrinter()): # noqa: E501
+                                        log_wire=False, msg_update_callback=NullPrinter()):  # noqa: E501
 
-    policy = None
     cpm = compute_policy_manager.ComputePolicyManager(client,
                                                       log_wire=log_wire)
     try:
@@ -67,7 +66,7 @@ def assign_placement_policy_to_template(client, cse_placement_policy,
         raise
 
 
-class TemplateBuilder():
+class TemplateBuilder:
     """Builder calls for K8 templates."""
 
     def __init__(self, client, sys_admin_client, build_params, org=None,
@@ -101,39 +100,39 @@ class TemplateBuilder():
             return
 
         # validate and populate required fields
-        self.template_name = build_params.get(TemplateBuildKey.TEMPLATE_NAME) # noqa: E501
-        self.template_revision = build_params.get(TemplateBuildKey.TEMPLATE_REVISION) # noqa: E501
-        self.ova_name = build_params.get(TemplateBuildKey.SOURCE_OVA_NAME) # noqa: E501
-        self.ova_href = build_params.get(TemplateBuildKey.SOURCE_OVA_HREF) # noqa: E501
-        self.ova_sha256 = build_params.get(TemplateBuildKey.SOURCE_OVA_SHA256) # noqa: E501
+        self.template_name = build_params.get(TemplateBuildKey.TEMPLATE_NAME)  # noqa: E501
+        self.template_revision = build_params.get(TemplateBuildKey.TEMPLATE_REVISION)  # noqa: E501
+        self.ova_name = build_params.get(TemplateBuildKey.SOURCE_OVA_NAME)  # noqa: E501
+        self.ova_href = build_params.get(TemplateBuildKey.SOURCE_OVA_HREF)  # noqa: E501
+        self.ova_sha256 = build_params.get(TemplateBuildKey.SOURCE_OVA_SHA256)  # noqa: E501
 
         if org:
             self.org = org
             self.org_name = org.get_name()
         else:
-            self.org_name = build_params.get(TemplateBuildKey.ORG_NAME) # noqa: E501
+            self.org_name = build_params.get(TemplateBuildKey.ORG_NAME)  # noqa: E501
             self.org = get_org(self.client, org_name=self.org_name)
         if vdc:
             self.vdc = vdc
             self.vdc.get_resource()  # to make sure vdc.resource is populated
             self.vdc_name = vdc.name
         else:
-            self.vdc_name = build_params.get(TemplateBuildKey.VDC_NAME) # noqa: E501
+            self.vdc_name = build_params.get(TemplateBuildKey.VDC_NAME)  # noqa: E501
             self.vdc = get_vdc(self.client, vdc_name=self.vdc_name,
                                org=self.org)
-        self.catalog_name = build_params.get(TemplateBuildKey.CATALOG_NAME) # noqa: E501
-        self.catalog_item_name = build_params.get(TemplateBuildKey.CATALOG_ITEM_NAME) # noqa: E501
+        self.catalog_name = build_params.get(TemplateBuildKey.CATALOG_NAME)  # noqa: E501
+        self.catalog_item_name = build_params.get(TemplateBuildKey.CATALOG_ITEM_NAME)  # noqa: E501
         self.catalog_item_description = \
-            build_params.get(TemplateBuildKey.CATALOG_ITEM_DESCRIPTION) # noqa: E501
+            build_params.get(TemplateBuildKey.CATALOG_ITEM_DESCRIPTION)  # noqa: E501
 
-        self.temp_vapp_name = build_params.get(TemplateBuildKey.TEMP_VAPP_NAME) # noqa: E501
-        self.temp_vm_name = build_params.get(TemplateBuildKey.TEMP_VM_NAME) # noqa: E501
+        self.temp_vapp_name = build_params.get(TemplateBuildKey.TEMP_VAPP_NAME)  # noqa: E501
+        self.temp_vm_name = build_params.get(TemplateBuildKey.TEMP_VM_NAME)  # noqa: E501
         self.cpu = build_params.get(TemplateBuildKey.CPU)
         self.memory = build_params.get(TemplateBuildKey.MEMORY)
-        self.network_name = build_params.get(TemplateBuildKey.NETWORK_NAME) # noqa: E501
-        self.ip_allocation_mode = build_params.get(TemplateBuildKey.IP_ALLOCATION_MODE) # noqa: E501
-        self.storage_profile = build_params.get(TemplateBuildKey.STORAGE_PROFILE) # noqa: E501
-        self.cse_placement_policy = build_params.get(TemplateBuildKey.CSE_PLACEMENT_POLICY) # noqa: E501
+        self.network_name = build_params.get(TemplateBuildKey.NETWORK_NAME)  # noqa: E501
+        self.ip_allocation_mode = build_params.get(TemplateBuildKey.IP_ALLOCATION_MODE)  # noqa: E501
+        self.storage_profile = build_params.get(TemplateBuildKey.STORAGE_PROFILE)  # noqa: E501
+        self.cse_placement_policy = build_params.get(TemplateBuildKey.CSE_PLACEMENT_POLICY)  # noqa: E501
         self.remote_cookbook_version = build_params.get(TemplateBuildKey.REMOTE_COOKBOOK_VERSION)  # noqa: E501
         self.log_wire = log_wire
 
@@ -165,7 +164,6 @@ class TemplateBuilder():
         build_params.
 
         :param str item_name: name of the item to delete.
-        :param str item_type
         """
         try:
             self.org.delete_catalog_item(name=self.catalog_name,

--- a/container_service_extension/installer/templates/template_builder.py
+++ b/container_service_extension/installer/templates/template_builder.py
@@ -56,7 +56,7 @@ def assign_placement_policy_to_template(client, cse_placement_policy,
         else:
             msg = f"{catalog_item_name} already tagged with" \
                   f" placement policy {cse_placement_policy}."
-        msg_update_callback.info(msg)
+        msg_update_callback.general(msg)
         logger.info(msg)
     except Exception as err:
         msg = f"Failed to tag template {catalog_item_name} with " \

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -2658,7 +2658,7 @@ def _execute_script_in_nodes(sysadmin_client: vcd_client.Client,
             all_results.append(result)
         except Exception as err:
             msg = f"Error executing script in node {node_name}: {str(err)}"
-            LOGGER.error(msg, exc_infop=True)
+            LOGGER.error(msg, exc_info=True)
             raise exceptions.ScriptExecutionError(msg)  # noqa: E501
 
     return all_results


### PR DESCRIPTION
Whenever `-t` flag is used with `cse install/upgrade`, warn users that without a valid template in inventory, CSE startup will fail.

Additionally there was a bug in the way templates are updated from v1 to v2, the scripts files are not re-downloaded into proper v2 script directory. This PR fixes that issue too.

Testing done:
Ran `cse upgrade` with -t flag and checked console for the error message.

Ran a proper cse upgrade from 3.0.3 to 3.1.0, output attached below

```
(cse) D:\code\cse\container-service-extension>cse upgrade -c config.yaml -st
Required Python version: >= 3.7.3
Installed Python version: 3.7.3 (v3.7.3:ef4ec6ed12, Mar 25 2019, 21:26:53) [MSC v.1916 32 bit (Intel)]
Validating config file 'config.yaml'
InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised.
Connected to vCloud Director (bos1-vcloud-static-170-222.eng.vmware.com:443)
Connected to vCenter Server 'vc1' as 'administrator@vsphere.local' (bos1-vcloud-static-171-33.eng.vmware.com)
Config file 'config.yaml' is valid
Upgrading CSE on vCloud Director using config file 'config.yaml'
Connected to vCD as system administrator: bos1-vcloud-static-170-222.eng.vmware.com:443
Found CSE api extension registered by CSE '3.0.3' in non-legacy mode.
Setting up placement policies for cluster types
Skipping creation of global PVDC compute policy. Policy already exists
Skipping creation of VDC placement policy 'native'. Policy already exists
Registering Runtime defined entity schema
Using RDE version: 2.0.0
Built in kubernetes interface 'urn:vcloud:interface:vmware:k8s:1.0.0' found.
Skipping creation of interface 'urn:vcloud:interface:cse:k8s:1.0.0'. Interface already exists.
Skipping creation of behavior 'urn:vcloud:behavior-interface:createCluster:cse:k8s:1.0.0' on interface 'urn:vcloud:interface:cse:k8s:1.0.0'.Behavior already found.
Skipping creation of behavior 'urn:vcloud:behavior-interface:updateCluster:cse:k8s:1.0.0' on interface 'urn:vcloud:interface:cse:k8s:1.0.0'.Behavior already found.
Skipping creation of behavior 'urn:vcloud:behavior-interface:deleteCluster:cse:k8s:1.0.0' on interface 'urn:vcloud:interface:cse:k8s:1.0.0'.Behavior already found.
Skipping creation of behavior 'urn:vcloud:behavior-interface:deleteNfsNode:cse:k8s:1.0.0' on interface 'urn:vcloud:interface:cse:k8s:1.0.0'.Behavior already found.
Skipping creation of Native Entity Type 'urn:vcloud:type:cse:nativeCluster:2.0.0'. Native Entity Type already exists.
Skipping behavior overriding for 'urn:vcloud:behavior-type:createKubeConfig:cse:nativeCluster:2.0.0:vmware:k8s:1.0.0' on entity type 'urn:vcloud:type:cse:nativeCluster:2.0.0'
Setting ACLs on behaviors of the entity type 'urn:vcloud:type:cse:nativeCluster:2.0.0'
Updated user-role: CSE Service Role with Rights-bundle: cse:nativeCluster Entitlement
Skipping creation of templates.
Please note, CSE server startup needs at least one valid template.
Please create CSE K8s template(s) using the command `cse template install`.
Processing existing templates.
Downloaded remote template cookbook from https://raw.githubusercontent.com/vmware/container-service-extension-templates/master/template_v2.yaml
Template ubuntu-16.04_k8-1.20_weave-2.6.5 revision 2 will be processed.
Successfully updated metadata of local template : ubuntu-16.04_k8-1.20_weave-2.6.5 revision 2.
Downloading file from 'https://raw.githubusercontent.com/vmware/container-service-extension-templates/master/scripts_v2/ubuntu-16.04_k8-1.20_weave-2.6.5_rev2/cust.sh' to 'C:\Users\Aritra\.cse_scripts\2.0.0\ubuntu-16.04_k8-1.20_weave-2.6.5_rev2\cust.sh'...
Download complete
Downloading file from 'https://raw.githubusercontent.com/vmware/container-service-extension-templates/master/scripts_v2/ubuntu-16.04_k8-1.20_weave-2.6.5_rev2/init.sh' to 'C:\Users\Aritra\.cse_scripts\2.0.0\ubuntu-16.04_k8-1.20_weave-2.6.5_rev2\init.sh'...
Download complete
Downloading file from 'https://raw.githubusercontent.com/vmware/container-service-extension-templates/master/scripts_v2/ubuntu-16.04_k8-1.20_weave-2.6.5_rev2/nfsd.sh' to 'C:\Users\Aritra\.cse_scripts\2.0.0\ubuntu-16.04_k8-1.20_weave-2.6.5_rev2\nfsd.sh'...
Download complete
Downloading file from 'https://raw.githubusercontent.com/vmware/container-service-extension-templates/master/scripts_v2/ubuntu-16.04_k8-1.20_weave-2.6.5_rev2/cluster-upgrade/docker-upgrade.sh' to 'C:\Users\Aritra\.cse_scripts\2.0.0\ubuntu-16.04_k8-1.20_weave-2.6.5_rev2\cluster-upgrade/docker-upgrade.sh'...
Download complete
Downloading file from 'https://raw.githubusercontent.com/vmware/container-service-extension-templates/master/scripts_v2/ubuntu-16.04_k8-1.20_weave-2.6.5_rev2/cluster-upgrade/control-plane-cni-apply.sh' to 'C:\Users\Aritra\.cse_scripts\2.0.0\ubuntu-16.04_k8-1.20_weave-2.6.5_rev2\cluster-upgrade/control-plane-cni-apply.sh'...
Download complete
Downloading file from 'https://raw.githubusercontent.com/vmware/container-service-extension-templates/master/scripts_v2/ubuntu-16.04_k8-1.20_weave-2.6.5_rev2/cluster-upgrade/control-plane-k8s-upgrade.sh' to 'C:\Users\Aritra\.cse_scripts\2.0.0\ubuntu-16.04_k8-1.20_weave-2.6.5_rev2\cluster-upgrade/control-plane-k8s-upgrade.sh'...
Download complete
Downloading file from 'https://raw.githubusercontent.com/vmware/container-service-extension-templates/master/scripts_v2/ubuntu-16.04_k8-1.20_weave-2.6.5_rev2/cluster-upgrade/worker-k8s-upgrade.sh' to 'C:\Users\Aritra\.cse_scripts\2.0.0\ubuntu-16.04_k8-1.20_weave-2.6.5_rev2\cluster-upgrade/worker-k8s-upgrade.sh'...
Download complete
Assigning placement policies to existing templates.
Processing template ubuntu-16.04_k8-1.20_weave-2.6.5 revision 2
Successfully tagged template ubuntu-16.04_k8-1.20_weave-2.6.5_rev2 with placement policy native.
Loading all CSE clusters for processing...
Assigning placement compute policy(s) to vDC(s) hosting existing CSE clusters.
Identifying vDC(s) that are currently hosting CSE clusters.
Found 1 vDC(s) hosting NATIVE CSE clusters.
Added compute policy 'native' to vDC 'test-orgvdc'
Publishing CSE native cluster right bundles to orgs where clusters are deployed
Successfully published CSE native cluster right bundle to Orgs
Removing old sizing compute policies created by CSE.
Processing Org : 'System'
Finished processing Org : 'System'
Processing Org : 'cse-org'
Processing Org VDC : 'cse-orgvdc'
Finished processing Org VDC : 'cse-orgvdc'
Finished processing Org : 'cse-org'
Processing Org : 'test-org'
Processing Org VDC : 'test-orgvdc'
Finished processing Org VDC : 'test-orgvdc'
Finished processing Org : 'test-org'
Processing existing CSE k8s clusters
Processing cluster 'cluster1'
Updating cluster1 RDE from 1.0.0 to 2.0.0
Updated cluster id of cluster 'cluster1'
Finished processing all clusters.
Removing old native entity types
Deleting entity type: urn:vcloud:type:cse:nativeCluster:1.0.0
The following users own CSE k8s clusters and will require `cse:nativeCluster Entitlement` right bundle to access them in CSE 3.1
Org : test-org -> Users : system
Updated MQTT extension 'cse'
Upgraded CSE successfully
```

Also created a cluster from this upgraded template in CSE 3.1, it went through successfully.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1104)
<!-- Reviewable:end -->
