### PR TITLE
[VCDA-2700] Update CSE logs for delete entity on resolution error

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -352,7 +352,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                         invoke_hooks=False)
                 except Exception:
                     msg = f"Failed to delete defined entity for cluster " \
-                          f"{cluster_name} ({entity_id})"
+                          f"{cluster_name} ({entity_id} with state " \
+                          f"({curr_rde.state})"
                     LOGGER.error(msg, exc_info=True)
             else:
                 # update status to CREATE:FAILED
@@ -1113,7 +1114,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                                                            invoke_hooks=False)
                 except Exception:
                     LOGGER.error("Failed to delete the defined entity for "
-                                 f"cluster '{cluster_name}'", exc_info=True)
+                                 f"cluster '{cluster_name}' with state "
+                                 f"'{curr_rde.state}'", exc_info=True)
 
             self._update_task(BehaviorTaskStatus.ERROR,
                               message=msg,
@@ -1908,7 +1910,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             except (exceptions.NodeOperationError, exceptions.ScriptExecutionError) as err:  # noqa: E501
                 LOGGER.warning(f"Failed to drain nodes: {nodes_to_del}"
                                f" in cluster '{cluster_name}'."
-                               f" Continuing node delete...\nError: {err}")
+                               f" Continuing node delete...\nError: {err}",
+                               exc_info=True)
 
             msg = f"Deleting {len(nodes_to_del)} node(s) from " \
                   f"cluster '{cluster_name}': {nodes_to_del}"


### PR DESCRIPTION
-  Updated the RDE delete failures after resolving entity
-  Verified all the exceptions are logged with `exec_info=True` (exception trace)
-  Verified unlogged exceptions are raised

@sahithi @Anirudh9794

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1135)
<!-- Reviewable:end -->
