### PR TITLE
[VCDA-2703, VCDA-2699] Fix RDE creation/update during CSE upgrade

### DIFF
--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -2524,7 +2524,13 @@ def _create_cluster_rde(client, cluster, kind, runtime_rde_version,
     org_resource = vcd_utils.get_org(client, org_name=cluster['org_name'])
     org_id = org_resource.href.split('/')[-1]
     def_entity = common_models.DefEntity(entity=cluster_entity, entityType=target_entity_type.id)  # noqa: E501
-    entity_svc.create_entity(target_entity_type.id, entity=def_entity, tenant_org_context=org_id, delete_status_from_payload=False)  # noqa: E501
+    entity_svc.create_entity(
+        target_entity_type.id,
+        entity=def_entity,
+        # tenant_org_context=org_id,
+        delete_status_from_payload=False,
+        invoke_hooks=False
+    )
 
     def_entity = entity_svc.get_native_rde_by_name_and_rde_version(cluster['name'], runtime_rde_version)  # noqa: E501
     def_entity_id = def_entity.id

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -1127,26 +1127,26 @@ def _deregister_cse_amqp_extension(client,
     INSTALL_LOGGER.info(msg)
 
 
-def _update_user_role_with_right_bundle(right_bundle_name,
-                                        client: Client,
-                                        msg_update_callback=utils.NullPrinter(),  # noqa: E501
-                                        logger_debug=NULL_LOGGER,
-                                        log_wire=False):
+def _update_user_role_with_right_bundle(
+        right_bundle_name,
+        client: Client,
+        msg_update_callback=utils.NullPrinter(),
+        logger_debug=NULL_LOGGER,
+        log_wire=False):
     """Add defined entity rights to user's role.
 
     This method should only be called on valid configurations.
-    In order to call this function, caller has to make sure that the contextual
-    defined entity is already created inside VCD and corresponding right-bundle
-    exists in VCD.
+        In order to call this function, caller has to make sure that the
+        contextual defined entity is already created inside VCD and
+        corresponding right-bundle exists in VCD.
     The defined entity right bundle is created by VCD at the time of defined
-    entity creation, dynamically. Hence, it doesn't exist before-hand
-    (when user initiated the operation).
-    :param str right_bundle_name : right_bundle_name
+        entity creation, dynamically. Hence, it doesn't exist before-hand
+        (when user initiated the operation).
+
+    :param str right_bundle_name:
     :param pyvcloud.vcd.client.Client client:
-    :param core_utils.ConsoleMessagePrinter msg_update_callback: Callback object.  # noqa: E501
-    :param bool log_wire: wire logging enabled
-    :rtype bool: result of operation. If the rights were added to user's role
-    or not
+    :param core_utils.ConsoleMessagePrinter msg_update_callback:
+    :param bool log_wire:
     """
     # Only a user from System Org can execute this function
     vcd_utils.raise_error_if_user_not_from_system_org(client)
@@ -1165,7 +1165,7 @@ def _update_user_role_with_right_bundle(right_bundle_name,
     if role_record_read_only:
         msg = "User has predefined non editable role. Not adding native entitlement rights."  # noqa: E501
         msg_update_callback.general(msg)
-        return False
+        return
 
     # Determine the rights necessary from rights bundle
     # It is assumed that user already has "View Rights Bundle" Right
@@ -1192,8 +1192,6 @@ def _update_user_role_with_right_bundle(right_bundle_name,
         str(right_bundle_name)
     msg_update_callback.general(msg)
     logger_debug.info(msg)
-
-    return True
 
 
 def _register_def_schema(client: Client,
@@ -1254,21 +1252,24 @@ def _register_def_schema(client: Client,
 
         # Update user's role with right bundle associated with native defined
         # entity
-        if(_update_user_role_with_right_bundle(
-                def_constants.DEF_NATIVE_ENTITY_TYPE_RIGHT_BUNDLE,
-                client=client,
-                msg_update_callback=msg_update_callback,
-                logger_debug=INSTALL_LOGGER,
-                log_wire=log_wire)):
-            # Given that Rights for the current user have been updated, CSE
-            # should logout the user and login again.
-            # This will make sure that SecurityContext object in VCD is
-            # recreated and newly added rights are effective for the user.
-            client.logout()
-            credentials = BasicLoginCredentials(config['vcd']['username'],
-                                                shared_constants.SYSTEM_ORG_NAME,  # noqa: E501
-                                                config['vcd']['password'])
-            client.set_credentials(credentials)
+        _update_user_role_with_right_bundle(
+            def_constants.DEF_NATIVE_ENTITY_TYPE_RIGHT_BUNDLE,
+            client=client,
+            msg_update_callback=msg_update_callback,
+            logger_debug=INSTALL_LOGGER,
+            log_wire=log_wire
+        )
+        # Given that Rights for the current user have been updated, CSE
+        # should logout the user and login again.
+        # This will make sure that SecurityContext object in VCD is
+        # recreated and newly added rights are effective for the user.
+        client.logout()
+        credentials = BasicLoginCredentials(
+            config['vcd']['username'],
+            shared_constants.SYSTEM_ORG_NAME,
+            config['vcd']['password']
+        )
+        client.set_credentials(credentials)
     except cse_exception.DefNotSupportedException:
         msg = "Skipping defined entity type and defined entity interface" \
               " registration"
@@ -2527,9 +2528,8 @@ def _create_cluster_rde(client, cluster, kind, runtime_rde_version,
     entity_svc.create_entity(
         target_entity_type.id,
         entity=def_entity,
-        # tenant_org_context=org_id,
-        delete_status_from_payload=False,
-        invoke_hooks=False
+        tenant_org_context=org_id,
+        delete_status_from_payload=False
     )
 
     def_entity = entity_svc.get_native_rde_by_name_and_rde_version(cluster['name'], runtime_rde_version)  # noqa: E501

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -76,6 +76,7 @@ class DefEntityService:
     def create_entity(self, entity_type_id: str, entity: DefEntity,
                       tenant_org_context: str = None,
                       delete_status_from_payload=True,
+                      invoke_hooks=True,
                       is_request_async=False) -> Union[dict, Tuple[dict, dict]]:  # noqa: E501
         """Create defined entity instance of an entity type.
 
@@ -83,6 +84,7 @@ class DefEntityService:
         :param DefEntity entity: Defined entity instance
         :param str tenant_org_context:
         :param bool delete_status_from_payload: should delete status from payload?  # noqa: E501
+        :param bool invoke_hooks:
         :param bool is_request_async: The request is intended to be asynchronous
             if this flag is set, href of the task is returned in addition to
             the response body
@@ -98,13 +100,21 @@ class DefEntityService:
         if delete_status_from_payload:
             payload.get('entity', {}).pop('status', None)
 
+        resource_url_relative_path = f"{CloudApiResource.ENTITY_TYPES}/{entity_type_id}"  # noqa: E501
+        vcd_api_version = self._cloudapi_client.get_api_version()
+        # TODO Float conversions must be changed to Semantic versioning.
+        # TODO: Also include any persona having Administrator:FullControl
+        #  on CSE:nativeCluster
+        if float(vcd_api_version) >= float(ApiVersion.VERSION_36.value) and \
+                self._cloudapi_client.is_sys_admin and not invoke_hooks:
+            resource_url_relative_path += "?invokeHooks=false"
+
         # response will be a tuple (response_body, response_header) if
         # is_request_async is true. Else, it will be just response_body
         response = self._cloudapi_client.do_request(
             method=RequestMethod.POST,
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
-            resource_url_relative_path=f"{CloudApiResource.ENTITY_TYPES}/"
-                                       f"{entity_type_id}",
+            resource_url_relative_path=resource_url_relative_path,
             payload=payload,
             additional_request_headers=additional_request_headers,
             return_response_headers=is_request_async)

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -76,7 +76,6 @@ class DefEntityService:
     def create_entity(self, entity_type_id: str, entity: DefEntity,
                       tenant_org_context: str = None,
                       delete_status_from_payload=True,
-                      invoke_hooks=True,
                       is_request_async=False) -> Union[dict, Tuple[dict, dict]]:  # noqa: E501
         """Create defined entity instance of an entity type.
 
@@ -84,7 +83,6 @@ class DefEntityService:
         :param DefEntity entity: Defined entity instance
         :param str tenant_org_context:
         :param bool delete_status_from_payload: should delete status from payload?  # noqa: E501
-        :param bool invoke_hooks:
         :param bool is_request_async: The request is intended to be asynchronous
             if this flag is set, href of the task is returned in addition to
             the response body
@@ -101,14 +99,6 @@ class DefEntityService:
             payload.get('entity', {}).pop('status', None)
 
         resource_url_relative_path = f"{CloudApiResource.ENTITY_TYPES}/{entity_type_id}"  # noqa: E501
-        vcd_api_version = self._cloudapi_client.get_api_version()
-        # TODO Float conversions must be changed to Semantic versioning.
-        # TODO: Also include any persona having Administrator:FullControl
-        #  on CSE:nativeCluster
-        if float(vcd_api_version) >= float(ApiVersion.VERSION_36.value) and \
-                self._cloudapi_client.is_sys_admin and not invoke_hooks:
-            resource_url_relative_path += "?invokeHooks=false"
-
         # response will be a tuple (response_body, response_header) if
         # is_request_async is true. Else, it will be just response_body
         response = self._cloudapi_client.do_request(

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -310,9 +310,14 @@ class NativeEntity(AbstractNativeEntity):
                     # it just took a list and string-ified it. The piece of
                     # code below reverses the string representation of the list
                     # back into a list of strings.
-                    export_list_string = nfs_node.exports
-                    export_list_string.replace('[', '').replace(']', '').replace('\'', '')  # noqa: E501
-                    export_list = export_list_string.split(", ")
+                    if isinstance(nfs_node.exports, str):
+                        export_list_string = nfs_node.exports
+                        export_list_string.replace('[', '').replace(']', '').replace('\'', '')  # noqa: E501
+                        export_list = export_list_string.split(", ")
+                    elif isinstance(nfs_node.exports, list):
+                        export_list = nfs_node.exports
+                    else:
+                        export_list = [str(nfs_node.exports)]
 
                     nfs_node_2_x = NfsNode(
                         name=nfs_node.name,
@@ -482,7 +487,9 @@ class NativeEntity(AbstractNativeEntity):
                 nodes=Nodes(
                     control_plane=Node(
                         name=cluster['master_nodes'][0]['name'],
-                        ip=cluster['master_nodes'][0]['ipAddress']),
+                        ip=cluster['master_nodes'][0]['ipAddress'],
+                        storage_profile=cluster['storage_profile_name']
+                    ),
                     workers=worker_nodes,
                     nfs=nfs_nodes
                 ),

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -291,14 +291,16 @@ class NativeEntity(AbstractNativeEntity):
                 control_plane = Node(
                     name=rde_1_x_entity.status.nodes.control_plane.name,
                     ip=rde_1_x_entity.status.nodes.control_plane.ip,
-                    sizing_class=rde_1_x_entity.status.nodes.control_plane.sizing_class  # noqa: E501
+                    sizing_class=rde_1_x_entity.status.nodes.control_plane.sizing_class,  # noqa: E501
+                    storage_profile=rde_1_x_entity.spec.control_plane.storage_profile  # noqa: E501
                 )
                 workers = []
                 for worker in rde_1_x_entity.status.nodes.workers:
                     worker_node_2_x = Node(
                         name=worker.name,
                         ip=worker.ip,
-                        sizing_class=worker.sizing_class
+                        sizing_class=worker.sizing_class,
+                        storage_profile=rde_1_x_entity.spec.workers.storage_profile  # noqa: E501
                     )
                     workers.append(worker_node_2_x)
                 nfs_nodes = []
@@ -316,6 +318,7 @@ class NativeEntity(AbstractNativeEntity):
                         name=nfs_node.name,
                         ip=nfs_node.ip,
                         sizing_class=nfs_node.sizing_class,
+                        storage_profile=rde_1_x_entity.spec.nfs.storage_profile,  # noqa: E501
                         exports=export_list
                     )
                     nfs_nodes.append(nfs_node_2_x)
@@ -406,7 +409,12 @@ class NativeEntity(AbstractNativeEntity):
         worker_nodes = []
         for item in cluster['nodes']:
             worker_nodes.append(
-                Node(name=item['name'], ip=item['ipAddress']))
+                Node(
+                    name=item['name'],
+                    ip=item['ipAddress'],
+                    storage_profile=cluster['storage_profile_name']
+                )
+            )
         nfs_nodes = []
         for item in cluster['nfs_nodes']:
             # The item['exports'] field is a string
@@ -422,6 +430,7 @@ class NativeEntity(AbstractNativeEntity):
                 NfsNode(
                     name=item['name'],
                     ip=item['ipAddress'],
+                    storage_profile=cluster['storage_profile_name'],
                     exports=exports_list
                 )
             )

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -169,15 +169,23 @@ def load_rde_schema(schema_file: str) -> dict:
             pass
 
 
-def find_diff_fields(input_spec: dict, reference_spec: dict, exclude_fields: list = None) -> list:  # noqa: E501
+def find_diff_fields(input_spec: dict, reference_spec: dict, exclude_fields: list = None) -> dict:  # noqa: E501
     if exclude_fields is None:
         exclude_fields = []
     input_dict = core_utils.flatten_dictionary(input_spec)
     reference_dict = core_utils.flatten_dictionary(reference_spec)
     exclude_key_set = set(exclude_fields)
     key_set_for_validation = set(input_dict.keys()) - exclude_key_set
-    return [key for key in key_set_for_validation
-            if input_dict.get(key) is not None and input_dict.get(key) != reference_dict.get(key)]  # noqa: E501
+    result = {}
+    for key in key_set_for_validation:
+        expected = reference_dict.get(key)
+        actual = input_dict.get(key)
+        if actual is not None and actual != expected:
+            result[key] = {
+                "expected": expected,
+                "actual": actual
+            }
+    return result
 
 
 def raise_error_if_unsupported_payload_version(payload_version: str):

--- a/container_service_extension/rde/validators/validator_rde_2_x.py
+++ b/container_service_extension/rde/validators/validator_rde_2_x.py
@@ -128,9 +128,9 @@ def validate_cluster_update_request_and_check_cluster_upgrade(input_spec: rde_2_
             keys_with_invalid_value[k] = v
 
     # Raise exception if fields which cannot be changed are updated
-    if len(keys_with_invalid_value.keys()) > 0:
+    if len(keys_with_invalid_value) > 0:
         err_msg = "Invalid input values found in fields ["
-        for k in sorted(keys_with_invalid_value.keys()):
+        for k in sorted(keys_with_invalid_value):
             err_msg += \
                 f"{k} found : {keys_with_invalid_value[k]['actual']} " \
                 f"expected : {keys_with_invalid_value[k]['expected']}, "
@@ -138,13 +138,13 @@ def validate_cluster_update_request_and_check_cluster_upgrade(input_spec: rde_2_
         raise BadRequestError(err_msg)
 
     is_resize_operation = False
-    if FlattenedClusterSpecKey2X.WORKERS_COUNT.value in diff_fields.keys() or \
-            FlattenedClusterSpecKey2X.NFS_COUNT.value in diff_fields.keys():  # noqa: E501
+    if FlattenedClusterSpecKey2X.WORKERS_COUNT.value in diff_fields or \
+            FlattenedClusterSpecKey2X.NFS_COUNT.value in diff_fields:
         is_resize_operation = True
     is_upgrade_operation = False
 
-    if FlattenedClusterSpecKey2X.TEMPLATE_NAME.value in diff_fields.keys() or \
-            FlattenedClusterSpecKey2X.TEMPLATE_REVISION.value in diff_fields.keys():  # noqa: E501
+    if FlattenedClusterSpecKey2X.TEMPLATE_NAME.value in diff_fields or \
+            FlattenedClusterSpecKey2X.TEMPLATE_REVISION.value in diff_fields:
         is_upgrade_operation = True
 
     # Raise exception if resize and upgrade are performed at the same time

--- a/container_service_extension/rde/validators/validator_rde_2_x.py
+++ b/container_service_extension/rde/validators/validator_rde_2_x.py
@@ -129,7 +129,7 @@ def validate_cluster_update_request_and_check_cluster_upgrade(input_spec: rde_2_
 
     # Raise exception if fields which cannot be changed are updated
     if len(keys_with_invalid_value) > 0:
-        err_msg = "Invalid input values found in fields ["
+        err_msg = "Change detected in immutable field(s) ["
         for k in sorted(keys_with_invalid_value):
             err_msg += \
                 f"{k} found : {keys_with_invalid_value[k]['actual']} " \

--- a/container_service_extension/server/request_handlers/cluster_handler.py
+++ b/container_service_extension/server/request_handlers/cluster_handler.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-"""Support CSE 3.1 custer requests.
+"""Support CSE 3.1 cluster requests.
 
 Starting CSE 3.1, this module handles all the cluster requests coming in at
 any RDE version (>= 2.0) and at any request api_version (>=36).

--- a/container_service_extension/server/request_handlers/request_utils.py
+++ b/container_service_extension/server/request_handlers/request_utils.py
@@ -71,7 +71,7 @@ def flatten_request_data(request_data, keys_to_flatten):
 
     # remove None values
     keys_to_remove = []
-    for k in processed_data.keys():
+    for k in processed_data:
         if processed_data[k] is None:
             keys_to_remove.append(k)
     for k in keys_to_remove:
@@ -132,9 +132,9 @@ def validate_request_payload(input_spec: dict, reference_spec: dict,
     """
     keys_with_invalid_value = rde_utils.find_diff_fields(
         input_spec, reference_spec, exclude_fields=exclude_fields)
-    if len(keys_with_invalid_value.keys()) > 0:
+    if len(keys_with_invalid_value) > 0:
         err_msg = "Invalid input values found in fields ["
-        for k in sorted(keys_with_invalid_value.keys()):
+        for k in sorted(keys_with_invalid_value):
             err_msg += \
                 f"`{k}` found : {keys_with_invalid_value[k]['actual']} " \
                 f"expected : {keys_with_invalid_value[k]['expected']}, "

--- a/container_service_extension/server/request_handlers/request_utils.py
+++ b/container_service_extension/server/request_handlers/request_utils.py
@@ -133,7 +133,7 @@ def validate_request_payload(input_spec: dict, reference_spec: dict,
     keys_with_invalid_value = rde_utils.find_diff_fields(
         input_spec, reference_spec, exclude_fields=exclude_fields)
     if len(keys_with_invalid_value) > 0:
-        err_msg = "Invalid input values found in fields ["
+        err_msg = "Change detected in immutable field(s) ["
         for k in sorted(keys_with_invalid_value):
             err_msg += \
                 f"`{k}` found : {keys_with_invalid_value[k]['actual']} " \

--- a/container_service_extension/server/request_handlers/request_utils.py
+++ b/container_service_extension/server/request_handlers/request_utils.py
@@ -13,17 +13,17 @@ import container_service_extension.rde.utils as rde_utils
 
 MISSING_KEY_TO_MINOR_ERROR_CODE_MAPPING = {
     RequestKey.CLUSTER_NAME: MinorErrorCode.REQUEST_KEY_CLUSTER_NAME_MISSING,
-    RequestKey.COMPUTE_POLICY_ACTION: MinorErrorCode.REQUEST_KEY_COMPUTE_POLICY_ACTION_MISSING, # noqa: E501
-    RequestKey.COMPUTE_POLICY_NAME: MinorErrorCode.REQUEST_KEY_COMPUTE_POLICY_NAME_MISSING, # noqa: E501
+    RequestKey.COMPUTE_POLICY_ACTION: MinorErrorCode.REQUEST_KEY_COMPUTE_POLICY_ACTION_MISSING,  # noqa: E501
+    RequestKey.COMPUTE_POLICY_NAME: MinorErrorCode.REQUEST_KEY_COMPUTE_POLICY_NAME_MISSING,  # noqa: E501
     RequestKey.K8S_PROVIDER: MinorErrorCode.REQUEST_KEY_K8S_PROVIDER_MISSING,
     RequestKey.NETWORK_NAME: MinorErrorCode.REQUEST_KEY_NETWORK_NAME_MISSING,
     RequestKey.NODE_NAME: MinorErrorCode.REQUEST_KEY_NODE_NAME_MISSING,
-    RequestKey.NODE_NAMES_LIST: MinorErrorCode.REQUEST_KEY_NODE_NAMES_LIST_MISSING, # noqa: E501
+    RequestKey.NODE_NAMES_LIST: MinorErrorCode.REQUEST_KEY_NODE_NAMES_LIST_MISSING,  # noqa: E501
     RequestKey.NUM_WORKERS: MinorErrorCode.REQUEST_KEY_NUM_WORKERS_MISSING,
     RequestKey.ORG_NAME: MinorErrorCode.REQUEST_KEY_ORG_NAME_MISSING,
     RequestKey.OVDC_ID: MinorErrorCode.REQUEST_KEY_OVDC_ID_MISSING,
     RequestKey.OVDC_NAME: MinorErrorCode.REQUEST_KEY_OVDC_NAME_MISSING,
-    RequestKey.PKS_CLUSTER_DOMAIN: MinorErrorCode.REQUEST_KEY_PKS_CLUSTER_DOMAIN_MISSING, # noqa: E501
+    RequestKey.PKS_CLUSTER_DOMAIN: MinorErrorCode.REQUEST_KEY_PKS_CLUSTER_DOMAIN_MISSING,  # noqa: E501
     RequestKey.PKS_EXT_HOST: MinorErrorCode.REQUEST_KEY_PKS_EXT_HOST_MISSING,
     RequestKey.PKS_PLAN_NAME: MinorErrorCode.REQUEST_KEY_PKS_PLAN_NAME_MISSING,
     RequestKey.SERVER_ACTION: MinorErrorCode.REQUEST_KEY_SERVER_ACTION_MISSING
@@ -31,17 +31,17 @@ MISSING_KEY_TO_MINOR_ERROR_CODE_MAPPING = {
 
 INVALID_VALUE_TO_MINOR_ERROR_CODE_MAPPING = {
     RequestKey.CLUSTER_NAME: MinorErrorCode.REQUEST_KEY_CLUSTER_NAME_INVALID,
-    RequestKey.COMPUTE_POLICY_ACTION: MinorErrorCode.REQUEST_KEY_COMPUTE_POLICY_ACTION_INVALID, # noqa: E501
-    RequestKey.COMPUTE_POLICY_NAME: MinorErrorCode.REQUEST_KEY_COMPUTE_POLICY_NAME_INVALID, # noqa: E501
+    RequestKey.COMPUTE_POLICY_ACTION: MinorErrorCode.REQUEST_KEY_COMPUTE_POLICY_ACTION_INVALID,  # noqa: E501
+    RequestKey.COMPUTE_POLICY_NAME: MinorErrorCode.REQUEST_KEY_COMPUTE_POLICY_NAME_INVALID,  # noqa: E501
     RequestKey.K8S_PROVIDER: MinorErrorCode.REQUEST_KEY_K8S_PROVIDER_INVALID,
     RequestKey.NETWORK_NAME: MinorErrorCode.REQUEST_KEY_NETWORK_NAME_INVALID,
     RequestKey.NODE_NAME: MinorErrorCode.REQUEST_KEY_NODE_NAME_INVALID,
-    RequestKey.NODE_NAMES_LIST: MinorErrorCode.REQUEST_KEY_NODE_NAMES_LIST_INVALID, # noqa: E501
+    RequestKey.NODE_NAMES_LIST: MinorErrorCode.REQUEST_KEY_NODE_NAMES_LIST_INVALID,  # noqa: E501
     RequestKey.NUM_WORKERS: MinorErrorCode.REQUEST_KEY_NUM_WORKERS_INVALID,
     RequestKey.ORG_NAME: MinorErrorCode.REQUEST_KEY_ORG_NAME_INVALID,
     RequestKey.OVDC_ID: MinorErrorCode.REQUEST_KEY_OVDC_ID_INVALID,
     RequestKey.OVDC_NAME: MinorErrorCode.REQUEST_KEY_OVDC_NAME_INVALID,
-    RequestKey.PKS_CLUSTER_DOMAIN: MinorErrorCode.REQUEST_KEY_PKS_CLUSTER_DOMAIN_INVALID, # noqa: E501
+    RequestKey.PKS_CLUSTER_DOMAIN: MinorErrorCode.REQUEST_KEY_PKS_CLUSTER_DOMAIN_INVALID,  # noqa: E501
     RequestKey.PKS_EXT_HOST: MinorErrorCode.REQUEST_KEY_PKS_EXT_HOST_INVALID,
     RequestKey.PKS_PLAN_NAME: MinorErrorCode.REQUEST_KEY_PKS_PLAN_NAME_INVALID,
     RequestKey.SERVER_ACTION: MinorErrorCode.REQUEST_KEY_SERVER_ACTION_INVALID
@@ -70,9 +70,12 @@ def flatten_request_data(request_data, keys_to_flatten):
         processed_data[key] = request_data[key]
 
     # remove None values
+    keys_to_remove = []
     for k in processed_data.keys():
-        if processed_data[key] is None:
-            del processed_data[key]
+        if processed_data[k] is None:
+            keys_to_remove.append(k)
+    for k in keys_to_remove:
+        del processed_data[k]
 
     return processed_data
 
@@ -91,6 +94,7 @@ def validate_payload(payload, required_keys):
     """
     valid = True
     minor_error_code = None
+    error_message = ""
 
     required = set(required_keys)
     if not required.issubset(payload.keys()):
@@ -102,13 +106,13 @@ def validate_payload(payload, required_keys):
         if key in MISSING_KEY_TO_MINOR_ERROR_CODE_MAPPING:
             minor_error_code = MISSING_KEY_TO_MINOR_ERROR_CODE_MAPPING[key]
     else:
-        keys_with_none_value = [k for k, v in payload.items() if k in required and v is None] # noqa: E501
+        keys_with_none_value = [k for k, v in payload.items() if k in required and v is None]  # noqa: E501
         if len(keys_with_none_value) > 0:
-            error_message = f"Following keys in request payloads have None as value: {keys_with_none_value}" # noqa: E501
+            error_message = f"Following keys in request payloads have None as value: {keys_with_none_value}"  # noqa: E501
             valid = False
             key = RequestKey(keys_with_none_value[0])
             if key in INVALID_VALUE_TO_MINOR_ERROR_CODE_MAPPING:
-                minor_error_code = INVALID_VALUE_TO_MINOR_ERROR_CODE_MAPPING[key] # noqa: E501
+                minor_error_code = INVALID_VALUE_TO_MINOR_ERROR_CODE_MAPPING[key]  # noqa: E501
 
     if not valid:
         raise BadRequestError(error_message, minor_error_code)
@@ -123,15 +127,19 @@ def validate_request_payload(input_spec: dict, reference_spec: dict,
     :param dict input_spec: input spec
     :param dict reference_spec: reference spec to validate the desired spec
     :param list exclude_fields: exclude the list of given flattened-keys from validation  # noqa: E501
-    :return: true on successful validation
-    :rtype: bool
+
     :raises: BadRequestError on encountering invalid payload value
     """
     keys_with_invalid_value = rde_utils.find_diff_fields(
         input_spec, reference_spec, exclude_fields=exclude_fields)
-    if len(keys_with_invalid_value) > 0:
-        error_msg = f"Invalid input values found in {sorted(keys_with_invalid_value)}"  # noqa: E501
-        raise BadRequestError(error_msg)
+    if len(keys_with_invalid_value.keys()) > 0:
+        err_msg = "Invalid input values found in fields ["
+        for k in sorted(keys_with_invalid_value.keys()):
+            err_msg += \
+                f"`{k}` found : {keys_with_invalid_value[k]['actual']} " \
+                f"expected : {keys_with_invalid_value[k]['expected']}, "
+        err_msg += "]."
+        raise BadRequestError(err_msg)
 
 
 def cluster_api_exception_handler(func):


### PR DESCRIPTION
Legacy native K8s clusters are converted to RDE 1.0.0 or RDE 2.0.0 (depending on the VCD) during CSE upgrade. However during this conversion, the `StorageProfile` field in status section is not updated properly. This PR fixes it.

Additionally, this PR also 
1. improves the error message when RDE validation fails during various CSE workflows viz. cluster apply.
2. Refreshes the user context after native entitlement rights are added to roles explicitly by CSE or implicitly by VCD (e.g. built in roles)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1114)
<!-- Reviewable:end -->
