### PR TITLE
VCDA-2877: Remove vmware internal nameserver

### DIFF
--- a/cluster_scripts/v2_x_tkgm/control_plane.sh
+++ b/cluster_scripts/v2_x_tkgm/control_plane.sh
@@ -72,7 +72,7 @@ vmtoolsd --cmd "info-set guestinfo.postcustomization.store.sshkey.status success
 vmtoolsd --cmd "info-set guestinfo.postcustomization.nameserverconfig.resolvconf.status in_progress"
   cat > /etc/systemd/resolved.conf << END
 [Resolve]
-DNS=10.166.1.201 8.8.8.8
+DNS=8.8.8.8
 END
 
   systemctl daemon-reload


### PR DESCRIPTION
Remove internal nameserver and keep google's

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1191)
<!-- Reviewable:end -->
