### PR TITLE
[VCDA-2732] Replace vsphere guest scripts execution by consolidated post boot script

### DIFF
--- a/cluster_scripts/v2_x/control_plane_new.sh
+++ b/cluster_scripts/v2_x/control_plane_new.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+catch() {{
+   vmtoolsd --cmd "info-set post_customization_script_execution_status $?"
+   error_message="$(date) $(caller): $BASH_COMMAND"
+   echo "$error_message" &>> /var/log/cse/customization/error.log
+   vmtoolsd --cmd "info-set post_customization_script_execution_failure_reason $error_message"
+}}
+
+mkdir -p /var/log/cse/customization
+
+trap 'catch $? $LINENO' ERR
+
+set -e
+
+if [[ x$1 = x"postcustomization" ]];
+then
+    echo "$(date) This script was called with $1" &>> /var/log/cse/customization/status.log
+    echo "$(date) post customization script execution in progress" &>> /var/log/cse/customization/status.log
+    tkg_plus_kind="TKG+"
+    input_kind="{cluster_kind}"
+    kubeadm_config_path=/root/kubeadm-defaults.conf
+    ssh_key="{ssh_key}"
+
+    control_plane_end_point="{expose_ip}"
+
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.store.sshkey.status in_progress"
+    if [[ ! -z "$ssh_key" ]];
+    then
+        mkdir -p /root/.ssh
+        echo $ssh_key >> /root/.ssh/authorized_keys
+        chmod -R go-rwx /root/.ssh
+    fi
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.store.sshkey.status successful"
+
+    while [[ `systemctl is-active docker` != 'active' ]]; do echo 'waiting for docker'; sleep 5; done
+
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeinit.status in_progress"
+    if [[ ! -z "$control_plane_end_point" ]];
+    then
+        echo "$(date) executing kubeadm init --control-plane-endpoint" &>> /var/log/cse/customization/status.log
+        kubeadm init --control-plane-endpoint=$control_plane_end_point:6443 --kubernetes-version=v{k8s_version} --token-ttl=0 > /root/kubeadm-init.out
+    else
+        echo "$(date) executing kubeadm init" &>> /var/log/cse/customization/status.log
+        kubeadm init --kubernetes-version=v{k8s_version} --token-ttl=0 > /root/kubeadm-init.out
+    fi
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeinit.status successful"
+
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.apply.weave.status in_progress"
+    export kubever=$(kubectl version --client | base64 | tr -d '\n')
+    export KUBECONFIG=/etc/kubernetes/admin.conf
+    WEAVE_VERSIONED_FILE="/root/weave_v$(echo {cni_version} | sed -r 's/\./\-/g').yml"
+    echo $WEAVE_VERSIONED_FILE >> /var/log/cse/customization/status.log
+    kubectl apply -f $WEAVE_VERSIONED_FILE >> /var/log/cse/customization/status.log 2>> /var/log/cse/customization/error.log
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.apply.weave.status successful"
+
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.join.status in_progress"
+    kubeadm_join_info=$(kubeadm token create --print-join-command 2> /dev/null)
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.join.status successful"
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.join $kubeadm_join_info"
+    echo "$(date) post customization script execution completed" &>> /var/log/cse/customization/status.log
+else
+    echo "$(date) This script was called with $1" &>> /var/log/cse/customization/status.log
+fi

--- a/cluster_scripts/v2_x/control_plane_new.sh
+++ b/cluster_scripts/v2_x/control_plane_new.sh
@@ -49,6 +49,8 @@ then
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.apply.weave.status in_progress"
     export kubever=$(kubectl version --client | base64 | tr -d '\n')
     export KUBECONFIG=/etc/kubernetes/admin.conf
+    vmtoolsd --cmd "info-set guestinfo.kubeconfig $(cat /etc/kubernetes/admin.conf)"
+
     WEAVE_VERSIONED_FILE="/root/weave_v$(echo {cni_version} | sed -r 's/\./\-/g').yml"
     echo $WEAVE_VERSIONED_FILE >> /var/log/cse/customization/status.log
     kubectl apply -f $WEAVE_VERSIONED_FILE >> /var/log/cse/customization/status.log 2>> /var/log/cse/customization/error.log
@@ -59,6 +61,4 @@ then
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.join.status successful"
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.join $kubeadm_join_info"
     echo "$(date) post customization script execution completed" &>> /var/log/cse/customization/status.log
-else
-    echo "$(date) This script was called with $1" &>> /var/log/cse/customization/status.log
 fi

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -200,6 +200,7 @@ class ClusterScriptFile(str, Enum):
 
     SCRIPTS_DIR = "cluster_scripts"
     CONTROL_PLANE = 'control_plane.sh'
+    CONTROL_PLANE_NEW = 'control_plane_new.sh'
     NODE = 'node.sh'
 
     # Note that we need _ in the version instead of dots to allow
@@ -722,8 +723,16 @@ class PostCustomizationStatus(Enum):
     SUCCESSFUL = 'successful'
 
 
+@unique
+class PostCustomizationPhase(Enum):
+    STORE_SSH_KEY = 'guestinfo.postcustomization.store.sshkey.status'
+    KUBEADM_INIT = 'guestinfo.postcustomization.kubeinit.status'
+    KUBECTL_APPLY_WEAVE = 'guestinfo.postcustomization.kubectl.apply.weave.status'  # noqa: E501
+    KUBEADM_JOIN = 'guestinfo.postcustomization.kubeadm.join.status'
+
+
 POST_CUSTOMIZATION_SCRIPT_EXECUTION_STATUS = 'post_customization_script_execution_status'  # noqa: E501
 POST_CUSTOMIZATION_SCRIPT_EXECUTION_FAILURE_REASON = 'post_customization_script_execution_failure_reason'  # noqa: E501
 DEFAULT_POST_CUSTOMIZATION_STATUS_LIST = [cust_status.value for cust_status in PostCustomizationStatus]  # noqa: E501
 DEFAULT_POST_CUSTOMIZATION_POLL_SEC = 5
-DEFAULT_POST_CUSTOMIZATION_TIMEOUT_SEC = 180
+DEFAULT_POST_CUSTOMIZATION_TIMEOUT_SEC = 600

--- a/container_service_extension/common/utils/pyvcloud_utils.py
+++ b/container_service_extension/common/utils/pyvcloud_utils.py
@@ -733,6 +733,7 @@ def wait_for_completion_of_post_customization_step(
     remaining_statuses = list(expected_target_status_list)
 
     while True:
+        vm.reload()
         new_status = get_vm_extra_config_element(vm, customization_phase)
         if new_status not in remaining_statuses:
             logger.error(f"Invalid VM Post guest customization status:{new_status}")  # noqa: E501
@@ -740,8 +741,8 @@ def wait_for_completion_of_post_customization_step(
         # update the remaining statuses on status change
         if new_status != current_status:
             remaining_statuses.remove(current_status)
-            logger.info(f"Post guest customization phase {customization_phase } in {new_status}")  # noqa: E501
             current_status = new_status
+        logger.info(f"Post guest customization phase {customization_phase } is {new_status}")  # noqa: E501
         # Check for successful customization: reaching last status between
         if new_status == expected_target_status_list[-1]:
             return new_status
@@ -756,5 +757,5 @@ def wait_for_completion_of_post_customization_step(
         if datetime.now() - start_time > timedelta(seconds=timeout):
             break
         time.sleep(poll_frequency)
-    logger.error("VM Post guest customization failed due to timeout")  # noqa: E501
+    logger.error(f"VM Post guest customization failed due to timeout({timeout} sec)")  # noqa: E501
     raise exceptions.PostCustomizationTimeoutError

--- a/container_service_extension/rde/backend/common/network_expose_helper.py
+++ b/container_service_extension/rde/backend/common/network_expose_helper.py
@@ -194,33 +194,6 @@ def expose_cluster(client: vcd_client.Client, org_name: str, ovdc_name: str,
     return expose_ip
 
 
-def get_nsxt_external_ip(client: vcd_client.Client,
-                         org_name: str,
-                         ovdc_name: str,
-                         network_name: str):
-    """Get a free static IP.
-
-     Get a free static IP from the edge gateway powering the Org VDC network,
-        and create a DNAT rule to expose the @internal_ip
-
-    :param vcd_client.Client client:
-    :param str org_name:
-    :param str ovdc_name:
-    :param str network_name:
-
-    :raises Exception: If CSE is unable to get a free IP.
-
-    :returns: The newly acquired exposed Ip of the cluster
-
-    :rtype: str
-    """
-    # Auto reserve ip
-    nsxt_gateway_svc = _get_nsxt_backed_gateway_service(
-        client, org_name, ovdc_name, network_name)
-    expose_ip = nsxt_gateway_svc.get_available_ip()
-    return expose_ip if expose_ip is not None else ''
-
-
 def handle_delete_expose_dnat_rule(client: vcd_client.Client,
                                    org_name: str,
                                    ovdc_name: str,

--- a/container_service_extension/rde/backend/common/network_expose_helper.py
+++ b/container_service_extension/rde/backend/common/network_expose_helper.py
@@ -194,6 +194,33 @@ def expose_cluster(client: vcd_client.Client, org_name: str, ovdc_name: str,
     return expose_ip
 
 
+def get_nsxt_external_ip(client: vcd_client.Client,
+                         org_name: str,
+                         ovdc_name: str,
+                         network_name: str):
+    """Get a free static IP.
+
+     Get a free static IP from the edge gateway powering the Org VDC network,
+        and create a DNAT rule to expose the @internal_ip
+
+    :param vcd_client.Client client:
+    :param str org_name:
+    :param str ovdc_name:
+    :param str network_name:
+
+    :raises Exception: If CSE is unable to get a free IP.
+
+    :returns: The newly acquired exposed Ip of the cluster
+
+    :rtype: str
+    """
+    # Auto reserve ip
+    nsxt_gateway_svc = _get_nsxt_backed_gateway_service(
+        client, org_name, ovdc_name, network_name)
+    expose_ip = nsxt_gateway_svc.get_available_ip()
+    return expose_ip if expose_ip is not None else ''
+
+
 def handle_delete_expose_dnat_rule(client: vcd_client.Client,
                                    org_name: str,
                                    ovdc_name: str,


### PR DESCRIPTION
-  Control plane node creation using consolidated post customization script
-  Currently, control plane node creation uses vsphere tools guest library. This PR replaces this logic with post guest customization script. TODO: added for upcoming tasks
- Tested with Ubuntu template and native cluster.
- Tested wait polling on customization phases. Error handling in the script: error out on first error.
- Tested with expose_ip logic with dummy values. 
- NOTE: Currently, the control_plane script is in a new bash script file. 

![image](https://user-images.githubusercontent.com/5530442/128208368-5b22e9dd-3232-47d4-ad5d-fae27b29a0fb.png)
![image](https://user-images.githubusercontent.com/5530442/128208573-1cda4197-11e1-45a4-b006-6a196f0d067b.png)
![image](https://user-images.githubusercontent.com/5530442/128209298-ccd98a33-10b4-40af-93db-581ede0cc515.png)

-------
kubeconfig in vm extra config
![image](https://user-images.githubusercontent.com/5530442/128275154-04826fcf-15e6-424f-8485-d04d9baebb47.png)


@arunmk @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1152)
<!-- Reviewable:end -->
