### PR TITLE
CSE Support-For-Syslog

### DIFF
--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -310,11 +310,17 @@ class Service(object, metaclass=Singleton):
     def run(self, msg_update_callback=utils.NullPrinter()):
         sysadmin_client = None
         try:
-            syslog_host = self.config['service'].get('syslog_host')
+            syslog_host = None
+            syslog_port = None
+            try:
+                syslog_host = self.config.get_value_at('service.syslog_host')
+                syslog_port = self.config.get_value_at('service.syslog_port')
+            except KeyError:
+                pass
             if syslog_host:
                 logger.configure_loggers_for_syslog(
                     syslog_host=syslog_host,
-                    syslog_port=self.config['service'].get('syslog_port')
+                    syslog_port=syslog_port
                 )
         except Exception as err:
             logger.SERVER_LOGGER.error(f"Syslog server error:{err}")

--- a/container_service_extension/server/service.py
+++ b/container_service_extension/server/service.py
@@ -310,6 +310,15 @@ class Service(object, metaclass=Singleton):
     def run(self, msg_update_callback=utils.NullPrinter()):
         sysadmin_client = None
         try:
+            syslog_host = self.config['service'].get('syslog_host')
+            if syslog_host:
+                logger.configure_loggers_for_syslog(
+                    syslog_host=syslog_host,
+                    syslog_port=self.config['service'].get('syslog_port')
+                )
+        except Exception as err:
+            logger.SERVER_LOGGER.error(f"Syslog server error:{err}")
+        try:
             sysadmin_client = vcd_utils.get_sys_admin_client(api_version=None)
             verify_version_compatibility(
                 sysadmin_client,


### PR DESCRIPTION
- CSE logger support extended for remote Syslog
- In addition to local logging, if there is Syslog server specified in CSE server config, logging happens at Syslog server end
- Supported and tested for server info, debug, server wire, cloud wire

- `Tested with the syslogd in a remote VM`

**rsyslog.conf changes required**


```
Edit /etc/rsyslog.conf : Uncomment the following entries

module(load="imudp")
input(type="imudp" port="514")

Rules to be defined in rsyslog configuration


local0.*                        -/var/log/cse-logs/server-info.log
local1.*                        -/var/log/cse-logs/server-debug.log
local2.*                        -/var/log/cse-logs/server-wire-debug.log
local3.*                        -/var/log/cse-logs/cloudapi-wire.log
local4.*                        -/var/log/cse-logs/nsxt-wire.log


Add the following facilty based rules in either of the following

/etc/rsyslog.conf
/etc/rsyslog.d/50-default.conf ﻿
Any new file .conf under /etc/rsyslog.d  ﻿ ﻿ ﻿

All files under /etc/rsyslog.d are included by having this entry in /etc/rsyslog.conf

#
# Include all config files in /etc/rsyslog.d/
#
$IncludeConfig /etc/rsyslog.d/*.conf



systemctl restart rsyslog
systemctl enable rsyslog


Changes required to support syslog in CSE server config file:

service:
  syslog_host: <host-name/ip>
  syslog_port: <port>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1302)
<!-- Reviewable:end -->
