### PR TITLE
[VCDA-3192] Remove dependency on config file from the commands `cse template import`

### DIFF
--- a/container_service_extension/common/utils/core_utils.py
+++ b/container_service_extension/common/utils/core_utils.py
@@ -196,7 +196,7 @@ def str_to_bool(s):
 
     :param s: input string
 
-    :return: True if val is ['true' or 'yes' or 'Y'] otherwise False
+    :return: True if val is ['true' or 'yes' or 'y'] otherwise False
     """
     return str(s).lower() in ('true', 'yes', 'y')
 

--- a/container_service_extension/common/utils/core_utils.py
+++ b/container_service_extension/common/utils/core_utils.py
@@ -90,9 +90,9 @@ def get_installed_cse_version() -> semantic_version.Version:
     return semantic_version.Version('.'.join(tokens))
 
 
-def prompt_text(text, color='black', hide_input=False):
+def prompt_text(text, color='black', hide_input=False, type=str):
     click_text = click.style(str(text), fg=color)
-    return click.prompt(click_text, hide_input=hide_input, type=str)
+    return click.prompt(click_text, hide_input=hide_input, type=type)
 
 
 def is_environment_variable_enabled(env_var_name):
@@ -196,9 +196,9 @@ def str_to_bool(s):
 
     :param s: input string
 
-    :return: True if val is 'true' otherwise False
+    :return: True if val is ['true' or 'yes' or 'Y'] otherwise False
     """
-    return str(s).lower() == 'true'
+    return str(s).lower() in ('true', 'yes', 'y')
 
 
 def get_sha256(filepath):

--- a/container_service_extension/installer/configure_cse.py
+++ b/container_service_extension/installer/configure_cse.py
@@ -44,7 +44,7 @@ from container_service_extension.lib.telemetry.telemetry_handler \
 from container_service_extension.lib.telemetry.telemetry_handler import \
     record_user_action_details
 from container_service_extension.lib.telemetry.telemetry_utils import \
-    store_telemetry_settings
+    update_with_telemetry_settings
 from container_service_extension.logging.logger import INSTALL_LOGGER
 from container_service_extension.logging.logger import INSTALL_WIRELOG_FILEPATH
 from container_service_extension.logging.logger import NULL_LOGGER
@@ -419,7 +419,14 @@ def install_cse(
         # been registered as an extension, we should update the telemetry
         # config with the correct instance_id
         if config['service']['telemetry']['enable']:
-            store_telemetry_settings(config)
+            update_with_telemetry_settings(
+                config_dict=config,
+                vcd_host=config['vcd']['host'],
+                vcd_username=config['vcd']['username'],
+                vcd_password=config['vcd']['password'],
+                verify_ssl=config['vcd']['verify'],
+                is_mqtt_exchange=server_utils.should_use_mqtt_protocol(config)
+            )
 
         # Telemetry - Record successful install action
         record_user_action(

--- a/container_service_extension/lib/telemetry/telemetry_handler.py
+++ b/container_service_extension/lib/telemetry/telemetry_handler.py
@@ -170,11 +170,14 @@ def _send_data_to_telemetry_server(payload, telemetry_settings):
     :param dict payload: json metadata about CSE operation
     :param dict telemetry_settings: telemetry section of config->service
     """
-    vac_client = VacClient(
-        base_url=telemetry_settings['vac_url'],
-        collector_id=telemetry_settings['collector_id'],
-        instance_id=telemetry_settings['instance_id'],
-        vcd_ceip_id=telemetry_settings['vcd_ceip_id'],
-        logger_debug=LOGGER
-    )
-    vac_client.send_data(payload)
+    try:
+        vac_client = VacClient(
+            base_url=telemetry_settings['vac_url'],
+            collector_id=telemetry_settings['collector_id'],
+            instance_id=telemetry_settings['instance_id'],
+            vcd_ceip_id=telemetry_settings['vcd_ceip_id'],
+            logger_debug=LOGGER
+        )
+        vac_client.send_data(payload)
+    except Exception as err:
+        LOGGER.warning(f"Error in sending data to VAC :{str(err)}", exc_info=True)  # noqa: E501

--- a/container_service_extension/server/cli/server_cli.py
+++ b/container_service_extension/server/cli/server_cli.py
@@ -1346,17 +1346,17 @@ def import_tkgm_template(
             required_options = {
                 "vcd.host": {
                     "type": str,
-                    "prompt": "Enter VCD hostname",
+                    "prompt": "Please enter VCD hostname",
                     "hidden_field": False
                 },
                 "vcd.username": {
                     "type": str,
-                    "prompt": "Enter username for connecting to VCD",
+                    "prompt": "Please enter username for connecting to VCD",
                     "hidden_field": False
                 },
                 "vcd.password": {
                     "type": str,
-                    "prompt": "Enter password of the user for connecting to VCD",  # noqa: E501
+                    "prompt": "Please enter password of the user for connecting to VCD",  # noqa: E501
                     "hidden_field": True
                 },
                 "vcd.verify": {
@@ -1366,12 +1366,12 @@ def import_tkgm_template(
                 },
                 "broker.org": {
                     "type": str,
-                    "prompt": "Enter the name of the org where you want to import the OVA",  # noqa: E501
+                    "prompt": "Please enter the name of the org where you want to import the OVA",  # noqa: E501
                     "hidden_field": False
                 },
                 "broker.catalog": {
                     "type": str,
-                    "prompt": "Enter the name of the catalog where you want to import the OVA",  # noqa: E501
+                    "prompt": "Please enter the name of the catalog where you want to import the OVA",  # noqa: E501
                     "hidden_field": False
                 }
             }
@@ -1388,6 +1388,13 @@ def import_tkgm_template(
                 required_options,
                 default_option_values
             )
+
+            # To suppress the warning message that pyvcloud prints if
+            # ssl_cert verification is skipped.
+            if config and config.get('vcd') and \
+                    not config['vcd'].get('verify'):
+                requests.packages.urllib3.disable_warnings()
+
             config = config_validator.add_additional_details_to_config(
                 config=config,
                 vcd_host=config['vcd']['host'],


### PR DESCRIPTION
* Made the -c/--config param optional
* Added -x/--extra-option new param, this param takes two strings as input (key-value), this param can be repeated
* In case --config option is not provided by user, the -x params are used to create a dummy config dictionary in memory and passed onto the following methods
* Every method in the template import workflow that depends on config has been redesigned to explicitly state the actual fields of config it uses. This helps immensely to narrow down the scope of the dummy config file.
* A minimum set of required fields have been defined, if all of them is not specified by -x option, CSE will prompt the user to enter them interactively.
* Additional care has been taken to make sure that type-casting is done properly to the input key-value (str, str) pair received via -x option.

Testing Done:
Ran the command `cse template import`
1. without -c and -x options. Got prompted for all the required details
2. without -c and partial -x options. Got prompted for only the missing details
3. without -c and all required -x options. No prompt, command executed as normal.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1281)
<!-- Reviewable:end -->
