### PR TITLE
[VCDA-2856] Allow CSE server to function in Only TKGm mode

### DIFF
--- a/container_service_extension/common/utils/server_utils.py
+++ b/container_service_extension/common/utils/server_utils.py
@@ -61,6 +61,8 @@ def is_tkg_plus_enabled(config: dict = None):
     Check if TKG plus is enabled by the provider in the config.
 
     :param dict config: configuration provided by the user.
+
+    :return: whether TKG+ is enabled or not.
     :rtype: bool
     """
     if not config:
@@ -90,6 +92,28 @@ def should_use_mqtt_protocol(config):
     """
     return config.get('mqtt') is not None and \
         not utils.str_to_bool(config['service'].get('legacy_mode'))
+
+
+def is_tkgm_only_mode(config: dict = None):
+    """Check if TKGm only mode is enabled by the provider in the config.
+
+    :param dict config: configuration provided by the user.
+
+    :return: whether TKGm only mode is enabled or not.
+    :rtype: bool
+    """
+    if not config:
+        try:
+            config = get_server_runtime_config()
+        except Exception:
+            return False
+    service_section = config.get('service', {})
+    is_tkgm_only = service_section.get('tkgm_only_mode', False)
+    if isinstance(is_tkgm_only, bool):
+        return is_tkgm_only
+    elif isinstance(is_tkgm_only, str):
+        return utils.str_to_bool(is_tkgm_only)
+    return False
 
 
 def get_template_descriptor_keys(cookbook_version: semantic_version.Version) -> enum.EnumMeta:  # noqa: E501

--- a/container_service_extension/common/utils/server_utils.py
+++ b/container_service_extension/common/utils/server_utils.py
@@ -6,6 +6,7 @@
 
 import enum
 import math
+from typing import Optional
 
 import semantic_version
 
@@ -55,8 +56,7 @@ def is_pks_enabled():
     return Service().is_pks_enabled()
 
 
-# noinspection PyBroadException
-def is_tkg_plus_enabled(config: dict = None):
+def is_tkg_plus_enabled(config: Optional[dict] = None) -> bool:
     """
     Check if TKG plus is enabled by the provider in the config.
 
@@ -79,7 +79,7 @@ def is_tkg_plus_enabled(config: dict = None):
     return False
 
 
-def should_use_mqtt_protocol(config):
+def should_use_mqtt_protocol(config: dict) -> bool:
     """Return true if should use the mqtt protocol; false otherwise.
 
     The MQTT protocol should be used if the config file contains "mqtt" key
@@ -94,7 +94,7 @@ def should_use_mqtt_protocol(config):
         not utils.str_to_bool(config['service'].get('legacy_mode'))
 
 
-def is_tkgm_only_mode(config: dict = None):
+def is_tkgm_only_mode(config: Optional[dict] = None) -> bool:
     """Check if TKGm only mode is enabled by the provider in the config.
 
     :param dict config: configuration provided by the user.
@@ -129,12 +129,15 @@ def get_template_descriptor_keys(cookbook_version: semantic_version.Version) -> 
     return cookbook_version_to_template_descriptor_keys_map[cookbook_version]
 
 
-def construct_paginated_response(values, result_total,
-                                 page_number=shared_constants.CSE_PAGINATION_FIRST_PAGE_NUMBER,  # noqa: E501
-                                 page_size=shared_constants.CSE_PAGINATION_DEFAULT_PAGE_SIZE,  # noqa: E501
-                                 page_count=None,
-                                 next_page_uri=None,
-                                 prev_page_uri=None):
+def construct_paginated_response(
+        values,
+        result_total,
+        page_number=shared_constants.CSE_PAGINATION_FIRST_PAGE_NUMBER,
+        page_size=shared_constants.CSE_PAGINATION_DEFAULT_PAGE_SIZE,
+        page_count=None,
+        next_page_uri=None,
+        prev_page_uri=None
+):
     if not page_count:
         extra_page = 1 if bool(result_total % page_size) else 0
         page_count = result_total // page_size + extra_page
@@ -163,7 +166,8 @@ def create_links_and_construct_paginated_result(
         result_total,
         page_number=shared_constants.CSE_PAGINATION_FIRST_PAGE_NUMBER,
         page_size=shared_constants.CSE_PAGINATION_DEFAULT_PAGE_SIZE,
-        query_params=None):
+        query_params=None
+):
     if query_params is None:
         query_params = {}
     next_page_uri: str = ''

--- a/container_service_extension/common/utils/vsphere_utils.py
+++ b/container_service_extension/common/utils/vsphere_utils.py
@@ -77,8 +77,11 @@ def get_vsphere(sys_admin_client, vapp, vm_name, logger=NULL_LOGGER):
                    cache[vm_id]['password'], cache[vm_id]['port'])
 
 
-def vgr_callback(prepend_msg='',
-                 logger=NULL_LOGGER, msg_update_callback=NullPrinter()):
+def vgr_callback(
+        prepend_msg='',
+        logger=NULL_LOGGER,
+        msg_update_callback=NullPrinter()
+):
     """Create a callback function to use for vsphere-guest-run functions.
 
     :param str prepend_msg: string to prepend to all messages received from

--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -176,14 +176,15 @@ def get_validated_config(
     )
 
     try:
-        _validate_vcd_config(
-            config['vcd'],
-            msg_update_callback,
-            log_file=log_wire_file,
-            log_wire=log_wire
-        )
-        if not is_tkgm_only_mode:
-            _validate_vcs_config(
+        if is_tkgm_only_mode:
+            _validate_vcd_config(
+                config['vcd'],
+                msg_update_callback,
+                log_file=log_wire_file,
+                log_wire=log_wire
+            )
+        else:
+            _validate_vcd_and_vcs_config(
                 config['vcd'],
                 config['vcs'],
                 msg_update_callback,
@@ -476,7 +477,7 @@ def _validate_vcd_config(
             client.logout()
 
 
-def _validate_vcs_config(
+def _validate_vcd_and_vcs_config(
         vcd_dict,
         vcs,
         msg_update_callback=NullPrinter(),

--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -128,13 +128,13 @@ def get_validated_config(
         f"Validating config file '{config_file_name}'"
     )
 
-    # This allows us to compare top-level config keys and value types
     is_tkgm_only_mode = server_utils.is_tkgm_only_mode(config)
 
     use_mqtt = server_utils.should_use_mqtt_protocol(config)
     sample_message_queue_config = SAMPLE_AMQP_CONFIG if not use_mqtt \
         else SAMPLE_MQTT_CONFIG
 
+    # This allows us to compare top-level config keys and value types
     sample_config = {
         **sample_message_queue_config,
         **SAMPLE_VCD_CONFIG,

--- a/container_service_extension/installer/sample_generator.py
+++ b/container_service_extension/installer/sample_generator.py
@@ -112,7 +112,8 @@ SAMPLE_SERVICE_CONFIG = {
         'telemetry': {
             'enable': True
         },
-        'legacy_mode': False
+        'legacy_mode': False,
+        'tkgm_only_mode': False
     }
 }
 

--- a/container_service_extension/installer/templates/template_builder.py
+++ b/container_service_extension/installer/templates/template_builder.py
@@ -304,17 +304,25 @@ class TemplateBuilder:
             self.remote_cookbook_version,
             self.template_name,
             self.template_revision,
-            TemplateScriptFile.CUST)
+            TemplateScriptFile.CUST
+        )
         cust_script = read_data_file(
-            cust_script_filepath, logger=self.logger,
-            msg_update_callback=self.msg_update_callback)
+            cust_script_filepath,
+            logger=self.logger,
+            msg_update_callback=self.msg_update_callback
+        )
 
-        vs = get_vsphere(self.sys_admin_client, vapp, vm_name,
-                         logger=self.logger)
+        vs = get_vsphere(
+            self.sys_admin_client,
+            vapp,
+            vm_name,
+            logger=self.logger
+        )
         callback = vgr_callback(
             prepend_msg='Waiting for guest tools, status: "',
             logger=self.logger,
-            msg_update_callback=self.msg_update_callback)
+            msg_update_callback=self.msg_update_callback
+        )
         wait_until_tools_ready(vapp, vm_name, vs, callback=callback)
         password_auto = vapp.get_admin_password(vm_name)
 

--- a/container_service_extension/lib/nsxt/cluster_network_isolater.py
+++ b/container_service_extension/lib/nsxt/cluster_network_isolater.py
@@ -12,7 +12,7 @@ from container_service_extension.lib.nsxt.dfw_manager import DFWManager
 from container_service_extension.lib.nsxt.nsgroup_manager import NSGroupManager
 
 
-class ClusterNetworkIsolater(object):
+class ClusterNetworkIsolater:
     """Facilitate network isolation of PKS clusters."""
 
     RULE1_NAME = "Block pods to node communication"
@@ -22,7 +22,7 @@ class ClusterNetworkIsolater(object):
     def __init__(self, nsxt_client):
         """Initialize a ClusterNetworkIsolater object.
 
-        :param NSXTCLient nsxt_client: client to make NSX-T REST requests.
+        :param NSXTClient nsxt_client: client to make NSX-T REST requests.
         """
         self._nsxt_client = nsxt_client
 
@@ -71,9 +71,10 @@ class ClusterNetworkIsolater(object):
         if len(rules) != 2:
             return False
 
-        found_rule_names = set([
+        found_rule_names = {
             rules[0]['display_name'],
-            rules[1]['display_name']])
+            rules[1]['display_name']
+        }
         if self.RULE2_NAME not in found_rule_names or \
                 self.RULE3_NAME not in found_rule_names:
             return False
@@ -81,7 +82,7 @@ class ClusterNetworkIsolater(object):
         return True
 
     def remove_cluster_isolation(self, cluster_name):
-        """Revert isolatation of a PKS cluster's network.
+        """Revert isolation of a PKS cluster's network.
 
         :param str cluster_name: name of the cluster whose network isolation
             needs to be reverted.
@@ -104,11 +105,11 @@ class ClusterNetworkIsolater(object):
         nsgroup_manager.delete_nsgroup(pods_nsgroup_name, force=True)
 
     def _create_nsgroups_for_cluster(self, cluster_name, cluster_id):
-        """Create NSgroups for cluster isolateion.
+        """Create NSGroups for cluster isolation.
 
         One NSGroup to include all nodes in the cluster.
         One NSGroup to include all pods in the cluster.
-        One NSgroup to include all nodes and pods in the cluster.
+        One NSGroup to include all nodes and pods in the cluster.
 
         :param str cluster_name: name of the cluster whose network is being
             isolated.
@@ -127,7 +128,7 @@ class ClusterNetworkIsolater(object):
             cluster_name, nodes_nsgroup_id, pods_nsgroup_id)
         nodes_pods_nsgroup_id = nodes_pods_nsgroup['id']
 
-        return (nodes_nsgroup_id, pods_nsgroup_id, nodes_pods_nsgroup_id)
+        return nodes_nsgroup_id, pods_nsgroup_id, nodes_pods_nsgroup_id
 
     def _get_nodes_nsgroup_name(self, cluster_name):
         return f"{cluster_name}_nodes"
@@ -174,10 +175,11 @@ class ClusterNetworkIsolater(object):
         expression1['scope'] = "pks/cluster"
         expression1['tag'] = str(cluster_id)
 
-        expression2 = {}
-        expression2['resource_type'] = "NSGroupTagExpression"
-        expression2['target_type'] = "LogicalSwitch"
-        expression2['scope'] = "pks/floating_ip"
+        expression2 = {
+            'resource_type': "NSGroupTagExpression",
+            'target_type': "LogicalSwitch",
+            'scope': "pks/floating_ip"
+        }
 
         criteria['expressions'] = [expression1, expression2]
 
@@ -295,7 +297,7 @@ class ClusterNetworkIsolater(object):
         :param str cluster_name: name of the cluster whose network is being
             isolated.
         :param str applied_to_nsgroup_id: id of the NSGroup on which the rules
-            in this DFW SEction will apply to.
+            in this DFW Section will apply to.
         """
         section_name = self._get_firewall_section_name_for_cluster(
             cluster_name)

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -1215,7 +1215,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             unexpose_success: bool = False
             if unexpose:
                 org_name: str = curr_native_entity.metadata.org_name
-                ovdc_name: str = curr_native_entity.metadata.virtual_data_center_name
+                ovdc_name: str = curr_native_entity.metadata.virtual_data_center_name  # noqa: E501
                 network_name: str = current_spec.settings.ovdc_network
                 try:
                     # We need to get the internal IP via script and not rely

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -1088,7 +1088,7 @@ class ClusterService(abstract_broker.AbstractBroker):
             unexpose_success: bool = False
             if unexpose:
                 org_name: str = curr_native_entity.metadata.org_name
-                ovdc_name: str = curr_native_entity.metadata.virtual_data_center_name
+                ovdc_name: str = curr_native_entity.metadata.virtual_data_center_name  # noqa: E501
                 network_name: str = current_spec.settings.ovdc_network
                 try:
                     # We need to get the internal IP via script and not rely
@@ -2268,8 +2268,8 @@ def _get_kube_config_from_control_plane_vm(sysadmin_client: vcd_client.Client, v
     control_plane_vm.reload()
     kube_config: str = vcd_utils.get_vm_extra_config_element(control_plane_vm, KUBE_CONFIG)  # noqa: E501
     if not kube_config:
-        raise exceptions.KubeconfigNotFound("kubeconfig not found in control plane extra configuration")   # noqa: E501
-    LOGGER.debug(f"Got kubeconfig from control plane extra configuration successfully")  # noqa: E501
+        raise exceptions.KubeconfigNotFound("kubeconfig not found in control plane extra configuration")  # noqa: E501
+    LOGGER.debug("Got kubeconfig from control plane extra configuration successfully")  # noqa: E501
     kube_config_in_bytes: bytes = base64.b64decode(kube_config)
     return kube_config_in_bytes.decode()
 

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -15,9 +15,9 @@ import pkg_resources
 import pyvcloud.vcd.client as vcd_client
 import pyvcloud.vcd.org as vcd_org
 import pyvcloud.vcd.vapp as vcd_vapp
-import validators
 from pyvcloud.vcd.vdc import VDC
 import pyvcloud.vcd.vm as vcd_vm
+import validators
 
 from container_service_extension.common.constants.server_constants import CLUSTER_ENTITY  # noqa: E501
 from container_service_extension.common.constants.server_constants import ClusterMetadataKey  # noqa: E501
@@ -1828,6 +1828,7 @@ def _is_valid_vcd_url(vcd_site: str) -> bool:
     if parsed_url.netloc != cse_server_host:
         return False
     return True
+
 
 def _cluster_exists(client, cluster_name, org_name=None, ovdc_name=None):
     query_filter = f'name=={urllib.parse.quote(cluster_name)}'

--- a/container_service_extension/rde/backend/cluster_service_factory.py
+++ b/container_service_extension/rde/backend/cluster_service_factory.py
@@ -21,7 +21,6 @@ class ClusterServiceFactory:
 
         Factory method to return the ClusterService based on the RDE version in use.
         :param rde_version_in_use (str)
-        :param op_ctx Union[OperationContext, BehaviorRequestContext]
         :param bool skip_tkgm_check: flag specifying not to use TKGm cluster service
 
         :rtype cluster_service (container_service_extension.server.abstract_broker.AbstractBroker)  # noqa: E501

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -428,7 +428,7 @@ class DefEntityService:
         # TODO: Also include any persona having Administrator:FullControl
         #  on CSE:nativeCluster
         if (
-            vcd_api_version >= VCDApiVersion(vcd_client.ApiVersion.VERSION_36.value)
+            vcd_api_version >= VCDApiVersion(vcd_client.ApiVersion.VERSION_36.value)  # noqa: E501
             and self._cloudapi_client.is_sys_admin and not invoke_hooks
         ):
             resource_url_relative_path += f"?invokeHooks={str(invoke_hooks).lower()}"  # noqa: E501

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -12,7 +12,7 @@ from typing import Union
 from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 import semantic_version
 
-from container_service_extension.common.constants.shared_constants import ClusterEntityKind # noqa: E501
+from container_service_extension.common.constants.shared_constants import ClusterEntityKind  # noqa: E501
 import container_service_extension.common.utils.core_utils as core_utils
 import container_service_extension.common.utils.server_utils as server_utils
 import container_service_extension.exception.exceptions as exceptions

--- a/container_service_extension/security/authorization.py
+++ b/container_service_extension/security/authorization.py
@@ -16,7 +16,7 @@ def secure(required_rights=None):
     Only compatible with methods in AbstractBroker-derived classes.
 
     :param list required_rights: a list of rights (as str). The right name
-        shouldn't be namespaced.
+        shouldn't be namespace-ed.
 
     :return: a method reference to the decorating method.
 
@@ -38,10 +38,10 @@ def secure(required_rights=None):
 
                 missing_rights = []
                 for right_name in required_rights:
-                    namespaced_name = f'{{{CSE_SERVICE_NAMESPACE}}}' \
-                                      f':{right_name}'
-                    if namespaced_name not in user_rights:
-                        missing_rights.append(namespaced_name)
+                    right_name_with_namespace = \
+                        f"{{{CSE_SERVICE_NAMESPACE}}}:{right_name}"
+                    if right_name_with_namespace not in user_rights:
+                        missing_rights.append(right_name_with_namespace)
 
                 if len(missing_rights) > 0:
                     LOGGER.debug(f"Authorization failed for user "

--- a/container_service_extension/security/security.py
+++ b/container_service_extension/security/security.py
@@ -10,7 +10,7 @@ import container_service_extension.common.thread_local_data as thread_local_data
 
 
 class RedactingFilter(logging.Filter):
-    """Filter class to redact sensitive infomarion in logs.
+    """Filter class to redact sensitive information in logs.
 
     This filter looks for certain sensitive keys and if a match is found, the
     value will be redacted. The value are expected to be strings. If they are
@@ -54,7 +54,7 @@ class RedactingFilter(logging.Filter):
         #      token for a dict or list
         #   6. Look for 0 or 1 instance of '
         #   7. Put everything that is not ', space or } in a group,
-        #      this group must be atleast of length 1.
+        #      this group must be at least of length 1.
         self._pattern = r"((" + pattern_key + r")(\"|')?:\s+[{\[]*'?)([^',}]+)"
 
     def filter(self, record):
@@ -96,7 +96,7 @@ class RedactingFilter(logging.Filter):
 
         is_iterable = True
         try:
-            iter(theElement)
+            iter(obj)
         except (NameError, TypeError):
             is_iterable = False
 
@@ -184,7 +184,7 @@ def _test_redaction_filter():
     msg = base_str + str(dikt)
     logger.debug(msg)
 
-    # Case 10 : Battle Royale
+    # Case 10 : Battle Royal
     dikt1 = {
         'Authorization': 'Base 64 encoded string',
         'PasswOrd': 'super secret password',

--- a/container_service_extension/security/security.py
+++ b/container_service_extension/security/security.py
@@ -94,7 +94,9 @@ class RedactingFilter(logging.Filter):
         if obj is None:
             return obj
 
-        is_iterable = True
+        # strings are iterable but we don't want to process
+        # individual characters in this method.
+        is_iterable = not isinstance(obj, str)
         try:
             iter(obj)
         except (NameError, TypeError):

--- a/container_service_extension/server/pks/pks_cache.py
+++ b/container_service_extension/server/pks/pks_cache.py
@@ -5,16 +5,16 @@
 from collections import namedtuple
 
 from container_service_extension.common.constants.server_constants import PKS_CLUSTER_DOMAIN_KEY  # noqa: E501
-from container_service_extension.common.constants.server_constants import PKS_COMPUTE_PROFILE_KEY # noqa: E501
+from container_service_extension.common.constants.server_constants import PKS_COMPUTE_PROFILE_KEY  # noqa: E501
 from container_service_extension.common.constants.server_constants import PKS_PLANS_KEY  # noqa: E501
-from container_service_extension.common.utils.pyvcloud_utils import get_pvdc_id_from_pvdc_name # noqa: E501
+from container_service_extension.common.utils.pyvcloud_utils import get_pvdc_id_from_pvdc_name  # noqa: E501
 
 
 class PksCache(object):
     """Immutable in-memory cache for CSE PKS.
 
     An immutable class acting as an in-memory cache for
-    Container Service Extention(CSE) PKS.
+    Container Service Extension(CSE) PKS.
     """
 
     __slots__ = [
@@ -241,7 +241,7 @@ class PksCache(object):
         name, host, port, uaac and vc name) based on its account name,
         from the pks information obtained from configuration.
 
-        :param list pks_accounts: list of dictionaires, where each dict
+        :param list pks_accounts: list of dictionaries, where each dict
             represents a PKS account. Details include name, username, secret
             and the PKS server which owns the account.
 

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -364,7 +364,8 @@ class Service(object, metaclass=Singleton):
                 if sysadmin_client:
                     sysadmin_client.logout()
 
-        populate_vsphere_list(self.config['vcs'])
+        if not server_utils.is_tkgm_only_mode(self.config):
+            populate_vsphere_list(self.config['vcs'])
 
         # Load def entity-type and interface
         self._load_def_schema(msg_update_callback=msg_update_callback)

--- a/container_service_extension/system_test_framework/utils.py
+++ b/container_service_extension/system_test_framework/utils.py
@@ -9,7 +9,6 @@ from vcd_cli.vcd import vcd
 import yaml
 
 import container_service_extension.system_test_framework.environment as env
-import container_service_extension.system_test_framework.utils as testutils
 
 
 def dict_to_yaml_file(dikt, filepath):
@@ -57,8 +56,9 @@ def execute_commands(cmd_list):
         result = env.CLI_RUNNER.invoke(vcd, cmd.split(), input='y',
                                        catch_exceptions=False)
         assert result.exit_code == expected_exit_code, \
-            testutils.format_command_info(
-                'vcd', cmd, result.exit_code, result.output)
+            format_command_info(
+                'vcd', cmd, result.exit_code, result.output
+            )
 
         if action.validate_output_func is not None:
             action.validate_output_func(result.output, action.test_user)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,32 +1,56 @@
-# Commented versions are the versions being picked up for CSE 3.1 by default
-# as of 2021-30-03
+# Commented versions are the versions being picked up for CSE 3.1.1 by default
+# as of 16th September, 2021
 
 # cachetools 3.1.1
-cachetools >= 2.0.1, < 4.0.0
+cachetools >= 3.1.1, < 4.0.0
 
-# cryptography 3.4.7
-cryptography >= 3.2, < 4.0
+# certifi 2020.12.5
+certifi >= 2020.12.5, < 2021.0.0
+
+# click 7.1.2
+click >= 7.1.2, < 8.0.0
+
+# cryptography 3.4.8
+cryptography >= 3.4.8, < 4.0
+
+# dataclasses-json 0.5.6
+dataclasses-json >= 0.5.6, < 1.0.0
 
 # humanfriendly 4.18
 humanfriendly >= 4.8, < 5.0
 
 # lru-dict 1.1.7
-lru-dict >=1.1.6, < 2.0.0
+lru-dict >=1.1.7, < 2.0.0
 
-#paho-mqtt 1.5.1
-paho-mqtt >=1.5.0, < 1.6.0
+# lxml 4.6.3
+lxml >= 4.6.3, < 5.0.0
+
+# paho-mqtt 1.5.1
+paho-mqtt >= 1.5.1, < 1.6.0
 
 # pika 1.2.0
-pika >= 1.0.0, < 2.0.0
+pika >= 1.2.0, < 2.0.0
 
-# pyvcloud 23.0.2
+# pyvcloud 23.0.3.dev12
 pyvcloud == 23.0.3.dev12
 
 # pyvmomi 6.7.3
-pyvmomi >= 6.7.0, < 7.0.0
+pyvmomi >= 6.7.3, < 7.0.0
+
+# PyYaml 5.4.1
+PyYaml >= 5.4.1, <= 6.0.0
+
+# requests 2.26.0
+requests >= 2.26.0, < 3.0.0
 
 # semantic-version 2.8.5
-semantic-version >= 2.8.4, < 3.0.0
+semantic-version >= 2.8.5, < 3.0.0
+
+# six 1.16.0
+six >= 1.16.0, < 2.0.0
+
+# urlib3 1.26.6
+urllib3 >= 1.26.6, < 2.0.0
 
 # validators 0.18.2
 validators ~= 0.18.2
@@ -36,7 +60,3 @@ vcd-cli >= 24.0.1, < 25.0.0
 
 # vsphere-guest-run 0.0.7
 vsphere-guest-run >= 0.0.7, < 1.0.0
-
-# dataclasses-json
-dataclasses-json >= 0.5.2, < 1.0.0
-


### PR DESCRIPTION
* Added a new key in config file under `service` section. viz. `tkgm_only_mode`. This mode allows the provider to omit the entire `vcs` section from the config file, as well as it suppresses any piece of code in CSE that tries to connect to the vSphere server(s) either directly or via guest-run-library.
* Added relevant code in config sample generator, and config validation.
* Added checks in `cse template install`, `cse install` and `cse upgrade` to make sure that these command don't create templates if `tkgm_only_mode` is set to True in config file.
* config validation will remove `vcs` section from server runtime config if the flag `tkgm_only_mode` is set to True. This makes sure that even if the code paths in vcdbroker, cluster_service_1_x or cluster_service_2_x tries to connect to any vCenter server, the code fail with proper error message.

* Updated requirements.txt

* Fixed a bunch of style issues and flake8 bugs.

Testing done:
With `tkgm_only_mode` set to True, ran 
1. `cse install` without -t flag .. failure recorded
2. `cse install` with -t flag (on an existing CSE installation) .. failure recorded with the correct message asking user to upgrade CSE
3. `cse upgrade` without -t flag .. failure recorded
4. `cse upgrade` with -t flag .. success recorded
5. `template install` .. .failure recorded
6. `cse run` .. success recorded
7. Tried deploying native cluster .. failure recorded

With `tkgm_only_mode` set to False, ran 
1. `cse run` with `vcs` section missing .. failure recorded

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1199)
<!-- Reviewable:end -->
