### PR TITLE
[VCDA-3072] Server-Config-Proxy-Support

### DIFF
--- a/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
+++ b/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
@@ -103,12 +103,12 @@ write_files:
     vmtoolsd --cmd "info-set guestinfo.postcustomization.store.sshkey.status successful"
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status in_progress"
-    export HTTP_PROXY={http_proxy}
-    export HTTPS_PROXY={https_proxy}
-    export http_proxy={http_proxy}
-    export https_proxy={https_proxy}
-    export NO_PROXY={no_proxy}
-    export no_proxy={no_proxy}
+    export HTTP_PROXY="{http_proxy}"
+    export HTTPS_PROXY="{https_proxy}"
+    export http_proxy="{http_proxy}"
+    export https_proxy="{https_proxy}"
+    export NO_PROXY="{no_proxy}"
+    export no_proxy="{no_proxy}"
 
     mkdir -p /etc/systemd/system/containerd.service.d
     cat <<END > /etc/systemd/system/containerd.service.d/http-proxy.conf

--- a/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
+++ b/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
@@ -102,6 +102,27 @@ write_files:
       fi
     vmtoolsd --cmd "info-set guestinfo.postcustomization.store.sshkey.status successful"
 
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status in_progress"
+    export HTTP_PROXY={http_proxy}
+    export HTTPS_PROXY={https_proxy}
+    export http_proxy={http_proxy}
+    export https_proxy={https_proxy}
+    export NO_PROXY={no_proxy}
+    export no_proxy={no_proxy}
+
+    mkdir -p /etc/systemd/system/containerd.service.d
+    cat <<END > /etc/systemd/system/containerd.service.d/http-proxy.conf
+    [Service]
+    Environment="HTTP_PROXY={http_proxy}"
+    Environment="HTTPS_PROXY={https_proxy}"
+    Environment="http_proxy={http_proxy}"
+    Environment="https_proxy={https_proxy}"
+    Environment="no_proxy={no_proxy}"
+    Environment="NO_PROXY={no_proxy}"
+    END
+    systemctl daemon-reload
+    systemctl restart containerd
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status successful"
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeinit.status in_progress"
       # tag images

--- a/cluster_scripts/v2_x_tkgm/cloud_init_node.yaml
+++ b/cluster_scripts/v2_x_tkgm/cloud_init_node.yaml
@@ -59,12 +59,12 @@ write_files:
     vmtoolsd --cmd "info-set guestinfo.postcustomization.store.sshkey.status successful"
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status in_progress"
-    export HTTP_PROXY={http_proxy}
-    export HTTPS_PROXY={https_proxy}
-    export http_proxy={http_proxy}
-    export https_proxy={https_proxy}
-    export NO_PROXY={no_proxy}
-    export no_proxy={no_proxy}
+    export HTTP_PROXY="{http_proxy}"
+    export HTTPS_PROXY="{https_proxy}"
+    export http_proxy="{http_proxy}"
+    export https_proxy="{https_proxy}"
+    export NO_PROXY="{no_proxy}"
+    export no_proxy="{no_proxy}"
 
     mkdir -p /etc/systemd/system/containerd.service.d
     cat <<END > /etc/systemd/system/containerd.service.d/http-proxy.conf

--- a/cluster_scripts/v2_x_tkgm/cloud_init_node.yaml
+++ b/cluster_scripts/v2_x_tkgm/cloud_init_node.yaml
@@ -58,6 +58,27 @@ write_files:
       fi
     vmtoolsd --cmd "info-set guestinfo.postcustomization.store.sshkey.status successful"
 
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status in_progress"
+    export HTTP_PROXY={http_proxy}
+    export HTTPS_PROXY={https_proxy}
+    export http_proxy={http_proxy}
+    export https_proxy={https_proxy}
+    export NO_PROXY={no_proxy}
+    export no_proxy={no_proxy}
+
+    mkdir -p /etc/systemd/system/containerd.service.d
+    cat <<END > /etc/systemd/system/containerd.service.d/http-proxy.conf
+    [Service]
+    Environment="HTTP_PROXY={http_proxy}"
+    Environment="HTTPS_PROXY={https_proxy}"
+    Environment="http_proxy={http_proxy}"
+    Environment="https_proxy={https_proxy}"
+    Environment="no_proxy={no_proxy}"
+    Environment="NO_PROXY={no_proxy}"
+    END
+    systemctl daemon-reload
+    systemctl restart containerd
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status successful"
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.node.join.status in_progress"
       # tag images

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -765,6 +765,13 @@ AUTH_CONTEXT_HEADER = 'X-VMWARE-VCLOUD-AUTH-CONTEXT'
 VCLOUD_AUTHORIZATION_HEADER = 'X-vCloud-Authorization'
 
 
+# tkgm proxy key in CSE server config -> actual key as in http-proxy.config
+class TKGmProxyKey(Enum):
+    tkgm_http_proxy = 'http_proxy'
+    tkgm_https_proxy = 'https_proxy'
+    tkgm_no_proxy = 'no_proxy'
+
+
 @unique
 class PostCustomizationStatus(Enum):
     NONE = None
@@ -782,6 +789,7 @@ class PostCustomizationPhase(Enum):
     KUBECTL_APPLY_CSI = 'guestinfo.postcustomization.kubectl.csi.install.status'  # noqa: E501
     KUBEADM_TOKEN_GENERATE = 'guestinfo.postcustomization.kubeadm.token.generate.status'  # noqa: E501
     KUBEADM_NODE_JOIN = 'guestinfo.postcustomization.kubeadm.node.join.status'
+    PROXY_SETTING = 'guestinfo.postcustomization.proxy.setting.status'
 
 
 KUBEADM_TOKEN_INFO = 'guestinfo.postcustomization.kubeadm.token.info'

--- a/container_service_extension/common/utils/pyvcloud_utils.py
+++ b/container_service_extension/common/utils/pyvcloud_utils.py
@@ -765,7 +765,7 @@ def wait_for_completion_of_post_customization_procedure(
         if script_execution_status and int(script_execution_status) != 0:
             script_execution_failure_reason = get_vm_extra_config_element(vm, server_constants.POST_CUSTOMIZATION_SCRIPT_EXECUTION_FAILURE_REASON)  # noqa: E501
             logger.error(f"VM Post guest customization script failed with error:{script_execution_failure_reason}")  # noqa: E501
-            raise exceptions.ScriptExecutionError
+            raise exceptions.ScriptExecutionError(error_message=script_execution_failure_reason)  # noqa: E501
 
         if datetime.now() - start_time > timedelta(seconds=timeout):
             break

--- a/container_service_extension/installer/sample_generator.py
+++ b/container_service_extension/installer/sample_generator.py
@@ -184,8 +184,8 @@ COMMENTED_EXTRA_OPTIONS_SECTION = """# [Optional] Extra options section
 # Example 'extra_options' section:
 #extra_options:
 #   tkgm_http_proxy: http://192.168.7.10:3128
-#   tkgm_https_proxy: http://192.168.7.10:3128
-#   tkgm_no_proxy: localhost,192.168.7.0/24
+#   tkgm_https_proxy: https://192.168.7.10:3128
+#   tkgm_no_proxy: localhost,127.0.0.1,192.168.7.0/24
 """
 
 

--- a/container_service_extension/installer/sample_generator.py
+++ b/container_service_extension/installer/sample_generator.py
@@ -175,6 +175,19 @@ COMMENTED_AMQP_SECTION = """\
 #  vhost: /
 """
 
+COMMENTED_EXTRA_OPTIONS_SECTION = """# [Optional] Extra options section
+# Support for proxy server for TKGm only.
+# Use case: container runtime needs to pull images from external repos
+# through a proxy.
+# Creates http-proxy.conf in cluster vms with the proxy relevant environment
+# variables with the provided values in this section.
+# Example 'extra_options' section:
+#extra_options:
+#   tkgm_http_proxy: http://192.168.7.10:3128
+#   tkgm_https_proxy: http://192.168.7.10:3128
+#   tkgm_no_proxy: localhost,192.168.7.0/24
+"""
+
 
 PKS_SERVERS_SECTION_KEY = 'pks_api_servers'
 SAMPLE_PKS_SERVERS_SECTION = {
@@ -337,6 +350,9 @@ def generate_sample_config(
 
         if SAMPLE_SERVICE_CONFIG['service']['legacy_mode']:
             sample_config += TEMPLATE_RULE_NOTE + '\n'
+
+        if not SAMPLE_SERVICE_CONFIG['service']['legacy_mode']:
+            sample_config += COMMENTED_EXTRA_OPTIONS_SECTION
     else:
         sample_config = yaml.safe_dump(
             SAMPLE_PKS_SERVERS_SECTION, default_flow_style=False) + '\n'

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -1928,7 +1928,7 @@ def _get_tkgm_template(name: str):
     )
 
 
-def _get_proxy_config() -> dict:
+def _get_tkgm_proxy_config() -> dict:
     server_config = server_utils.get_server_runtime_config()
     extra_options: dict = server_config.get('extra_options', {})
     return {
@@ -2023,7 +2023,7 @@ def _add_control_plane_nodes(
         )
         # encode refresh-token to base64
         base64_refresh_token = base64.b64encode(refresh_token.encode("utf-8"))
-        proxy_config = _get_proxy_config()
+        proxy_config = _get_tkgm_proxy_config()
         for spec in vm_specs:
             spec['cloud_init_spec'] = templated_script.format(
                 vcd_host=vcd_host.replace("/", r"\/"),
@@ -2200,7 +2200,7 @@ def _add_worker_nodes(sysadmin_client, num_nodes, org, vdc, vapp,
         ip_port = parts[2]
         token = parts[4]
         discovery_token_ca_cert_hash = parts[6]
-        proxy_config = _get_proxy_config()
+        proxy_config = _get_tkgm_proxy_config()
 
         # The cust_script needs the vm host name which is computed in the
         # _get_vm_specifications function, so the specs are obtained and

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -35,6 +35,7 @@ from container_service_extension.common.constants.server_constants import PostCu
 from container_service_extension.common.constants.server_constants import ThreadLocalData  # noqa: E501
 from container_service_extension.common.constants.server_constants import TKGM_DEFAULT_POD_NETWORK_CIDR  # noqa: E501
 from container_service_extension.common.constants.server_constants import TKGM_DEFAULT_SERVICE_CIDR  # noqa: E501
+from container_service_extension.common.constants.server_constants import TKGmProxyKey  # noqa: E501
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
 from container_service_extension.common.constants.shared_constants import \
     CSE_PAGINATION_DEFAULT_PAGE_SIZE, SYSTEM_ORG_NAME
@@ -1927,6 +1928,15 @@ def _get_tkgm_template(name: str):
     )
 
 
+def _get_proxy_config() -> dict:
+    server_config = server_utils.get_server_runtime_config()
+    extra_options: dict = server_config.get('extra_options', {})
+    return {
+        proxy_key.value: extra_options.get(proxy_key.name, '')
+        for proxy_key in TKGmProxyKey
+    }
+
+
 def _set_cloud_init_spec(
         sysadmin_client,
         vapp,
@@ -2013,6 +2023,7 @@ def _add_control_plane_nodes(
         )
         # encode refresh-token to base64
         base64_refresh_token = base64.b64encode(refresh_token.encode("utf-8"))
+        proxy_config = _get_proxy_config()
         for spec in vm_specs:
             spec['cloud_init_spec'] = templated_script.format(
                 vcd_host=vcd_host.replace("/", r"\/"),
@@ -2029,6 +2040,7 @@ def _add_control_plane_nodes(
                 ssh_key=ssh_key if ssh_key else '',
                 control_plane_endpoint='',
                 base64_encoded_refresh_token=base64_refresh_token.decode("utf-8"),  # noqa: E501
+                **proxy_config
             )
 
         task = vapp.add_vms(
@@ -2102,6 +2114,7 @@ def _add_control_plane_nodes(
                 ssh_key=ssh_key if ssh_key else '',
                 control_plane_endpoint=f"{control_plane_endpoint}:6443",
                 base64_encoded_refresh_token=base64_refresh_token.decode("utf-8"),  # noqa: E501
+                **proxy_config
             )
             # create a cloud-init spec and update the VMs with it
             _set_cloud_init_spec(sysadmin_client, vapp, vm, cloud_init_spec)
@@ -2118,6 +2131,7 @@ def _add_control_plane_nodes(
             for customization_phase in [
                 PostCustomizationPhase.NETWORK_CONFIGURATION,
                 PostCustomizationPhase.STORE_SSH_KEY,
+                PostCustomizationPhase.PROXY_SETTING,
                 PostCustomizationPhase.KUBEADM_INIT,
                 PostCustomizationPhase.KUBECTL_APPLY_CNI,
                 PostCustomizationPhase.KUBECTL_APPLY_CPI,
@@ -2186,6 +2200,7 @@ def _add_worker_nodes(sysadmin_client, num_nodes, org, vdc, vapp,
         ip_port = parts[2]
         token = parts[4]
         discovery_token_ca_cert_hash = parts[6]
+        proxy_config = _get_proxy_config()
 
         # The cust_script needs the vm host name which is computed in the
         # _get_vm_specifications function, so the specs are obtained and
@@ -2211,6 +2226,7 @@ def _add_worker_nodes(sysadmin_client, num_nodes, org, vdc, vapp,
                 ip_port=ip_port,
                 token=token,
                 discovery_token_ca_cert_hash=discovery_token_ca_cert_hash,
+                **proxy_config
             )
 
         task = vapp.add_vms(
@@ -2261,6 +2277,7 @@ def _add_worker_nodes(sysadmin_client, num_nodes, org, vdc, vapp,
             for customization_phase in [
                 PostCustomizationPhase.NETWORK_CONFIGURATION,
                 PostCustomizationPhase.STORE_SSH_KEY,
+                PostCustomizationPhase.PROXY_SETTING,
                 PostCustomizationPhase.KUBEADM_NODE_JOIN,
             ]:
                 vapp.reload()


### PR DESCRIPTION
- Inject http proxy configuration from cse server config file
- New section namely `extra_options` in server config file
- New tkgm only proxy variable in server config:`tkgm_http_proxy, tkgm_https_proxy, tkgm_no_proxy`
- Updated cloud-init control plane and node scripts
- Tested in special testbed setup created using:[NSXT-Setup](https://confluence.eng.vmware.com/display/VCD/NSX-T+Testbed+Outbound+Access+Setup)
- Ref: [TKGm-Squid setup](https://confluence.eng.vmware.com/pages/viewpage.action?spaceKey=VCD&title=Proxy+Configuration+on+TKGm+clusters)
- verified cluster creation with no proxy setup fails with:` Error adding control plane node: failure on creating nodes:/root/control_plane.sh: wget -O $antrea_path https://github.com/vmware-tanzu/antrea/releases/download/v0.11.3/antrea.yml`
- Verified the squid access log while TKGm cluster creation for outbound requests for github vmware requests
- Verified the http-proxy.config on control-plane and worker node vm
- Completed testing on conventional TKGm setup as per: [TKGM on VCD](https://confluence.eng.vmware.com/display/VCD/TKGm+on+VCD%3A+CPI+testing)

![image](https://user-images.githubusercontent.com/5530442/142909060-e6b9fd78-1762-4785-920d-049506564edf.png)

![image](https://user-images.githubusercontent.com/5530442/142913443-1a4e6774-68a8-4f2f-b23d-3f2ee5c9af0d.png)

![image](https://user-images.githubusercontent.com/5530442/142913905-04b5320d-6a57-473d-a3c5-00df86982e14.png)

![image](https://user-images.githubusercontent.com/5530442/142914594-a3bd82a5-8ac6-42b6-825f-2cf65d358b6a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1260)
<!-- Reviewable:end -->
