### PR TITLE
[VCDA-2737] store kube config, kubeadm token in rde

### DIFF
--- a/cluster_scripts/v2_x/control_plane_customization.sh
+++ b/cluster_scripts/v2_x/control_plane_customization.sh
@@ -52,7 +52,7 @@ then
     cp -f /etc/kubernetes/admin.conf /root/.kube/config
     chown $(id -u):$(id -g) /root/.kube/config
     export KUBECONFIG=/etc/kubernetes/admin.conf
-    vmtoolsd --cmd "info-set guestinfo.kubeconfig $(cat /etc/kubernetes/admin.conf)"
+    vmtoolsd --cmd "info-set guestinfo.kubeconfig $(cat /etc/kubernetes/admin.conf | base64 | tr -d '\n')"
 
     WEAVE_VERSIONED_FILE="/root/weave_v$(echo {cni_version} | sed -r 's/\./\-/g').yml"
     echo $WEAVE_VERSIONED_FILE >> /var/log/cse/customization/status.log

--- a/cluster_scripts/v2_x/control_plane_customization.sh
+++ b/cluster_scripts/v2_x/control_plane_customization.sh
@@ -46,7 +46,7 @@ then
     fi
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeinit.status successful"
 
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.apply.weave.status in_progress"
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.apply.cni.status in_progress"
     export kubever=$(kubectl version --client | base64 | tr -d '\n')
     mkdir -p /root/.kube
     cp -f /etc/kubernetes/admin.conf /root/.kube/config
@@ -57,7 +57,7 @@ then
     WEAVE_VERSIONED_FILE="/root/weave_v$(echo {cni_version} | sed -r 's/\./\-/g').yml"
     echo $WEAVE_VERSIONED_FILE >> /var/log/cse/customization/status.log
     kubectl apply -f $WEAVE_VERSIONED_FILE >> /var/log/cse/customization/status.log 2>> /var/log/cse/customization/error.log
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.apply.weave.status successful"
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.apply.cni.status successful"
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.token.generate.status in_progress"
     kubeadm_join_info=$(kubeadm token create --print-join-command 2> /dev/null)

--- a/cluster_scripts/v2_x/node.sh
+++ b/cluster_scripts/v2_x/node.sh
@@ -31,7 +31,7 @@ then
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.node.join.status in_progress"
     echo "$(date) executing {kubeadm_join_cmd} on the node" &>> /var/log/cse/customization/status.log
-    $({kubeadm_join_cmd} >> /var/log/cse/customization/status.log 2>> /var/log/cse/customization/error.log)
+    {kubeadm_join_cmd} >> /var/log/cse/customization/status.log 2>> /var/log/cse/customization/error.log
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.node.join.status successful"
     echo "$(date) post customization script execution completed" &>> /var/log/cse/customization/status.log
 fi

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -732,7 +732,7 @@ class PostCustomizationStatus(Enum):
 class PostCustomizationPhase(Enum):
     STORE_SSH_KEY = 'guestinfo.postcustomization.store.sshkey.status'
     KUBEADM_INIT = 'guestinfo.postcustomization.kubeinit.status'
-    KUBECTL_APPLY_WEAVE = 'guestinfo.postcustomization.kubectl.apply.weave.status'  # noqa: E501
+    KUBECTL_APPLY_CNI = 'guestinfo.postcustomization.kubectl.apply.cni.status'  # noqa: E501
     KUBEADM_TOKEN_GENERATE = 'guestinfo.postcustomization.kubeadm.token.generate.status'  # noqa: E501
     KUBEADM_NODE_JOIN = 'guestinfo.postcustomization.kubeadm.node.join.status'
 

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -634,6 +634,11 @@ CSE_SERVICE_ROLE_RIGHTS = [
     "vmware:tkgcluster: View"
 ]
 
+CSE_NATIVE_CLUSTER_FULL_ACCESS_RIGHTS = {
+    'cse:nativeCluster: Administrator View',
+    'cse:nativeCluster: Full Access'
+}
+
 
 @dataclass
 class DefEntityPhase:
@@ -733,6 +738,7 @@ class PostCustomizationPhase(Enum):
 
 
 KUBEADM_TOKEN_INFO = 'guestinfo.postcustomization.kubeadm.token.info'
+KUBE_CONFIG = 'guestinfo.kubeconfig'
 POST_CUSTOMIZATION_SCRIPT_EXECUTION_STATUS = 'guestinfo.post_customization_script_execution_status'  # noqa: E501
 POST_CUSTOMIZATION_SCRIPT_EXECUTION_FAILURE_REASON = 'guestinfo.post_customization_script_execution_failure_reason'  # noqa: E501
 DEFAULT_POST_CUSTOMIZATION_STATUS_LIST = [cust_status.value for cust_status in PostCustomizationStatus]  # noqa: E501

--- a/container_service_extension/common/utils/pyvcloud_utils.py
+++ b/container_service_extension/common/utils/pyvcloud_utils.py
@@ -11,7 +11,9 @@ import urllib
 
 import pyvcloud.vcd.client as vcd_client
 from pyvcloud.vcd.exceptions import EntityNotFoundException
+from pyvcloud.vcd.exceptions import OperationNotSupportedException
 import pyvcloud.vcd.org as vcd_org
+import pyvcloud.vcd.role as vcd_role
 from pyvcloud.vcd.utils import extract_id
 from pyvcloud.vcd.utils import get_admin_href
 from pyvcloud.vcd.utils import to_dict
@@ -759,3 +761,32 @@ def wait_for_completion_of_post_customization_procedure(
         time.sleep(poll_frequency)
     logger.error(f"VM Post guest customization failed due to timeout({timeout} sec)")  # noqa: E501
     raise exceptions.PostCustomizationTimeoutError
+
+
+def has_full_access_to_native_cluster(
+        client: vcd_client.Client,
+        logger=NULL_LOGGER):
+    """Check the logged-in user has role with full access to native cluster.
+
+    :param vcd_client.Client client: current client
+    :param logging.Logger logger: logger to record errors.
+    :return: True if the role has full access to native cluster else False
+    :rtype: bool
+    """
+    try:
+        role_name = get_user_role_name(client)
+        org_obj = vcd_org.Org(client, resource=client.get_org())
+        role_obj = vcd_role.Role(client, resource=org_obj.get_role_resource(role_name))  # noqa: E501
+        rights_set = set(
+            [right['name'] for right in role_obj.list_rights() if
+             right['name'].startswith('cse')]
+        )
+        for native_right in server_constants.CSE_NATIVE_CLUSTER_FULL_ACCESS_RIGHTS:  # noqa: E501
+            if native_right in rights_set:
+                return True
+    except OperationNotSupportedException as err:
+        logger.info(f"Cannot determine the rights associated with role:{role_name} {err}")  # noqa: E501
+    except Exception as err:
+        logger.info(f"Cannot determine the rights associated with role:{role_name} {err}")  # noqa: E501
+
+    return False

--- a/container_service_extension/exception/exceptions.py
+++ b/container_service_extension/exception/exceptions.py
@@ -157,6 +157,10 @@ class ClusterJoiningError(ClusterOperationError):
     """Raised when any error happens while cluster join operation."""
 
 
+class KubeconfigNotFound(ClusterOperationError):
+    """Raised when any error happens while getting Kubeconfig from control plane."""   # noqa: E501
+
+
 class ClusterInitializationError(ClusterOperationError):
     """Raised when any error happens while cluster initialization."""
 

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -2680,10 +2680,8 @@ def _get_kube_config_from_control_plane_vm(sysadmin_client: vcd_client.Client, v
     return kube_config_in_bytes.decode()
 
 
-def wait_for_update_customization(message, exception=None):
-    LOGGER.debug(f"waiting for updating customization, status: {message}")  # noqa: E501
-    if exception is not None:
-        LOGGER.error(f"exception: {str(exception)}")
+def wait_for_update_customization(task):
+    LOGGER.debug(f"waiting for updating customization, status: {task.get('status').lower()}")  # noqa: E501
 
 
 def wait_for_adding_control_plane_vm_to_vapp(task):

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -894,7 +894,11 @@ class ClusterService(abstract_broker.AbstractBroker):
                 ClusterMetadataKey.CNI: template[LocalTemplateKey.CNI],
                 ClusterMetadataKey.CNI_VERSION: template[LocalTemplateKey.CNI_VERSION]  # noqa: E501
             }
-            vapp = vcd_vapp.VApp(client_v36,
+
+            sysadmin_client_v36 = self.context.get_sysadmin_client(
+                api_version=DEFAULT_API_VERSION)
+            # Extra config elements of VApp are visible only for admin client
+            vapp = vcd_vapp.VApp(sysadmin_client_v36,
                                  href=vapp_resource.get('href'))
             task = vapp.set_multiple_metadata(tags)
             client_v36.get_task_monitor().wait_for_status(task)
@@ -906,8 +910,6 @@ class ClusterService(abstract_broker.AbstractBroker):
             vapp.reload()
             server_config = server_utils.get_server_runtime_config()
             catalog_name = server_config['broker']['catalog']
-            sysadmin_client_v36 = self.context.get_sysadmin_client(
-                api_version=DEFAULT_API_VERSION)
 
             msg = f"Adding control plane node for '{cluster_name}' ({cluster_id})"  # noqa: E501
             LOGGER.debug(msg)
@@ -1363,7 +1365,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                 api_version=DEFAULT_API_VERSION)
             org = vcd_utils.get_org(client_v36, org_name=org_name)
             ovdc = vcd_utils.get_vdc(client_v36, vdc_name=ovdc_name, org=org)
-            vapp = vcd_vapp.VApp(client_v36, href=vapp_href)
+            # Extra config elements of VApp are visible only for admin client
+            vapp = vcd_vapp.VApp(sysadmin_client_v36, href=vapp_href)
 
             if num_workers_to_add > 0:
                 msg = f"Creating {num_workers_to_add} workers from template" \

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -2444,7 +2444,7 @@ def _add_control_plane_nodes(sysadmin_client, num_nodes, org, vdc, vapp,
                 )
                 vcd_utils.wait_for_completion_of_post_customization_procedure(
                     vm,
-                    customization_phase=PostCustomizationPhase.KUBECTL_APPLY_WEAVE.value,  # noqa: E501
+                    customization_phase=PostCustomizationPhase.KUBECTL_APPLY_CNI.value,  # noqa: E501
                     logger=LOGGER
                 )
 

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -1411,7 +1411,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                     storage_profile=worker_storage_profile,
                     ssh_key=ssh_key,
                     sizing_class_name=worker_sizing_class,
-                    control_plane_join_cmd=curr_native_entity.status.private.kube_token  # noqa: E501control_plane_join_cmd=curr_native_entity.status.private.kube_token  # noqa: E501
+                    control_plane_join_cmd=curr_native_entity.status.private.kube_token  # noqa: E501
                 )
 
                 msg = f"Added {num_workers_to_add} node(s) to cluster " \

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -1399,6 +1399,16 @@ class ClusterService(abstract_broker.AbstractBroker):
                     f"{cluster_name}({cluster_id})"
                 self._update_task(BehaviorTaskStatus.RUNNING, message=msg)
 
+                # Get join cmd from RDE;fallback to control plane extra config  # noqa: E501
+                if hasattr(curr_native_entity.status, 'private') and hasattr(
+                        curr_native_entity.status.private, 'kube_token'):
+                    control_plane_join_cmd = curr_native_entity.status.private.kube_token  # noqa: E501
+                else:
+                    control_plane_join_cmd = _get_join_cmd(
+                        sysadmin_client=sysadmin_client_v36,
+                        vapp=vapp
+                    )
+
                 _add_worker_nodes(
                     sysadmin_client_v36,
                     num_nodes=num_workers_to_add,
@@ -1411,7 +1421,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                     storage_profile=worker_storage_profile,
                     ssh_key=ssh_key,
                     sizing_class_name=worker_sizing_class,
-                    control_plane_join_cmd=curr_native_entity.status.private.kube_token  # noqa: E501
+                    control_plane_join_cmd=control_plane_join_cmd  # noqa: E501
                 )
 
                 msg = f"Added {num_workers_to_add} node(s) to cluster " \

--- a/container_service_extension/rde/backend/common/network_expose_helper.py
+++ b/container_service_extension/rde/backend/common/network_expose_helper.py
@@ -141,16 +141,23 @@ def construct_script_to_update_kubeconfig_with_internal_ip(
 
     :rtype: str
     """
-    kubeconfig_with_internal_ip = re.sub(
-        pattern=IP_PORT_REGEX,
-        repl=f'{internal_ip}:6443',
-        string=str(kubeconfig_with_exposed_ip)
+    kubeconfig_with_internal_ip = get_updated_kubeconfig_with_internal_ip(
+        kubeconfig_with_exposed_ip, internal_ip
     )
-
     script = f"#!/usr/bin/env bash\n" \
              f"echo \'{kubeconfig_with_internal_ip}\' > " \
              f"{CSE_CLUSTER_KUBECONFIG_PATH}\n"
     return script
+
+
+def get_updated_kubeconfig_with_internal_ip(
+        kubeconfig_with_exposed_ip,
+        internal_ip: str):
+    return re.sub(
+        pattern=IP_PORT_REGEX,
+        repl=f'{internal_ip}:6443',
+        string=str(kubeconfig_with_exposed_ip)
+    )
 
 
 def expose_cluster(client: vcd_client.Client, org_name: str, ovdc_name: str,


### PR DESCRIPTION
- Base 64 encoded value of kubeconfig in vm extra config
- Read kubeconfig from vm extra config and store in RDE 
- Read kubeadm token from vm extra config in RDE, if not found fallback to getting it from control-plane extra config 
- worker node creation, resize use RDE stored values
- Updated kubeconfig based on expose cluster logic stored back in RDE
- Entity update - Replace sysadmin only check with user role with cse:nativeCluster full access rights
- Tested create with and without worker node, resize cluster with worker node, delete cluster
- Testing in progress

@arunmk @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1164)
<!-- Reviewable:end -->
