### PR TITLE
[VCDA-3183] Fix broken CSE cluster commands

### DIFF
--- a/container_service_extension/client/de_cluster.py
+++ b/container_service_extension/client/de_cluster.py
@@ -14,6 +14,7 @@ from container_service_extension.client.de_cluster_native import DEClusterNative
 from container_service_extension.client.de_cluster_tkg_s import DEClusterTKGS
 import container_service_extension.client.tkgclient.rest as tkg_rest
 import container_service_extension.client.utils as client_utils
+from container_service_extension.common.constants.shared_constants import CAPVCD_CLUSTER_FILTER  # noqa: E501
 from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE, PaginationKey  # noqa: E501
 from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
 import container_service_extension.common.utils.core_utils as core_utils
@@ -100,7 +101,9 @@ class DECluster:
                         version=common_models.K8Interface.VCD_INTERFACE.value.version,  # noqa: E501
                         filters=filters,
                         page_number=page_number,
-                        page_size=page_size)
+                        page_size=page_size,
+                        exclude_entity_type_filter=CAPVCD_CLUSTER_FILTER
+                    )
                     # Get the list of cluster defined entities
                     entities: List[common_models.GenericClusterEntity] = clusters_page_results[PaginationKey.VALUES]  # noqa: E501
                     clusters = []

--- a/container_service_extension/client/de_cluster.py
+++ b/container_service_extension/client/de_cluster.py
@@ -14,9 +14,9 @@ from container_service_extension.client.de_cluster_native import DEClusterNative
 from container_service_extension.client.de_cluster_tkg_s import DEClusterTKGS
 import container_service_extension.client.tkgclient.rest as tkg_rest
 import container_service_extension.client.utils as client_utils
-from container_service_extension.common.constants.shared_constants import CAPVCD_CLUSTER_FILTER  # noqa: E501
 from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_DEFAULT_PAGE_SIZE, PaginationKey  # noqa: E501
 from container_service_extension.common.constants.shared_constants import CSE_PAGINATION_FIRST_PAGE_NUMBER  # noqa: E501
+from container_service_extension.common.constants.shared_constants import EntityTypeId  # noqa: E501
 import container_service_extension.common.utils.core_utils as core_utils
 import container_service_extension.common.utils.pyvcloud_utils as vcd_utils
 import container_service_extension.exception.exceptions as cse_exceptions
@@ -102,7 +102,7 @@ class DECluster:
                         filters=filters,
                         page_number=page_number,
                         page_size=page_size,
-                        exclude_entity_type_filter=CAPVCD_CLUSTER_FILTER
+                        exclude_entity_type_ids=[EntityTypeId.CAPVCD_1_0_0.value]  # noqa: E501
                     )
                     # Get the list of cluster defined entities
                     entities: List[common_models.GenericClusterEntity] = clusters_page_results[PaginationKey.VALUES]  # noqa: E501

--- a/container_service_extension/common/constants/shared_constants.py
+++ b/container_service_extension/common/constants/shared_constants.py
@@ -27,6 +27,7 @@ RESPONSE_MESSAGE_KEY = "message"
 CSE_SERVER_API_VERSION = "cse_server_api_version"
 CSE_SERVER_SUPPORTED_API_VERSIONS = "cse_server_supported_api_versions"
 CSE_SERVER_LEGACY_MODE = "cse_server_running_in_legacy_mode"
+CAPVCD_CLUSTER_FILTER = 'entityType!=urn:vcloud:type:vmware:capvcd:1.0.0'
 
 
 class ClusterEntityKind(Enum):

--- a/container_service_extension/common/constants/shared_constants.py
+++ b/container_service_extension/common/constants/shared_constants.py
@@ -27,7 +27,10 @@ RESPONSE_MESSAGE_KEY = "message"
 CSE_SERVER_API_VERSION = "cse_server_api_version"
 CSE_SERVER_SUPPORTED_API_VERSIONS = "cse_server_supported_api_versions"
 CSE_SERVER_LEGACY_MODE = "cse_server_running_in_legacy_mode"
-CAPVCD_CLUSTER_FILTER = 'entityType!=urn:vcloud:type:vmware:capvcd:1.0.0'
+
+
+class EntityTypeId(Enum):
+    CAPVCD_1_0_0 = 'urn:vcloud:type:vmware:capvcd:1.0.0'
 
 
 class ClusterEntityKind(Enum):

--- a/container_service_extension/common/utils/core_utils.py
+++ b/container_service_extension/common/utils/core_utils.py
@@ -374,9 +374,7 @@ def construct_filter_string(filters: dict):
     """
     filter_string = ""
     if filters:
-        # TODO(): This CAPVCD filter is temporary and should be removed after
-        #  CAPVCDCluster kind adoption in CSE
-        filter_expressions = ['entityType!=urn:vcloud:type:vmware:capvcd:1.0.0']  # noqa: E501
+        filter_expressions = []
         for (key, value) in filters.items():
             if key and value:
                 filter_exp = f"{key}=={urllib.parse.quote(escape_query_filter_expression_value(value))}"  # noqa: E501

--- a/container_service_extension/common/utils/core_utils.py
+++ b/container_service_extension/common/utils/core_utils.py
@@ -374,7 +374,9 @@ def construct_filter_string(filters: dict):
     """
     filter_string = ""
     if filters:
-        filter_expressions = []
+        # TODO(): This CAPVCD filter is temporary and should be removed after
+        #  CAPVCDCluster kind adoption in CSE
+        filter_expressions = ['entityType!=urn:vcloud:type:vmware:capvcd:1.0.0']  # noqa: E501
         for (key, value) in filters.items():
             if key and value:
                 filter_exp = f"{key}=={urllib.parse.quote(escape_query_filter_expression_value(value))}"  # noqa: E501

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -221,7 +221,8 @@ class DefEntityService:
     def get_all_entities_per_page_by_interface(self, vendor: str, nss: str, version: str,  # noqa: E501
                                                filters: dict = None,
                                                page_number: int = CSE_PAGINATION_FIRST_PAGE_NUMBER,  # noqa: E501
-                                               page_size: int = CSE_PAGINATION_DEFAULT_PAGE_SIZE):  # noqa: E501
+                                               page_size: int = CSE_PAGINATION_DEFAULT_PAGE_SIZE, # noqa: E501
+                                               exclude_entity_type_filter: str = None):  # noqa: E501
         """Get a page of entities belonging to an interface.
 
         An interface is uniquely identified by properties vendor, nss and
@@ -233,17 +234,16 @@ class DefEntityService:
         :param dict filters:
         :param int page_number:
         :param int page_size:
+        :param str exclude_entity_type_filter: exclude entity type filter
 
         :return: Generator of entities of that interface type
         :rtype: Generator[List, None, None]
         """
         filter_string = utils.construct_filter_string(filters)
-        # TODO(): This CAPVCD filter is temporary and should be removed after
-        #  CAPVCDCluster kind adoption in CSE
         if filter_string:
-            filter_string += f";{shared_constants.CAPVCD_CLUSTER_FILTER}"
+            filter_string += f";{exclude_entity_type_filter}"
         else:
-            filter_string = shared_constants.CAPVCD_CLUSTER_FILTER
+            filter_string = exclude_entity_type_filter
 
         query_string = f"page={page_number}&pageSize={page_size}"
         if filter_string:

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -222,7 +222,7 @@ class DefEntityService:
                                                filters: dict = None,
                                                page_number: int = CSE_PAGINATION_FIRST_PAGE_NUMBER,  # noqa: E501
                                                page_size: int = CSE_PAGINATION_DEFAULT_PAGE_SIZE, # noqa: E501
-                                               exclude_entity_type_filter: str = None):  # noqa: E501
+                                               exclude_entity_type_ids: list = None):  # noqa: E501
         """Get a page of entities belonging to an interface.
 
         An interface is uniquely identified by properties vendor, nss and
@@ -234,14 +234,20 @@ class DefEntityService:
         :param dict filters:
         :param int page_number:
         :param int page_size:
-        :param str exclude_entity_type_filter: exclude entity type filter
+        :param list exclude_entity_type_ids: exclude entity types
 
         :return: Generator of entities of that interface type
         :rtype: Generator[List, None, None]
         """
         filter_string = utils.construct_filter_string(filters)
+
+        exclude_entity_type_filter = ''
+        if exclude_entity_type_ids:
+            exclude_entity_type_filter = ";".join([f"entityType!={entity_type}" for entity_type in exclude_entity_type_ids])  # noqa: E501
+
         if filter_string:
-            filter_string += f";{exclude_entity_type_filter}"
+            if exclude_entity_type_filter:
+                filter_string += f";{exclude_entity_type_filter}"
         else:
             filter_string = exclude_entity_type_filter
 

--- a/container_service_extension/rde/common/entity_service.py
+++ b/container_service_extension/rde/common/entity_service.py
@@ -238,6 +238,13 @@ class DefEntityService:
         :rtype: Generator[List, None, None]
         """
         filter_string = utils.construct_filter_string(filters)
+        # TODO(): This CAPVCD filter is temporary and should be removed after
+        #  CAPVCDCluster kind adoption in CSE
+        if filter_string:
+            filter_string += f";{shared_constants.CAPVCD_CLUSTER_FILTER}"
+        else:
+            filter_string = shared_constants.CAPVCD_CLUSTER_FILTER
+
         query_string = f"page={page_number}&pageSize={page_size}"
         if filter_string:
             query_string = f"filter={filter_string}&{query_string}"


### PR DESCRIPTION
- Filter out the capvcd kind clusters for now to unblock CSE native/tkg clusters operations
- Issue noticed when the CLI user persona has both native and CAPVCD clusters created.
- Tested using CLI. Endpoint works fine with POSTMAN testing

@sahithi @Anirudh9794

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1272)
<!-- Reviewable:end -->
