### PR TITLE
Split CSE MQTT extension registration and description update as two separate phases

### DIFF
--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -350,9 +350,13 @@ Please create CSE K8s template(s) using the command `cse template install`."""
 
         # Setup extension based on message bus protocol
         if server_utils.should_use_mqtt_protocol(config):
+            description = \
+                _construct_cse_extension_description(
+                    config['service']['rde_version_in_use']
+                )
             _register_cse_as_mqtt_extension(
                 client,
-                rde_version_in_use=config['service']['rde_version_in_use'],
+                description=description,
                 msg_update_callback=msg_update_callback)  # noqa: E501
         else:
             # create amqp exchange if it doesn't exist
@@ -781,7 +785,6 @@ def upgrade_cse(config_file_name, config, skip_template_creation,
             _register_cse_as_mqtt_extension(
                 client,
                 description=ext_description,
-                rde_version_in_use=config['service']['rde_version_in_use'],
                 msg_update_callback=msg_update_callback)
 
         if source_cse_running_in_legacy_mode and target_cse_running_in_legacy_mode:  # noqa: E501
@@ -1020,20 +1023,18 @@ def _get_existing_extension_type(client):
 
 
 def _register_cse_as_mqtt_extension(client,
-                                    description=None,
-                                    rde_version_in_use=None,
+                                    description,
                                     msg_update_callback=utils.NullPrinter()):
     """Install the MQTT extension and api filter.
 
     :param Client client: client used to install cse server components
+    :param str description:
     :param core_utils.ConsoleMessagePrinter msg_update_callback: Callback object.  # noqa: E501
 
     :raises requests.exceptions.HTTPError: if the MQTT extension and api filter
         were not set up correctly
     """
     mqtt_ext_manager = MQTTExtensionManager(client)
-    if not description:
-        description = _construct_cse_extension_description(rde_version_in_use)
     ext_info = mqtt_ext_manager.setup_extension(
         ext_name=server_constants.CSE_SERVICE_NAME,
         ext_version=server_constants.MQTT_EXTENSION_VERSION,

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -104,8 +104,11 @@ def verify_version_compatibility(
         sysadmin_client: Client,
         should_cse_run_in_legacy_mode: bool,
         is_mqtt_extension: bool):
-    dikt = configure_cse.parse_cse_extension_description(
-        sysadmin_client, is_mqtt_extension)
+    ext_description = configure_cse.get_extension_description(
+        sysadmin_client,
+        is_mqtt_extension
+    )
+    dikt = configure_cse.parse_cse_extension_description(ext_description)
     ext_cse_version = dikt[server_constants.CSE_VERSION_KEY]
     ext_in_legacy_mode = dikt[server_constants.LEGACY_MODE_KEY]
     ext_rde_in_use = dikt[server_constants.RDE_VERSION_IN_USE_KEY]


### PR DESCRIPTION
CSE extension is stamped with CSE specific data to record which version of CSE is being installed, which api version is CSE using etc. This update helps with future CSE upgrades.

The data stamping is generally the last step of CSE upgrade to preserve idempotency of the upgrade process itself.
This also means that if we are upgrading from a CSE system that uses AMQP to one that uses MQTT as the message bus, the MQTT exchange won't be ready until the entire upgrade process is complete.

This poses an issue since the the cluster conversions (creation/update of RDE from cluster data on vapp metadata) will not go through since in VCD 10.3, CSE native RDE operations expect the CSE MQTT exchange to be present in the system.

To solve this problem, we are splitting the AMQP -> MQTT conversion and stamping of CSE upgrade data on the extension as two separate steps. The AMQP -> MQTT conversion will take place as the first step of upgrade, while the data stamping will be the last.

Testing:
Install CSE 3.1 with VCD 10.3 in legacy mode, created a cluster and then proceeded to run `cse upgrade` and set legacy mode to false. This also triggered a migration from AMQP to MQTT as the bus. Verified that the upgrade process was successful and the legacy cluster was converted to RDE 2.0.0 cluster correctly.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1118)
<!-- Reviewable:end -->
