### PR TITLE
[VCDA-2571] Use cpu and memory for control plane and worker nodes

### DIFF
--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -137,6 +137,8 @@ class FlattenedClusterSpecKey1X(Enum):
 class FlattenedClusterSpecKey2X(Enum):
     WORKERS_COUNT = 'topology.workers.count'
     WORKERS_SIZING_CLASS = 'topology.workers.sizingClass'
+    WORKERS_CPU_COUNT = 'topology.workers.cpu'
+    WORKERS_MEMORY_MB = 'topology.workers.memory'
     WORKERS_STORAGE_PROFILE = 'topology.workers.storageProfile'
     NFS_COUNT = 'topology.nfs.count'
     NFS_SIZING_CLASS = 'topology.nfs.sizingClass'

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -106,21 +106,42 @@ def construct_2_0_0_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Sta
     :return: Cluster Specification as defined in rde_2_0_0 model
     """
     # Currently only single control-plane is supported.
-    control_plane = rde_2_0_0.ControlPlane(
-        sizing_class=entity_status.nodes.control_plane.sizing_class,
-        storage_profile=entity_status.nodes.control_plane.storage_profile,
-        count=1)
+    if entity_status.nodes.control_plane.sizing_class:
+        control_plane = rde_2_0_0.ControlPlane(
+            sizing_class=entity_status.nodes.control_plane.sizing_class,
+            storage_profile=entity_status.nodes.control_plane.storage_profile,
+            cpu=None,
+            memory=None,
+            count=1)
+    else:
+        control_plane = rde_2_0_0.ControlPlane(
+            sizing_class=None,
+            storage_profile=entity_status.nodes.control_plane.storage_profile,
+            cpu=entity_status.nodes.control_plane.cpu,
+            memory=entity_status.nodes.control_plane.memory,
+            count=1)
 
     workers_count = len(entity_status.nodes.workers)
     if workers_count == 0:
         workers = rde_2_0_0.Workers(sizing_class=None,
+                                    cpu=None,
+                                    memory=None,
                                     storage_profile=None,
                                     count=0)
     else:
-        workers = rde_2_0_0.Workers(
-            sizing_class=entity_status.nodes.workers[0].sizing_class,
-            storage_profile=entity_status.nodes.workers[0].storage_profile,
-            count=workers_count)
+        if entity_status.nodes.workers[0].sizing_class:
+            workers = rde_2_0_0.Workers(
+                sizing_class=entity_status.nodes.workers[0].sizing_class,
+                storage_profile=entity_status.nodes.workers[0].storage_profile,
+                cpu=None,
+                memory=None,
+                count=workers_count)
+        else:
+            workers = rde_2_0_0.Workers(
+                sizing_class=None,
+                cpu=entity_status.nodes.workers[0].cpu,
+                memory=entity_status.nodes.workers[0].memory,
+                count=workers_count)
 
     nfs_count = len(entity_status.nodes.nfs)
     if nfs_count == 0:


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Use CPU and memory parameters for cluster operations.

Points to note:
* Clusters present after cse upgrade will have cpu and memory properties populated only if they are upgraded from legacy mode to non-legacy mode
* If the user specifies cpu or memory and sizing class during cluster creation, the creation should fail
  * cluster creation requires only one of sizing class or (cpu/memory)
* Users are not allowed to resize a cluster by specifying sizing class if the cluster is created using cpu/memory and vice versa
* The status section should contain cpu and memory values even if sizing class value is present.

Testing done:
* create cluster using sizing class
* create cluster using sizing class and cpu/mem (should fail)
* resize cluster created using cpu/mem by specifying sizing class (should fail)
* resize cluster created using cpu/mem using cpu/mem
* resize cluster created using sizing class using sizing class
* check if the cluster contains values for cpu and memory all the time
* after cse upgrade from legacy mode, resize the cluster using sizing class (should fail because legacy mode doesn't support creation of cluster using sizing class) (TODO)


@sahithi @sakthisunda @ltimothy7 @arunmk @rocknes 