### PR TITLE
Fix TKGm template being identified as TKG+ during cluster upgrade

### DIFF
--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -2347,9 +2347,13 @@ def _get_placement_policy_name_from_template_name(template_name):
     if 'k8' in template_name:
         policy_name = \
             shared_constants.NATIVE_CLUSTER_RUNTIME_INTERNAL_NAME
-    # Some earlier TKG+ templates had just `tkg` in their name and
-    # not `tkgplus`
-    elif 'tkg' in template_name or 'tkgplus' in template_name:
+    # Some earlier TKG+ templates had just `_tkg-` in their name and
+    # not `tkgplus`. We are looking for `_tkg-` because the old TKG+ templates
+    # used to be of the format `ubuntu-16.04_tkg-1.17_weave-2.5.2` and we do
+    # not want to identify TKGm templates, which have the format
+    # ubuntu-2004-kube-v1.20.5-vmware.2-tkg.1-6700972457122900687, as a
+    # TKG+ template
+    elif '_tkg-' in template_name or 'tkgplus' in template_name:
         policy_name = \
             shared_constants.TKG_PLUS_CLUSTER_RUNTIME_INTERNAL_NAME
     else:


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Because we are checking `tkg` in template name to identify the template as TKG+ while processing clusters in cse upgrade,
TKGm templates, if present, will be identified as TKG+ tempalte.
This PR fixes the string being matched to prevent such upgrade errors

Testing done:
* Created a cluster with TKGm in no_vc_communication_mode: true and successfully upgraded cse to no_vc_communication_mode: false

@rocknes @arunmk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1220)
<!-- Reviewable:end -->
