### PR TITLE
[VCDA-2974] Fix unexpose network in native cluster update

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -680,8 +680,12 @@ class ClusterService(abstract_broker.AbstractBroker):
         current_nfs_count = current_spec.topology.nfs.count
         desired_workers_count = input_native_entity.spec.topology.workers.count
         desired_nfs_count = input_native_entity.spec.topology.nfs.count
+        current_expose_flag = current_spec.settings.network.expose
+        desired_expose_flag = input_native_entity.spec.settings.network.expose
 
-        if current_workers_count != desired_workers_count or current_nfs_count != desired_nfs_count:  # noqa: E501
+        if current_workers_count != desired_workers_count \
+                or current_nfs_count != desired_nfs_count\
+                or current_expose_flag != desired_expose_flag:
             return self.resize_cluster(cluster_id, input_native_entity)
 
         current_template_name = current_spec.distribution.template_name


### PR DESCRIPTION
- Fixed the unexpose network in native cluster update
- Check for desired and current unexpose and trigger DNAT deletion
- Tested with existing network exposed cluster with DNAT rule 
-  Verified the DNAT gets removed on cluster apply with network.expose:false

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1224)
<!-- Reviewable:end -->
