### PR TITLE
Make local testing easier by skipping creation of prerequisites

### DIFF
--- a/container_service_extension/system_test_framework/environment.py
+++ b/container_service_extension/system_test_framework/environment.py
@@ -125,6 +125,9 @@ VCD_SITE = None
 # Location at which the cluster apply spec will be generated and used
 APPLY_SPEC_PATH = 'cluster_apply_specification.yaml'
 
+SHOULD_INSTALL_PREREQUISITES = True
+IS_CSE_SERVER_RUNNING = False
+
 
 def _init_test_vars(config, logger=NULL_LOGGER):
     """Initialize all the environment variables that are used for test.
@@ -133,7 +136,8 @@ def _init_test_vars(config, logger=NULL_LOGGER):
     """
     global TEMPLATE_DEFINITIONS, TEARDOWN_INSTALLATION, TEARDOWN_CLUSTERS, \
         TEST_ALL_TEMPLATES, TEST_ORG, TEST_VDC, TEST_NETWORK, \
-        USERNAME_TO_CLUSTER_NAME
+        USERNAME_TO_CLUSTER_NAME, SHOULD_INSTALL_PREREQUISITES, \
+        IS_CSE_SERVER_RUNNING
     USERNAME_TO_CLUSTER_NAME = {
         SYS_ADMIN_NAME: SYS_ADMIN_TEST_CLUSTER_NAME,
         CLUSTER_ADMIN_NAME: ORG_ADMIN_TEST_CLUSTER_NAME,
@@ -167,6 +171,9 @@ def _init_test_vars(config, logger=NULL_LOGGER):
                             specified_templates_def.append(template_def)
                             break
             TEMPLATE_DEFINITIONS = specified_templates_def
+    SHOULD_INSTALL_PREREQUISITES = \
+        test_config.get('should_install_prerequisites', True)
+    IS_CSE_SERVER_RUNNING = test_config.get('is_cse_server_running', False)
 
 
 _init_test_vars(testutils.yaml_to_dict(BASE_CONFIG_FILEPATH))
@@ -265,9 +272,9 @@ def init_rde_environment(config_filepath=BASE_CONFIG_FILEPATH, logger=NULL_LOGGE
     logger.debug(f"Using test org {test_org.get_name()} "
                  f"with href {TEST_ORG_HREF}")
     logger.debug(f"Using test vdc {test_vdc.name} with href {TEST_VDC_HREF}")
-
-    create_cluster_admin_role(config['vcd'], logger=logger)
-    create_cluster_author_role(config['vcd'], logger=logger)
+    if SHOULD_INSTALL_PREREQUISITES:
+        create_cluster_admin_role(config['vcd'], logger=logger)
+        create_cluster_author_role(config['vcd'], logger=logger)
 
 
 # TODO remove after removing legacy mode

--- a/system_tests_v2/base_config.yaml
+++ b/system_tests_v2/base_config.yaml
@@ -2,6 +2,12 @@
 # Fill in fields marked with '???'
 
 test:
+  is_cse_server_running: false                             # Affects test_cse_client.py,
+                                                           #   if true, the tests will assume that CSE server is already up and running.
+                                                           #   if false, cse server will be started up prior to running the tests.
+                                                           #   This flag helps in faster local testing.
+  should_install_prerequisites: true                       # If set to true, prerequisites like role, users and sizing policies won't be
+                                                           #    attempted to be created. This flag is to help local testing faster.
   teardown_installation: true                              # Affects test_cse_server.py.
                                                            #   if true, delete all installation entities (even on test failure).
                                                            #   if false, do not delete installation entities (even on test success).

--- a/system_tests_v2/conftest.py
+++ b/system_tests_v2/conftest.py
@@ -59,16 +59,17 @@ def vcd_users():
     - create Cluster admin user if it doesn't exist
     - create Cluster author user if it doesn't exist
     """
-    # org_admin -> cluster_admin
-    # k8_author -> cluster_author
-    env.create_user(env.CLUSTER_ADMIN_NAME,
-                    env.CLUSTER_ADMIN_PASSWORD,
-                    env.CLUSTER_ADMIN_ROLE_NAME,
-                    logger=pytest_logger.PYTEST_LOGGER)
-    env.create_user(env.CLUSTER_AUTHOR_NAME,
-                    env.CLUSTER_AUTHOR_PASSWORD,
-                    env.CLUSTER_AUTHOR_ROLE_NAME,
-                    logger=pytest_logger.PYTEST_LOGGER)
+    if env.SHOULD_INSTALL_PREREQUISITES:
+        # org_admin -> cluster_admin
+        # k8_author -> cluster_author
+        env.create_user(env.CLUSTER_ADMIN_NAME,
+                        env.CLUSTER_ADMIN_PASSWORD,
+                        env.CLUSTER_ADMIN_ROLE_NAME,
+                        logger=pytest_logger.PYTEST_LOGGER)
+        env.create_user(env.CLUSTER_AUTHOR_NAME,
+                        env.CLUSTER_AUTHOR_PASSWORD,
+                        env.CLUSTER_AUTHOR_ROLE_NAME,
+                        logger=pytest_logger.PYTEST_LOGGER)
 
 
 @pytest.fixture

--- a/system_tests_v2/test_cse_client.py
+++ b/system_tests_v2/test_cse_client.py
@@ -74,6 +74,9 @@ def cse_server():
     Teardown tasks:
     - Stop CSE server
     """
+    if env.IS_CSE_SERVER_RUNNING:
+        # CSE server is already running
+        return
     env.setup_active_config(logger=PYTEST_LOGGER)
     if env.is_cse_registered_as_mqtt_ext(logger=PYTEST_LOGGER):
         cmd = ['upgrade',


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Included 2 flags `should_install_prerequisites` and `is_cse_server_running` to help local testing.

Since the current tests make a lot of API calls to try setting up the environment even if it has already been set up by a previous run or by the developer themself, it takes a long time to even get started with running the tests. This PR fixes the issue by introducing 2 flags `should_install_prerequisites` and `is_cse_server_running`. With this change a developer can run test_cse_client.py by starting a CSE server in parallel.

@rocknes @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1230)
<!-- Reviewable:end -->
