### PR TITLE
Cluster upgrade tests 3 1 updates

### DIFF
--- a/container_service_extension/system_test_framework/environment.py
+++ b/container_service_extension/system_test_framework/environment.py
@@ -141,7 +141,6 @@ TEMPLATE_UPGRADE_PATH_LIST = []
 
 def _populate_template_upgrade_paths(config, logger=NULL_LOGGER):
     global TEMPLATE_UPGRADE_PATH_LIST
-    print(config['broker']['remote_template_cookbook_url'])
     rtm = RemoteTemplateManager(
         config['broker']['remote_template_cookbook_url'],
         legacy_mode=config['service']['legacy_mode'])
@@ -154,7 +153,6 @@ def _populate_template_upgrade_paths(config, logger=NULL_LOGGER):
     # filter out photon templates
     all_ubuntu_templates = \
         [template_definition for template_definition in all_template_definitions if 'ubuntu' in template_definition['name']]  # noqa: E501
-    print(rtm.unfiltered_cookbook)
     logger.debug(f"All template definitions: {all_ubuntu_templates}")
     RT_KEYS = get_template_descriptor_keys(rtm.cookbook_version)
 

--- a/container_service_extension/system_test_framework/utils.py
+++ b/container_service_extension/system_test_framework/utils.py
@@ -73,7 +73,7 @@ def execute_commands(cmd_list, logger=logger.NULL_LOGGER):
 
         if action.validate_output_func is not None:
             assert action.validate_output_func(result.output, action.test_user), \
-                "Command execution failed."
+                "Command execution failed."  # noqa: E501
 
         logger.debug(f"Executed command: {cmd}")
         logger.debug(f"Output: {result.output}")


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

Added cluster upgrade tests.
- New test config flag `test_cluster_upgrades` to control execution cluster upgrade tests

@rocknes @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1237)
<!-- Reviewable:end -->
