### PR TITLE
[VCDA-2768] Expose TKGm template list API endpoint

### DIFF
--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -455,6 +455,7 @@ class CseOperation(Enum):
     SYSTEM_INFO = ('get info of system', '/cse/system')
     SYSTEM_UPDATE = ('update system status', '/cse/system')
     TEMPLATE_LIST = ('list all templates', '/cse/templates')
+    TKGM_TEMPLATE_LIST = ('list TKGm templates', '/cse/templates/tkgm')
 
     V35_OVDC_LIST = ('list ovdcs for v35', '/cse/3.0/ovdcs')
     V35_ORG_VDC_LIST = ('list org VDCs', '/cse/3.0/orgvdcs')

--- a/container_service_extension/server/request_dispatcher.py
+++ b/container_service_extension/server/request_dispatcher.py
@@ -79,6 +79,17 @@ TEMPLATE_HANDLERS = [
                 'handler': template_handler.template_list
             }
         }
+    },
+    {
+        'url': "cse/templates/tkgm",
+        RequestMethod.GET: {
+            ('36.0', ): {
+                'allowed_params': [],
+                'required_params': [],
+                'operation': CseOperation.TEMPLATE_LIST,
+                'handler': template_handler.tkgm_template_list
+            }
+        }
     }
 ]
 

--- a/container_service_extension/server/request_handlers/template_handler.py
+++ b/container_service_extension/server/request_handlers/template_handler.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from container_service_extension.common.constants.server_constants import LocalTemplateKey  # noqa: E501
+from container_service_extension.common.constants.server_constants import TKGmTemplateKey  # noqa: E501
 import container_service_extension.common.utils.server_utils as server_utils
 from container_service_extension.lib.telemetry.constants import CseOperation
 from container_service_extension.lib.telemetry.telemetry_handler import record_user_action_telemetry  # noqa: E501
@@ -42,3 +43,35 @@ def template_list(request_data, op_ctx):
         })
 
     return sorted(templates, key=lambda i: (i['name'], i['revision']), reverse=True)  # noqa: E501
+
+
+def tkgm_template_list(request_data, op_ctx):
+    """Request handler for template list operation.
+
+    :return: List of dictionaries with template info.
+    """
+    config = server_utils.get_server_runtime_config()
+    tkgm_templates = []
+
+    for t in config['broker']['tkgm_templates']:
+        tkgm_templates.append({
+            'catalog': config['broker']['catalog'],
+            'catalog_item': t[TKGmTemplateKey.NAME],
+            'cni': t[TKGmTemplateKey.CNI],
+            'cni_version': t[TKGmTemplateKey.CNI_VERSION],
+            'cse_version': t[TKGmTemplateKey.CSE_VERSION],
+            'deprecated': 'n/a',
+            'description': '',
+            'docker_version': 'n/a',
+            'container_runtime': t[TKGmTemplateKey.CONTAINER_RUNTIME],
+            'container_runtime_version': t[TKGmTemplateKey.CONTAINER_RUNTIME_VERSION],
+            'is_default': 'No',
+            'kind': t[TKGmTemplateKey.KIND],
+            'kubernetes': t[TKGmTemplateKey.KUBERNETES],
+            'kubernetes_version': t[TKGmTemplateKey.KUBERNETES_VERSION],
+            'name': t[TKGmTemplateKey.NAME],
+            'os': f"{t[TKGmTemplateKey.OS]}-{t[TKGmTemplateKey.OS_VERSION]}",
+            'revision': str(t[TKGmTemplateKey.REVISION])
+        })
+
+    return sorted(tkgm_templates, key=lambda i: (i['name'], i['revision']), reverse=True)  # noqa: E501


### PR DESCRIPTION
Expose GET /api/cse/template/tkgm endpoint to retrieve TKGm templates in CSE catalog.
Additionally during CSE startup, read all TKGm template into memory.

Testing Done:
Invoked GET /api/cse/template/tkgm from POSTman and made sure that the response received is correct

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1168)
<!-- Reviewable:end -->
