### PR TITLE
[VCDA-2693] Fixed legacy to RDE cluster upgrade failure

### DIFF
--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -2029,7 +2029,9 @@ def _upgrade_to_cse_3_1_non_legacy(client, config,
         msg_update_callback=msg_update_callback,
         log_wire=log_wire)
 
-    # This check should be done before registering def schema
+    # IMPORTANT: This statement decides if the upgrade is for legacy or non
+    # legacy cluster. This check should be done always before registering def
+    # schema. This statement should not be moved around otherwise.
     def_entity_type_registered = _is_def_entity_type_registered(client=client)
 
     # Register def schema

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -2029,6 +2029,9 @@ def _upgrade_to_cse_3_1_non_legacy(client, config,
         msg_update_callback=msg_update_callback,
         log_wire=log_wire)
 
+    # This check should be done before registering def schema
+    def_entity_type_registered = _is_def_entity_type_registered(client=client)
+
     # Register def schema
     _register_def_schema(
         client=client,
@@ -2084,7 +2087,6 @@ Please create CSE K8s template(s) using the command `cse template install`."""
     # designed to gate cluster deployment and has no play once the cluster has
     # been deployed.
 
-    def_entity_type_registered = _is_def_entity_type_registered(client=client)
     if def_entity_type_registered:
         _process_non_legacy_clusters(
             client=client,


### PR DESCRIPTION
- Fix for legacy to RDE cluster upgrade failure
- Fixed failing upgrade from legacy to non legacy by checking the defined entity type in VCD before registering any defined entity schema
- Tested manually and verified the upgrade happened successfully thru CLI 

@rocknes @sahithi 

**Before fix**
![image](https://user-images.githubusercontent.com/5530442/125315703-3ab48380-e2ec-11eb-999c-79d05b14352a.png)

**After fix**

![image](https://user-images.githubusercontent.com/5530442/125315903-6fc0d600-e2ec-11eb-844f-972378d70a62.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1108)
<!-- Reviewable:end -->
