### PR TITLE
Fix failing ovdc system tests 

### DIFF
--- a/container_service_extension/server/request_dispatcher.py
+++ b/container_service_extension/server/request_dispatcher.py
@@ -957,7 +957,7 @@ def process_request(message, mqtt_publisher=None):
         required_feature_flags = matched_handler.get('feature_flags', {})
         feature_flags_satisfied = True
         for feature_flag in required_feature_flags:
-            value = server_config['feature_flags'].get(feature_flag, False)
+            value = server_config.get_value_at('feature_flags').get(feature_flag, False)
             if not value:
                 LOGGER.debug("Url matched but failed to satisfy feature "
                              f"flag {feature_flag}")


### PR DESCRIPTION
After the recent changes to ServerConfig object, `request_dispatcher` is still using index operator to access elements in the config dictionary, and a result of this, any REST call that invoked the `feature_flag` path would fail.

This PR fixes the issue.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1306)
<!-- Reviewable:end -->
