### PR TITLE
[VCDA-2678]  Fix RDE status conversion error

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -493,10 +493,8 @@ class ClusterService(abstract_broker.AbstractBroker):
         phase: DefEntityPhase = DefEntityPhase.from_phase(
             curr_native_entity.status.phase)
 
-        # TODO: Cannot delete the defined entity if not in RESOLVED state.
-        #   Add check for resolved state before deleting the Vapp
         # Check if cluster is busy
-        if curr_rde.state != def_constants.DEF_RESOLVED_STATE or phase.is_entity_busy():  # noqa: E501
+        if phase.is_entity_busy():
             raise exceptions.CseServerError(
                 f"Cluster {cluster_name} with id {cluster_id} is not in a "
                 f"valid state to be deleted. Please contact administrator.")

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -2023,6 +2023,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                 status=status.value, message=message, progress=progress)
         response_json = self.mqtt_publisher.construct_behavior_response_json(
             task_id=self.task_id, entity_id=self.entity_id, payload=payload)
+        LOGGER.debug(f"Sending behavior response:{response_json}")
         self.mqtt_publisher.send_response(response_json)
         self.task_status = status.value
 

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -278,7 +278,7 @@ class DefEntityService:
         # TODO: Also include any persona having Administrator:FullControl
         #  on CSE:nativeCluster
         if float(vcd_api_version) >= float(ApiVersion.VERSION_36.value) and \
-                self._cloudapi_client.is_sys_admin:
+                self._cloudapi_client.is_sys_admin and not invoke_hooks:
             resource_url_relative_path += f"?invokeHooks={str(invoke_hooks).lower()}"  # noqa: E501
 
         payload: dict = entity.to_dict()
@@ -427,7 +427,7 @@ class DefEntityService:
         # TODO: Also include any persona having Administrator:FullControl
         #  on CSE:nativeCluster
         if float(vcd_api_version) >= float(ApiVersion.VERSION_36.value) and \
-                self._cloudapi_client.is_sys_admin:
+                self._cloudapi_client.is_sys_admin and not invoke_hooks:
             resource_url_relative_path += f"?invokeHooks={str(invoke_hooks).lower()}"  # noqa: E501
 
         response = self._cloudapi_client.do_request(

--- a/container_service_extension/rde/models/rde_1_0_0.py
+++ b/container_service_extension/rde/models/rde_1_0_0.py
@@ -258,53 +258,57 @@ class NativeEntity(AbstractNativeEntity):
                 expose=rde_2_x_entity.spec.settings.network.expose
             )
 
-            if rde_2_x_entity.status.cloud_properties.exposed:
-                control_plane_ip = rde_2_x_entity.status.external_ip
-            else:
-                control_plane_ip = \
-                    rde_2_x_entity.status.nodes.control_plane.ip
+            # Convert "status" only for entities that are already created
+            # New cluster creation won't have "status" section in RDE
+            status = cls.status
+            if rde_2_x_entity.status.nodes:
 
-            control_plane = Node(
-                name=rde_2_x_entity.status.nodes.control_plane.name,
-                ip=control_plane_ip,
-                sizing_class=rde_2_x_entity.status.nodes.control_plane.sizing_class  # noqa: E501
-            )
+                if rde_2_x_entity.status.cloud_properties.exposed:
+                    control_plane_ip = rde_2_x_entity.status.external_ip
+                else:
+                    control_plane_ip = rde_2_x_entity.status.nodes.control_plane.ip  # noqa: E501
 
-            workers = []
-            for worker_node in rde_2_x_entity.status.nodes.workers:
-                worker_node_1_x = Node(
-                    name=worker_node.name,
-                    ip=worker_node.ip,
-                    sizing_class=worker_node.sizing_class
+                control_plane = Node(
+                    name=rde_2_x_entity.status.nodes.control_plane.name,
+                    ip=control_plane_ip,
+                    sizing_class=rde_2_x_entity.status.nodes.control_plane.sizing_class  # noqa: E501
                 )
-                workers.append(worker_node_1_x)
 
-            nfs_nodes = []
-            for nfs_node in rde_2_x_entity.status.nodes.nfs:
-                nfs_node_1_x = NfsNode(
-                    name=nfs_node.name,
-                    ip=nfs_node.ip,
-                    sizing_class=nfs_node.sizing_class,
-                    exports=str(nfs_node.exports)
+                workers = []
+                for worker_node in rde_2_x_entity.status.nodes.workers:
+                    worker_node_1_x = Node(
+                        name=worker_node.name,
+                        ip=worker_node.ip,
+                        sizing_class=worker_node.sizing_class
+                    )
+                    workers.append(worker_node_1_x)
+
+                nfs_nodes = []
+                for nfs_node in rde_2_x_entity.status.nodes.nfs:
+                    nfs_node_1_x = NfsNode(
+                        name=nfs_node.name,
+                        ip=nfs_node.ip,
+                        sizing_class=nfs_node.sizing_class,
+                        exports=str(nfs_node.exports)
+                    )
+                    nfs_nodes.append(nfs_node_1_x)
+
+                nodes = Nodes(
+                    control_plane=control_plane,
+                    workers=workers,
+                    nfs=nfs_nodes
                 )
-                nfs_nodes.append(nfs_node_1_x)
 
-            nodes = Nodes(
-                control_plane=control_plane,
-                workers=workers,
-                nfs=nfs_nodes
-            )
-
-            status = Status(
-                phase=rde_2_x_entity.status.phase,
-                cni=rde_2_x_entity.status.cni,
-                task_href=rde_2_x_entity.status.task_href,
-                kubernetes=rde_2_x_entity.status.kubernetes,
-                docker_version=rde_2_x_entity.status.docker_version,
-                os=rde_2_x_entity.status.os,
-                nodes=nodes,
-                exposed=rde_2_x_entity.status.cloud_properties.exposed
-            )
+                status = Status(
+                    phase=rde_2_x_entity.status.phase,
+                    cni=rde_2_x_entity.status.cni,
+                    task_href=rde_2_x_entity.status.task_href,
+                    kubernetes=rde_2_x_entity.status.kubernetes,
+                    docker_version=rde_2_x_entity.status.docker_version,
+                    os=rde_2_x_entity.status.os,
+                    nodes=nodes,
+                    exposed=rde_2_x_entity.status.cloud_properties.exposed
+                )
 
             rde_1_entity = cls(
                 metadata=metadata,


### PR DESCRIPTION
- Fixes RDE conversion failure: RDE 1.0 <--> 2.0
- Use cases:  RDE 1.0 cluster workflow on RDE 2.0 supported CSE, VCD 
- While creating new RDE 1.0(api version:35.0) on VCD that supports RDE 2.0(api version 36.0), RDE conversion from 1.0 to 2.0 and RDE conversion from 2.0 to 1.0 need to skip conversion of `status` section as there is no status section available during cluster creation phase.
- Entity update and delete to take requests from sys admin for not invoking hooks, if required
- Logger debug statements in task_update()
- Tested with sys admin workflow create, update and delete
- Tested native API endpoints with Accept:application/*;version=35.0 that uncovered this defect (RDE conversion error:`**'NoneType' object has no attribute 'control_plane'**  `(Using Postman)
-  **Testing in progress** with GA dist [https://buildweb.eng.vmware.com/ob/18296069/](https://buildweb.eng.vmware.com/ob/18296069/ )

**Update:**
![image](https://user-images.githubusercontent.com/5530442/125146188-6e6b8f80-e0d9-11eb-85fc-7f8446897b36.png)
**Delete**
![image](https://user-images.githubusercontent.com/5530442/125146197-75929d80-e0d9-11eb-982a-14f0a9db4540.png)

@sahithi @rocknes 


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1106)
<!-- Reviewable:end -->
