### PR TITLE
[VCDA-2944, VCDA-2946] Fix sample generation, Stop loading native templates during CSE startup if `no_vc_communication_mode` flag is turned on

### DIFF
--- a/container_service_extension/installer/config_validator.py
+++ b/container_service_extension/installer/config_validator.py
@@ -605,15 +605,18 @@ def _validate_broker_config(
     :param dict broker_dict: 'broker' section of config file as a dict.
     :param utils.ConsoleMessagePrinter msg_update_callback: Callback object.
 
-    :raises KeyError: if @broker_dict has missing or extra properties.
+    :raises KeyError: if @broker_dict has missing properties.
     :raises TypeError: if the value type for a @broker_dict property is
         incorrect.
     :raises ValueError: if 'ip_allocation_mode' is not 'dhcp' or 'pool'. Or
         if remote_template_cookbook_url is invalid.
     """
-    check_keys_and_value_types(broker_dict, SAMPLE_BROKER_CONFIG['broker'],
-                               location="config file 'broker' section",
-                               msg_update_callback=msg_update_callback)
+    check_keys_and_value_types(
+        broker_dict,
+        SAMPLE_BROKER_CONFIG['broker'],
+        location="config file 'broker' section",
+        msg_update_callback=msg_update_callback
+    )
     valid_ip_allocation_modes = [
         'dhcp',
         'pool'

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -479,15 +479,6 @@ def install_template(
 
     client = None
     try:
-        is_no_vc_communication_mode = \
-            server_utils.is_no_vc_communication_mode(config)
-        if is_no_vc_communication_mode:
-            msg = "Native template can not be installed when " \
-                  "running in `No communication with VCenter` mode."
-            raise Exception(msg)
-        else:
-            populate_vsphere_list(config['vcs'])
-
         # Telemetry data construction
         cse_params = {
             PayloadKey.TEMPLATE_NAME: template_name,
@@ -502,6 +493,15 @@ def install_template(
             cse_operation=CseOperation.TEMPLATE_INSTALL,
             cse_params=cse_params,
             telemetry_settings=config['service']['telemetry'])
+
+        is_no_vc_communication_mode = \
+            server_utils.is_no_vc_communication_mode(config)
+        if is_no_vc_communication_mode:
+            msg = "Native template can not be installed when " \
+                  "running in `No communication with VCenter` mode."
+            raise Exception(msg)
+        else:
+            populate_vsphere_list(config['vcs'])
 
         log_filename = None
         log_wire = utils.str_to_bool(config['service'].get('log_wire'))
@@ -2217,6 +2217,7 @@ Please note, CSE server startup needs at least one valid template.
 Please create CSE K8s template(s) using the command `cse template install`."""
         msg_update_callback.info(msg)
         INSTALL_LOGGER.info(msg)
+
         _process_existing_templates(
             client=client,
             config=config,

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -562,9 +562,12 @@ class DefEntityService:
         return def_constants.DEF_NATIVE_ENTITY_TYPE_NSS in response_body['entityType']  # noqa: E501
 
     @handle_entity_service_exception
-    def upgrade_entity(self, entity_id: str,
-                       upgraded_native_entity: AbstractNativeEntity,
-                       target_entity_type_id: str):
+    def upgrade_entity(
+            self,
+            entity_id: str,
+            upgraded_native_entity: AbstractNativeEntity,
+            target_entity_type_id: str
+    ):
         """Upgrade entity type of the entity to the specified one.
 
         :param str entity_id: ID of the entity to upgrade

--- a/container_service_extension/rde/models/rde_2_0_0.py
+++ b/container_service_extension/rde/models/rde_2_0_0.py
@@ -634,8 +634,8 @@ class NativeEntity(AbstractNativeEntity):
         if k8_runtime == shared_constants.ClusterEntityKind.TKG_M.value:
             del native_entity_dict['spec']['topology']['nfs']
             native_entity_dict['spec']['settings']['network']['expose'] = True
-            native_entity_dict['spec']['settings']['network']['pods'] = ['100.96.0.0/11']  # noqa: E501
-            native_entity_dict['spec']['settings']['network']['services'] = ['100.64.0.0/13']  # noqa: E501
+            native_entity_dict['spec']['settings']['network']['pods']['cidr_blocks'] = ['100.96.0.0/11']  # noqa: E501
+            native_entity_dict['spec']['settings']['network']['services']['cidr_blocks'] = ['100.64.0.0/13']  # noqa: E501
         else:
             del native_entity_dict['spec']['settings']['network']['pods']
             del native_entity_dict['spec']['settings']['network']['services']

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -1011,24 +1011,35 @@ def list_template(ctx, config_file_path, skip_config_decryption,
         config_dict = _get_unvalidated_config(
             config_file_path=config_file_path,
             skip_config_decryption=skip_config_decryption,
-            msg_update_callback=console_message_printer)
+            msg_update_callback=console_message_printer
+        )
 
         # Record telemetry details
         cse_params = {
             PayloadKey.DISPLAY_OPTION: display_option,
             PayloadKey.WAS_DECRYPTION_SKIPPED: bool(skip_config_decryption)
         }
-        record_user_action_details(cse_operation=CseOperation.TEMPLATE_LIST,
-                                   cse_params=cse_params,
-                                   telemetry_settings=config_dict['service']['telemetry'])  # noqa: E501
+        record_user_action_details(
+            cse_operation=CseOperation.TEMPLATE_LIST,
+            cse_params=cse_params,
+            telemetry_settings=config_dict['service']['telemetry']
+        )
 
         log_wire_file = None
-        log_wire = utils.str_to_bool(config_dict['service'].get('log_wire'))  # noqa: E501
+        log_wire = utils.str_to_bool(config_dict.get('service', {}).get('log_wire', False))  # noqa: E501
         if log_wire:
             log_wire_file = SERVER_DEBUG_WIRELOG_FILEPATH
 
+        legacy_mode = None
+        if 'service' in config_dict:
+            if 'legacy_mode' in config_dict.get('service'):
+                legacy_mode = config_dict['service']['legacy_mode']
+        if legacy_mode is None:
+            msg = "Unable to find `legacy_mode` under " \
+                  "`service` section in config file."
+            raise Exception(msg)
+
         tkgm_templates = []
-        legacy_mode = config_dict['service']['legacy_mode']
         if display_option == DISPLAY_TKGM and not legacy_mode:
             client = None
             try:

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -372,9 +372,15 @@ class Service(object, metaclass=Singleton):
 
         # Read k8s catalog definition from catalog item metadata and append
         # the same to to server run-time config
-        self._load_template_definition_from_catalog(
-            msg_update_callback=msg_update_callback
-        )
+        if not server_utils.is_no_vc_communication_mode(self.config):
+            self._load_template_definition_from_catalog(
+                msg_update_callback=msg_update_callback
+            )
+        else:
+            msg = "Skipping loading k8s template definition from catalog " \
+                  "since `No communication with VCenter` mode is on."
+            logger.SERVER_LOGGER.info(msg)
+            msg_update_callback.general_no_color(msg)
 
         # Read TKGm catalog definition from catalog item metadata and append
         # the same to to server run-time config


### PR DESCRIPTION
Fixed sample generation to generate the correct hierarchy for pod and service cidr blocks

With `no_vc_communication_mode`, CSE should disallow users from creating new templates, native clusters or any other operation that requires VCenter communication. In a previous PR, new template creation command viz. `cse template install` has been suppressed whenever the flag in question is set to 'True'. However, users could effectively smuggle native templates via `cse upgrade` and then use them to deploy native clusters which would fail with unpredictable errors since VC communication has been turned off. To prevent these unpredictable errors, CSE will stop loading any native templates during startup if the is_vc_communication_mode flag is set to True.


Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1217)
<!-- Reviewable:end -->
