### PR TITLE
[VCDA-2170] Move VAC url back to staging

### DIFF
--- a/container_service_extension/lib/telemetry/constants.py
+++ b/container_service_extension/lib/telemetry/constants.py
@@ -7,7 +7,7 @@ from enum import unique
 
 # End point of Vmware telemetry staging server
 # TODO() : This URL should reflect production server during release
-VAC_URL = "https://vcsa.vmware.com/ph/api/hyper/send"
+VAC_URL = "https://vcsa.vmware.com/ph-stg/api/hyper/send/"
 
 # Value of collector id that is required as part of HTTP request
 # to post sample data to telemetry server


### PR DESCRIPTION
- Move VAC url back to staging
@rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1129)
<!-- Reviewable:end -->
