### PR TITLE
[VCDA-2985] Fix vcd cse template list

### DIFF
--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -381,6 +381,7 @@ class Service(object, metaclass=Singleton):
                   "since `No communication with VCenter` mode is on."
             logger.SERVER_LOGGER.info(msg)
             msg_update_callback.general_no_color(msg)
+            self.config['broker']['templates'] = []
 
         # Read TKGm catalog definition from catalog item metadata and append
         # the same to to server run-time config


### PR DESCRIPTION
- Fix `vcd cse template list` when `no_vc_communication_mode` is true
- KeyError got fixed by initializing native template list to empty list
- Tested manually

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1231)
<!-- Reviewable:end -->
