### PR TITLE
[VCDA-2724] Fix cluster list when cse server running in api-version 34.0

### DIFF
--- a/container_service_extension/request_processor.py
+++ b/container_service_extension/request_processor.py
@@ -628,7 +628,7 @@ def _get_legacy_url_data(method: str, url: str, api_version: str):
 
     if operation_type == shared_constants.OperationType.NATIVE_CLUSTER:
         if api_version not in (VcdApiVersion.VERSION_33.value,
-                               VcdApiVersion.VERSION_35.value):
+                               VcdApiVersion.VERSION_34.value):
             raise cse_exception.NotFoundRequestError()
         if num_tokens == 4:
             if method == shared_constants.RequestMethod.GET:


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

Cluster list when CSE server is running in api_version 34.0 used to return the following error - 
`Invalid url - not found`
This PR fixes this and error.

Testing done:
* Create cluster and list all the. clusters

@rocknes @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1134)
<!-- Reviewable:end -->
