### PR TITLE
[VCDA-2982] Check presence of NFS section before converting it

### DIFF
--- a/container_service_extension/rde/models/rde_1_0_0.py
+++ b/container_service_extension/rde/models/rde_1_0_0.py
@@ -284,14 +284,15 @@ class NativeEntity(AbstractNativeEntity):
                     workers.append(worker_node_1_x)
 
                 nfs_nodes = []
-                for nfs_node in rde_2_x_entity.status.nodes.nfs:
-                    nfs_node_1_x = NfsNode(
-                        name=nfs_node.name,
-                        ip=nfs_node.ip,
-                        sizing_class=nfs_node.sizing_class,
-                        exports=str(nfs_node.exports)
-                    )
-                    nfs_nodes.append(nfs_node_1_x)
+                if rde_2_x_entity.status.nodes.nfs:
+                    for nfs_node in rde_2_x_entity.status.nodes.nfs:
+                        nfs_node_1_x = NfsNode(
+                            name=nfs_node.name,
+                            ip=nfs_node.ip,
+                            sizing_class=nfs_node.sizing_class,
+                            exports=str(nfs_node.exports)
+                        )
+                        nfs_nodes.append(nfs_node_1_x)
 
                 nodes = Nodes(
                     control_plane=control_plane,


### PR DESCRIPTION
In RDE 2.0.0, TKGm clusters have `nfs` section in `status` set to null, as a result while converting to RDE 1.0.0, we need to take care that we don't try to iterate over None object.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1226)
<!-- Reviewable:end -->
