### PR TITLE
Port fix K8s version parsing from RDE to cse_3_0_updates

### DIFF
--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1272,10 +1272,10 @@ class ClusterService(abstract_broker.AbstractBroker):
             c_docker = curr_entity.entity.status.docker_version
             t_docker = template[LocalTemplateKey.DOCKER_VERSION]
             k8s_details = curr_entity.entity.status.kubernetes.split(' ')
-            c_k8s = semver.Version(k8s_details[1])
+            c_k8s = semver.Version(k8s_details[-1])
             t_k8s = semver.Version(template[LocalTemplateKey.KUBERNETES_VERSION])  # noqa: E501
             cni_details = curr_entity.entity.status.cni.split(' ')
-            c_cni = semver.Version(cni_details[1])
+            c_cni = semver.Version(cni_details[-1])
             t_cni = semver.Version(template[LocalTemplateKey.CNI_VERSION])
 
             upgrade_docker = t_docker > c_docker


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

Porting changes made by PR https://github.com/vmware/container-service-extension/pull/1109 to cse_3_0_updates

While parsing the field kubernetes from RDE to determine the version of K8s installed on the cluster, CSE code incorrectly picks the second item in the fragmented list as the version. Ideally it should pick the last element in the list. This faulty logic causes cluster upgrade failures if the kubernetes string contains more than 2 words, e.g.
For, kubernetes = "Tanzu Kubernetes Grid 1.17.4"
The current logic will incorrectly pick version as "Kubernetes".
This PR addresses the issue.

@rocknes @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1131)
<!-- Reviewable:end -->
