### PR TITLE
Fix K8s version parsing from RDE

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_1_x.py
+++ b/container_service_extension/rde/backend/cluster_service_1_x.py
@@ -1400,10 +1400,10 @@ class ClusterService(abstract_broker.AbstractBroker):
             c_docker = curr_entity.entity.status.docker_version
             t_docker = template[LocalTemplateKey.DOCKER_VERSION]
             k8s_details = curr_entity.entity.status.kubernetes.split(' ')
-            c_k8s = semver.Version(k8s_details[1])
+            c_k8s = semver.Version(k8s_details[-1])
             t_k8s = semver.Version(template[LocalTemplateKey.KUBERNETES_VERSION])  # noqa: E501
             cni_details = curr_entity.entity.status.cni.split(' ')
-            c_cni = semver.Version(cni_details[1])
+            c_cni = semver.Version(cni_details[-1])
             t_cni = semver.Version(template[LocalTemplateKey.CNI_VERSION])
 
             upgrade_docker = t_docker > c_docker

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -1607,10 +1607,10 @@ class ClusterService(abstract_broker.AbstractBroker):
             c_docker = curr_native_entity.status.docker_version
             t_docker = template[LocalTemplateKey.DOCKER_VERSION]
             k8s_details = curr_native_entity.status.kubernetes.split(' ')
-            c_k8s = semver.Version(k8s_details[1])
+            c_k8s = semver.Version(k8s_details[-1])
             t_k8s = semver.Version(template[LocalTemplateKey.KUBERNETES_VERSION])  # noqa: E501
             cni_details = curr_native_entity.status.cni.split(' ')
-            c_cni = semver.Version(cni_details[1])
+            c_cni = semver.Version(cni_details[-1])
             t_cni = semver.Version(template[LocalTemplateKey.CNI_VERSION])
 
             upgrade_docker = t_docker > c_docker


### PR DESCRIPTION
While parsing the field `kubernetes` from RDE to determine the version of K8s installed on the cluster, CSE code incorrectly picks the second item in the fragmented list as the version. Ideally it should pick the last element in the list. This faulty logic causes cluster upgrade failures if the kubernetes string contains more than 2 words, e.g.
For, kubernetes = "Tanzu Kubernetes Grid 1.17.4"
The current  logic will incorrectly pick version as "Kubernetes".
This PR addresses the issue.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1109)
<!-- Reviewable:end -->
