### PR TITLE
[VCDA-2834] telemetry for import template

### DIFF
--- a/container_service_extension/lib/telemetry/constants.py
+++ b/container_service_extension/lib/telemetry/constants.py
@@ -49,6 +49,7 @@ class CseOperation(Enum):
     SERVICE_UPGRADE = ('upgrade server', 'SERVER', 'UPGRADE', 'CSE_SERVICE_UPGRADE')  # noqa: E501
     SERVICE_RUN = ('run server', 'SERVER', 'RUN', 'CSE_SERVICE_RUN')
     TEMPLATE_INSTALL = ('template install', 'TEMPLATE', 'INSTALL', 'CSE_TEMPLATE_INSTALL')  # noqa: E501
+    TEMPLATE_IMPORT = ('template import', 'TEMPLATE', 'IMPORT', 'CSE_TEMPLATE_IMPORT')  # noqa: E501
     TEMPLATE_LIST = ('template list', 'TEMPLATE', 'LIST', 'CSE_TEMPLATE_LIST')  # noqa: E501
 
     # vcd-cli CSE client commands
@@ -123,9 +124,13 @@ class PayloadKey(str, Enum):
     CLUSTER_KIND = 'cluster_kind'
     CNI = 'cni'
     CNI_VERSION = 'cni_version'
+    CONTAINER_RUNTIME = 'container_runtime'
+    CONTAINER_RUNTIME_VERSION = 'container_runtime_version'
     CPU = 'cpu'
+    CSE_VERSION = 'cse_version'
     DISPLAY_OPTION = 'display_option'
     FILTER_KEYS = 'filter_keys'
+    KIND = 'kind'
     K8S_DISTRIBUTION = 'k8s_distribution'
     K8S_PROVIDER = 'k8s_provider'
     K8S_VERSION = 'k8s_version',
@@ -138,8 +143,10 @@ class PayloadKey(str, Enum):
     NUMBER_OF_WORKER_NODES = 'number_of_worker_nodes'
     NUMBER_OF_NFS_NODES = 'number_of_nfs_nodes'
     OS = 'os'
+    OS_VERSION = 'os_version'
     PKS_CLUSTER_ID = 'uuid'
     PKS_VERSION = 'pks_version'
+    REVISION = 'revision'
     SOURCE_CSE_VERSION = 'source_cse_version'
     SOURCE_DESCRIPTION = 'source_description'
     SOURCE_ID = 'source_id'

--- a/container_service_extension/lib/telemetry/payload_generator.py
+++ b/container_service_extension/lib/telemetry/payload_generator.py
@@ -8,6 +8,7 @@ import pyvcloud.vcd.utils as pyvcd_utils
 
 from container_service_extension.common.constants.server_constants import CLUSTER_ENTITY  # noqa: E501
 from container_service_extension.common.constants.server_constants import LocalTemplateKey  # noqa: E501
+from container_service_extension.common.constants.server_constants import TKGmTemplateKey  # noqa: E501
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
 from container_service_extension.common.constants.shared_constants import AccessControlKey  # noqa: E501
 from container_service_extension.common.constants.shared_constants import ClusterAclKey  # noqa: E501
@@ -132,6 +133,34 @@ def get_payload_for_run_server(params):
         PayloadKey.WAS_DECRYPTION_SKIPPED: bool(params.get(PayloadKey.WAS_DECRYPTION_SKIPPED)),  # noqa: E501
         PayloadKey.WAS_PKS_CONFIG_FILE_PROVIDED: bool(params.get(PayloadKey.WAS_PKS_CONFIG_FILE_PROVIDED)),  # noqa: E501
         PayloadKey.WAS_INSTALLATION_CHECK_SKIPPED: bool(params.get(PayloadKey.WAS_INSTALLATION_CHECK_SKIPPED)),  # noqa: E501
+    }
+
+
+def get_payload_for_import_template(params):
+    """Construct telemetry payload of template import operation.
+
+    :param params: parameters provided to the operation
+
+    :return: json telemetry data for the operation
+
+    :type: dict
+    """
+    return {
+        PayloadKey.TYPE: CseOperation.TEMPLATE_IMPORT.telemetry_table,
+        PayloadKey.CNI: params.get(TKGmTemplateKey.CNI),
+        PayloadKey.CNI_VERSION: params.get(TKGmTemplateKey.CNI_VERSION),
+        PayloadKey.CONTAINER_RUNTIME: params.get(TKGmTemplateKey.CONTAINER_RUNTIME),  # noqa: E501
+        PayloadKey.CONTAINER_RUNTIME_VERSION: params.get(TKGmTemplateKey.CONTAINER_RUNTIME_VERSION),  # noqa: E501
+        PayloadKey.CSE_VERSION: str(params.get(TKGmTemplateKey.CSE_VERSION)),
+        PayloadKey.KIND: params.get(TKGmTemplateKey.KIND),
+        PayloadKey.K8S_DISTRIBUTION: params.get(TKGmTemplateKey.KUBERNETES),
+        PayloadKey.K8S_VERSION: params.get(TKGmTemplateKey.KUBERNETES_VERSION),
+        PayloadKey.TEMPLATE_NAME: params.get(TKGmTemplateKey.NAME),
+        PayloadKey.OS: params.get(TKGmTemplateKey.OS),
+        PayloadKey.OS_VERSION: params.get(TKGmTemplateKey.OS_VERSION),
+        PayloadKey.TEMPLATE_REVISION: params.get(TKGmTemplateKey.REVISION),
+        PayloadKey.WAS_DECRYPTION_SKIPPED: bool(params.get(PayloadKey.WAS_DECRYPTION_SKIPPED)),  # noqa: E501
+        PayloadKey.WERE_TEMPLATES_FORCE_UPDATED: bool(params.get(PayloadKey.WERE_TEMPLATES_FORCE_UPDATED)),  # noqa: E501
     }
 
 

--- a/container_service_extension/lib/telemetry/telemetry_handler.py
+++ b/container_service_extension/lib/telemetry/telemetry_handler.py
@@ -28,6 +28,7 @@ OPERATION_TO_PAYLOAD_GENERATOR = {
     CseOperation.SERVICE_RUN: payload_generator.get_payload_for_run_server,
 
     CseOperation.TEMPLATE_INSTALL: payload_generator.get_payload_for_install_template,  # noqa: E501
+    CseOperation.TEMPLATE_IMPORT: payload_generator.get_payload_for_import_template,  # noqa: E501
     CseOperation.TEMPLATE_LIST: payload_generator.get_payload_for_template_list,  # noqa: E501
 
     # vcd-cli CSE client commands

--- a/container_service_extension/server/request_handlers/template_handler.py
+++ b/container_service_extension/server/request_handlers/template_handler.py
@@ -42,6 +42,7 @@ def template_list(request_data, op_ctx):
     return sorted(templates, key=lambda i: (i['name'], i['revision']), reverse=True)  # noqa: E501
 
 
+@record_user_action_telemetry(cse_operation=CseOperation.TEMPLATE_LIST_CLIENT_SIDE)  # noqa: E501
 def tkgm_template_list(request_data, op_ctx):
     """Request handler for template list operation.
 


### PR DESCRIPTION
- Telemetry for `cse template import`
- `cse_user_actions`, `cse_template_import`
- Tested and verified creating TKGm template
cse_user_actions:
![image](https://user-images.githubusercontent.com/5530442/134267729-0f39afd2-9b63-4ca9-ba65-81b70c0141b3.png)

cse_template_import:
<img width="1326" alt="Screen Shot 2021-09-21 at 5 45 31 PM" src="https://user-images.githubusercontent.com/5530442/134267915-478ab249-7777-4d28-ba18-ced22839c4d5.png">
<img width="1323" src="https://user-images.githubusercontent.com/5530442/134267871-0b1c098b-1bf5-463e-9f3f-430f00d5590f.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1201)
<!-- Reviewable:end -->
