### PR TITLE
[VCDA-2855] Let CSE server startup without a default native template

### DIFF
--- a/container_service_extension/client/template_commands.py
+++ b/container_service_extension/client/template_commands.py
@@ -49,7 +49,6 @@ def list_templates(ctx, is_tkgm):
         value_field_to_display_field = {
             'name': 'Name',
             'revision': 'Revision',
-            'is_default': 'Default',
             'catalog': 'Catalog',
             'catalog_item': 'Catalog Item',
             'description': 'Description'

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -783,10 +783,10 @@ class PreCustomizationPhase(Enum):
 @unique
 class PostCustomizationPhase(Enum):
     HOSTNAME_SETUP = 'guestinfo.postcustomization.hostname.status'
-    NETWORK_CONFIGURATION = 'guestinfo.postcustomization.networkconfiguration.status'
+    NETWORK_CONFIGURATION = 'guestinfo.postcustomization.networkconfiguration.status'  # noqa: E501
     STORE_SSH_KEY = 'guestinfo.postcustomization.store.sshkey.status'
     KUBEADM_INIT = 'guestinfo.postcustomization.kubeinit.status'
-    NAMESERVER_SETUP = 'guestinfo.postcustomization.nameserverconfig.resolvconf.status'
+    NAMESERVER_SETUP = 'guestinfo.postcustomization.nameserverconfig.resolvconf.status'  # noqa: E501
     KUBECTL_APPLY_CNI = 'guestinfo.postcustomization.kubectl.apply.cni.status'  # noqa: E501
     KUBEADM_TOKEN_GENERATE = 'guestinfo.postcustomization.kubeadm.token.generate.status'  # noqa: E501
     KUBEADM_NODE_JOIN = 'guestinfo.postcustomization.kubeadm.node.join.status'

--- a/container_service_extension/common/utils/server_utils.py
+++ b/container_service_extension/common/utils/server_utils.py
@@ -45,14 +45,6 @@ def get_registered_def_interface() -> common_models.DefInterface:
     return Service().get_kubernetes_interface()
 
 
-def get_default_k8_distribution():
-    config = get_server_runtime_config()
-    import container_service_extension.rde.models.rde_1_0_0 as rde_1_0_0
-    return rde_1_0_0.Distribution(
-        template_name=config['broker']['default_template_name'],
-        template_revision=config['broker']['default_template_revision'])
-
-
 def get_pks_cache():
     from container_service_extension.server.service import Service
     return Service().get_pks_cache()

--- a/container_service_extension/installer/sample_generator.py
+++ b/container_service_extension/installer/sample_generator.py
@@ -124,8 +124,6 @@ SAMPLE_BROKER_CONFIG = {
         'network': 'my_network',
         'ip_allocation_mode': 'pool',
         'storage_profile': '*',
-        'default_template_name': 'my_template',
-        'default_template_revision': 0,
         'remote_template_cookbook_url': 'https://raw.githubusercontent.com/vmware/container-service-extension-templates/master/template_v2.yaml',  # noqa: E501
     }
 }

--- a/container_service_extension/installer/sample_generator.py
+++ b/container_service_extension/installer/sample_generator.py
@@ -124,7 +124,7 @@ SAMPLE_BROKER_CONFIG = {
         'network': 'my_network',
         'ip_allocation_mode': 'pool',
         'storage_profile': '*',
-        'remote_template_cookbook_url': 'https://raw.githubusercontent.com/vmware/container-service-extension-templates/master/template_v2.yaml',  # noqa: E501
+        'remote_template_cookbook_url': 'https://raw.githubusercontent.com/vmware/container-service-extension-templates/master/template_v2.yaml'  # noqa: E501
     }
 }
 

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -2321,7 +2321,7 @@ def _cluster_exists(client, cluster_name, org_name=None, ovdc_name=None):
 def _get_template(name=None, revision=None):
     if not name or not revision:
         raise ValueError(
-            "Template name and revision both must be is specified."
+            "Template name and revision both must be specified."
         )
     server_config = server_utils.get_server_runtime_config()
     for template in server_config['broker']['templates']:

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -1935,7 +1935,7 @@ def _add_control_plane_nodes(
             # lives. Guest customization works with the following gross steps:
             # 1. run script with parameter "precustomization"
             # 2. set up network
-            # 3. convert script with parameter "precustomization" to service
+            # 3. convert script with parameter "postcustomization" to service
             #   a. set the 'guestinfo.gc.status' to 'Successful'.
             # 4. check if a forked script has completed setting up hostname
             #       (this fails sometimes)

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -112,12 +112,12 @@ def construct_2_0_0_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Sta
     control_plane_cpu = None
     control_plane_memory = None
     if (
-        entity_status is not None and
-        entity_status.nodes is not None and
+        entity_status is not None and  # noqa: W504
+        entity_status.nodes is not None and  # noqa: W504
         entity_status.nodes.control_plane is not None
     ):
-        control_plane_sizing_class = entity_status.nodes.control_plane.sizing_class
-        control_plane_storage_profile = entity_status.nodes.control_plane.storage_profile
+        control_plane_sizing_class = entity_status.nodes.control_plane.sizing_class  # noqa: E501
+        control_plane_storage_profile = entity_status.nodes.control_plane.storage_profile  # noqa: E501
         control_plane_cpu = entity_status.nodes.control_plane.cpu
         control_plane_memory = entity_status.nodes.control_plane.memory
         if control_plane_sizing_class:
@@ -136,14 +136,14 @@ def construct_2_0_0_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Sta
     worker_cpu = None
     worker_memory = None
     if (
-        entity_status is not None and
-        entity_status.nodes is not None and
+        entity_status is not None and  # noqa: W504
+        entity_status.nodes is not None and  # noqa: W504
         entity_status.nodes.workers is not None
     ):
         workers_count = len(entity_status.nodes.workers)
         if workers_count > 0:
             worker_sizing_class = entity_status.nodes.workers[0].sizing_class
-            worker_storage_profile = entity_status.nodes.workers[0].storage_profile
+            worker_storage_profile = entity_status.nodes.workers[0].storage_profile  # noqa: E501
             worker_cpu = entity_status.nodes.workers[0].cpu
             worker_memory = entity_status.nodes.workers[0].memory
         if worker_sizing_class:
@@ -159,8 +159,8 @@ def construct_2_0_0_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Sta
     nfs_sizing_class = None
     nfs_storage_profile = None
     if (
-        entity_status is not None and
-        entity_status.nodes is not None and
+        entity_status is not None and  # noqa: W504
+        entity_status.nodes is not None and  # noqa: W504
         entity_status.nodes.nfs is not None
     ):
         nfs_count = len(entity_status.nodes.nfs)

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -1089,10 +1089,6 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                         is_tkg_plus_enabled=is_tkg_plus_enabled,
                         org_name=org_name,
                         logger_debug=SERVER_CLI_LOGGER)
-                default_template_name = \
-                    config_dict['broker']['default_template_name']
-                default_template_revision = \
-                    str(config_dict['broker']['default_template_revision'])
 
                 for definition in local_template_definitions:
                     local_template = {
@@ -1106,12 +1102,7 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                     }
                     if legacy_mode:
                         local_template['compute_policy'] = definition[server_constants.LegacyLocalTemplateKey.COMPUTE_POLICY]  # noqa: E501
-                    # Any metadata read from vCD is sting due to how pyvcloud
-                    # is coded, so we need to cast it back to int.
-                    if (definition[server_constants.LocalTemplateKey.NAME], str(definition[server_constants.LocalTemplateKey.REVISION])) == (default_template_name, default_template_revision):  # noqa: E501
-                        local_template['default'] = 'Yes'
-                    else:
-                        local_template['default'] = 'No'
+                    local_template['default'] = 'No'
                     local_template['deprecated'] = 'Yes' if utils.str_to_bool(definition[server_constants.LocalTemplateKey.DEPRECATED]) else 'No'  # noqa: E501
 
                     local_templates.append(local_template)

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -1102,7 +1102,6 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                     }
                     if legacy_mode:
                         local_template['compute_policy'] = definition[server_constants.LegacyLocalTemplateKey.COMPUTE_POLICY]  # noqa: E501
-                    local_template['default'] = 'No'
                     local_template['deprecated'] = 'Yes' if utils.str_to_bool(definition[server_constants.LocalTemplateKey.DEPRECATED]) else 'No'  # noqa: E501
 
                     local_templates.append(local_template)
@@ -1135,8 +1134,6 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                 if legacy_mode:
                     remote_template['compute_policy'] = \
                         definition[remote_template_keys.COMPUTE_POLICY]
-                if display_option is DISPLAY_ALL:
-                    remote_template['default'] = 'No'
                 remote_template['deprecated'] = 'Yes' if utils.str_to_bool(definition[remote_template_keys.DEPRECATED]) else 'No'  # noqa: E501
 
                 remote_templates.append(remote_template)
@@ -1155,7 +1152,6 @@ def list_template(ctx, config_file_path, skip_config_decryption,
                             remote_template['compute_policy'] = \
                                 local_template['compute_policy']
                         remote_template['local'] = local_template['local']
-                        remote_template['default'] = local_template['default']
                         found = True
                         break
                 if not found:

--- a/container_service_extension/server/request_handlers/template_handler.py
+++ b/container_service_extension/server/request_handlers/template_handler.py
@@ -17,13 +17,10 @@ def template_list(request_data, op_ctx):
     """
     config = server_utils.get_server_runtime_config()
     templates = []
-    default_template_name = config['broker']['default_template_name']
-    default_template_revision = str(config['broker']['default_template_revision'])  # noqa: E501
 
     for t in config['broker']['templates']:
         template_name = t[LocalTemplateKey.NAME]
         template_revision = str(t[LocalTemplateKey.REVISION])
-        is_default = (template_name, template_revision) == (default_template_name, default_template_revision)  # noqa: E501
 
         templates.append({
             'catalog': config['broker']['catalog'],
@@ -33,7 +30,7 @@ def template_list(request_data, op_ctx):
             'deprecated': t[LocalTemplateKey.DEPRECATED],
             'description': t[LocalTemplateKey.DESCRIPTION].replace("\\n", ", "),  # noqa: E501
             'docker_version': t[LocalTemplateKey.DOCKER_VERSION],
-            'is_default': 'Yes' if is_default else 'No',
+            'is_default': 'No',
             'kind': t[LocalTemplateKey.KIND],
             'kubernetes': t[LocalTemplateKey.KUBERNETES],
             'kubernetes_version': t[LocalTemplateKey.KUBERNETES_VERSION],

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -650,33 +650,6 @@ class Service(object, metaclass=Singleton):
                 logger_debug=logger.SERVER_LOGGER,
                 msg_update_callback=msg_update_callback)
 
-            if not k8_templates:
-                msg = "No valid K8 templates were found in catalog " \
-                      f"'{catalog_name}'. Unable to start CSE server."
-                msg_update_callback.error(msg)
-                logger.SERVER_LOGGER.error(msg)
-                sys.exit(1)
-
-            # Check that default k8s template exists in vCD at the correct
-            # revision
-            default_template_name = \
-                self.config['broker']['default_template_name']
-            default_template_revision = \
-                str(self.config['broker']['default_template_revision'])
-            found_default_template = False
-            for template in k8_templates:
-                if str(template[server_constants.LocalTemplateKey.REVISION]) == default_template_revision and \
-                        template[server_constants.LocalTemplateKey.NAME] == default_template_name:  # noqa: E501
-                    found_default_template = True
-
-            if not found_default_template:
-                msg = f"Default template {default_template_name} with " \
-                      f"revision {default_template_revision} not found." \
-                      " Unable to start CSE server."
-                msg_update_callback.error(msg)
-                logger.SERVER_LOGGER.error(msg)
-                sys.exit(1)
-
             self.config['broker']['templates'] = k8_templates
         finally:
             if client:

--- a/container_service_extension/server/vcdbroker.py
+++ b/container_service_extension/server/vcdbroker.py
@@ -2015,7 +2015,8 @@ def _init_cluster(sysadmin_client: vcd_client.Client, vapp, template_name,
                 f"{node_names}:{errors}")
         if result[0][0] != 0:
             raise e.ClusterInitializationError(
-                f"Could not initialize cluster:\n{result[0][2].content.decode()}"
+                "Could not initialize cluster:\n"
+                f"{result[0][2].content.decode()}"
             )
     except Exception as err:
         LOGGER.error(err, exc_info=True)

--- a/container_service_extension/server/vcdbroker.py
+++ b/container_service_extension/server/vcdbroker.py
@@ -1817,12 +1817,11 @@ def _get_cluster(client, cluster_name, cluster_id=None, org_name=None,
 
 
 def _get_template(name=None, revision=None):
-    if (name is None and revision is not None) or (name is not None and revision is None):  # noqa: E501
-        raise ValueError("If template revision is specified, then template "
-                         "name must also be specified (and vice versa).")
+    if name is None or revision is None:
+        raise ValueError(
+            "Template name and revision both must be specified."
+        )
     server_config = server_utils.get_server_runtime_config()
-    name = name or server_config['broker']['default_template_name']
-    revision = revision or server_config['broker']['default_template_revision']
     for template in server_config['broker']['templates']:
         if (template[LocalTemplateKey.NAME], str(template[LocalTemplateKey.REVISION])) == (name, str(revision)):  # noqa: E501
             return template
@@ -2015,11 +2014,14 @@ def _init_cluster(sysadmin_client: vcd_client.Client, vapp, template_name,
                 f"Initialize cluster script execution failed on node "
                 f"{node_names}:{errors}")
         if result[0][0] != 0:
-            raise e.ClusterInitializationError(f"Couldn't initialize cluster:\n{result[0][2].content.decode()}")  # noqa: E501
+            raise e.ClusterInitializationError(
+                f"Could not initialize cluster:\n{result[0][2].content.decode()}"
+            )
     except Exception as err:
         LOGGER.error(err, exc_info=True)
         raise e.ClusterInitializationError(
-            f"Couldn't initialize cluster: {str(err)}")
+            f"Could not initialize cluster: {str(err)}"
+        )
 
 
 def _join_cluster(sysadmin_client: vcd_client.Client, vapp, template_name,
@@ -2060,11 +2062,12 @@ def _join_cluster(sysadmin_client: vcd_client.Client, vapp, template_name,
                                          f" {node_names}:{errors}")
         for result in worker_results:
             if result[0] != 0:
-                raise e.ClusterJoiningError(f"Couldn't join cluster:"
-                                            f"\n{result[2].content.decode()}")
+                raise e.ClusterJoiningError(
+                    f"Could not join cluster:\n{result[2].content.decode()}"
+                )
     except Exception as err:
         LOGGER.error(err, exc_info=True)
-        raise e.ClusterJoiningError(f"Couldn't join cluster: {str(err)}")
+        raise e.ClusterJoiningError(f"Could not join cluster: {str(err)}")
 
 
 def _wait_until_ready_to_exec(vs, vm, password, tries=30):


### PR DESCRIPTION
Removed code that 
1. Checked for presence of at least one native template as well as default template during CSE server startup
2. Chose default template if none is provided during cluster operations. Now, an error would be thrown instead.
3. Generated default template and revision in sample config

Fixed a bunch of flake8 errors.

Testing:
Was able to successfully startup CSE with no native templates in system.

Tried to deploy a native cluster and verified that it failed with proper error.
```
(cse) D:\code\cse\container-service-extension>vcd task wait 12f5ef7a-d112-4c44-a218-73bde685c7ed
task: 12f5ef7a-d112-4c44-a218-73bde685c7ed, result: error, message: Template 'ubuntu-16.04_k8-1.20_weave-2.6.5' at revision 2 not found.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1182)
<!-- Reviewable:end -->
