### PR TITLE
[VCDA-3161] Handle-Empty-Tkgm-Proxy-Extra-options

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -1933,6 +1933,7 @@ def _get_tkgm_template(name: str):
 def _get_tkgm_proxy_config() -> dict:
     server_config = server_utils.get_server_runtime_config()
     extra_options: dict = server_config.get('extra_options', {})
+    extra_options = extra_options if isinstance(extra_options, dict) else {}
     return {
         proxy_key.value: extra_options.get(proxy_key.name, '')
         for proxy_key in TKGmProxyKey


### PR DESCRIPTION
- Fixed failing cluster creation on empty extra_options in server config
- Explicit verfication of empty extra_options 
- Tested cluster creation successfully

@Anirudh9794 @arunmk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1267)
<!-- Reviewable:end -->
