### PR TITLE
[VCDA-2669] Replace float version comparisions with version object comparisons

### DIFF
--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import pyvcloud.vcd.client as vcd_client
-from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 
 from container_service_extension.client.de_cluster import DECluster
 from container_service_extension.client.de_cluster_native import DEClusterNative  # noqa: E501

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -30,10 +30,10 @@ class Cluster:
 
         :return: instance of version specific client side cluster
         """
-        api_version = client.get_api_version()
-        if VCDApiVersion(api_version) < VCDApiVersion(vcd_client.ApiVersion.VERSION_35.value):   # noqa: E501
+        api_version = client.get_vcd_api_version()
+        if api_version < vcd_client.VcdApiVersionObj.VERSION_35.value:
             return LegacyClusterNative(client)
-        elif VCDApiVersion(api_version) >= VCDApiVersion(vcd_client.ApiVersion.VERSION_35.value):  # noqa: E501
+        elif api_version >= vcd_client.VcdApiVersionObj.VERSION_35.value:
             if k8_runtime in CSE_SERVER_RUNTIMES:
                 return DEClusterNative(client)
             elif k8_runtime == ClusterEntityKind.TKG_S.value:

--- a/container_service_extension/client/cluster.py
+++ b/container_service_extension/client/cluster.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import pyvcloud.vcd.client as vcd_client
+from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 
 from container_service_extension.client.de_cluster import DECluster
 from container_service_extension.client.de_cluster_native import DEClusterNative  # noqa: E501
@@ -30,9 +31,9 @@ class Cluster:
         :return: instance of version specific client side cluster
         """
         api_version = client.get_api_version()
-        if float(api_version) < float(vcd_client.ApiVersion.VERSION_35.value):   # noqa: E501
+        if VCDApiVersion(api_version) < VCDApiVersion(vcd_client.ApiVersion.VERSION_35.value):   # noqa: E501
             return LegacyClusterNative(client)
-        elif float(api_version) >= float(vcd_client.ApiVersion.VERSION_35.value):  # noqa: E501
+        elif VCDApiVersion(api_version) >= VCDApiVersion(vcd_client.ApiVersion.VERSION_35.value):  # noqa: E501
             if k8_runtime in CSE_SERVER_RUNTIMES:
                 return DEClusterNative(client)
             elif k8_runtime == ClusterEntityKind.TKG_S.value:

--- a/container_service_extension/client/de_cluster_tkg_s.py
+++ b/container_service_extension/client/de_cluster_tkg_s.py
@@ -5,6 +5,7 @@
 import json
 
 from pyvcloud.vcd.client import ApiVersion
+from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 import yaml
 
 import container_service_extension.client.constants as cli_constants
@@ -55,7 +56,7 @@ class DEClusterTKGS:
 
         # api_version = self._client.get_api_version()
         # use api_version 37.0.0-alpha if VCD 10.3 is used.
-        if float(max_api_version) >= float(ApiVersion.VERSION_36.value):
+        if VCDApiVersion(max_api_version) >= VCDApiVersion(ApiVersion.VERSION_36.value):  # noqa: E501
             api_version = '37.0.0-alpha'
         self._tkg_s_client.set_default_header(cli_constants.TKGRequestHeaderKey.ACCEPT,  # noqa: E501
                                               f"application/json;version={api_version}")  # noqa: E501

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import pyvcloud.vcd.client as vcd_client
-from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 
 from container_service_extension.client.metadata_based_ovdc import MetadataBasedOvdc  # noqa: E501
 from container_service_extension.client.policy_based_ovdc import PolicyBasedOvdc  # noqa: E501
@@ -21,8 +20,9 @@ class Ovdc:
         :param pyvcloud.vcd.client client: vcd client
         :return: instance of version specific client side Ovdc class
         """
-        api_version = client.get_api_version()
-        if VCDApiVersion(api_version) < VCDApiVersion(vcd_client.ApiVersion.VERSION_35.value):  # noqa: E501
+        api_version = client.get_vcd_api_version()
+        
+        if api_version < vcd_client.VcdApiVersionObj.VERSION_35.value:
             return MetadataBasedOvdc(client)
-        elif VCDApiVersion(api_version) >= VCDApiVersion(vcd_client.ApiVersion.VERSION_35.value):  # noqa: E501
+        elif api_version >= vcd_client.VcdApiVersionObj.VERSION_35.value:  # noqa: E501
             return PolicyBasedOvdc(client)

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import pyvcloud.vcd.client as vcd_client
+from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 
 from container_service_extension.client.metadata_based_ovdc import MetadataBasedOvdc  # noqa: E501
 from container_service_extension.client.policy_based_ovdc import PolicyBasedOvdc  # noqa: E501
@@ -21,7 +22,7 @@ class Ovdc:
         :return: instance of version specific client side Ovdc class
         """
         api_version = client.get_api_version()
-        if float(api_version) < float(vcd_client.ApiVersion.VERSION_35.value):
+        if VCDApiVersion(api_version) < VCDApiVersion(vcd_client.ApiVersion.VERSION_35.value):  # noqa: E501
             return MetadataBasedOvdc(client)
-        elif float(api_version) >= float(vcd_client.ApiVersion.VERSION_35.value):  # noqa: E501
+        elif VCDApiVersion(api_version) >= VCDApiVersion(vcd_client.ApiVersion.VERSION_35.value):  # noqa: E501
             return PolicyBasedOvdc(client)

--- a/container_service_extension/client/ovdc.py
+++ b/container_service_extension/client/ovdc.py
@@ -21,7 +21,7 @@ class Ovdc:
         :return: instance of version specific client side Ovdc class
         """
         api_version = client.get_vcd_api_version()
-        
+
         if api_version < vcd_client.VcdApiVersionObj.VERSION_35.value:
             return MetadataBasedOvdc(client)
         elif api_version >= vcd_client.VcdApiVersionObj.VERSION_35.value:  # noqa: E501

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -5,7 +5,7 @@
 """Utility methods used only by the CLI client."""
 
 import click
-from pyvcloud.vcd.client import Client
+from pyvcloud.vcd.client import Client, VcdApiVersionObj
 import pyvcloud.vcd.org as vcd_org
 import pyvcloud.vcd.utils as vcd_utils
 from pyvcloud.vcd.vcd_api_version import VCDApiVersion
@@ -140,11 +140,11 @@ def _override_client(ctx) -> None:
                 if is_cse_server_running_in_legacy_mode:
                     common_supported_api_versions = \
                         [VCDApiVersion(x) for x in common_supported_api_versions  # noqa: E501
-                            if VCDApiVersion(x) < VCDApiVersion('35.0')]
+                            if VCDApiVersion(x) < VcdApiVersionObj.VERSION_35.value]  # noqa: E501
                 else:
                     common_supported_api_versions = \
                         [VCDApiVersion(x) for x in common_supported_api_versions  # noqa: E501
-                            if VCDApiVersion(x) >= VCDApiVersion('35.0')]
+                            if VCDApiVersion(x) >= VcdApiVersionObj.VERSION_35.value]  # noqa: E501
 
                 cse_server_api_version = \
                     str(max(common_supported_api_versions))

--- a/container_service_extension/client/utils.py
+++ b/container_service_extension/client/utils.py
@@ -8,6 +8,7 @@ import click
 from pyvcloud.vcd.client import Client
 import pyvcloud.vcd.org as vcd_org
 import pyvcloud.vcd.utils as vcd_utils
+from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 import requests
 import semantic_version
 import six
@@ -138,12 +139,12 @@ def _override_client(ctx) -> None:
                 # ToDo: Instead of float use proper version comparison
                 if is_cse_server_running_in_legacy_mode:
                     common_supported_api_versions = \
-                        [float(x) for x in common_supported_api_versions
-                            if float(x) < 35.0]
+                        [VCDApiVersion(x) for x in common_supported_api_versions  # noqa: E501
+                            if VCDApiVersion(x) < VCDApiVersion('35.0')]
                 else:
                     common_supported_api_versions = \
-                        [float(x) for x in common_supported_api_versions
-                            if float(x) >= 35.0]
+                        [VCDApiVersion(x) for x in common_supported_api_versions  # noqa: E501
+                            if VCDApiVersion(x) >= VCDApiVersion('35.0')]
 
                 cse_server_api_version = \
                     str(max(common_supported_api_versions))

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -7,9 +7,8 @@
 from dataclasses import dataclass
 from enum import Enum
 from enum import unique
-from pyvcloud.vcd.client import VcdApiVersionObj
 
-from pyvcloud.vcd.vcd_api_version import VCDApiVersion
+from pyvcloud.vcd.client import VcdApiVersionObj
 import requests
 import semantic_version
 

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -7,6 +7,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from enum import unique
+from pyvcloud.vcd.client import VcdApiVersionObj
 
 from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 import requests
@@ -66,7 +67,7 @@ MQTT_EXTENSION_VENDOR = 'VMWare'
 MQTT_EXTENSION_URN = 'urn:vcloud:extension-api:' + MQTT_EXTENSION_VENDOR + ':'\
                      + CSE_SERVICE_NAME + ':' + MQTT_EXTENSION_VERSION
 MQTT_EXTENSION_PRIORITY = 100
-MQTT_MIN_API_VERSION = VCDApiVersion('35.0')
+MQTT_MIN_API_VERSION = VcdApiVersionObj.VERSION_35.value
 MQTT_TOKEN_NAME = "mqttCseToken"
 TOKEN_PATH = 'tokens'
 

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from enum import Enum
 from enum import unique
 
+from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 import requests
 import semantic_version
 
@@ -65,7 +66,7 @@ MQTT_EXTENSION_VENDOR = 'VMWare'
 MQTT_EXTENSION_URN = 'urn:vcloud:extension-api:' + MQTT_EXTENSION_VENDOR + ':'\
                      + CSE_SERVICE_NAME + ':' + MQTT_EXTENSION_VERSION
 MQTT_EXTENSION_PRIORITY = 100
-MQTT_MIN_API_VERSION = 35.0
+MQTT_MIN_API_VERSION = VCDApiVersion('35.0')
 MQTT_TOKEN_NAME = "mqttCseToken"
 TOKEN_PATH = 'tokens'
 

--- a/container_service_extension/common/utils/core_utils.py
+++ b/container_service_extension/common/utils/core_utils.py
@@ -15,6 +15,7 @@ import urllib
 
 import click
 import pkg_resources
+from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 import requests
 import semantic_version
 
@@ -402,4 +403,4 @@ def extract_id_from_href(href):
 # without converting the strings to float.
 # e.g. 5.20 will be smaller than 5.8 if compared as float, which is wrong
 def get_max_api_version(api_versions: List[str]) -> str:
-    return str(max(float(x) for x in api_versions))
+    return str(max(VCDApiVersion(x) for x in api_versions))

--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -59,7 +59,7 @@ from container_service_extension.security.encryption_engine import \
 from container_service_extension.server.pks.pks_cache import Credentials
 
 
-_MAX_API_VERSION_TO_RUN_CSE_WITH_AMQP_IN_NON_LEGACY_MODE = VcdApiVersionObj.VERSION_35.value
+_MAX_API_VERSION_TO_RUN_CSE_WITH_AMQP_IN_NON_LEGACY_MODE = VcdApiVersionObj.VERSION_35.value  # noqa: E501
 
 
 def get_validated_config(config_file_name,
@@ -297,7 +297,7 @@ def _raise_error_if_amqp_not_supported(is_mqtt_used, default_api_version,
     :raises: AmqpError
     """
     if not is_mqtt_used and VCDApiVersion(default_api_version) > \
-        _MAX_API_VERSION_TO_RUN_CSE_WITH_AMQP_IN_NON_LEGACY_MODE:
+            _MAX_API_VERSION_TO_RUN_CSE_WITH_AMQP_IN_NON_LEGACY_MODE:
         msg = f"Cannot use AMQP message bus when working with api version" \
             f" {default_api_version}. Please upgrade to MQTT."
         logger.error(msg)

--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 import cryptography
 import pika
-from pyvcloud.vcd.client import BasicLoginCredentials
+from pyvcloud.vcd.client import BasicLoginCredentials, VcdApiVersionObj
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.platform import Platform
 from pyvcloud.vcd.vcd_api_version import VCDApiVersion
@@ -59,7 +59,7 @@ from container_service_extension.security.encryption_engine import \
 from container_service_extension.server.pks.pks_cache import Credentials
 
 
-_MAX_API_VERSION_TO_RUN_CSE_WITH_AMQP_IN_NON_LEGACY_MODE = '35.0'
+_MAX_API_VERSION_TO_RUN_CSE_WITH_AMQP_IN_NON_LEGACY_MODE = VcdApiVersionObj.VERSION_35.value
 
 
 def get_validated_config(config_file_name,
@@ -253,11 +253,11 @@ def _add_additional_details_to_config(
         if is_legacy_mode:
             common_supported_api_versions = \
                 [x for x in common_supported_api_versions
-                 if VCDApiVersion(x) < VCDApiVersion('35.0')]
+                 if VCDApiVersion(x) < VcdApiVersionObj.VERSION_35.value]
         else:
             common_supported_api_versions = \
                 [x for x in common_supported_api_versions
-                 if VCDApiVersion(x) >= VCDApiVersion('35.0')]
+                 if VCDApiVersion(x) >= VcdApiVersionObj.VERSION_35.value]
         config['service']['supported_api_versions'] = \
             common_supported_api_versions
     finally:
@@ -297,7 +297,7 @@ def _raise_error_if_amqp_not_supported(is_mqtt_used, default_api_version,
     :raises: AmqpError
     """
     if not is_mqtt_used and VCDApiVersion(default_api_version) > \
-            VCDApiVersion(_MAX_API_VERSION_TO_RUN_CSE_WITH_AMQP_IN_NON_LEGACY_MODE):  # noqa: E501
+        _MAX_API_VERSION_TO_RUN_CSE_WITH_AMQP_IN_NON_LEGACY_MODE:
         msg = f"Cannot use AMQP message bus when working with api version" \
             f" {default_api_version}. Please upgrade to MQTT."
         logger.error(msg)

--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -9,6 +9,7 @@ import pika
 from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.platform import Platform
+from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 from pyVmomi import vim
 import requests
 from requests.exceptions import HTTPError
@@ -252,11 +253,11 @@ def _add_additional_details_to_config(
         if is_legacy_mode:
             common_supported_api_versions = \
                 [x for x in common_supported_api_versions
-                 if float(x) < 35.0]
+                 if VCDApiVersion(x) < VCDApiVersion('35.0')]
         else:
             common_supported_api_versions = \
                 [x for x in common_supported_api_versions
-                 if float(x) >= 35.0]
+                 if VCDApiVersion(x) >= VCDApiVersion('35.0')]
         config['service']['supported_api_versions'] = \
             common_supported_api_versions
     finally:
@@ -295,8 +296,8 @@ def _raise_error_if_amqp_not_supported(is_mqtt_used, default_api_version,
     :param str default_api_version: max VCD API version used by CSE.
     :raises: AmqpError
     """
-    if not is_mqtt_used and float(default_api_version) > \
-            float(_MAX_API_VERSION_TO_RUN_CSE_WITH_AMQP_IN_NON_LEGACY_MODE):
+    if not is_mqtt_used and VCDApiVersion(default_api_version) > \
+            VCDApiVersion(_MAX_API_VERSION_TO_RUN_CSE_WITH_AMQP_IN_NON_LEGACY_MODE):  # noqa: E501
         msg = f"Cannot use AMQP message bus when working with api version" \
             f" {default_api_version}. Please upgrade to MQTT."
         logger.error(msg)

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -9,6 +9,7 @@ import pyvcloud.vcd.api_extension as api_extension
 from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.client import NSMAP
+from pyvcloud.vcd.client import VcdApiVersionObj
 from pyvcloud.vcd.exceptions import AccessForbiddenException
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import MissingRecordException
@@ -209,7 +210,7 @@ def parse_cse_extension_description(description: str):
             vcd_api_tokens = tokens[1].split("-")
             if len(vcd_api_tokens) == 2:
                 vcd_api_version = vcd_api_tokens[1]
-                if VCDApiVersion(vcd_api_version) >= VCDApiVersion('35.0'):
+                if VCDApiVersion(vcd_api_version) >= VcdApiVersionObj.VERSION_35.value:  # noqa: E501
                     legacy_mode = False
         result = {
             server_constants.CSE_VERSION_KEY: cse_version,

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -16,6 +16,7 @@ from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.role import Role
 import pyvcloud.vcd.utils as pyvcloud_vcd_utils
 from pyvcloud.vcd.vapp import VApp
+from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 import requests
 import semantic_version
 
@@ -208,7 +209,7 @@ def parse_cse_extension_description(description: str):
             vcd_api_tokens = tokens[1].split("-")
             if len(vcd_api_tokens) == 2:
                 vcd_api_version = vcd_api_tokens[1]
-                if float(vcd_api_version) >= 35.0:
+                if VCDApiVersion(vcd_api_version) >= VCDApiVersion('35.0'):
                     legacy_mode = False
         result = {
             server_constants.CSE_VERSION_KEY: cse_version,

--- a/container_service_extension/lib/cloudapi/cloudapi_client.py
+++ b/container_service_extension/lib/cloudapi/cloudapi_client.py
@@ -43,6 +43,7 @@ class CloudApiClient(object):
         self._last_response = None
         self.is_sys_admin = is_sys_admin
         self._api_version = api_version
+        self._vcd_api_version = VCDApiVersion(api_version)
 
     def get_api_version(self):
         return self._api_version

--- a/container_service_extension/lib/cloudapi/cloudapi_client.py
+++ b/container_service_extension/lib/cloudapi/cloudapi_client.py
@@ -49,7 +49,7 @@ class CloudApiClient(object):
         return self._api_version
 
     def get_vcd_api_version(self):
-        return VCDApiVersion(self._api_version)
+        return self._vcd_api_version
 
     def get_base_url(self):
         return self._base_url

--- a/container_service_extension/lib/cloudapi/cloudapi_client.py
+++ b/container_service_extension/lib/cloudapi/cloudapi_client.py
@@ -7,6 +7,7 @@ import json
 import logging
 from urllib import parse
 
+from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 import requests
 
 from container_service_extension.lib.cloudapi.constants import ResponseKeys
@@ -45,6 +46,9 @@ class CloudApiClient(object):
 
     def get_api_version(self):
         return self._api_version
+
+    def get_vcd_api_version(self):
+        return VCDApiVersion(self._api_version)
 
     def get_base_url(self):
         return self._base_url

--- a/container_service_extension/mqi/mqtt_extension_manager.py
+++ b/container_service_extension/mqi/mqtt_extension_manager.py
@@ -73,7 +73,7 @@ class MQTTExtensionManager:
                  debug_logger=logger.SERVER_LOGGER, log_wire=True):
         # Ensure correct credentials and api version
         vcd_utils.raise_error_if_user_not_from_system_org(sysadmin_client)
-        client_api_version = float(sysadmin_client.get_api_version())
+        client_api_version = sysadmin_client.get_vcd_api_version()
         if client_api_version < constants.MQTT_MIN_API_VERSION:
             raise ValueError(f'API version {client_api_version} '
                              f'is less than required version '

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -7,6 +7,7 @@ import json
 from typing import List, Tuple, Union
 
 import pyvcloud.vcd.client as vcd_client
+from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 from requests.exceptions import HTTPError
 
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
@@ -273,11 +274,11 @@ class DefEntityService:
         :rtype: Union[DefEntity, Tuple[DefEntity, dict]]
         """
         resource_url_relative_path = f"{CloudApiResource.ENTITIES}/{entity_id}"
-        vcd_api_version = self._cloudapi_client.get_api_version()
+        vcd_api_version = self._cloudapi_client.get_vcd_api_version()
         # TODO Float conversions must be changed to Semantic versioning.
         # TODO: Also include any persona having Administrator:FullControl
         #  on CSE:nativeCluster
-        if float(vcd_api_version) >= float(vcd_client.ApiVersion.VERSION_36.value) and \
+        if vcd_api_version >= VCDApiVersion(vcd_client.ApiVersion.VERSION_36.value) and \
                 self._cloudapi_client.is_sys_admin and not invoke_hooks:  # noqa: E501
             resource_url_relative_path += f"?invokeHooks={str(invoke_hooks).lower()}"  # noqa: E501
 
@@ -320,7 +321,7 @@ class DefEntityService:
         :param str entity_id: Id of the entity.
         :return: Details of the entity.
         :rtype: DefEntity
-        """
+    """
         response_body = self._cloudapi_client.do_request(
             method=RequestMethod.GET,
             cloudapi_version=CloudApiVersion.VERSION_1_0_0,
@@ -421,7 +422,7 @@ class DefEntityService:
         """
         # response will be a tuple (response_body, response_header) if
         # is_request_async is true. Else, it will be just response_body
-        vcd_api_version = self._cloudapi_client.get_api_version()
+        vcd_api_version = self._cloudapi_client.get_vcd_api_version()
         resource_url_relative_path = f"{CloudApiResource.ENTITIES}/{entity_id}"
 
         # TODO: Also include any persona having Administrator:FullControl

--- a/container_service_extension/rde/constants.py
+++ b/container_service_extension/rde/constants.py
@@ -6,6 +6,8 @@
 from enum import Enum
 from enum import unique
 
+from pyvcloud.vcd.vcd_api_version import VCDApiVersion
+
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
 
 CLUSTER_ACL_LIST_FIELDS = [shared_constants.AccessControlKey.ACCESS_LEVEL_ID,
@@ -17,7 +19,7 @@ ACTION_CONTROL_ACCESS_PATH = '/action/controlAccess/'
 DEF_INTERFACE_ID_PREFIX = 'urn:vcloud:interface'
 DEF_NATIVE_ENTITY_TYPE_NSS = 'nativeCluster'
 DEF_ENTITY_TYPE_ID_PREFIX = 'urn:vcloud:type'
-DEF_API_MIN_VERSION = 35.0
+DEF_API_MIN_VERSION = VCDApiVersion('35.0')
 DEF_SCHEMA_DIRECTORY = 'cse_def_schema'
 DEF_ERROR_MESSAGE_KEY = 'message'
 DEF_RESOLVED_STATE = 'RESOLVED'
@@ -120,8 +122,8 @@ class RDEMetadataKey(str, Enum):
 # 37.0: 3.0.0 (Newly introduced RDE)
 # }
 MAP_VCD_API_VERSION_TO_RUNTIME_RDE_VERSION = {
-    '35.0': RuntimeRDEVersion.RDE_1_X.value,
-    '36.0': RuntimeRDEVersion.RDE_2_X.value
+    35: RuntimeRDEVersion.RDE_1_X.value,
+    36: RuntimeRDEVersion.RDE_2_X.value
 }
 
 # Below map answers the question - "what is the RDE version introduced by CSE

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -6,10 +6,10 @@
 import importlib
 from importlib import resources as pkg_resources
 import json
-import math
 from typing import Type
 from typing import Union
 
+from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 import semantic_version
 
 import container_service_extension.common.utils.core_utils as core_utils
@@ -28,7 +28,7 @@ def raise_error_if_def_not_supported(cloudapi_client: CloudApiClient):
 
     :param cloudapi_client CloudApiClient
     """
-    if float(cloudapi_client.get_api_version()) < \
+    if cloudapi_client.get_vcd_api_version() < \
             def_constants.DEF_API_MIN_VERSION:
         raise exceptions.DefNotSupportedException(
             "Defined entity framework is not"
@@ -66,7 +66,7 @@ def generate_entity_type_id(vendor, nss, version):
 
 
 def get_runtime_rde_version_by_vcd_api_version(vcd_api_version: str) -> str:
-    major_vcd_api_version = str(math.floor(float(vcd_api_version)) * 1.0)
+    major_vcd_api_version = VCDApiVersion(vcd_api_version).major
     val = def_constants.MAP_VCD_API_VERSION_TO_RUNTIME_RDE_VERSION.get(major_vcd_api_version)  # noqa: E501
     if not val:
         val = '0.0.0'

--- a/container_service_extension/server/compute_policy_manager.py
+++ b/container_service_extension/server/compute_policy_manager.py
@@ -7,6 +7,7 @@ from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 from pyvcloud.vcd.task import Task
 from pyvcloud.vcd.utils import retrieve_compute_policy_id_from_href
+from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 from pyvcloud.vcd.vm import VM
 import requests
 
@@ -22,7 +23,7 @@ import container_service_extension.logging.logger as logger
 # cse compute policy prefix
 CSE_COMPUTE_POLICY_PREFIX = 'cse----'
 _SYSTEM_DEFAULT_COMPUTE_POLICY = 'System Default'
-GLOBAL_PVDC_COMPUTE_POLICY_MIN_VERSION = 35.0
+GLOBAL_PVDC_COMPUTE_POLICY_MIN_VERSION = VCDApiVersion('35.0')
 PVDC_VM_POLICY_NAME = "PvdcVmPolicy"
 VDC_VM_POLICY_NAME = "VdcVmPolicy"
 
@@ -56,7 +57,7 @@ class ComputePolicyManager:
                                                               wire_logger)
             self._cloudapi_version = \
                 cloudapi_constants.CloudApiVersion.VERSION_2_0_0
-            if float(self._cloudapi_client.get_api_version()) < \
+            if self._cloudapi_client.get_vcd_api_version() < \
                     GLOBAL_PVDC_COMPUTE_POLICY_MIN_VERSION:
                 self._cloudapi_version = \
                     cloudapi_constants.CloudApiVersion.VERSION_1_0_0
@@ -534,7 +535,7 @@ class ComputePolicyManager:
 
     def _raise_error_if_global_pvdc_compute_policy_not_supported(self):
         """Raise exception if higher api version is needed."""
-        api_version = float(self._cloudapi_client.get_api_version())
+        api_version = self._cloudapi_client.get_vcd_api_version()
         if api_version < GLOBAL_PVDC_COMPUTE_POLICY_MIN_VERSION: # noqa: E501
             msg = f"Recieved api version {api_version}." \
                   f" But atleast {GLOBAL_PVDC_COMPUTE_POLICY_MIN_VERSION} is required" # noqa: E501

--- a/container_service_extension/server/compute_policy_manager.py
+++ b/container_service_extension/server/compute_policy_manager.py
@@ -7,7 +7,6 @@ from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 from pyvcloud.vcd.task import Task
 from pyvcloud.vcd.utils import retrieve_compute_policy_id_from_href
-from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 from pyvcloud.vcd.vm import VM
 import requests
 

--- a/container_service_extension/server/compute_policy_manager.py
+++ b/container_service_extension/server/compute_policy_manager.py
@@ -23,7 +23,7 @@ import container_service_extension.logging.logger as logger
 # cse compute policy prefix
 CSE_COMPUTE_POLICY_PREFIX = 'cse----'
 _SYSTEM_DEFAULT_COMPUTE_POLICY = 'System Default'
-GLOBAL_PVDC_COMPUTE_POLICY_MIN_VERSION = VCDApiVersion('35.0')
+GLOBAL_PVDC_COMPUTE_POLICY_MIN_VERSION = vcd_client.VcdApiVersionObj.VERSION_35.value  # noqa: E501
 PVDC_VM_POLICY_NAME = "PvdcVmPolicy"
 VDC_VM_POLICY_NAME = "VdcVmPolicy"
 

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -574,7 +574,7 @@ class Service(object, metaclass=Singleton):
         msg_update_callback.general(msg)
         try:
             sysadmin_client = vcd_utils.get_sys_admin_client(api_version=None)
-            if float(sysadmin_client.get_api_version()) < compute_policy_manager.GLOBAL_PVDC_COMPUTE_POLICY_MIN_VERSION:  # noqa: E501
+            if sysadmin_client.get_vcd_api_version() < compute_policy_manager.GLOBAL_PVDC_COMPUTE_POLICY_MIN_VERSION:  # noqa: E501
                 msg = "Placement policies for kubernetes runtimes not " \
                       " supported in api version " \
                       f"{sysadmin_client.get_api_version()}"  # noqa: E501


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Using VCDApiVersion object for comparing versions instead of converting to float.

Testing done:
* cse upgrade
* cse run
* cluster create (TODO)
* cluster resize (TODO)

@sakthisunda @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1180)
<!-- Reviewable:end -->
