### PR TITLE
[VCDA-2902] TKGm to make use of cpu and memory properties for cluster operations

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -731,7 +731,11 @@ class ClusterService(abstract_broker.AbstractBroker):
             ovdc_name = input_native_entity.metadata.virtual_data_center_name
             num_workers = input_native_entity.spec.topology.workers.count
             control_plane_sizing_class = input_native_entity.spec.topology.control_plane.sizing_class  # noqa: E501
+            control_plane_cpu_count = input_native_entity.spec.topology.control_plane.cpu # noqa: E501
+            control_plane_memory_mb = input_native_entity.spec.topology.control_plane.memory # noqa: E501
             worker_sizing_class = input_native_entity.spec.topology.workers.sizing_class  # noqa: E501
+            worker_cpu_count = input_native_entity.spec.topology.workers.cpu
+            worker_memory_mb = input_native_entity.spec.topology.workers.memory
             control_plane_storage_profile = input_native_entity.spec.topology.control_plane.storage_profile  # noqa: E501
             worker_storage_profile = input_native_entity.spec.topology.workers.storage_profile  # noqa: E501
             network_name = input_native_entity.spec.settings.ovdc_network
@@ -849,6 +853,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                     storage_profile=control_plane_storage_profile,
                     ssh_key=ssh_key,
                     sizing_class_name=control_plane_sizing_class,
+                    cpu_count=control_plane_cpu_count,
+                    memory_mb=control_plane_memory_mb,
                     expose=expose,
                     cluster_name=cluster_name,
                     cluster_id=cluster_id,
@@ -882,6 +888,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                     storage_profile=worker_storage_profile,
                     ssh_key=ssh_key,
                     sizing_class_name=worker_sizing_class,
+                    cpu_count=worker_cpu_count,
+                    memory_mb=worker_memory_mb,
                     control_plane_join_cmd=control_plane_join_cmd
                 )
             except Exception as err:
@@ -1268,6 +1276,8 @@ class ClusterService(abstract_broker.AbstractBroker):
             # viz., template, storage_profile, and network among others.
             worker_storage_profile = input_native_entity.spec.topology.workers.storage_profile  # noqa: E501
             worker_sizing_class = input_native_entity.spec.topology.workers.sizing_class  # noqa: E501
+            worker_cpu_count = input_native_entity.spec.topology.workers.cpu
+            worker_memory_mb = input_native_entity.spec.topology.workers.memory
             network_name = input_native_entity.spec.settings.ovdc_network
             ssh_key = input_native_entity.spec.settings.ssh_key
             rollback = input_native_entity.spec.settings.rollback_on_failure
@@ -1319,6 +1329,8 @@ class ClusterService(abstract_broker.AbstractBroker):
                     storage_profile=worker_storage_profile,
                     ssh_key=ssh_key,
                     sizing_class_name=worker_sizing_class,
+                    cpu_count=worker_cpu_count,
+                    memory_mb=worker_memory_mb,
                     control_plane_join_cmd=control_plane_join_cmd
                 )
 
@@ -1784,18 +1796,25 @@ def _get_nodes_details(vapp):
                 policy_name = vm.ComputePolicy.VmSizingPolicy.get('name')
                 sizing_class = compute_policy_manager.\
                     get_cse_policy_display_name(policy_name)
+            vm_obj = vcd_vm.VM(vapp.client, resource=vm)
+            cpu_count = vm_obj.get_cpus()['num_cpus']
+            memory_mb = vm_obj.get_memory()
             storage_profile: Optional[str] = None
             if hasattr(vm, 'StorageProfile'):
                 storage_profile = vm.StorageProfile.get('name')
             if vm_name.startswith(NodeType.CONTROL_PLANE):
                 control_plane = rde_2_x.Node(name=vm_name, ip=ip,
                                              sizing_class=sizing_class,
-                                             storage_profile=storage_profile)
+                                             storage_profile=storage_profile,
+                                             cpu=cpu_count,
+                                             memory=memory_mb)
             elif vm_name.startswith(NodeType.WORKER):
                 workers.append(
                     rde_2_x.Node(name=vm_name, ip=ip,
                                  sizing_class=sizing_class,
-                                 storage_profile=storage_profile))
+                                 storage_profile=storage_profile,
+                                 cpu=cpu_count,
+                                 memory=memory_mb))
         return rde_2_x.Nodes(control_plane=control_plane, workers=workers)
     except Exception as err:
         LOGGER.error("Failed to retrieve the status of the nodes of the "
@@ -1928,12 +1947,19 @@ def _add_control_plane_nodes(
         storage_profile=None,
         ssh_key=None,
         sizing_class_name=None,
+        cpu_count=None,
+        memory_mb=None,
         expose=False,
         cluster_name=None,
         cluster_id=None,
         refresh_token=None) -> Tuple[str, List[Dict]]:
 
     vcd_utils.raise_error_if_user_not_from_system_org(sysadmin_client)
+
+    if (cpu_count or memory_mb) and sizing_class_name:
+        raise exceptions.BadRequestError("Cannot specify both cpu/memory and "
+                                         "sizing class for control plane "
+                                         "node creation")
 
     vm_specs = []
     expose_ip = ''
@@ -2020,6 +2046,20 @@ def _add_control_plane_nodes(
                     # This is a deviation from native: we do not want silent failures when expose  # noqa: E501
                     # functionality fails.
                     raise
+
+            # modify CPU and memory if needed
+            if cpu_count and cpu_count > 0:
+                # updating cpu count on the VM
+                task = vm.modify_cpu(cpu_count)
+                sysadmin_client.get_task_monitor().wait_for_status(
+                    task,
+                    callback=wait_for_cpu_update)
+            if memory_mb and memory_mb > 0:
+                # updating memory
+                task = vm.modify_memory(memory_mb)
+                sysadmin_client.get_task_monitor().wait_for_status(
+                    task,
+                    callback=wait_for_memory_update)
 
             # If expose is set, control_plane_endpoint is exposed ip
             # Else control_plane_endpoint is internal_ip
@@ -2138,9 +2178,14 @@ def _add_control_plane_nodes(
 def _add_worker_nodes(sysadmin_client, num_nodes, org, vdc, vapp,
                       catalog_name, template, network_name,
                       storage_profile=None, ssh_key=None,
-                      sizing_class_name=None,
+                      sizing_class_name=None, cpu_count=None, memory_mb=None,
                       control_plane_join_cmd='') -> List:
     vcd_utils.raise_error_if_user_not_from_system_org(sysadmin_client)
+
+    if (cpu_count or memory_mb) and sizing_class_name:
+        raise exceptions.BadRequestError("Cannot specify both cpu/memory and "
+                                         "sizing class for control plane "
+                                         "node creation")
 
     vm_specs = []
     if num_nodes <= 0:
@@ -2206,6 +2251,20 @@ def _add_worker_nodes(sysadmin_client, num_nodes, org, vdc, vapp,
             vm_name = spec['target_vm_name']
             vm_resource = vapp.get_vm(vm_name)
             vm = vcd_vm.VM(sysadmin_client, resource=vm_resource)
+
+            # modify CPU and memory if needed
+            if cpu_count and cpu_count > 0:
+                # updating cpu count on the VM
+                task = vm.modify_cpu(cpu_count)
+                sysadmin_client.get_task_monitor().wait_for_status(
+                    task,
+                    callback=wait_for_cpu_update)
+            if memory_mb and memory_mb > 0:
+                # updating memory
+                task = vm.modify_memory(memory_mb)
+                sysadmin_client.get_task_monitor().wait_for_status(
+                    task,
+                    callback=wait_for_memory_update)
 
             task = vm.power_on_and_force_recustomization()
             # wait_for_vm_power_on is reused for all vm creation callback
@@ -2325,6 +2384,14 @@ def _get_kube_config_from_control_plane_vm(sysadmin_client: vcd_client.Client, v
     LOGGER.debug("Got kubeconfig from control plane extra configuration successfully")  # noqa: E501
     kube_config_in_bytes: bytes = base64.b64decode(kube_config)
     return kube_config_in_bytes.decode()
+
+
+def wait_for_cpu_update(task):
+    LOGGER.debug(f"Updating CPU count, status: {task.get('status').lower()}")
+
+
+def wait_for_memory_update(task):
+    LOGGER.debug(f"Updating memory, status: {task.get('status').lower()}")
 
 
 def wait_for_update_customization(task):

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -554,10 +554,26 @@ class ClusterService(abstract_broker.AbstractBroker):
         # TODO: Make use of current entity in the behavior payload
         curr_rde = self.entity_svc.get_entity(cluster_id)
         curr_native_entity: rde_2_x.NativeEntity = curr_rde.entity
+        sysadmin_client_v36 = \
+            self.context.get_sysadmin_client(DEFAULT_API_VERSION)
+        vdc: VDC = vcd_utils.get_vdc(
+            sysadmin_client_v36,
+            vdc_name=curr_native_entity.status.cloud_properties.virtual_data_center_name,  # noqa: E501
+            org_name=curr_native_entity.status.cloud_properties.org_name)
+        vdc_resource = vdc.get_resource_admin()
+        default_cp_name = vdc_resource.DefaultComputePolicy.get('name')
+        control_plane_sizing_class = curr_native_entity.status.nodes.control_plane.sizing_class  # noqa: E501
+        is_tkgm_with_default_sizing_in_control_plane = \
+            (control_plane_sizing_class == default_cp_name)
+        is_tkgm_with_default_sizing_in_workers = \
+            (len(curr_native_entity.status.nodes.workers) > 0
+                and curr_native_entity.status.nodes.workers[0].sizing_class == default_cp_name)  # noqa: E501
         current_spec: rde_2_x.ClusterSpec = \
             def_utils.construct_cluster_spec_from_entity_status(
                 curr_native_entity.status,
-                server_utils.get_rde_version_in_use())
+                server_utils.get_rde_version_in_use(),
+                is_tkgm_with_default_sizing_in_control_plane=is_tkgm_with_default_sizing_in_control_plane,  # noqa: E501
+                is_tkgm_with_default_sizing_in_workers=is_tkgm_with_default_sizing_in_workers)  # noqa: E501
         current_workers_count = current_spec.topology.workers.count
         desired_workers_count = input_native_entity.spec.topology.workers.count
         current_expose_flag = current_spec.settings.network.expose

--- a/container_service_extension/rde/utils.py
+++ b/container_service_extension/rde/utils.py
@@ -83,24 +83,36 @@ def get_rde_metadata(rde_version: str) -> dict:
     return MAP_RDE_VERSION_TO_ITS_METADATA[rde_version]
 
 
-def construct_cluster_spec_from_entity_status(entity_status: Union[rde_1_0_0.Status, rde_2_0_0.Status], rde_version: str) -> Union[rde_1_0_0.ClusterSpec, rde_2_0_0.ClusterSpec]:  # noqa: E501
+def construct_cluster_spec_from_entity_status(
+        entity_status: Union[rde_1_0_0.Status, rde_2_0_0.Status],
+        rde_version: str,
+        is_tkgm_with_default_sizing_in_control_plane: bool = False,
+        is_tkgm_with_default_sizing_in_workers: bool = False) -> Union[rde_1_0_0.ClusterSpec, rde_2_0_0.ClusterSpec]:  # noqa: E501
     """Construct cluster spec of the specified rde version from the current status of the cluster.
 
     :param rde_X_X_X Status entity_status: Entity Status of rde of given version  # noqa: E501
     :param str rde_version: RDE version of the spec to be created from the status # noqa: E501
+    :param bool is_tkgm_with_default_sizing_in_control_plane: is tkgm cluster
+        with default sizing policy in control plane
+    :param bool is_tkgm_with_default_sizing_in_workers: is tkgm cluster with
+        with default sizing policy in worker nodes
     :return: Cluster Specification of respective rde_version_in_use
     :raises NotImplementedError
     """
     # TODO: Refactor this multiple if to rde_version -> handler pattern
     if rde_version == def_constants.RDEVersion.RDE_2_0_0.value:
-        return construct_2_0_0_cluster_spec_from_entity_status(entity_status)
+        return construct_2_0_0_cluster_spec_from_entity_status(
+            entity_status,
+            is_tkgm_with_default_sizing_in_control_plane=is_tkgm_with_default_sizing_in_control_plane,  # noqa: E501
+            is_tkgm_with_default_sizing_in_workers=is_tkgm_with_default_sizing_in_workers)  # noqa: E501
     # elif rde_version == def_constants.RDEVersion.RDE_2_1_0:
     #    return construct_2_1_0_cluster_spec_from_entity_status(entity_status)
     raise NotImplementedError(f"constructing cluster spec from entity status for {rde_version} is"  # noqa:
                               f" not implemented ")
 
 
-def construct_2_0_0_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Status) -> rde_2_0_0.ClusterSpec:  # noqa:
+def construct_2_0_0_cluster_spec_from_entity_status(
+    entity_status: rde_2_0_0.Status, is_tkgm_with_default_sizing_in_control_plane=False, is_tkgm_with_default_sizing_in_workers=False) -> rde_2_0_0.ClusterSpec:  # noqa:
     """Construct cluster specification from entity status using rde_2_0_0 model.
 
     :param rde_2_0_0.Status entity_status: Entity Status as defined in rde_2_0_0  # noqa: E501
@@ -121,7 +133,7 @@ def construct_2_0_0_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Sta
         control_plane_storage_profile = entity_status.nodes.control_plane.storage_profile  # noqa: E501
         control_plane_cpu = entity_status.nodes.control_plane.cpu
         control_plane_memory = entity_status.nodes.control_plane.memory
-        if control_plane_sizing_class:
+        if not is_tkgm_with_default_sizing_in_control_plane and control_plane_sizing_class:  # noqa: E501
             control_plane_cpu = None
             control_plane_memory = None
     control_plane = rde_2_0_0.ControlPlane(
@@ -147,7 +159,7 @@ def construct_2_0_0_cluster_spec_from_entity_status(entity_status: rde_2_0_0.Sta
             worker_storage_profile = entity_status.nodes.workers[0].storage_profile  # noqa: E501
             worker_cpu = entity_status.nodes.workers[0].cpu
             worker_memory = entity_status.nodes.workers[0].memory
-        if worker_sizing_class:
+        if not is_tkgm_with_default_sizing_in_workers and worker_sizing_class:
             worker_cpu = None
             worker_memory = None
     workers = rde_2_0_0.Workers(sizing_class=worker_sizing_class,

--- a/container_service_extension/rde/validators/abstract_validator.py
+++ b/container_service_extension/rde/validators/abstract_validator.py
@@ -4,6 +4,8 @@
 
 import abc
 
+from pyvcloud.vcd.client import Client
+
 from container_service_extension.lib.cloudapi.cloudapi_client import CloudApiClient  # noqa: E501
 from container_service_extension.rde.behaviors.behavior_model import BehaviorOperation  # noqa: E501
 
@@ -13,9 +15,11 @@ class AbstractValidator(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def validate(self, cloudapi_client: CloudApiClient, entity_id: str = None,
+    def validate(self, cloudapi_client: CloudApiClient,
+                 sysadmin_client: Client,
+                 entity_id: str = None,
                  entity: dict = None,
-                 operation: BehaviorOperation = None) -> bool:
+                 operation: BehaviorOperation = None, **kwargs) -> bool:
         """Validate the entity.
 
         This method performs

--- a/container_service_extension/rde/validators/validator_rde_2_x.py
+++ b/container_service_extension/rde/validators/validator_rde_2_x.py
@@ -2,8 +2,12 @@
 # Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+from pyvcloud.vcd.client import Client
+from pyvcloud.vcd.vdc import VDC
+
 from container_service_extension.common.constants.server_constants import FlattenedClusterSpecKey2X  # noqa: E501
 from container_service_extension.common.constants.server_constants import VALID_UPDATE_FIELDS_2X  # noqa: E501
+from container_service_extension.common.utils.pyvcloud_utils import get_vdc  # noqa: E501
 from container_service_extension.exception.exceptions import BadRequestError
 from container_service_extension.lib.cloudapi.cloudapi_client import CloudApiClient  # noqa: E501
 from container_service_extension.rde.behaviors.behavior_model import BehaviorOperation  # noqa: E501
@@ -20,8 +24,8 @@ class Validator_2_0_0(AbstractValidator):
     def __init__(self):
         pass
 
-    def validate(self, cloudapi_client: CloudApiClient, entity_id: str = None,
-                 entity: dict = None, operation: BehaviorOperation = BehaviorOperation.CREATE_CLUSTER) -> bool:  # noqa: E501
+    def validate(self, cloudapi_client: CloudApiClient, sysadmin_client: Client, entity_id: str = None,  # noqa: E501
+                 entity: dict = None, operation: BehaviorOperation = BehaviorOperation.CREATE_CLUSTER, **kwargs) -> bool:  # noqa: E501
         """Validate the input request.
 
         This method performs
@@ -41,6 +45,7 @@ class Validator_2_0_0(AbstractValidator):
         :return: is validation successful or failure
         :rtype: bool
         """
+        is_tkgm_cluster = kwargs.get('is_tkgm_cluster', False)
         if not entity_id and not entity:
             raise ValueError('Either entity_id or entity is required to validate.')  # noqa: E501
         entity_svc = DefEntityService(cloudapi_client=cloudapi_client)
@@ -64,20 +69,20 @@ class Validator_2_0_0(AbstractValidator):
                 msg = f"Failed to parse request body: {err}"
                 raise BadRequestError(msg)
 
+        # Need to ensure that sizing class along with cpu/memory is not
+        # present in the request
+        bad_request_msg = ""
+        if isinstance(input_entity, rde_2_0_0.NativeEntity):
+            # cpu and mem are properties of only rde 2.0.0
+            if input_entity.spec.topology.workers.sizing_class and \
+                    (input_entity.spec.topology.workers.cpu or input_entity.spec.topology.workers.memory):  # noqa: E501
+                bad_request_msg = "Cannot specify both sizing class and cpu/memory for Workers nodes."  # noqa: E501
+            if input_entity.spec.topology.control_plane.sizing_class and (input_entity.spec.topology.control_plane.cpu or input_entity.spec.topology.control_plane.memory): # noqa: E501
+                bad_request_msg = "Cannot specify both sizing class and cpu/memory for Control Plane nodes." # noqa: E501
+            if bad_request_msg:
+                raise BadRequestError(bad_request_msg)
         # Return True if the operation is not specified.
         if operation == BehaviorOperation.CREATE_CLUSTER:
-            # Need to ensure that sizing class along with cpu/memory is not
-            # present in the request
-            bad_request_msg = ""
-            if isinstance(input_entity, rde_2_0_0.NativeEntity):
-                # cpu and mem are properties of only rde 2.0.0
-                if input_entity.spec.topology.workers.sizing_class and \
-                        (input_entity.spec.topology.workers.cpu or input_entity.spec.topology.workers.memory):  # noqa: E501
-                    bad_request_msg = "Cannot specify both sizing class and cpu/memory for Workers nodes."  # noqa: E501
-                if input_entity.spec.topology.control_plane.sizing_class and (input_entity.spec.topology.control_plane.cpu or input_entity.spec.topology.control_plane.memory): # noqa: E501
-                    bad_request_msg = "Cannot specify both sizing class and cpu/memory for Control Plane nodes." # noqa: E501
-                if bad_request_msg:
-                    raise BadRequestError(bad_request_msg)
             return True
 
         # TODO: validators for rest of the CSE operations in V36 will be
@@ -89,9 +94,34 @@ class Validator_2_0_0(AbstractValidator):
             current_entity: AbstractNativeEntity = entity_svc.get_entity(entity_id).entity  # noqa: E501
             input_entity_spec: rde_2_0_0.ClusterSpec = input_entity.spec
             current_entity_status: rde_2_0_0.Status = current_entity.status
+            is_tkgm_with_default_sizing_in_control_plane = False
+            is_tkgm_with_default_sizing_in_workers = False
+            if is_tkgm_cluster:
+                # NOTE: Since for TKGm cluster, if cluster is created without
+                # a sizing class, default sizing class is assigned by VCD,
+                # If we find the default sizing policy in the status section,
+                # validate cpu/memory and sizing policy.
+                # Also note that at this point in code, we are sure that only
+                # one of sizing class or cpu/mem will be associated with
+                # control plane and workers.
+                vdc: VDC = get_vdc(
+                    sysadmin_client,
+                    vdc_name=current_entity_status.cloud_properties.virtual_data_center_name,  # noqa: E501
+                    org_name=current_entity_status.cloud_properties.org_name)
+                vdc_resource = vdc.get_resource_admin()
+                default_cp_name = vdc_resource.DefaultComputePolicy.get('name')
+                control_plane_sizing_class = current_entity_status.nodes.control_plane.sizing_class  # noqa: E501
+                is_tkgm_with_default_sizing_in_control_plane = \
+                    (control_plane_sizing_class == default_cp_name)
+                is_tkgm_with_default_sizing_in_workers = \
+                    (len(current_entity_status.nodes.workers) > 0
+                     and current_entity_status.nodes.workers[0].sizing_class == default_cp_name)  # noqa: E501
             current_entity_spec = \
                 rde_utils.construct_cluster_spec_from_entity_status(
-                    current_entity_status, rde_constants.RDEVersion.RDE_2_0_0.value)  # noqa: E501
+                    current_entity_status,
+                    rde_constants.RDEVersion.RDE_2_0_0.value,
+                    is_tkgm_with_default_sizing_in_control_plane=is_tkgm_with_default_sizing_in_control_plane,  # noqa: E501
+                    is_tkgm_with_default_sizing_in_workers=is_tkgm_with_default_sizing_in_workers)  # noqa: E501
             return validate_cluster_update_request_and_check_cluster_upgrade(
                 input_entity_spec,
                 current_entity_spec)
@@ -101,7 +131,7 @@ class Validator_2_0_0(AbstractValidator):
 
 
 def validate_cluster_update_request_and_check_cluster_upgrade(input_spec: rde_2_0_0.ClusterSpec,  # noqa: E501
-                                                              reference_spec: rde_2_0_0.ClusterSpec) -> bool:  # noqa: E501
+                                                              reference_spec: rde_2_0_0.ClusterSpec,) -> bool:  # noqa: E501
     """Validate the desired spec with curr spec and check if upgrade operation.
 
     :param dict input_spec: input spec

--- a/container_service_extension/rde/validators/validator_rde_2_x.py
+++ b/container_service_extension/rde/validators/validator_rde_2_x.py
@@ -71,9 +71,9 @@ class Validator_2_0_0(AbstractValidator):
 
         # Need to ensure that sizing class along with cpu/memory is not
         # present in the request
-        bad_request_msg = ""
         if isinstance(input_entity, rde_2_0_0.NativeEntity):
             # cpu and mem are properties of only rde 2.0.0
+            bad_request_msg = ""
             if input_entity.spec.topology.workers.sizing_class and \
                     (input_entity.spec.topology.workers.cpu or input_entity.spec.topology.workers.memory):  # noqa: E501
                 bad_request_msg = "Cannot specify both sizing class and cpu/memory for Workers nodes."  # noqa: E501

--- a/container_service_extension/server/behavior_handler.py
+++ b/container_service_extension/server/behavior_handler.py
@@ -4,12 +4,13 @@
 
 import functools
 
-from container_service_extension.common.constants.shared_constants import RequestKey  # noqa: E501
+from container_service_extension.common.constants.shared_constants import ClusterEntityKind, RequestKey  # noqa: E501
 import container_service_extension.exception.exceptions as cse_exception
 from container_service_extension.lib.cloudapi.cloudapi_client import \
     CloudApiClient
 from container_service_extension.logging.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.rde.backend import cluster_service_factory
+from container_service_extension.rde.behaviors.behavior_model import BehaviorOperation  # noqa: E501
 import container_service_extension.rde.constants as rde_constants
 import container_service_extension.rde.utils as rde_utils
 import container_service_extension.rde.validators.validator_factory as rde_validator_factory  # noqa: E501
@@ -87,10 +88,17 @@ def update_cluster(behavior_ctx: RequestContext):
 
     # Validate the Input payload based on the (Operation, payload_version).
     # Get the validator based on the payload_version
+    kind = input_entity['kind']
+    is_tkgm_cluster = (kind == ClusterEntityKind.TKG_M.value)
+    sysadmin_client = behavior_ctx.sysadmin_client
     input_rde_version = rde_constants.MAP_INPUT_PAYLOAD_VERSION_TO_RDE_VERSION[payload_version]  # noqa: E501
     rde_validator_factory.get_validator(
         rde_version=input_rde_version). \
-        validate(cloudapi_client=cloudapi_client, entity=input_entity)
+        validate(cloudapi_client=cloudapi_client,
+                 sysadmin_client=sysadmin_client,
+                 operation=BehaviorOperation.UPDATE_CLUSTER,
+                 entity=input_entity,
+                 is_tkgm_cluster=is_tkgm_cluster)
 
     # Convert the input entity to runtime rde format.
     # Based on the runtime rde, call the appropriate backend method.

--- a/container_service_extension/server/behavior_handler.py
+++ b/container_service_extension/server/behavior_handler.py
@@ -67,7 +67,9 @@ def create_cluster(behavior_ctx: RequestContext):
     input_rde_version = rde_constants.MAP_INPUT_PAYLOAD_VERSION_TO_RDE_VERSION[payload_version]  # noqa: E501
     rde_validator_factory.get_validator(
         rde_version=input_rde_version). \
-        validate(cloudapi_client=cloudapi_client, entity=input_entity)
+        validate(cloudapi_client=cloudapi_client,
+                 sysadmin_client=behavior_ctx.op_ctx.sysadmin_client,
+                 entity=input_entity)
 
     # Convert the input entity to runtime rde format.
     # Based on the runtime rde, call the appropriate backend method.
@@ -90,13 +92,14 @@ def update_cluster(behavior_ctx: RequestContext):
     # Get the validator based on the payload_version
     kind = input_entity['kind']
     is_tkgm_cluster = (kind == ClusterEntityKind.TKG_M.value)
-    sysadmin_client = behavior_ctx.sysadmin_client
+    sysadmin_client = behavior_ctx.op_ctx.sysadmin_client
     input_rde_version = rde_constants.MAP_INPUT_PAYLOAD_VERSION_TO_RDE_VERSION[payload_version]  # noqa: E501
     rde_validator_factory.get_validator(
         rde_version=input_rde_version). \
         validate(cloudapi_client=cloudapi_client,
                  sysadmin_client=sysadmin_client,
                  operation=BehaviorOperation.UPDATE_CLUSTER,
+                 entity_id=entity_id,
                  entity=input_entity,
                  is_tkgm_cluster=is_tkgm_cluster)
 

--- a/container_service_extension/server/request_handlers/cluster_handler.py
+++ b/container_service_extension/server/request_handlers/cluster_handler.py
@@ -66,6 +66,7 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     rde_validator_factory.get_validator(
         rde_version=rde_constants.MAP_INPUT_PAYLOAD_VERSION_TO_RDE_VERSION[
             payload_version]).validate(cloudapi_client=op_ctx.cloudapi_client,
+                                       sysadmin_client=op_ctx.sysadmin_client,
                                        entity=input_entity)
 
     def_entity_service = entity_service.DefEntityService(op_ctx.cloudapi_client)  # noqa: E501

--- a/container_service_extension/server/request_handlers/cluster_handler.py
+++ b/container_service_extension/server/request_handlers/cluster_handler.py
@@ -19,6 +19,7 @@ Responsibility of the functions in this file:
 
 import container_service_extension.common.constants.server_constants as server_constants  # noqa: E501
 from container_service_extension.common.constants.shared_constants import ClusterAclKey  # noqa: E501
+from container_service_extension.common.constants.shared_constants import ClusterEntityKind  # noqa: E501
 from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
 from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
 from container_service_extension.common.constants.shared_constants import PaginationKey  # noqa: E501
@@ -193,12 +194,17 @@ def cluster_update(data: dict, op_ctx: ctx.OperationContext):
     # Validate the Input payload based on the (Operation, payload_version).
     # Get the validator based on the payload_version
     # ToDo : Don't use default cloudapi_client. Use the specific versioned one
+    kind = input_entity['kind']
+    is_tkgm_cluster = (kind == ClusterEntityKind.TKG_M.value)
+    sysadmin_client = op_ctx.sysadmin_client
     rde_validator_factory.get_validator(
         rde_version=rde_constants.MAP_INPUT_PAYLOAD_VERSION_TO_RDE_VERSION[
             payload_version]). \
-        validate(cloudapi_client=op_ctx.cloudapi_client, entity_id=cluster_id,
+        validate(cloudapi_client=op_ctx.cloudapi_client,
+                 sysadmin_client=sysadmin_client, entity_id=cluster_id,
                  entity=input_entity,
-                 operation=BehaviorOperation.UPDATE_CLUSTER)
+                 operation=BehaviorOperation.UPDATE_CLUSTER,
+                 is_tkgm_cluster=is_tkgm_cluster)
 
     # Convert the input entity to runtime rde format.
     # Based on the runtime rde, call the appropriate backend method.


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

 * Fill up cpu and memory properties in status section for tkgm clusters
 * Validation changes to include cpu and memory validation for TKGm clusters
   * If TKGm cluster was created using cpu/memory, Do not ignore sizingClass in validation for resize.
 * Remove conditional logic which prevented displaying cpu and memory properties in cluster apply --sample command
 
Testing done:
* Create TKGm cluster using cpu/memory. Try resizing the cluster with a sizing Class other than system default. (should fail)
* Create TKGm cluster using a sizing Class (other than system default) and resize using cpu/memory (should fail)
* Create TKGm cluster using cpu/memory, resize the cluster using same value for cpu/memory (should succeed)
* Create TKGm cluster using sizingClass, resize the cluster using the same sizingClass (should succeed)
* Create TKGm cluster using cpu/memory. Try resizing the cluster using different value for cpu/memory (should fail)
* Create TKGm cluster using sizingClass, resize the cluster using a different sizingClass (should fail)

@rocknes @sakthisunda @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1202)
<!-- Reviewable:end -->
