### PR TITLE
VCDA-2670, 2706, 2895: DNS and site validations

### DIFF
--- a/cluster_scripts/v2_x_tkgm/control_plane.sh
+++ b/cluster_scripts/v2_x_tkgm/control_plane.sh
@@ -135,7 +135,11 @@ vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeinit.status successful"
 
 
 vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.apply.cni.status in_progress"
-  kubectl apply -f https://github.com/vmware-tanzu/antrea/releases/download/{antrea_cni_version}/antrea.yml
+  antrea_path=/root/antrea-{antrea_cni_version}.yaml
+  wget -O $antrea_path https://github.com/vmware-tanzu/antrea/releases/download/{antrea_cni_version}/antrea.yml
+  # This does not need to be done from v0.12.0 onwards inclusive
+  sed -i 's/antrea\/antrea-ubuntu:{antrea_cni_version}/projects.registry.vmware.com\/antrea\/antrea-ubuntu:{antrea_cni_version}/g' $antrea_path
+  kubectl apply -f $antrea_path
 vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.apply.cni.status successful"
 
 

--- a/cluster_scripts/v2_x_tkgm/control_plane.sh
+++ b/cluster_scripts/v2_x_tkgm/control_plane.sh
@@ -163,7 +163,7 @@ vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.cpi.install.status 
 
 vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.csi.install.status in_progress"
   wget -O $vcloud_csi_configmap_path https://raw.githubusercontent.com/vmware/cloud-director-named-disk-csi-driver/0.1.0-beta/manifests/vcloud-csi-config.yaml
-  sed -i 's/VCD_HOST/"https:\/\/{vcd_host}"/' $vcloud_csi_configmap_path
+  sed -i 's/VCD_HOST/"{vcd_host}"/' $vcloud_csi_configmap_path
   sed -i 's/ORG/"{org}"/' $vcloud_csi_configmap_path
   sed -i 's/OVDC/"{vdc}"/' $vcloud_csi_configmap_path
   sed -i 's/CLUSTER_ID/"{cluster_id}"/' $vcloud_csi_configmap_path

--- a/cluster_scripts/v2_x_tkgm/control_plane.sh
+++ b/cluster_scripts/v2_x_tkgm/control_plane.sh
@@ -70,18 +70,6 @@ vmtoolsd --cmd "info-set guestinfo.postcustomization.store.sshkey.status in_prog
 vmtoolsd --cmd "info-set guestinfo.postcustomization.store.sshkey.status successful"
 
 
-vmtoolsd --cmd "info-set guestinfo.postcustomization.nameserverconfig.resolvconf.status in_progress"
-  cat > /etc/systemd/resolved.conf << END
-[Resolve]
-DNS=8.8.8.8 10.166.1.201
-END
-
-  systemctl daemon-reload
-  systemctl restart systemd-resolved.service
-  ln -fs /run/systemd/resolve/resolv.conf /etc/resolv.conf
-vmtoolsd --cmd "info-set guestinfo.postcustomization.nameserverconfig.resolvconf.status successful"
-
-
 vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeinit.status in_progress"
   # tag images
   coredns_image_version=""
@@ -156,7 +144,7 @@ vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.cpi.install.status 
   kubectl apply -f $vcloud_basic_auth_path
 
   wget -O $vcloud_configmap_path https://raw.githubusercontent.com/vmware/cloud-provider-for-cloud-director/0.1.0-beta/manifests/vcloud-configmap.yaml
-  sed -i 's/VCD_HOST/"https:\/\/{vcd_host}"/' $vcloud_configmap_path
+  sed -i 's/VCD_HOST/"{vcd_host}"/' $vcloud_configmap_path
   sed -i 's/ORG/"{org}"/' $vcloud_configmap_path
   sed -i 's/OVDC/"{vdc}"/' $vcloud_configmap_path
   sed -i 's/NETWORK/"{network_name}"/' $vcloud_configmap_path

--- a/cluster_scripts/v2_x_tkgm/node.sh
+++ b/cluster_scripts/v2_x_tkgm/node.sh
@@ -58,18 +58,6 @@ vmtoolsd --cmd "info-set guestinfo.postcustomization.store.sshkey.status in_prog
 vmtoolsd --cmd "info-set guestinfo.postcustomization.store.sshkey.status successful"
 
 
-vmtoolsd --cmd "info-set guestinfo.postcustomization.nameserverconfig.resolvconf.status in_progress"
-  cat > /etc/systemd/resolved.conf << END
-[Resolve]
-DNS=10.166.1.201 8.8.8.8
-END
-
-  systemctl daemon-reload
-  systemctl restart systemd-resolved.service
-  ln -fs /run/systemd/resolve/resolv.conf /etc/resolv.conf
-vmtoolsd --cmd "info-set guestinfo.postcustomization.nameserverconfig.resolvconf.status successful"
-
-
 vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.node.join.status in_progress"
   # tag images
   coredns_image_version=""

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -785,7 +785,6 @@ class PostCustomizationPhase(Enum):
     NETWORK_CONFIGURATION = 'guestinfo.postcustomization.networkconfiguration.status'  # noqa: E501
     STORE_SSH_KEY = 'guestinfo.postcustomization.store.sshkey.status'
     KUBEADM_INIT = 'guestinfo.postcustomization.kubeinit.status'
-    NAMESERVER_SETUP = 'guestinfo.postcustomization.nameserverconfig.resolvconf.status'  # noqa: E501
     KUBECTL_APPLY_CNI = 'guestinfo.postcustomization.kubectl.apply.cni.status'  # noqa: E501
     KUBEADM_TOKEN_GENERATE = 'guestinfo.postcustomization.kubeadm.token.generate.status'  # noqa: E501
     KUBEADM_NODE_JOIN = 'guestinfo.postcustomization.kubeadm.node.join.status'

--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -344,7 +344,7 @@ def _validate_amqp_config(amqp_dict, msg_update_callback=NullPrinter()):
             connection.close()
 
 
-def _validate_vcd_url(vcd_url: Optional[str]) -> None:
+def _validate_vcd_url_scheme(vcd_url: Optional[str]) -> None:
     """Ensures that the 'host' parameter in the config is valid.
 
     Checks that
@@ -402,7 +402,7 @@ def _validate_vcd_and_vcs_config(vcd_dict,
 
     client = None
     try:
-        _validate_vcd_url(vcd_dict['host'])
+        _validate_vcd_url_scheme(vcd_dict['host'])
         client = Client(vcd_dict['host'],
                         verify_ssl_certs=vcd_dict['verify'],
                         log_file=log_file,

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -245,7 +245,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             # check that the vcd site is a valid url
             if not _is_valid_vcd_url(vcd_site):
                 raise exceptions.CseServerError(
-                    f"Invalid site '{vcd_site}'")
+                    f"'{vcd_site}' should have a https scheme"
+                    f" and match CSE server config file.")
 
             # check that cluster name is syntactically valid
             if not _is_valid_cluster_name(cluster_name):

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -427,8 +427,10 @@ class DefEntityService:
 
         # TODO: Also include any persona having Administrator:FullControl
         #  on CSE:nativeCluster
-        if float(vcd_api_version) >= float(vcd_client.ApiVersion.VERSION_36.value) and \
-                self._cloudapi_client.is_sys_admin and not invoke_hooks:  # noqa: E501
+        if (
+            vcd_api_version >= VCDApiVersion(vcd_client.ApiVersion.VERSION_36.value)
+            and self._cloudapi_client.is_sys_admin and not invoke_hooks
+        ):
             resource_url_relative_path += f"?invokeHooks={str(invoke_hooks).lower()}"  # noqa: E501
 
         response = self._cloudapi_client.do_request(

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,9 @@ pyvmomi >= 6.7.0, < 7.0.0
 # semantic-version 2.8.5
 semantic-version >= 2.8.4, < 3.0.0
 
+# validators 0.18.2
+validators ~= 0.18.2
+
 # vcd-cli 24.0.1
 vcd-cli >= 24.0.1, < 25.0.0
 
@@ -36,3 +39,15 @@ vsphere-guest-run >= 0.0.7, < 1.0.0
 
 # dataclasses-json
 dataclasses-json >= 0.5.2, < 1.0.0
+
+setuptools~=57.1.0
+six~=1.16.0
+virtualenv~=20.7.2
+wheel~=0.36.2
+requests~=2.26.0
+pytest~=6.2.4
+certifi~=2021.5.30
+urllib3~=1.26.6
+lxml~=4.6.3
+PyYAML~=5.4.1
+click~=8.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,15 +39,3 @@ vsphere-guest-run >= 0.0.7, < 1.0.0
 
 # dataclasses-json
 dataclasses-json >= 0.5.2, < 1.0.0
-
-setuptools~=57.1.0
-six~=1.16.0
-virtualenv~=20.7.2
-wheel~=0.36.2
-requests~=2.26.0
-pytest~=6.2.4
-certifi~=2021.5.30
-urllib3~=1.26.6
-lxml~=4.6.3
-PyYAML~=5.4.1
-click~=8.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ vsphere-guest-run >= 0.0.7, < 1.0.0
 
 # dataclasses-json
 dataclasses-json >= 0.5.2, < 1.0.0
+


### PR DESCRIPTION
VCDA-2670: vcd['host'] should not specify scheme in config file (MQTT does not understand it)
VCDA-2706: RDE should validate site (validates http format and also if the value is same as set in config)
VCDA-2895: Remove DNS related configuration (use VCD setup)

The additional change is that the requirements.txt did not have a few dependencies that were called from source. The PyCharm IDE added them cleanly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1198)
<!-- Reviewable:end -->
