### PR TITLE
[VCDA-2958] fix cluster resize, delete nodes failure

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -2000,7 +2000,12 @@ class ClusterService(abstract_broker.AbstractBroker):
         new_status: rde_2_x.Status = curr_rde.entity.status
         if curr_nodes_status:
             new_status.nodes = curr_nodes_status
-        return self._update_cluster_entity(cluster_id, new_status)
+        # Update cluster entity requires flattened entity.status
+        new_status_as_flattened_dict = utils.flatten_dictionary(
+            input_dict=asdict(new_status),
+            parent_key='entity.status.'
+        )
+        return self._update_cluster_entity(cluster_id, new_status_as_flattened_dict)  # noqa: E501
 
     def _update_cluster_entity(self, cluster_id: str,
                                changes: dict = None,


### PR DESCRIPTION
- Fix for native/tkg+ cluster resize failure
- New changes of VCDA-2884 and VCDA-2925 needs flattened RDE status dictionary for RDE update operations for updating status
- Affected operations: cluster resize and node delete
- Verified with creating a new cluster, resize

@Anirudh9794 @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1213)
<!-- Reviewable:end -->
