### PR TITLE
 Port [VCDA-2723]Handle exceptions when connecting to remote template cookbook to cse_3_1_updates

### DIFF
--- a/container_service_extension/installer/templates/remote_template_manager.py
+++ b/container_service_extension/installer/templates/remote_template_manager.py
@@ -245,7 +245,22 @@ class RemoteTemplateManager:
             self.logger.debug(msg)
             self.msg_update_callback(msg)
         else:
-            template_cookbook_as_str = download_file_into_memory(self.url)
+            template_cookbook_as_str = None
+            try:
+                template_cookbook_as_str = download_file_into_memory(self.url)
+            except requests.exceptions.ConnectionError as e:
+                msg = f"Error connecting to {self.url}: {e}"
+                self.logger.error(msg, exc_info=True)
+                raise Exception(msg)
+            except requests.exceptions.Timeout as e:
+                msg = f"Timeout when connecting to {self.url}: {e}"
+                self.logger.error(msg, exc_info=True)
+                raise Exception(msg)
+            except requests.exceptions.RequestException as e:
+                msg = f"Error occurred when connecting to url {self.url}: {e}"
+                self.logger.error(msg, exc_info=True)
+                raise Exception(msg)
+
             self.unfiltered_cookbook = yaml.safe_load(template_cookbook_as_str)
             msg = f"Downloaded remote template cookbook from {self.url}"
             self.logger.debug(msg)


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

porting https://github.com/vmware/container-service-extension/pull/1143 to cse_3_1_updates

Testing done:

* Check if exceptions are caught if incorrect cookbook url is supplied during CSE run
@rocknes @sakthisunda @ltimothy7 @sahithi @arunmk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1144)
<!-- Reviewable:end -->
