### PR TITLE
VCDA-2953: Ensure that pod and svc cidrs go through validation

### DIFF
--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -151,6 +151,8 @@ class FlattenedClusterSpecKey2X(Enum):
     TEMPLATE_NAME = 'distribution.templateName'
     TEMPLATE_REVISION = 'distribution.templateRevision'
     EXPOSE = 'settings.network.expose'
+    POD_CIDR = 'settings.network.pods.cidrBlocks'
+    SVC_CIDR = 'settings.network.services.cidrBlocks'
 
 
 VALID_UPDATE_FIELDS_2X = \

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -598,9 +598,14 @@ class ClusterService(abstract_broker.AbstractBroker):
             raise Exception(
                 "Upgrades not supported for TKGm in this version of CSE"
             )
-        raise exceptions.CseServerError(
-            "update not supported for the specified input specification"
-        )
+
+        nothing_to_do_payload = {
+            "status": "success",
+            "result": {
+                "resultContent": "Nothing to Update"
+            },
+        }
+        return nothing_to_do_payload
 
     def get_cluster_acl_info(self, cluster_id, page: int, page_size: int):
         """Get cluster ACL info based on the defined entity ACL."""


### PR DESCRIPTION
For some fields (pod and svc cidr), the validator functions do not work since they are only present in the spec section and not the status section. For these fields, the ideal way out is to add them to the status section. Until that happens, we bypass them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1215)
<!-- Reviewable:end -->
