### PR TITLE
[VCDA-2691] Fix upgrade failure when OLM pods are present

### DIFF
--- a/container_service_extension/def_/cluster_service.py
+++ b/container_service_extension/def_/cluster_service.py
@@ -1802,7 +1802,7 @@ def _drain_nodes(sysadmin_client: vcd_client.Client, vapp_href, node_names,
     script = "#!/usr/bin/env bash\n"
     for node_name in node_names:
         script += f"kubectl drain {node_name} " \
-                  f"--ignore-daemonsets --timeout=60s --delete-local-data\n"
+                  f"--force --ignore-daemonsets --timeout=60s --delete-local-data\n"  # noqa: E501
 
     try:
         vapp = vcd_vapp.VApp(sysadmin_client, href=vapp_href)

--- a/container_service_extension/vcdbroker.py
+++ b/container_service_extension/vcdbroker.py
@@ -1399,7 +1399,7 @@ def _drain_nodes(sysadmin_client: vcd_client.Client, vapp_href, node_names,
     script = "#!/usr/bin/env bash\n"
     for node_name in node_names:
         script += f"kubectl drain {node_name} " \
-                  f"--ignore-daemonsets --timeout=60s --delete-local-data\n"
+                  f"--force --ignore-daemonsets --timeout=60s --delete-local-data\n"  # noqa: E501
 
     try:
         vapp = vcd_vapp.VApp(sysadmin_client, href=vapp_href)


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 
`kubectl drain ...` command which is executed when upgrading cluster and deleting cluster fails when OLM is present as reported by the issue 
https://github.com/vmware/container-service-extension/issues/1102.
This PR adds `--force` parameter to the `kubectl drain` command so that the node can be drained.

Testing:
cluster upgrade

@rocknes @arunmk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1133)
<!-- Reviewable:end -->
