### PR TITLE
[VCDA-2846] Switch telemetry url 

### DIFF
--- a/container_service_extension/lib/telemetry/constants.py
+++ b/container_service_extension/lib/telemetry/constants.py
@@ -7,7 +7,7 @@ from enum import unique
 
 # End point of Vmware telemetry staging server
 # TODO() : This URL should reflect production server during release
-VAC_URL = "https://vcsa.vmware.com/ph-stg/api/hyper/send/"
+VAC_URL = "https://vcsa.vmware.com/ph/api/hyper/send/"
 
 # Value of collector id that is required as part of HTTP request
 # to post sample data to telemetry server


### PR DESCRIPTION
- Telemetry url changed to production VAC server
@rocknes @Anirudh9794 