### PR TITLE
cluster name should be less than 25 chars

### DIFF
--- a/system_tests_v2/test_cse_client.py
+++ b/system_tests_v2/test_cse_client.py
@@ -575,7 +575,7 @@ def _follow_delete_output(expect_failure=False):
         SYSTEM_TOGGLE_TEST_PARAM(
             user=env.SYS_ADMIN_NAME,
             password=None,
-            cluster_name=f"{env.SYS_ADMIN_TEST_CLUSTER_NAME}-system-test",
+            cluster_name=f"{env.SYS_ADMIN_TEST_CLUSTER_NAME}-s1",
             worker_count=0, nfs_count=0, rollback=True,
             sizing_class=None, storage_profile=None,
             ovdc_network="Invalid_network",


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

CSE tests when ran against VCD 10.2.2 will fail because cluster name has a char limit of 25

Decreased the cluster name length for each cluster name exceeding 25 chars

@rocknes @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1241)
<!-- Reviewable:end -->
