### PR TITLE
Port [VCDA-2691] Fix upgrade failure when OLM pods are present to master

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_1_x.py
+++ b/container_service_extension/rde/backend/cluster_service_1_x.py
@@ -1963,7 +1963,7 @@ def _drain_nodes(sysadmin_client: vcd_client.Client, vapp_href, node_names,
     script = "#!/usr/bin/env bash\n"
     for node_name in node_names:
         script += f"kubectl drain {node_name} " \
-                  f"--ignore-daemonsets --timeout=60s --delete-local-data\n"
+                  f"--force --ignore-daemonsets --timeout=60s --delete-local-data\n"
 
     try:
         vapp = vcd_vapp.VApp(sysadmin_client, href=vapp_href)

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -2176,7 +2176,7 @@ def _drain_nodes(sysadmin_client: vcd_client.Client, vapp_href, node_names,
     script = "#!/usr/bin/env bash\n"
     for node_name in node_names:
         script += f"kubectl drain {node_name} " \
-                  f"--ignore-daemonsets --timeout=60s --delete-local-data\n"
+                  f"--force --ignore-daemonsets --timeout=60s --delete-local-data\n"  # noqa: E501
 
     try:
         vapp = vcd_vapp.VApp(sysadmin_client, href=vapp_href)

--- a/container_service_extension/server/vcdbroker.py
+++ b/container_service_extension/server/vcdbroker.py
@@ -1463,7 +1463,7 @@ def _drain_nodes(sysadmin_client: vcd_client.Client, vapp_href, node_names,
     script = "#!/usr/bin/env bash\n"
     for node_name in node_names:
         script += f"kubectl drain {node_name} " \
-                  f"--ignore-daemonsets --timeout=60s --delete-local-data\n"
+                  f"--force --ignore-daemonsets --timeout=60s --delete-local-data\n"
 
     try:
         vapp = vcd_vapp.VApp(sysadmin_client, href=vapp_href)


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 
`kubectl drain ...` command which is executed when upgrading cluster and deleting cluster fails when OLM is present as reported by the issue 
https://github.com/vmware/container-service-extension/issues/1102.
This PR adds `--force` parameter to the `kubectl drain` command so that the node can be drained.

Testing:
cluster upgrade

@rocknes @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1145)
<!-- Reviewable:end -->
