### PR TITLE
Improve logging for code paths using CloudApiClient

### DIFF
--- a/container_service_extension/client/command_filter.py
+++ b/container_service_extension/client/command_filter.py
@@ -77,10 +77,17 @@ UNSUPPORTED_SUBCOMMAND_OPTIONS_BY_VERSION = {
             cli_constants.CommandNameKey.CREATE: ['cpu', 'memory']
         },
         cli_constants.GroupKey.OVDC: {
-            cli_constants.CommandNameKey.ENABLE: [] if str_to_bool(
-                os.getenv(cli_constants.ENV_CSE_TKG_PLUS_ENABLED)) else ['enable_tkg_plus'],  # noqa: E501
-            cli_constants.CommandNameKey.DISABLE: [] if str_to_bool(
-                os.getenv(cli_constants.ENV_CSE_TKG_PLUS_ENABLED)) else ['disable_tkg_plus']  # noqa: E501
+            cli_constants.CommandNameKey.ENABLE: []
+            if str_to_bool(
+                os.getenv(cli_constants.ENV_CSE_TKG_PLUS_ENABLED)
+            )
+            else ['enable_tkg_plus'],
+
+            cli_constants.CommandNameKey.DISABLE: []
+            if str_to_bool(
+                os.getenv(cli_constants.ENV_CSE_TKG_PLUS_ENABLED)
+            )
+            else ['disable_tkg_plus']
         }
     }
 }

--- a/container_service_extension/client/cse_client/cse_client.py
+++ b/container_service_extension/client/cse_client/cse_client.py
@@ -16,9 +16,9 @@ from container_service_extension.exception.minor_error_codes import MinorErrorCo
 from container_service_extension.logging.logger import CLIENT_WIRE_LOGGER
 from container_service_extension.logging.logger import NULL_LOGGER
 
-wire_logger = NULL_LOGGER
-if str_to_bool(os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING)):
-    wire_logger = CLIENT_WIRE_LOGGER
+wire_logger = CLIENT_WIRE_LOGGER \
+    if str_to_bool(os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING)) \
+    else NULL_LOGGER
 
 
 def _deserialize_response_content(response):

--- a/container_service_extension/client/de_cluster.py
+++ b/container_service_extension/client/de_cluster.py
@@ -16,6 +16,7 @@ import container_service_extension.client.tkgclient.rest as tkg_rest
 import container_service_extension.client.utils as client_utils
 from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE, PaginationKey  # noqa: E501
 from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
+import container_service_extension.common.utils.core_utils as core_utils
 import container_service_extension.common.utils.pyvcloud_utils as vcd_utils
 import container_service_extension.exception.exceptions as cse_exceptions
 import container_service_extension.logging.logger as logger
@@ -41,9 +42,11 @@ class DECluster:
     """
 
     def __init__(self, client):
-        logger_wire = logger.NULL_LOGGER
-        if os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING):
-            logger_wire = logger.CLIENT_WIRE_LOGGER
+        logger_wire = logger.CLIENT_WIRE_LOGGER \
+            if core_utils.str_to_bool(
+                os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING)
+            ) \
+            else logger.NULL_LOGGER
         self._client = client
         self._cloudapi_client = \
             vcd_utils.get_cloudapi_client_from_vcd_client(

--- a/container_service_extension/client/de_cluster.py
+++ b/container_service_extension/client/de_cluster.py
@@ -47,8 +47,10 @@ class DECluster:
         self._client = client
         self._cloudapi_client = \
             vcd_utils.get_cloudapi_client_from_vcd_client(
-                client=client, logger_debug=logger.CLIENT_LOGGER,
-                logger_wire=logger_wire)
+                client=client,
+                logger_debug=logger.CLIENT_LOGGER,
+                logger_wire=logger_wire
+            )
         self._nativeCluster = DEClusterNative(client)
         self._tkgCluster = DEClusterTKGS(client)
         schema_svc = def_schema_svc.DefSchemaService(self._cloudapi_client)

--- a/container_service_extension/client/de_cluster_native.py
+++ b/container_service_extension/client/de_cluster_native.py
@@ -38,8 +38,10 @@ class DEClusterNative:
             logger_wire = logger.CLIENT_WIRE_LOGGER
         self._cloudapi_client = \
             vcd_utils.get_cloudapi_client_from_vcd_client(
-                client=client, logger_debug=logger.CLIENT_LOGGER,
-                logger_wire=logger_wire)
+                client=client,
+                logger_debug=logger.CLIENT_LOGGER,
+                logger_wire=logger_wire
+            )
         self._native_cluster_api = NativeClusterApi(client)
         self._client = client
         schema_service = def_schema_svc.DefSchemaService(self._cloudapi_client)
@@ -64,11 +66,18 @@ class DEClusterNative:
         msg = "Operation not supported; Under implementation"
         raise vcd_exceptions.OperationNotSupportedException(msg)
 
-    def get_cluster_info(self, cluster_name, cluster_id=None,
-                         org=None, vdc=None, **kwargs):
+    def get_cluster_info(
+            self,
+            cluster_name,
+            cluster_id=None,
+            org=None,
+            vdc=None,
+            **kwargs
+    ):
         """Get cluster information using DEF API.
 
         :param str cluster_name: name of the cluster
+        :param str cluster_id:
         :param str vdc: name of vdc
         :param str org: name of org
         :param kwargs: *filter (dict): keys,values for DEF API query filter
@@ -104,11 +113,17 @@ class DEClusterNative:
         logger.CLIENT_LOGGER.debug(f"Defined entity info from server: {def_entity}")  # noqa: E501
         return yaml.dump(def_entity.entity.to_dict())
 
-    def delete_cluster(self, cluster_name, cluster_id=None,
-                       org=None, vdc=None):
+    def delete_cluster(
+            self,
+            cluster_name,
+            cluster_id=None,
+            org=None,
+            vdc=None
+    ):
         """Delete DEF native cluster by name.
 
         :param str cluster_name: native cluster name
+        :param str cluster_id:
         :param str org: name of the org
         :param str vdc: name of the vdc
         :return: string containing delete operation task href
@@ -262,7 +277,7 @@ class DEClusterNative:
         return client_utils.construct_task_console_message(task_href)
 
     def _get_cluster_name_from_cluster_apply_specification(self, input_spec: dict):  # noqa: E501
-        """Derive cluster name from cluster apply specificaiton.
+        """Derive cluster name from cluster apply specification.
 
         :param dict input_spec: Input specification
         :return: cluster name
@@ -324,7 +339,7 @@ class DEClusterNative:
             cluster_id = self.get_cluster_id_by_name(cluster_name, org, vdc)
         org_href = self._client.get_org_by_name(org).get('href')
         name_to_id: dict = client_utils.create_user_name_to_id_dict(
-            self._client, users, org_href)
+            self._client, set(users), org_href)
 
         # Parse user id info
         update_acl_entries = []

--- a/container_service_extension/client/de_cluster_native.py
+++ b/container_service_extension/client/de_cluster_native.py
@@ -12,6 +12,7 @@ import container_service_extension.client.constants as cli_constants
 from container_service_extension.client.cse_client.api_35.native_cluster_api import NativeClusterApi  # noqa: E501
 import container_service_extension.client.utils as client_utils
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
+import container_service_extension.common.utils.core_utils as core_utils
 import container_service_extension.common.utils.pyvcloud_utils as vcd_utils
 import container_service_extension.exception.exceptions as cse_exceptions
 import container_service_extension.logging.logger as logger
@@ -33,9 +34,11 @@ class DEClusterNative:
     """
 
     def __init__(self, client):
-        logger_wire = logger.NULL_LOGGER
-        if os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING):
-            logger_wire = logger.CLIENT_WIRE_LOGGER
+        logger_wire = logger.CLIENT_WIRE_LOGGER \
+            if core_utils.str_to_bool(
+                os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING)
+            ) \
+            else logger.NULL_LOGGER
         self._cloudapi_client = \
             vcd_utils.get_cloudapi_client_from_vcd_client(
                 client=client,

--- a/container_service_extension/client/de_cluster_tkg_s.py
+++ b/container_service_extension/client/de_cluster_tkg_s.py
@@ -415,14 +415,17 @@ class DEClusterTKGS:
             self._client, set(users), org_href)
         org_user_id_to_name_dict = vcd_utils.create_org_user_id_to_name_dict(
             self._client, org)
-        logger_wire = logger.NULL_LOGGER
-        if os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING):
-            logger_wire = logger.CLIENT_WIRE_LOGGER
+        logger_wire = logger.CLIENT_WIRE_LOGGER \
+            if utils.str_to_bool(
+                os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING)
+            ) \
+            else logger.NULL_LOGGER
         acl_svc = cluster_acl_svc.ClusterACLService(
             cluster_id=cluster_id,
             client=self._client,
             logger_debug=logger.CLIENT_LOGGER,
-            logger_wire=logger_wire)
+            logger_wire=logger_wire
+        )
         for acl_entry in acl_svc.list_def_entity_acl_entries():
             username = org_user_id_to_name_dict.get(acl_entry.memberId)
             if name_to_id.get(username):
@@ -451,9 +454,11 @@ class DEClusterTKGS:
         name_to_id: dict = client_utils.create_user_name_to_id_dict(
             self._client, set(users), org_href)
         users_ids: set = {user_id for _, user_id in name_to_id.items()}
-        logger_wire = logger.NULL_LOGGER
-        if os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING):
-            logger_wire = logger.CLIENT_WIRE_LOGGER
+        logger_wire = logger.CLIENT_WIRE_LOGGER \
+            if utils.str_to_bool(
+                os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING)
+            )\
+            else logger.NULL_LOGGER
         acl_svc = cluster_acl_svc.ClusterACLService(
             cluster_id=cluster_id,
             client=self._client,
@@ -488,9 +493,11 @@ class DEClusterTKGS:
                 self._client, shared_constants.SYSTEM_ORG_NAME)
             org_user_id_to_name_dict.update(sys_org_user_id_to_name_dict)
 
-        logger_wire = logger.NULL_LOGGER
-        if os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING):
-            logger_wire = logger.CLIENT_WIRE_LOGGER
+        logger_wire = logger.CLIENT_WIRE_LOGGER \
+            if utils.str_to_bool(
+                os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING)
+            ) \
+            else logger.NULL_LOGGER
         acl_svc = cluster_acl_svc.ClusterACLService(
             cluster_id=cluster_id,
             client=self._client,

--- a/container_service_extension/client/de_cluster_tkg_s.py
+++ b/container_service_extension/client/de_cluster_tkg_s.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import json
+import os
 
 from pyvcloud.vcd.client import ApiVersion
 from pyvcloud.vcd.vcd_api_version import VCDApiVersion
@@ -414,7 +415,14 @@ class DEClusterTKGS:
             self._client, set(users), org_href)
         org_user_id_to_name_dict = vcd_utils.create_org_user_id_to_name_dict(
             self._client, org)
-        acl_svc = cluster_acl_svc.ClusterACLService(cluster_id, self._client)
+        logger_wire = logger.NULL_LOGGER
+        if os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING):
+            logger_wire = logger.CLIENT_WIRE_LOGGER
+        acl_svc = cluster_acl_svc.ClusterACLService(
+            cluster_id=cluster_id,
+            client=self._client,
+            logger_debug=logger.CLIENT_LOGGER,
+            logger_wire=logger_wire)
         for acl_entry in acl_svc.list_def_entity_acl_entries():
             username = org_user_id_to_name_dict.get(acl_entry.memberId)
             if name_to_id.get(username):
@@ -443,7 +451,14 @@ class DEClusterTKGS:
         name_to_id: dict = client_utils.create_user_name_to_id_dict(
             self._client, set(users), org_href)
         users_ids: set = {user_id for _, user_id in name_to_id.items()}
-        acl_svc = cluster_acl_svc.ClusterACLService(cluster_id, self._client)
+        logger_wire = logger.NULL_LOGGER
+        if os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING):
+            logger_wire = logger.CLIENT_WIRE_LOGGER
+        acl_svc = cluster_acl_svc.ClusterACLService(
+            cluster_id=cluster_id,
+            client=self._client,
+            logger_debug=logger.CLIENT_LOGGER,
+            logger_wire=logger_wire)
         delete_acl_ids = []
         for acl_entry in acl_svc.list_def_entity_acl_entries():
             if acl_entry.memberId in users_ids:
@@ -472,7 +487,15 @@ class DEClusterTKGS:
             sys_org_user_id_to_name_dict = vcd_utils.create_org_user_id_to_name_dict(  # noqa:E501
                 self._client, shared_constants.SYSTEM_ORG_NAME)
             org_user_id_to_name_dict.update(sys_org_user_id_to_name_dict)
-        acl_svc = cluster_acl_svc.ClusterACLService(cluster_id, self._client)
+
+        logger_wire = logger.NULL_LOGGER
+        if os.getenv(cli_constants.ENV_CSE_CLIENT_WIRE_LOGGING):
+            logger_wire = logger.CLIENT_WIRE_LOGGER
+        acl_svc = cluster_acl_svc.ClusterACLService(
+            cluster_id=cluster_id,
+            client=self._client,
+            logger_debug=logger.CLIENT_LOGGER,
+            logger_wire=logger_wire)
         page_num = result_count = 0
         while True:
             page_num += 1

--- a/container_service_extension/common/utils/pyvcloud_utils.py
+++ b/container_service_extension/common/utils/pyvcloud_utils.py
@@ -522,9 +522,11 @@ def get_storage_profile_name_of_first_vm_in_vapp(vapp):
     return storage_profile_name
 
 
-def get_cloudapi_client_from_vcd_client(client: vcd_client.Client,
-                                        logger_debug=NULL_LOGGER,
-                                        logger_wire=NULL_LOGGER):
+def get_cloudapi_client_from_vcd_client(
+        client: vcd_client.Client,
+        logger_debug=NULL_LOGGER,
+        logger_wire=NULL_LOGGER
+):
     token = client.get_access_token()
     is_jwt = True
     if not token:

--- a/container_service_extension/installer/right_bundle_manager.py
+++ b/container_service_extension/installer/right_bundle_manager.py
@@ -10,20 +10,21 @@ import container_service_extension.common.utils.pyvcloud_utils as vcd_utils
 from container_service_extension.lib.cloudapi.constants import CloudApiResource
 from container_service_extension.lib.cloudapi.constants import CloudApiVersion
 from container_service_extension.logging.logger import NULL_LOGGER
-from container_service_extension.logging.logger import SERVER_CLOUDAPI_WIRE_LOGGER  # noqa: E501
 
 
-class RightBundleManager():
-    def __init__(self, sysadmin_client: vcd_client.Client,
-                 log_wire=False, logger_debug=NULL_LOGGER):
+class RightBundleManager:
+    def __init__(
+            self,
+            sysadmin_client: vcd_client.Client,
+            logger_debug=NULL_LOGGER,
+            logger_wire=NULL_LOGGER
+    ):
         vcd_utils.raise_error_if_user_not_from_system_org(sysadmin_client)
-        self.logger_wire = SERVER_CLOUDAPI_WIRE_LOGGER \
-            if log_wire else NULL_LOGGER
-        self.logger_debug = logger_debug
         self.cloudapi_client = vcd_utils.get_cloudapi_client_from_vcd_client(
             sysadmin_client,
-            logger_debug=self.logger_debug,
-            logger_wire=self.logger_wire)
+            logger_debug=logger_debug,
+            logger_wire=logger_wire
+        )
 
     def get_right_bundle_by_name(self, right_bundle_name):
         """Get Right bundle by name.

--- a/container_service_extension/mqi/mqtt_extension_manager.py
+++ b/container_service_extension/mqi/mqtt_extension_manager.py
@@ -85,9 +85,11 @@ class MQTTExtensionManager:
             wire_logger = logger.SERVER_CLOUDAPI_WIRE_LOGGER
         self._wire_logger = wire_logger
         self._debug_logger = debug_logger
-        self._cloudapi_client = \
-            vcd_utils.get_cloudapi_client_from_vcd_client(
-                self._sysadmin_client, self._debug_logger, self._wire_logger)
+        self._cloudapi_client = vcd_utils.get_cloudapi_client_from_vcd_client(
+            client=self._sysadmin_client,
+            logger_debug=self._debug_logger,
+            logger_wire=self._wire_logger
+        )
 
     def setup_extension(self, ext_name, ext_version, ext_vendor,
                         priority=constants.MQTT_EXTENSION_PRIORITY,
@@ -389,7 +391,7 @@ class MQTTExtensionManager:
         :param str ext_vendor: the extension vendor
 
         :return: list of token ids (str)
-        :rtype: list of strs
+        :rtype: list of strings
         :raises: HTTPError if unable to make the GET request
         """
         token_ids = []

--- a/container_service_extension/rde/acl_service.py
+++ b/container_service_extension/rde/acl_service.py
@@ -1,6 +1,7 @@
 # container-service-extension
 # Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
+import logging
 from typing import Dict, List, Optional
 
 import lxml
@@ -13,6 +14,7 @@ import container_service_extension.common.constants.shared_constants as shared_c
 import container_service_extension.common.utils.core_utils as utils
 import container_service_extension.common.utils.pyvcloud_utils as vcd_utils
 import container_service_extension.lib.cloudapi.constants as cloudapi_constants
+from container_service_extension.logging.logger import NULL_LOGGER
 import container_service_extension.rde.common.entity_service as def_entity_svc
 import container_service_extension.rde.constants as def_constants
 import container_service_extension.rde.models.common_models as common_models
@@ -21,11 +23,19 @@ import container_service_extension.rde.models.common_models as common_models
 class ClusterACLService:
     """Manages retrieving and setting Cluster ACL information."""
 
-    def __init__(self, cluster_id: str,
-                 client: vcd_client.Client):
+    def __init__(
+            self,
+            cluster_id: str,
+            client: vcd_client.Client,
+            logger_debug: logging.Logger = NULL_LOGGER,
+            logger_wire: logging.Logger = NULL_LOGGER
+    ):
         self._client = client
-        self._cloudapi_client = \
-            vcd_utils.get_cloudapi_client_from_vcd_client(client)
+        self._cloudapi_client = vcd_utils.get_cloudapi_client_from_vcd_client(
+            client=client,
+            logger_debug=logger_debug,
+            logger_wire=logger_wire
+        )
         self._cluster_id = cluster_id
         self._def_entity: Optional[common_models.DefEntity] = None
         self._vapp: Optional[vcd_vapp.VApp] = None

--- a/container_service_extension/rde/backend/cluster_service_1_x.py
+++ b/container_service_extension/rde/backend/cluster_service_1_x.py
@@ -43,6 +43,8 @@ import container_service_extension.exception.exceptions as exceptions
 import container_service_extension.installer.templates.local_template_manager as ltm  # noqa: E501
 import container_service_extension.lib.telemetry.constants as telemetry_constants  # noqa: E501
 import container_service_extension.lib.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
+from container_service_extension.logging.logger import NULL_LOGGER
+from container_service_extension.logging.logger import SERVER_CLOUDAPI_WIRE_LOGGER  # noqa: E501
 from container_service_extension.logging.logger import SERVER_LOGGER as LOGGER
 import container_service_extension.rde.acl_service as acl_service
 import container_service_extension.rde.backend.common.network_expose_helper as nw_exp_helper  # noqa: E501
@@ -554,8 +556,16 @@ class ClusterService(abstract_broker.AbstractBroker):
             cse_params=telemetry_params)
 
         client_v35 = self.context.get_client(api_version=DEFAULT_API_VERSION)
-        acl_svc = acl_service.ClusterACLService(cluster_id,
-                                                client_v35)
+        config = server_utils.get_server_runtime_config()
+        logger_wire = NULL_LOGGER
+        if utils.str_to_bool(config['service']['log_wire']):
+            logger_wire = SERVER_CLOUDAPI_WIRE_LOGGER
+        acl_svc = acl_service.ClusterACLService(
+            cluster_id=cluster_id,
+            client=client_v35,
+            logger_debug=LOGGER,
+            logger_wire=logger_wire
+        )
         curr_entity: common_models.DefEntity = acl_svc.get_cluster_entity()
         user_id_names_dict = vcd_utils.create_org_user_id_to_name_dict(
             client=client_v35,
@@ -598,7 +608,16 @@ class ClusterService(abstract_broker.AbstractBroker):
 
         # Get previous def entity acl
         client_v35 = self.context.get_client(api_version=DEFAULT_API_VERSION)
-        acl_svc = acl_service.ClusterACLService(cluster_id, client_v35)
+        config = server_utils.get_server_runtime_config()
+        logger_wire = NULL_LOGGER
+        if utils.str_to_bool(config['service']['log_wire']):
+            logger_wire = SERVER_CLOUDAPI_WIRE_LOGGER
+        acl_svc = acl_service.ClusterACLService(
+            cluster_id=cluster_id,
+            client=client_v35,
+            logger_debug=LOGGER,
+            logger_wire=logger_wire
+        )
         prev_user_id_to_acl_entry_dict: \
             Dict[str, common_models.ClusterAclEntry] = \
             acl_svc.create_user_id_to_acl_entry_dict()

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -43,6 +43,8 @@ import container_service_extension.exception.exceptions as exceptions
 import container_service_extension.installer.templates.local_template_manager as ltm  # noqa: E501
 import container_service_extension.lib.telemetry.constants as telemetry_constants  # noqa: E501
 import container_service_extension.lib.telemetry.telemetry_handler as telemetry_handler  # noqa: E501
+from container_service_extension.logging.logger import NULL_LOGGER
+from container_service_extension.logging.logger import SERVER_CLOUDAPI_WIRE_LOGGER  # noqa: E501
 from container_service_extension.logging.logger import SERVER_LOGGER as LOGGER
 from container_service_extension.mqi.consumer.mqtt_publisher import MQTTPublisher  # noqa: E501
 import container_service_extension.rde.acl_service as acl_service
@@ -697,7 +699,16 @@ class ClusterService(abstract_broker.AbstractBroker):
             cse_params=telemetry_params)
 
         client_v36 = self.context.get_client(api_version=DEFAULT_API_VERSION)
-        acl_svc = acl_service.ClusterACLService(cluster_id, client_v36)
+        config = server_utils.get_server_runtime_config()
+        logger_wire = NULL_LOGGER
+        if utils.str_to_bool(config['service']['log_wire']):
+            logger_wire = SERVER_CLOUDAPI_WIRE_LOGGER
+        acl_svc = acl_service.ClusterACLService(
+            cluster_id=cluster_id,
+            client=client_v36,
+            logger_debug=LOGGER,
+            logger_wire=logger_wire
+        )
         curr_rde: common_models.DefEntity = acl_svc.get_cluster_entity()
         user_id_names_dict = vcd_utils.create_org_user_id_to_name_dict(
             client=client_v36,
@@ -748,8 +759,16 @@ class ClusterService(abstract_broker.AbstractBroker):
             cse_params=telemetry_params)
 
         client_v36 = self.context.get_client(api_version=DEFAULT_API_VERSION)
-        # Get previous def entity acl
-        acl_svc = acl_service.ClusterACLService(cluster_id, client_v36)
+        config = server_utils.get_server_runtime_config()
+        logger_wire = NULL_LOGGER
+        if utils.str_to_bool(config['service']['log_wire']):
+            logger_wire = SERVER_CLOUDAPI_WIRE_LOGGER
+        acl_svc = acl_service.ClusterACLService(
+            cluster_id=cluster_id,
+            client=client_v36,
+            logger_debug=LOGGER,
+            logger_wire=logger_wire
+        )
         prev_user_id_to_acl_entry_dict: \
             Dict[str, common_models.ClusterAclEntry] = \
             acl_svc.create_user_id_to_acl_entry_dict()

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -592,7 +592,16 @@ class ClusterService(abstract_broker.AbstractBroker):
             cse_params=telemetry_params)
 
         client_v36 = self.context.get_client(api_version=DEFAULT_API_VERSION)
-        acl_svc = acl_service.ClusterACLService(cluster_id, client_v36)
+        config = server_utils.get_server_runtime_config()
+        logger_wire = NULL_LOGGER
+        if utils.str_to_bool(config['service']['log_wire']):
+            logger_wire = SERVER_CLOUDAPI_WIRE_LOGGER
+        acl_svc = acl_service.ClusterACLService(
+            cluster_id=cluster_id,
+            client=client_v36,
+            logger_debug=LOGGER,
+            logger_wire=logger_wire
+        )
         curr_rde: common_models.DefEntity = acl_svc.get_cluster_entity()
         user_id_names_dict = vcd_utils.create_org_user_id_to_name_dict(
             client=client_v36,
@@ -643,8 +652,16 @@ class ClusterService(abstract_broker.AbstractBroker):
             cse_params=telemetry_params)
 
         client_v36 = self.context.get_client(api_version=DEFAULT_API_VERSION)
-        # Get previous def entity acl
-        acl_svc = acl_service.ClusterACLService(cluster_id, client_v36)
+        config = server_utils.get_server_runtime_config()
+        logger_wire = NULL_LOGGER
+        if utils.str_to_bool(config['service']['log_wire']):
+            logger_wire = SERVER_CLOUDAPI_WIRE_LOGGER
+        acl_svc = acl_service.ClusterACLService(
+            cluster_id=cluster_id,
+            client=client_v36,
+            logger_debug=LOGGER,
+            logger_wire=logger_wire
+        )
         prev_user_id_to_acl_entry_dict: \
             Dict[str, common_models.ClusterAclEntry] = \
             acl_svc.create_user_id_to_acl_entry_dict()

--- a/container_service_extension/security/context/operation_context.py
+++ b/container_service_extension/security/context/operation_context.py
@@ -93,9 +93,9 @@ class OperationContext:
         if log_wire:
             logger_wire = logger.SERVER_CLOUDAPI_WIRE_LOGGER
         _cloudapi_client = vcd_utils.get_cloudapi_client_from_vcd_client(
-            _client,
-            logger.SERVER_LOGGER,
-            logger_wire)
+            client=_client,
+            logger_debug=logger.SERVER_LOGGER,
+            logger_wire=logger_wire)
 
         _user_context = user_context.UserContext(
             client=_client, cloud_api_client=_cloudapi_client)
@@ -112,9 +112,9 @@ class OperationContext:
             logger_wire = logger.SERVER_CLOUDAPI_WIRE_LOGGER
         _sysadmin_cloudapi_client = \
             vcd_utils.get_cloudapi_client_from_vcd_client(
-                _sysadmin_client,
-                logger.SERVER_LOGGER,
-                logger_wire)
+                client=_sysadmin_client,
+                logger_debug=logger.SERVER_LOGGER,
+                logger_wire=logger_wire)
 
         _sysadmin_user_context = user_context.UserContext(
             client=_sysadmin_client,

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -1554,9 +1554,10 @@ def _get_clients_from_config(config, log_wire_file, log_wire):
         logger_wire = SERVER_CLOUDAPI_WIRE_LOGGER
 
     cloudapi_client = vcd_utils.get_cloudapi_client_from_vcd_client(
-        client,
-        SERVER_CLI_LOGGER,
-        logger_wire)
+        client=client,
+        logger_debug=SERVER_CLI_LOGGER,
+        logger_wire=logger_wire
+    )
 
     return client, cloudapi_client
 

--- a/container_service_extension/server/compute_policy_manager.py
+++ b/container_service_extension/server/compute_policy_manager.py
@@ -51,9 +51,11 @@ class ComputePolicyManager:
             if log_wire:
                 wire_logger = logger.SERVER_CLOUDAPI_WIRE_LOGGER
             self._cloudapi_client = \
-                vcd_utils.get_cloudapi_client_from_vcd_client(self._sysadmin_client, # noqa: E501
-                                                              logger.SERVER_LOGGER, # noqa: E501
-                                                              wire_logger)
+                vcd_utils.get_cloudapi_client_from_vcd_client(
+                    self._sysadmin_client,
+                    logger_debug=logger.SERVER_LOGGER,
+                    logger_wire=wire_logger
+                )
             self._cloudapi_version = \
                 cloudapi_constants.CloudApiVersion.VERSION_2_0_0
             if self._cloudapi_client.get_vcd_api_version() < \

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -521,9 +521,11 @@ class Service(object, metaclass=Singleton):
                 logger_wire = logger.SERVER_CLOUDAPI_WIRE_LOGGER
 
             cloudapi_client = \
-                vcd_utils.get_cloudapi_client_from_vcd_client(sysadmin_client,
-                                                              logger.SERVER_LOGGER,  # noqa: E501
-                                                              logger_wire)
+                vcd_utils.get_cloudapi_client_from_vcd_client(
+                    client=sysadmin_client,
+                    logger_debug=logger.SERVER_LOGGER,
+                    logger_wire=logger_wire
+                )
             raise_error_if_def_not_supported(cloudapi_client)
 
             server_rde_version = server_utils.get_rde_version_in_use()


### PR DESCRIPTION
In current CSE code, often CloudApiClient is being used without any loggers, as a result we are losing a lot of valuable logs. This PR addresses all such code flows and adds loggers (both debug and wire) wherever a CloudApiClient is being created from standard pyvcloud client.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1210)
<!-- Reviewable:end -->
