### PR TITLE
[VCDA-2894, VCDA-2906] Improve sample cluster spec generation, Add support for TKGm 1.4.0 OVA

### DIFF
--- a/container_service_extension/client/sample_generator.py
+++ b/container_service_extension/client/sample_generator.py
@@ -69,7 +69,11 @@ SAMPLE_TKG_CLUSTER_SPEC_HELP = """# Short description of various properties used
 """  # noqa: E501
 
 
-def get_sample_cluster_configuration(output=None, k8_runtime=None, server_rde_in_use=None):  # noqa: E501
+def get_sample_cluster_configuration(
+        output=None,
+        k8_runtime=None,
+        server_rde_in_use=None
+):
     """Generate sample cluster configuration.
 
     :param str output: full path of output file
@@ -80,7 +84,7 @@ def get_sample_cluster_configuration(output=None, k8_runtime=None, server_rde_in
     :rtype: str
     """
     if k8_runtime == shared_constants.ClusterEntityKind.TKG_S:
-        sample_cluster_config = SAMPLE_TKG_CLUSTER_SPEC_HELP + _get_sample_tkg_cluster_configuration()  # noqa: E501
+        sample_cluster_config = SAMPLE_TKG_CLUSTER_SPEC_HELP + _get_sample_tkg_s_cluster_configuration()  # noqa: E501
     else:
         if not server_rde_in_use:
             raise ValueError("CSE server API version required to generate sample config")  # noqa: E501
@@ -94,12 +98,12 @@ def get_sample_cluster_configuration(output=None, k8_runtime=None, server_rde_in
 
 
 def _get_sample_cluster_configuration_by_k8_runtime(k8_runtime, server_rde_in_use):  # noqa: E501
-    NativeEntityClass = rde_factory.get_rde_model(server_rde_in_use)
-    return NativeEntityClass.get_sample_native_cluster_specification(k8_runtime)  # noqa: E501
+    native_entity_class = rde_factory.get_rde_model(server_rde_in_use)
+    return native_entity_class.get_sample_native_cluster_specification(k8_runtime)  # noqa: E501
 
 
-def _get_sample_tkg_cluster_configuration():
-    sample_tkg_plus_config = {
+def _get_sample_tkg_s_cluster_configuration():
+    sample_tkg_s_config = {
         "kind": "TanzuKubernetesCluster",
         "spec": {
             "topology": {
@@ -124,6 +128,6 @@ def _get_sample_tkg_cluster_configuration():
             "virtualDataCenterName": "org_virtual_data_center_name"
         }
     }
-    sample_apply_spec = yaml.dump(sample_tkg_plus_config)
+    sample_apply_spec = yaml.dump(sample_tkg_s_config)
     CLIENT_LOGGER.info(sample_apply_spec)
     return sample_apply_spec

--- a/container_service_extension/installer/templates/tkgm_template_manager.py
+++ b/container_service_extension/installer/templates/tkgm_template_manager.py
@@ -21,7 +21,8 @@ def parse_tkgm_template_name(ova_file_name):
     # matches TKGm standard OVA name e.g.
     # ubuntu-2004-kube-v1.19.8-vmware.1-tkg.0-18171857641727074969.ova
     # ubuntu-2004-kube-v1.18.16-vmware.1-tkg.0-14744207219736322255.ova
-    name_regex = re.compile(r"ubuntu-([\d]+)-kube-v([\d]+[.][\d]+[.][\d]+[-vmware.[\d]*]*)-tkg[.][-|\d]*[.]ova")  # noqa: E501
+    # ubuntu-2004-kube-v1.21.2+vmware.1-tkg.1-7832907791984498322.ova
+    name_regex = re.compile(r"ubuntu-([\d]+)-kube-v([\d]+[.][\d]+[.][\d]+[-|+][vmware.[\d]*]*)-tkg[.][-|\d]*[.]ova")  # noqa: E501
     m = name_regex.match(ova_file_name)
     os_version = None
     kubernetes_version = None

--- a/container_service_extension/rde/models/rde_1_0_0.py
+++ b/container_service_extension/rde/models/rde_1_0_0.py
@@ -399,7 +399,10 @@ class NativeEntity(AbstractNativeEntity):
         return cluster_entity
 
     @classmethod
-    def get_sample_native_cluster_specification(cls, k8_runtime: str = shared_constants.ClusterEntityKind.NATIVE.value):  # noqa: E501
+    def get_sample_native_cluster_specification(
+            cls,
+            k8_runtime: str = shared_constants.ClusterEntityKind.NATIVE.value
+    ):
         cluster_spec_field_descriptions = """# Short description of various properties used in this sample cluster configuration
 # api_version: Represents the payload version of the cluster specification. By default, empty.
 # kind: The kind of the Kubernetes cluster.
@@ -436,29 +439,35 @@ class NativeEntity(AbstractNativeEntity):
 #
 # status: Current state of the cluster in the server. This is not a required section for any of the operations.\n
 """  # noqa: E501
-        metadata = Metadata('cluster_name', 'organization_name',
-                            'org_virtual_data_center_name')
-        status = Status()
-        settings = Settings(network='ovdc_network_name', ssh_key=None)
-        k8_distribution = Distribution(
-            template_name='ubuntu-16.04_k8-1.17_weave-2.6.0',
-            template_revision=2
+        metadata = Metadata(
+            'cluster_name',
+            'organization_name',
+            'org_virtual_data_center_name'
         )
+
         control_plane = ControlPlane(
             count=1,
             sizing_class='Large_sizing_policy_name',
             storage_profile='Gold_storage_profile_name'
         )
-        workers = Workers(
-            count=2,
-            sizing_class='Medium_sizing_policy_name',
-            storage_profile='Silver_storage_profile'
+
+        k8_distribution = Distribution(
+            template_name='ubuntu-16.04_k8-1.17_weave-2.6.0',
+            template_revision=2
         )
 
         nfs = Nfs(
             count=0,
             sizing_class='Large_sizing_policy_name',
             storage_profile='Platinum_storage_profile_name'
+        )
+
+        settings = Settings(network='ovdc_network_name', ssh_key=None)
+
+        workers = Workers(
+            count=2,
+            sizing_class='Medium_sizing_policy_name',
+            storage_profile='Silver_storage_profile'
         )
 
         cluster_spec = ClusterSpec(
@@ -469,10 +478,15 @@ class NativeEntity(AbstractNativeEntity):
             nfs=nfs
         )
 
-        native_entity_dict = NativeEntity(metadata=metadata,
-                                          spec=cluster_spec,
-                                          status=status,
-                                          kind=k8_runtime).to_dict()
+        status = Status()
+
+        native_entity_dict = NativeEntity(
+            metadata=metadata,
+            spec=cluster_spec,
+            status=status,
+            kind=k8_runtime
+        ).to_dict()
+
         # remove status part of the entity dict
         del native_entity_dict['status']
 

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -628,10 +628,6 @@ class NativeEntity(AbstractNativeEntity):
         del native_entity_dict['spec']['settings']['network']['cni']
 
         if k8_runtime == shared_constants.ClusterEntityKind.TKG_M.value:
-            del native_entity_dict['spec']['topology']['controlPlane']['cpu']
-            del native_entity_dict['spec']['topology']['controlPlane']['memory']  # noqa: E501
-            del native_entity_dict['spec']['topology']['workers']['cpu']
-            del native_entity_dict['spec']['topology']['workers']['memory']
             del native_entity_dict['spec']['topology']['nfs']
             native_entity_dict['spec']['settings']['network']['expose'] = True
             native_entity_dict['spec']['settings']['network']['pods'] = ['100.96.0.0/11']  # noqa: E501

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -634,8 +634,8 @@ class NativeEntity(AbstractNativeEntity):
             del native_entity_dict['spec']['topology']['workers']['memory']
             del native_entity_dict['spec']['topology']['nfs']
             native_entity_dict['spec']['settings']['network']['expose'] = True
-            native_entity_dict['spec']['settings']['network']['pods'] = ['1.1.1.1']  # noqa: E501
-            native_entity_dict['spec']['settings']['network']['services'] = ['2.2.2.2']  # noqa: E501
+            native_entity_dict['spec']['settings']['network']['pods'] = ['100.96.0.0/11']  # noqa: E501
+            native_entity_dict['spec']['settings']['network']['services'] = ['100.64.0.0/13']  # noqa: E501
         else:
             del native_entity_dict['spec']['settings']['network']['pods']
             del native_entity_dict['spec']['settings']['network']['services']

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -518,7 +518,10 @@ class NativeEntity(AbstractNativeEntity):
         return cluster_entity
 
     @classmethod
-    def get_sample_native_cluster_specification(cls, k8_runtime: str = shared_constants.ClusterEntityKind.NATIVE.value):  # noqa: E501
+    def get_sample_native_cluster_specification(
+            cls,
+            k8_runtime: str = shared_constants.ClusterEntityKind.NATIVE.value
+    ):
         """Create apply command cluster specification description.
 
         :returns: ClusterSpec field description
@@ -562,14 +565,13 @@ class NativeEntity(AbstractNativeEntity):
 #
 # status: Current state of the cluster in the server. This is not a required section for any of the operations.\n
 """  # noqa: E501
-        metadata = Metadata('cluster_name', 'organization_name',
-                            'org_virtual_data_center_name', 'VCD_site')
-        status = Status()
-        settings = Settings(ovdc_network='ovdc_network_name', ssh_key=None)
-        k8_distribution = Distribution(
-            template_name='ubuntu-16.04_k8-1.17_weave-2.6.0',
-            template_revision=2
+        metadata = Metadata(
+            'cluster_name',
+            'organization_name',
+            'org_virtual_data_center_name',
+            'VCD_site'
         )
+
         control_plane = ControlPlane(
             count=1,
             sizing_class='Large_sizing_policy_name',
@@ -593,18 +595,28 @@ class NativeEntity(AbstractNativeEntity):
             nfs=nfs
         )
 
+        k8_distribution = Distribution(
+            template_name='ubuntu-16.04_k8-1.17_weave-2.6.0',
+            template_revision=2
+        )
+
+        settings = Settings(ovdc_network='ovdc_network_name', ssh_key=None)
+
         cluster_spec = ClusterSpec(
             topology=topology,
             distribution=k8_distribution,
             settings=settings,
         )
 
+        status = Status()
+
         native_entity_dict = NativeEntity(
             api_version=rde_constants.PAYLOAD_VERSION_2_0,
             metadata=metadata,
             spec=cluster_spec,
             status=status,
-            kind=k8_runtime).to_dict()
+            kind=k8_runtime
+        ).to_dict()
 
         # remove status part of the entity dict
         del native_entity_dict['status']
@@ -614,14 +626,19 @@ class NativeEntity(AbstractNativeEntity):
         # for CSE 3.1.1 to accommodate Antrea as CNI
         # Below line can be deleted post Andromeda (CSE 3.1)
         del native_entity_dict['spec']['settings']['network']['cni']
-        del native_entity_dict['spec']['settings']['network']['pods']
-        del native_entity_dict['spec']['settings']['network']['services']
 
         if k8_runtime == shared_constants.ClusterEntityKind.TKG_M.value:
             del native_entity_dict['spec']['topology']['controlPlane']['cpu']
             del native_entity_dict['spec']['topology']['controlPlane']['memory']  # noqa: E501
             del native_entity_dict['spec']['topology']['workers']['cpu']
             del native_entity_dict['spec']['topology']['workers']['memory']
+            del native_entity_dict['spec']['topology']['nfs']
+            native_entity_dict['spec']['settings']['network']['expose'] = True
+            native_entity_dict['spec']['settings']['network']['pods'] = ['1.1.1.1']  # noqa: E501
+            native_entity_dict['spec']['settings']['network']['services'] = ['2.2.2.2']  # noqa: E501
+        else:
+            del native_entity_dict['spec']['settings']['network']['pods']
+            del native_entity_dict['spec']['settings']['network']['services']
 
         sample_apply_spec = yaml.dump(native_entity_dict)
         return cluster_spec_field_descriptions + sample_apply_spec


### PR DESCRIPTION
Improve sample cluster spec generation for native and TKGm
1. TKGm - Delete NFS section, Add default cidrs for pod and service. Change default of `expose` value to True.
2. Native - Hide pod and service cidr sections

Make sure that the new TKGm 1.4.0 OVAs are not flagged by the regex matcher.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1206)
<!-- Reviewable:end -->
