### PR TITLE
[VCDA-2783] Fix missing source id in telemetry

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_1_x.py
+++ b/container_service_extension/rde/backend/cluster_service_1_x.py
@@ -139,7 +139,10 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         telemetry_handler.record_user_action_details(
             cse_operation=telemetry_constants.CseOperation.V35_CLUSTER_LIST,
-            cse_params={telemetry_constants.PayloadKey.FILTER_KEYS: ','.join(filters.keys())}  # noqa: E501
+            cse_params={
+                telemetry_constants.PayloadKey.FILTER_KEYS: ','.join(filters.keys()),  # noqa: E501
+                telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
+            }
         )
 
         ent_type: common_models.DefEntityType = server_utils.get_registered_def_entity_type()  # noqa: E501

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -185,14 +185,6 @@ class ClusterService(abstract_broker.AbstractBroker):
         msg = f"{DOWNLOAD_KUBECONFIG_OPERATION_MESSAGE} ({cluster_id})"
         self._update_task(BehaviorTaskStatus.RUNNING, message=msg)
 
-        telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_CONFIG,
-            cse_params={
-                CLUSTER_ENTITY: curr_rde,
-                telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
-            }
-        )
-
         if curr_rde.externalId is None:
             msg = f"Cannot find VApp href for cluster {curr_rde.name} " \
                   f"with id {cluster_id}"
@@ -307,18 +299,13 @@ class ClusterService(abstract_broker.AbstractBroker):
                 'entity.status.task_href': self.task_href
             }
             try:
+
                 curr_rde = self._update_cluster_entity(entity_id, changes=changes)  # noqa: E501
             except Exception:
                 msg = f"Error updating the cluster '{cluster_name}' with the status"  # noqa: E501
                 LOGGER.error(msg, exc_info=True)
                 raise
-            telemetry_handler.record_user_action_details(
-                cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_APPLY,  # noqa: E501
-                cse_params={
-                    CLUSTER_ENTITY: curr_rde,
-                    telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
-                }
-            )
+
             # trigger async operation
             self.context.is_async = True
             self._create_cluster_async(entity_id, input_native_entity)
@@ -428,19 +415,6 @@ class ClusterService(abstract_broker.AbstractBroker):
                 f"Cluster {cluster_name} with id {cluster_id} is not in a "
                 f"valid state to be resized. Please contact the administrator")
 
-        # Record telemetry details
-        telemetry_data: common_models.DefEntity = common_models.DefEntity(
-            entityType=server_utils.get_registered_def_entity_type().id,
-            id=cluster_id,
-            entity=input_native_entity)
-        telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_APPLY,
-            cse_params={
-                CLUSTER_ENTITY: telemetry_data,
-                telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
-            }
-        )
-
         # update the task and defined entity.
         msg = f"Resizing the cluster '{cluster_name}' ({cluster_id}) to the " \
               f"desired worker count {desired_worker_count} and " \
@@ -494,14 +468,6 @@ class ClusterService(abstract_broker.AbstractBroker):
             raise exceptions.CseServerError(
                 f"Cluster {cluster_name} with id {cluster_id} is not in a "
                 f"valid state to be deleted. Please contact administrator.")
-
-        telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_DELETE,
-            cse_params={
-                CLUSTER_ENTITY: curr_rde,
-                telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
-            }
-        )
 
         # must _update_task here or else self.task_resource is None
         # do not logout of sys admin, or else in pyvcloud's session.request()

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -299,8 +299,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                 'entity.status.task_href': self.task_href
             }
             try:
-
-                curr_rde = self._update_cluster_entity(entity_id, changes=changes)  # noqa: E501
+                self._update_cluster_entity(entity_id, changes=changes)  # noqa: E501
             except Exception:
                 msg = f"Error updating the cluster '{cluster_name}' with the status"  # noqa: E501
                 LOGGER.error(msg, exc_info=True)

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -19,7 +19,6 @@ from pyvcloud.vcd.vdc import VDC
 import pyvcloud.vcd.vm as vcd_vm
 import validators
 
-from container_service_extension.common.constants.server_constants import CLUSTER_ENTITY  # noqa: E501
 from container_service_extension.common.constants.server_constants import ClusterMetadataKey  # noqa: E501
 from container_service_extension.common.constants.server_constants import ClusterScriptFile  # noqa: E501
 from container_service_extension.common.constants.server_constants import DefEntityOperation  # noqa: E501
@@ -136,13 +135,6 @@ class ClusterService(abstract_broker.AbstractBroker):
         if not filters:
             filters = {}
 
-        telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_LIST,
-            cse_params={
-                telemetry_constants.PayloadKey.FILTER_KEYS: ','.join(filters.keys()),  # noqa: E501
-                telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
-            }
-        )
         ent_type: common_models.DefEntityType = server_utils.get_registered_def_entity_type()  # noqa: E501
         return self.entity_svc.get_entities_per_page_by_entity_type(
             vendor=ent_type.vendor,
@@ -161,14 +153,6 @@ class ClusterService(abstract_broker.AbstractBroker):
         """
         if not filters:
             filters = {}
-
-        telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_LIST,
-            cse_params={
-                telemetry_constants.PayloadKey.FILTER_KEYS: ','.join(filters.keys()),  # noqa: E501
-                telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
-            }
-        )
 
         ent_type: common_models.DefEntityType = server_utils.get_registered_def_entity_type()  # noqa: E501
 
@@ -196,14 +180,6 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         msg = f"{DOWNLOAD_KUBECONFIG_OPERATION_MESSAGE} ({cluster_id})"
         self._update_task(BehaviorTaskStatus.RUNNING, message=msg)
-
-        telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_CONFIG,
-            cse_params={
-                CLUSTER_ENTITY: curr_rde,
-                telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
-            }
-        )
 
         # Get kube config from RDE
         kube_config = None
@@ -273,8 +249,6 @@ class ClusterService(abstract_broker.AbstractBroker):
             # check that requested/default template is valid
             template = _get_tkgm_template(template_name)
 
-            # TODO(DEF) design and implement telemetry VCDA-1564 defined entity
-            #  based clusters
             k8_distribution = rde_2_x.Distribution(
                 template_name=template_name,
                 template_revision=1,
@@ -314,13 +288,6 @@ class ClusterService(abstract_broker.AbstractBroker):
                 msg = f"Error updating the cluster '{cluster_name}' with the status"  # noqa: E501
                 LOGGER.error(msg)
                 raise
-            telemetry_handler.record_user_action_details(
-                cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_APPLY,  # noqa: E501
-                cse_params={
-                    CLUSTER_ENTITY: curr_rde,
-                    telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
-                }
-            )
             # trigger async operation
             self.context.is_async = True
             self._create_cluster_async(entity_id, input_native_entity)
@@ -427,19 +394,6 @@ class ClusterService(abstract_broker.AbstractBroker):
                 f"Cluster {cluster_name} with id {cluster_id} is not in a "
                 f"valid state to be resized. Please contact the administrator")
 
-        # Record telemetry details
-        telemetry_data: common_models.DefEntity = common_models.DefEntity(
-            entityType=server_utils.get_registered_def_entity_type().id,
-            id=cluster_id,
-            entity=input_native_entity)
-        telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_APPLY,
-            cse_params={
-                CLUSTER_ENTITY: telemetry_data,
-                telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
-            }
-        )
-
         # update the task and defined entity.
         msg = f"Resizing the cluster '{cluster_name}' ({cluster_id}) to the " \
               f"desired worker count {desired_worker_count}"
@@ -495,14 +449,6 @@ class ClusterService(abstract_broker.AbstractBroker):
             raise exceptions.CseServerError(
                 f"Cluster {cluster_name} with id {cluster_id} is not in a "
                 f"valid state to be deleted. Please contact administrator.")
-
-        telemetry_handler.record_user_action_details(
-            cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_DELETE,
-            cse_params={
-                CLUSTER_ENTITY: curr_rde,
-                telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
-            }
-        )
 
         # must _update_task here or else self.task_resource is None
         # do not logout of sys admin, or else in pyvcloud's session.request()
@@ -732,15 +678,13 @@ class ClusterService(abstract_broker.AbstractBroker):
               f"'{curr_native_entity.metadata.name}' ({cluster_id})"
         self._update_task(BehaviorTaskStatus.RUNNING, message=msg)
 
-        # TODO(DEF) design and implement telemetry VCDA-1564 defined entity
-        #  based clusters
-
         changes = {
             'entity.status.task_href': self.task_href,
             'entity.status.phase': str(
                 DefEntityPhase(DefEntityOperation.UPDATE,
                                DefEntityOperationStatus.IN_PROGRESS))
         }
+
         try:
             self._update_cluster_entity(cluster_id, changes=changes)
         except Exception as err:

--- a/container_service_extension/server/request_handlers/cluster_handler.py
+++ b/container_service_extension/server/request_handlers/cluster_handler.py
@@ -18,6 +18,7 @@ Responsibility of the functions in this file:
 """
 
 import container_service_extension.common.constants.server_constants as server_constants  # noqa: E501
+from container_service_extension.common.constants.server_constants import ThreadLocalData  # noqa: E501
 from container_service_extension.common.constants.shared_constants import ClusterAclKey  # noqa: E501
 from container_service_extension.common.constants.shared_constants import ClusterEntityKind  # noqa: E501
 from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE  # noqa: E501
@@ -90,6 +91,13 @@ def cluster_create(data: dict, op_ctx: ctx.OperationContext):
     entity_id = task_resource.Owner.get('id')
     def_entity = def_entity_service.get_entity(entity_id)
     def_entity.entity.status.task_href = task_href
+    telemetry_handler.record_user_action_details(
+        cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_APPLY,
+        cse_params={
+            server_constants.CLUSTER_ENTITY: def_entity,
+            telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
+        }
+    )
     return def_entity.to_dict()
 
 
@@ -169,7 +177,16 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     :return: Dict
     """
     cluster_id = data[RequestKey.CLUSTER_ID]
+    def_entity_service = entity_service.DefEntityService(op_ctx.cloudapi_client)  # noqa: E501
+    def_entity: common_models.DefEntity = def_entity_service.get_entity(cluster_id)  # noqa: E501
     behavior_svc = BehaviorService(cloudapi_client=op_ctx.cloudapi_client)
+    telemetry_handler.record_user_action_details(
+        cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_CONFIG,
+        cse_params={
+            server_constants.CLUSTER_ENTITY: def_entity,
+            telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
+        }
+    )
     config_task_href = behavior_svc.invoke_behavior(
         entity_id=cluster_id,
         behavior_interface_id=KUBE_CONFIG_BEHAVIOR_INTERFACE_ID)
@@ -220,6 +237,13 @@ def cluster_update(data: dict, op_ctx: ctx.OperationContext):
         changes=changes
     )
     updated_def_entity.entity.status.task_href = task_href
+    telemetry_handler.record_user_action_details(
+        cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_APPLY,
+        cse_params={
+            server_constants.CLUSTER_ENTITY: updated_def_entity,
+            telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
+        }
+    )
     # TODO: Response RDE must be compatible with the request RDE.
     #  Conversions may be needed especially if there is a major version
     #  difference in the input RDE and runtime RDE.
@@ -253,6 +277,13 @@ def cluster_delete(data: dict, op_ctx: ctx.OperationContext):
     cluster_id = data[RequestKey.CLUSTER_ID]
     def_entity_service = entity_service.DefEntityService(op_ctx.cloudapi_client)  # noqa: E501
     def_entity: common_models.DefEntity = def_entity_service.get_entity(cluster_id)  # noqa: E501
+    telemetry_handler.record_user_action_details(
+        cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_DELETE,
+        cse_params={
+            server_constants.CLUSTER_ENTITY: def_entity,
+            telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
+        }
+    )
     _, task_href = def_entity_service.delete_entity(cluster_id, invoke_hooks=True, is_request_async=True)  # noqa: E501
     def_entity.entity.status.task_href = task_href
     return def_entity.to_dict()

--- a/container_service_extension/server/vcdbroker.py
+++ b/container_service_extension/server/vcdbroker.py
@@ -132,12 +132,14 @@ class VcdBroker(abstract_broker.AbstractBroker):
             RequestKey.OVDC_NAME: None,
         }
         validated_data = {**defaults, **data}
+        cse_params = copy.deepcopy(validated_data)
+        cse_params[PayloadKey.SOURCE_DESCRIPTION] = thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
 
         if kwargs.get(KwargKey.TELEMETRY, True):
             # Record the data for telemetry
             record_user_action_details(
                 cse_operation=CseOperation.CLUSTER_LIST,
-                cse_params=copy.deepcopy(validated_data))
+                cse_params=cse_params)
 
         client_v33 = self.context.get_client(api_version=DEFAULT_API_VERSION)
         # "raw clusters" do not have well-defined cluster data keys
@@ -238,6 +240,8 @@ class VcdBroker(abstract_broker.AbstractBroker):
             cse_params = copy.deepcopy(validated_data)
             cse_params[PayloadKey.SOURCE_DESCRIPTION] = thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
             cse_params[PayloadKey.CLUSTER_ID] = cluster[ClusterDetailsKey.CLUSTER_ID.value]  # noqa: E501
+            cse_params[PayloadKey.TEMPLATE_NAME] = cluster[ClusterDetailsKey.TEMPLATE_NAME]  # noqa: E501
+            cse_params[PayloadKey.TEMPLATE_REVISION] = cluster[ClusterDetailsKey.TEMPLATE_REVISION]  # noqa: E501
             record_user_action_details(
                 cse_operation=CseOperation.CLUSTER_CONFIG,
                 cse_params=cse_params)
@@ -293,6 +297,7 @@ class VcdBroker(abstract_broker.AbstractBroker):
             # Record the telemetry data
             cse_params = copy.deepcopy(validated_data)
             cse_params[PayloadKey.CLUSTER_ID] = cluster[ClusterDetailsKey.CLUSTER_ID.value]  # noqa: E501
+            cse_params[PayloadKey.SOURCE_DESCRIPTION] = thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
             record_user_action_details(
                 cse_operation=CseOperation.CLUSTER_UPGRADE_PLAN,
                 cse_params=cse_params)


### PR DESCRIPTION
- Fix missing source description, id in telemetry for native and tkgm operations
- Before fix, when recording telemetry CRUD details in service (native, tkgm) code, the thread context looses the source id and description. This is fixed by extracting telemetry details with source information in handler logic before delegation to behavior implementation.  The affected operations are CREATE, DELETE, UPDATE and CONFIG
- Tested and verified manually in staging telemetry tables.
@rocknes @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1204)
<!-- Reviewable:end -->
