### PR TITLE
[VCDA-3083, VCDA-3102] Add wait before cluster creation when creating clusters from CTOTs

### DIFF
--- a/container_service_extension/common/utils/server_utils.py
+++ b/container_service_extension/common/utils/server_utils.py
@@ -129,12 +129,8 @@ def is_test_mode(config: Optional[dict] = None) -> bool:
             config = get_server_runtime_config()
         except Exception:
             return False
-    service_section = config.get('service', {})
-    is_test_mode = service_section.get('test_mode', False)
-    if isinstance(is_test_mode, bool):
-        return is_test_mode
-    elif isinstance(is_test_mode, str):
-        return utils.str_to_bool(is_test_mode)
+    if config.get('test'):
+        return True
     return False
 
 

--- a/container_service_extension/common/utils/server_utils.py
+++ b/container_service_extension/common/utils/server_utils.py
@@ -116,6 +116,28 @@ def is_no_vc_communication_mode(config: Optional[dict] = None) -> bool:
     return False
 
 
+def is_test_mode(config: Optional[dict] = None) -> bool:
+    """Check if test mode is enabled in the config.
+
+    :param dict config: configuration provided by the user.
+
+    :return: boolean indicating if test mode is enabled.
+    :rtype: bool
+    """
+    if not config:
+        try:
+            config = get_server_runtime_config()
+        except Exception:
+            return False
+    service_section = config.get('service', {})
+    is_test_mode = service_section.get('test_mode', False)
+    if isinstance(is_test_mode, bool):
+        return is_test_mode
+    elif isinstance(is_test_mode, str):
+        return utils.str_to_bool(is_test_mode)
+    return False
+
+
 def get_template_descriptor_keys(cookbook_version: semantic_version.Version) -> enum.EnumMeta:  # noqa: E501
     """Get template descriptor keys using the cookbook version."""
     # if cookbook version is None, use version 1.0

--- a/container_service_extension/rde/backend/cluster_service_1_x.py
+++ b/container_service_extension/rde/backend/cluster_service_1_x.py
@@ -805,6 +805,10 @@ class ClusterService(abstract_broker.AbstractBroker):
                     )
                     expose_ip = ''
 
+            if server_utils.is_test_mode():
+                # wait for a minute before proceeding to make sure the password
+                # is set in the VM by guest customization
+                time.sleep(60)
             _init_cluster(sysadmin_client_v35,
                           vapp,
                           template[LocalTemplateKey.KIND],
@@ -842,6 +846,10 @@ class ClusterService(abstract_broker.AbstractBroker):
             LOGGER.debug(msg)
             self._update_task(vcd_client.TaskStatus.RUNNING, message=msg)
             vapp.reload()
+            if server_utils.is_test_mode():
+                # wait for a minute before proceeding to make sure the password
+                # is set in the VM by guest customization
+                time.sleep(60)
             _join_cluster(sysadmin_client_v35, vapp)
 
             if nfs_count > 0:
@@ -1245,6 +1253,10 @@ class ClusterService(abstract_broker.AbstractBroker):
                 for spec in worker_nodes['specs']:
                     target_nodes.append(spec['target_vm_name'])
                 vapp.reload()
+                if server_utils.is_test_mode():
+                    # wait for a minute before proceeding to make sure the
+                    # password is set in the VM by guest customization
+                    time.sleep(60)
                 _join_cluster(sysadmin_client_v35,
                               vapp,
                               target_nodes)
@@ -2237,6 +2249,10 @@ def _add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
                         template[LocalTemplateKey.REVISION],
                         TemplateScriptFile.NFSD)
                     script = utils.read_data_file(script_filepath, logger=LOGGER)  # noqa: E501
+                    if server_utils.is_test_mode():
+                        # wait for a minute before proceeding to make sure the
+                        # password is set in the VM by guest customization
+                        time.sleep(60)
                     exec_results = _execute_script_in_nodes(
                         sysadmin_client, vapp=vapp, node_names=[vm_name],
                         script=script)

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -920,6 +920,10 @@ class ClusterService(abstract_broker.AbstractBroker):
             self._update_task(BehaviorTaskStatus.RUNNING, message=msg)
             vapp.reload()
 
+            if server_utils.is_test_mode():
+                # wait for a minute before proceeding to make sure the
+                # password is set in the VM by guest customization
+                time.sleep(60)
             control_plane_ip = _get_control_plane_ip(
                 sysadmin_client_v36, vapp, check_tools=True)
 
@@ -982,6 +986,10 @@ class ClusterService(abstract_broker.AbstractBroker):
             LOGGER.debug(msg)
             self._update_task(BehaviorTaskStatus.RUNNING, message=msg)
             vapp.reload()
+            if server_utils.is_test_mode():
+                # wait for a minute before proceeding to make sure the password
+                # is set in the VM by guest customization
+                time.sleep(60)
             _join_cluster(sysadmin_client_v36, vapp)
 
             if nfs_count > 0:
@@ -1413,6 +1421,10 @@ class ClusterService(abstract_broker.AbstractBroker):
                 for spec in worker_nodes['specs']:
                     target_nodes.append(spec['target_vm_name'])
                 vapp.reload()
+                if server_utils.is_test_mode():
+                    # wait for a minute before proceeding to make sure the
+                    # password is set in the VM by guest customization
+                    time.sleep(60)
                 _join_cluster(sysadmin_client_v36,
                               vapp,
                               target_nodes=target_nodes)
@@ -2452,6 +2464,10 @@ def _add_nodes(sysadmin_client, num_nodes, node_type, org, vdc, vapp,
                         template[LocalTemplateKey.REVISION],
                         TemplateScriptFile.NFSD)
                     script = utils.read_data_file(script_filepath, logger=LOGGER)  # noqa: E501
+                    if server_utils.is_test_mode():
+                        # wait for a minute before proceeding to make sure the
+                        # password is set in the VM by guest customization
+                        time.sleep(60)
                     exec_results = _execute_script_in_nodes(
                         sysadmin_client, vapp=vapp, node_names=[vm_name],
                         script=script)

--- a/system_tests_v2/base_config.yaml
+++ b/system_tests_v2/base_config.yaml
@@ -48,7 +48,6 @@ vcs:
   verify: false
 
 service:
-  test_mode: true
   enforce_authorization: false
   no_vc_communication_mode: false
   processors: 5

--- a/system_tests_v2/base_config.yaml
+++ b/system_tests_v2/base_config.yaml
@@ -48,6 +48,7 @@ vcs:
   verify: false
 
 service:
+  test_mode: true
   enforce_authorization: false
   no_vc_communication_mode: false
   processors: 5


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

* Added flag `test_mode` to server config file
* Set `test_mode` to true in system tests
* When test_mode is true, introduce a 1 min wait before executing scripts in the guest OS for the first time

Testing done:
Ran CToTs:
10.2.2: https://sp-taas-vcd-butler.svc.eng.vmware.com/view/CSE/job/CTOT4-CSE/2332/
10.3.2: https://sp-taas-vcd-butler.svc.eng.vmware.com/view/CSE/job/CTOT4-CSE/2329/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1277)
<!-- Reviewable:end -->
