### PR TITLE
[VCDA-3206] Avoid waiting on behavior task in the Native API kubeconfig handler

### DIFF
--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -804,5 +804,6 @@ CLOUDINIT_GUEST_USERDATA_ENCODING = 'guestinfo.userdata.encoding'
 
 MAX_RDE_UPDATE_ATTEMPTS = 10
 
-RESULT_MESSAGE_KEY = "result"
-RESULT_CONTENT_MESSAGE_KEY = "resultContent"
+# keys of the Behavior task response that gets sent to VCD
+BEHAVIOR_TASK_RESPONSE_RESULT_MESSAGE_KEY = "result"
+BEHAVIOR_TASK_RESPONSE_RESULT_CONTENT_MESSAGE_KEY = "resultContent"

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -803,3 +803,6 @@ CLOUDINIT_GUEST_USERDATA = 'guestinfo.userdata'
 CLOUDINIT_GUEST_USERDATA_ENCODING = 'guestinfo.userdata.encoding'
 
 MAX_RDE_UPDATE_ATTEMPTS = 10
+
+RESULT_MESSAGE_KEY = "result"
+RESULT_CONTENT_MESSAGE_KEY = "resultContent"

--- a/container_service_extension/rde/backend/cluster_service_factory.py
+++ b/container_service_extension/rde/backend/cluster_service_factory.py
@@ -10,10 +10,11 @@ from container_service_extension.rde.backend.cluster_service_1_x import ClusterS
 from container_service_extension.rde.backend.cluster_service_2_x import ClusterService as ClusterService2X  # noqa: E501
 from container_service_extension.rde.backend.cluster_service_2_x_tkgm import ClusterService as ClusterService2XTKGm  # noqa: E501
 import container_service_extension.rde.common.entity_service as entity_service
+import container_service_extension.security.context.behavior_request_context as behavior_ctx  # noqa: E501
 
 
 class ClusterServiceFactory:
-    def __init__(self, req_ctx):  # noqa: E501
+    def __init__(self, req_ctx: behavior_ctx.RequestContext):
         self.req_ctx = req_ctx
 
     def get_cluster_service(self, rde_version_in_use=None, skip_tkgm_check=False):  # noqa: E501

--- a/container_service_extension/rde/backend/cluster_service_factory.py
+++ b/container_service_extension/rde/backend/cluster_service_factory.py
@@ -10,11 +10,10 @@ from container_service_extension.rde.backend.cluster_service_1_x import ClusterS
 from container_service_extension.rde.backend.cluster_service_2_x import ClusterService as ClusterService2X  # noqa: E501
 from container_service_extension.rde.backend.cluster_service_2_x_tkgm import ClusterService as ClusterService2XTKGm  # noqa: E501
 import container_service_extension.rde.common.entity_service as entity_service
-import container_service_extension.security.context.behavior_request_context as behavior_ctx  # noqa: E501
 
 
 class ClusterServiceFactory:
-    def __init__(self, req_ctx: behavior_ctx.RequestContext):
+    def __init__(self, req_ctx):
         self.req_ctx = req_ctx
 
     def get_cluster_service(self, rde_version_in_use=None, skip_tkgm_check=False):  # noqa: E501

--- a/container_service_extension/server/request_handlers/cluster_handler.py
+++ b/container_service_extension/server/request_handlers/cluster_handler.py
@@ -177,11 +177,21 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     :return: Dict
     """
     cluster_id = data[RequestKey.CLUSTER_ID]
+    def_entity_service = entity_service.DefEntityService(op_ctx.cloudapi_client)  # noqa: E501
+    def_entity: common_models.DefEntity = def_entity_service.get_entity(cluster_id)  # noqa: E501
+    telemetry_handler.record_user_action_details(
+        cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_CONFIG,
+        cse_params={
+            server_constants.CLUSTER_ENTITY: def_entity,
+            telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
+        }
+    )
+
     op_ctx.entity_id = cluster_id  # hack for passing entity id
     svc = cluster_service_factory.ClusterServiceFactory(_get_request_context(op_ctx)).get_cluster_service()  # noqa: E501
     config_dict = svc.get_cluster_config(cluster_id)
 
-    config: str = config_dict.get(server_constants.RESULT_MESSAGE_KEY, {}).get(server_constants.RESULT_CONTENT_MESSAGE_KEY)  # noqa: E501
+    config: str = config_dict.get(server_constants.BEHAVIOR_TASK_RESPONSE_RESULT_MESSAGE_KEY, {}).get(server_constants.BEHAVIOR_TASK_RESPONSE_RESULT_CONTENT_MESSAGE_KEY)  # noqa: E501
     return_dict = {
         "message": config
     }

--- a/container_service_extension/server/request_handlers/cluster_handler.py
+++ b/container_service_extension/server/request_handlers/cluster_handler.py
@@ -33,7 +33,6 @@ import container_service_extension.lib.telemetry.telemetry_handler as telemetry_
 import container_service_extension.rde.backend.cluster_service_factory as cluster_service_factory  # noqa: E501
 from container_service_extension.rde.behaviors.behavior_model import BehaviorOperation  # noqa: E501
 from container_service_extension.rde.behaviors.behavior_model import DELETE_NFS_NODE_BEHAVIOR_ID  # noqa: E501
-from container_service_extension.rde.behaviors.behavior_model import KUBE_CONFIG_BEHAVIOR_INTERFACE_ID  # noqa: E501
 from container_service_extension.rde.behaviors.behavior_service import BehaviorService  # noqa: E501
 import container_service_extension.rde.common.entity_service as entity_service
 import container_service_extension.rde.constants as rde_constants
@@ -178,23 +177,15 @@ def cluster_config(data: dict, op_ctx: ctx.OperationContext):
     :return: Dict
     """
     cluster_id = data[RequestKey.CLUSTER_ID]
-    def_entity_service = entity_service.DefEntityService(op_ctx.cloudapi_client)  # noqa: E501
-    def_entity: common_models.DefEntity = def_entity_service.get_entity(cluster_id)  # noqa: E501
-    behavior_svc = BehaviorService(cloudapi_client=op_ctx.cloudapi_client)
-    telemetry_handler.record_user_action_details(
-        cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_CONFIG,
-        cse_params={
-            server_constants.CLUSTER_ENTITY: def_entity,
-            telemetry_constants.PayloadKey.SOURCE_DESCRIPTION: thread_local_data.get_thread_local_data(ThreadLocalData.USER_AGENT)  # noqa: E501
-        }
-    )
-    config_task_href = behavior_svc.invoke_behavior(
-        entity_id=cluster_id,
-        behavior_interface_id=KUBE_CONFIG_BEHAVIOR_INTERFACE_ID)
-    config_task = op_ctx.client.get_resource(config_task_href)
-    op_ctx.client.get_task_monitor().wait_for_success(config_task)
-    config_task = op_ctx.client.get_resource(config_task_href)
-    return config_task.Result.ResultContent.text
+    op_ctx.entity_id = cluster_id  # hack for passing entity id
+    svc = cluster_service_factory.ClusterServiceFactory(_get_request_context(op_ctx)).get_cluster_service()  # noqa: E501
+    config_dict = svc.get_cluster_config(cluster_id)
+
+    config: str = config_dict.get(server_constants.RESULT_MESSAGE_KEY, {}).get(server_constants.RESULT_CONTENT_MESSAGE_KEY)  # noqa: E501
+    return_dict = {
+        "message": config
+    }
+    return return_dict
 
 
 @telemetry_handler.record_user_action_telemetry(cse_operation=telemetry_constants.CseOperation.V36_CLUSTER_APPLY)  # noqa: E501


### PR DESCRIPTION
Signed-off-by: ltimothy7 <66969084+ltimothy7@users.noreply.github.com>

To help us process your pull request efficiently, please include: 

- (Required) Short description of changes in the PR topic line
Using cluster service function for getting kubeconfig
Tested getting TKGm and native kubeconfig

- (Optional) Names of reviewers using @ sign + name
@sahithi @Anirudh9794

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1276)
<!-- Reviewable:end -->
