### PR TITLE
[VCDA-2983] Raise logging level for kubeadm init and join

### DIFF
--- a/cluster_scripts/v2_x_tkgm/control_plane.sh
+++ b/cluster_scripts/v2_x_tkgm/control_plane.sh
@@ -127,7 +127,7 @@ kubernetesVersion: $kubernetes_version
 ---
 END
 
-  kubeadm init --config $kubeadm_config_path > /root/kubeadm-init.out
+  kubeadm init --config $kubeadm_config_path --v=10 > /root/kubeadm-init.out
   export KUBECONFIG=/etc/kubernetes/admin.conf
 vmtoolsd --cmd "info-set guestinfo.kubeconfig $(cat /etc/kubernetes/admin.conf | base64 | tr -d '\n')"
 vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeinit.status successful"

--- a/cluster_scripts/v2_x_tkgm/node.sh
+++ b/cluster_scripts/v2_x_tkgm/node.sh
@@ -99,7 +99,7 @@ nodeRegistration:
 ---
 END
 
-  kubeadm join --config /root/kubeadm-defaults-join.conf
+  kubeadm join --config /root/kubeadm-defaults-join.conf --v=10 > /root/kubeadm-join.out
 vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.node.join.status successful"
 
 echo "$(date) post customization script execution completed" &>> /var/log/cse/customization/status.log


### PR DESCRIPTION
- Increase logging level for `kubeadm init `and `kubeadm join`
- Tested and verified by creating a cluster with control-plane and worker

![image](https://user-images.githubusercontent.com/5530442/136269020-007f2cb5-f116-4a5f-9500-ffd69983b5de.png)
![image](https://user-images.githubusercontent.com/5530442/136269113-6cbf2b65-174b-4a34-82f1-fb454a3faf4b.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1233)
<!-- Reviewable:end -->
