### PR TITLE
Remove hyphenated variables in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,8 +5,8 @@
 [metadata]
 name = container-service-extension
 summary = Container Service Extension for vCloud Director
-description-file =
-    README.md
+long_description = file: README.md
+long_description_content_type = text/markdown
 author = Paco Gomez
 author_email = pgomez@vmware.com
 url = https://github.com/vmware/container-service-extension
@@ -22,7 +22,7 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 3
 
-requires-python = >=3
+python_requires = >= 3.7
 
 [entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,5 @@ setup(
     data_files=[
         (str(Path('/')), ['LICENSE.txt', 'NOTICE.txt', osl]),
     ],
-    long_description_content_type="text/markdown",
     pbr=True,
 )


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Referenced: https://gist.github.com/althonos/6914b896789d3f2078d1e6237642c35c for setup.cfg variables
Testing:
* validated if `python_requires` field is functional by setting value to `>= 3.8` and used python 3.7 to install the created build

@sakthisunda @rocknes @arunmk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1140)
<!-- Reviewable:end -->
