### PR TITLE
[VCDA-3237] Using TKR bom for antrea version

### DIFF
--- a/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
+++ b/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
@@ -157,9 +157,8 @@ write_files:
     # $\open_bracket/VAR/\close_bracket as a format variable that will be replaced by the python format function.
     vmtoolsd --cmd "info-set guestinfo.postcustomization.tkr.get_versions.status in_progress"
       tkr_bom_dir=/tmp/tkr_bom
-      mkdir $tkr_bom_dir
       bom_path=$tkr_bom_dir/bom
-      mkdir $bom_path
+      mkdir -p $bom_path
       components_path=$bom_path/components.yaml
       imgpkg_path=$tkr_bom_dir/imgpkg
       yq_path=$tkr_bom_dir/yq
@@ -167,7 +166,7 @@ write_files:
 
       xml_version_property=$(vmtoolsd --cmd "info-get guestinfo.ovfenv" | grep "oe:key=\"VERSION\"")
       init_k8s_version=$(echo $xml_version_property | sed 's/.*oe:value=\"//; s/\(.*\)-.*/\1/')
-      k8s_version=$(echo $OPEN_BRACKETinit_k8s_versionCLOSE_BRACKET | tr -s "+" "_")
+      k8s_version=$(echo $init_k8s_version | tr -s "+" "_")
 
       # install imgpkg, which is needed for getting the components yaml file
       wget -nv github.com/vmware-tanzu/carvel-imgpkg/releases/download/v0.24.0/imgpkg-linux-amd64 -O $imgpkg_path
@@ -180,7 +179,7 @@ write_files:
       do
         tkg_version=$(echo $OPEN_BRACKETk8s_version//*.CLOSE_BRACKET)
         tkg_version=$((tkg_version+1))
-        k8s_version=$(echo $OPEN_BRACKETk8s_versionCLOSE_BRACKET | sed "s/.$/"$tkg_version"/")
+        k8s_version=$(echo $k8s_version | sed "s/.$/"$tkg_version"/")
         if [[ $tkg_version -gt 10 ]]; then
           no_tkr_found=true
           break
@@ -203,7 +202,7 @@ write_files:
           antrea_version=$default_antrea_version
           echo "no antrea version found in tkr bom, will use default antrea version: $OPEN_BRACKETdefault_antrea_versionCLOSE_BRACKET" &>> /var/log/cse/customization/status.log
         else
-          antrea_version=$(echo $OPEN_BRACKETantrea_versionCLOSE_BRACKET | sed "s/v//") # remove leading `v`, which will be added later
+          antrea_version=$(echo $antrea_version | sed "s/v//") # remove leading `v`, which will be added later
         fi
       fi
 

--- a/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
+++ b/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
@@ -151,7 +151,8 @@ write_files:
     vmtoolsd --cmd "info-set guestinfo.kubeconfig $(cat /etc/kubernetes/admin.conf | base64 | tr -d '\n')"
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeinit.status successful"
 
-    # open_bracket(all caps) will be replaced by `{` and close_bracket (all caps) will be replaced by `}`.
+    # open_bracket(all caps) will be replaced by the open bracket and close_bracket (all caps)
+    # will be replaced by an open bracket.
     # This convention is needed so that python's template format function does not view the bash
     # $\open_bracket/VAR/\close_bracket as a format variable that will be replaced by the python format function.
     vmtoolsd --cmd "info-set guestinfo.postcustomization.tkr.get_versions.status in_progress"
@@ -187,7 +188,7 @@ write_files:
       done
 
       if [[ "$no_tkr_found" = true ]] ; then
-        echo "no tkr bom found, will use default component versions"  &>> /var/log/capvcd/customization/status.log
+        echo "no tkr bom found, will use default component versions"  &>> /var/log/cse/customization/status.log
         antrea_version=$default_antrea_version
       fi
 
@@ -200,7 +201,7 @@ write_files:
         antrea_version=$($yq_path e ".components.antrea[0].version" $components_path | sed 's/+.*//')
         if [[ -z "$antrea_version" ]] || [[ "$antrea_version" = "null" ]] || [[ "$antrea_version" = "false" ]]; then
           antrea_version=$default_antrea_version
-          echo "no antrea version found in tkr bom, will use default antrea version: $OPEN_BRACKETdefault_antrea_versionCLOSE_BRACKET" &>> /var/log/capvcd/customization/status.log
+          echo "no antrea version found in tkr bom, will use default antrea version: $OPEN_BRACKETdefault_antrea_versionCLOSE_BRACKET" &>> /var/log/cse/customization/status.log
         else
           antrea_version=$(echo $OPEN_BRACKETantrea_versionCLOSE_BRACKET | sed "s/v//") # remove leading `v`, which will be added later
         fi
@@ -210,12 +211,11 @@ write_files:
       rm -rf $tkr_bom_dir
     vmtoolsd --cmd "info-set guestinfo.postcustomization.tkr.get_versions.status successful"
 
-
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.cni.install.status in_progress"
       antrea_path=/root/antrea-$OPEN_BRACKETantrea_versionCLOSE_BRACKET.yaml
-      wget -O $antrea_path https://github.com/vmware-tanzu/antrea/releases/download/$OPEN_BRACKETantrea_versionCLOSE_BRACKET/antrea.yml
+      wget -O $antrea_path https://github.com/vmware-tanzu/antrea/releases/download/v$OPEN_BRACKETantrea_versionCLOSE_BRACKET/antrea.yml
       # This does not need to be done from v0.12.0 onwards inclusive
-      sed -i 's/antrea\/antrea-ubuntu:{antrea_cni_version}/projects.registry.vmware.com\/antrea\/antrea-ubuntu:{antrea_cni_version}/g' $antrea_path
+      sed -i "s/antrea\/antrea-ubuntu:v$OPEN_BRACKETantrea_versionCLOSE_BRACKET/projects.registry.vmware.com\/antrea\/antrea-ubuntu:v$OPEN_BRACKETantrea_versionCLOSE_BRACKET/g" $antrea_path
       kubectl apply -f $antrea_path
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.cni.install.status successful"
 

--- a/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
+++ b/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
@@ -151,10 +151,66 @@ write_files:
     vmtoolsd --cmd "info-set guestinfo.kubeconfig $(cat /etc/kubernetes/admin.conf | base64 | tr -d '\n')"
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeinit.status successful"
 
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.tkr.get_versions.status in_progress"
+      tkr_bom_dir=/tmp/tkr_bom
+      mkdir $tkr_bom_dir
+      bom_path=$tkr_bom_dir/bom
+      mkdir $bom_path
+      components_path=$bom_path/components.yaml
+      imgpkg_path=$tkr_bom_dir/imgpkg
+      yq_path=$tkr_bom_dir/yq
+      default_antrea_version="0.11.3"
+
+      xml_version_property=$(vmtoolsd --cmd "info-get guestinfo.ovfenv" | grep "oe:key=\"VERSION\"")
+      init_k8s_version=$(echo $xml_version_property | sed 's/.*oe:value=\"//; s/\(.*\)-.*/\1/')
+      k8s_version=$(echo ${init_k8s_version} | tr -s "+" "_")
+
+      # install imgpkg, which is needed for getting the components yaml file
+      wget -nv github.com/vmware-tanzu/carvel-imgpkg/releases/download/v0.24.0/imgpkg-linux-amd64 -O $imgpkg_path
+      chmod +x $imgpkg_path
+
+      # We need to loop through the `X` value in `tkg.X` because of some TKR unexpected design.
+      # We increment `X`, looking fir a valid tkr bom version.
+      no_tkr_found=false
+      until $imgpkg_path pull -i projects.registry.vmware.com/tkg/tkr-bom:${k8s_version} -o $bom_path
+      do
+        tkg_version=$(echo ${k8s_version//*.})
+        tkg_version=$((tkg_version+1))
+        k8s_version=$(echo ${k8s_version} | sed "s/.$/"$tkg_version"/")
+        if [[ $tkg_version -gt 10 ]]; then
+          no_tkr_found=true
+          break
+        fi
+      done
+
+      if [[ "$no_tkr_found" = true ]] ; then
+        echo "no tkr bom found, will use default component versions"  &>> /var/log/capvcd/customization/status.log
+        antrea_version=$default_antrea_version
+      fi
+
+      if [[ "$no_tkr_found" = false ]]; then
+        mv $bom_path/*.yaml $components_path
+
+        # install yq for yaml parsing
+        wget https://github.com/mikefarah/yq/releases/download/v4.2.0/yq_linux_amd64 -O $yq_path
+        chmod +x $yq_path
+        antrea_version=$($yq_path e ".components.antrea[0].version" $components_path | sed 's/+.*//')
+        if [[ -z "$antrea_version" ]] || [[ "$antrea_version" = "null" ]] || [[ "$antrea_version" = "false" ]]; then
+          antrea_version=$default_antrea_version
+          echo "no antrea version found in tkr bom, will use default antrea version: ${default_antrea_version}" &>> /var/log/capvcd/customization/status.log
+        else
+          antrea_version=$(echo ${antrea_version} | sed "s/v//") # remove leading `v`, which will be added later
+        fi
+      fi
+
+      # cleanup components downloads
+      rm -rf $tkr_bom_dir
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.tkr.get_versions.status successful"
+
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.cni.install.status in_progress"
-      antrea_path=/root/antrea-{antrea_cni_version}.yaml
-      wget -O $antrea_path https://github.com/vmware-tanzu/antrea/releases/download/{antrea_cni_version}/antrea.yml
+      antrea_path=/root/antrea-${antrea_version}.yaml
+      wget -O $antrea_path https://github.com/vmware-tanzu/antrea/releases/download/${antrea_version}/antrea.yml
       # This does not need to be done from v0.12.0 onwards inclusive
       sed -i 's/antrea\/antrea-ubuntu:{antrea_cni_version}/projects.registry.vmware.com\/antrea\/antrea-ubuntu:{antrea_cni_version}/g' $antrea_path
       kubectl apply -f $antrea_path

--- a/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
+++ b/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
@@ -151,6 +151,9 @@ write_files:
     vmtoolsd --cmd "info-set guestinfo.kubeconfig $(cat /etc/kubernetes/admin.conf | base64 | tr -d '\n')"
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeinit.status successful"
 
+    # open_bracket(all caps) will be replaced by `{` and close_bracket (all caps) will be replaced by `}`.
+    # This convention is needed so that python's template format function does not view the bash
+    # $\open_bracket/VAR/\close_bracket as a format variable that will be replaced by the python format function.
     vmtoolsd --cmd "info-set guestinfo.postcustomization.tkr.get_versions.status in_progress"
       tkr_bom_dir=/tmp/tkr_bom
       mkdir $tkr_bom_dir
@@ -163,7 +166,7 @@ write_files:
 
       xml_version_property=$(vmtoolsd --cmd "info-get guestinfo.ovfenv" | grep "oe:key=\"VERSION\"")
       init_k8s_version=$(echo $xml_version_property | sed 's/.*oe:value=\"//; s/\(.*\)-.*/\1/')
-      k8s_version=$(echo ${init_k8s_version} | tr -s "+" "_")
+      k8s_version=$(echo $OPEN_BRACKETinit_k8s_versionCLOSE_BRACKET | tr -s "+" "_")
 
       # install imgpkg, which is needed for getting the components yaml file
       wget -nv github.com/vmware-tanzu/carvel-imgpkg/releases/download/v0.24.0/imgpkg-linux-amd64 -O $imgpkg_path
@@ -172,11 +175,11 @@ write_files:
       # We need to loop through the `X` value in `tkg.X` because of some TKR unexpected design.
       # We increment `X`, looking fir a valid tkr bom version.
       no_tkr_found=false
-      until $imgpkg_path pull -i projects.registry.vmware.com/tkg/tkr-bom:${k8s_version} -o $bom_path
+      until $imgpkg_path pull -i projects.registry.vmware.com/tkg/tkr-bom:$OPEN_BRACKETk8s_versionCLOSE_BRACKET -o $bom_path
       do
-        tkg_version=$(echo ${k8s_version//*.})
+        tkg_version=$(echo $OPEN_BRACKETk8s_version//*.CLOSE_BRACKET)
         tkg_version=$((tkg_version+1))
-        k8s_version=$(echo ${k8s_version} | sed "s/.$/"$tkg_version"/")
+        k8s_version=$(echo $OPEN_BRACKETk8s_versionCLOSE_BRACKET | sed "s/.$/"$tkg_version"/")
         if [[ $tkg_version -gt 10 ]]; then
           no_tkr_found=true
           break
@@ -197,9 +200,9 @@ write_files:
         antrea_version=$($yq_path e ".components.antrea[0].version" $components_path | sed 's/+.*//')
         if [[ -z "$antrea_version" ]] || [[ "$antrea_version" = "null" ]] || [[ "$antrea_version" = "false" ]]; then
           antrea_version=$default_antrea_version
-          echo "no antrea version found in tkr bom, will use default antrea version: ${default_antrea_version}" &>> /var/log/capvcd/customization/status.log
+          echo "no antrea version found in tkr bom, will use default antrea version: $OPEN_BRACKETdefault_antrea_versionCLOSE_BRACKET" &>> /var/log/capvcd/customization/status.log
         else
-          antrea_version=$(echo ${antrea_version} | sed "s/v//") # remove leading `v`, which will be added later
+          antrea_version=$(echo $OPEN_BRACKETantrea_versionCLOSE_BRACKET | sed "s/v//") # remove leading `v`, which will be added later
         fi
       fi
 
@@ -209,8 +212,8 @@ write_files:
 
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.cni.install.status in_progress"
-      antrea_path=/root/antrea-${antrea_version}.yaml
-      wget -O $antrea_path https://github.com/vmware-tanzu/antrea/releases/download/${antrea_version}/antrea.yml
+      antrea_path=/root/antrea-$OPEN_BRACKETantrea_versionCLOSE_BRACKET.yaml
+      wget -O $antrea_path https://github.com/vmware-tanzu/antrea/releases/download/$OPEN_BRACKETantrea_versionCLOSE_BRACKET/antrea.yml
       # This does not need to be done from v0.12.0 onwards inclusive
       sed -i 's/antrea\/antrea-ubuntu:{antrea_cni_version}/projects.registry.vmware.com\/antrea\/antrea-ubuntu:{antrea_cni_version}/g' $antrea_path
       kubectl apply -f $antrea_path

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -801,6 +801,7 @@ class PostCustomizationPhase(Enum):
     NETWORK_CONFIGURATION = 'guestinfo.postcustomization.networkconfiguration.status'  # noqa: E501
     STORE_SSH_KEY = 'guestinfo.postcustomization.store.sshkey.status'
     KUBEADM_INIT = 'guestinfo.postcustomization.kubeinit.status'
+    TKR_GET_VERSIONS = 'guestinfo.postcustomization.tkr.get_versions.status'
     KUBECTL_APPLY_CNI = 'guestinfo.postcustomization.kubectl.cni.install.status'  # noqa: E501
     KUBECTL_APPLY_CPI = 'guestinfo.postcustomization.kubectl.cpi.install.status'  # noqa: E501
     KUBECTL_APPLY_CSI = 'guestinfo.postcustomization.kubectl.csi.install.status'  # noqa: E501

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -73,7 +73,6 @@ DEFAULT_API_VERSION = vcd_client.ApiVersion.VERSION_36.value
 
 # Hardcode the Antrea CNI version until there's a better way to retrieve it
 CNI_NAME = "antrea"
-ANTREA_CNI_VERSION = 'v0.11.3'
 CPI_VERSION = '1.1.0'
 CSI_VERSION = '1.1.0'
 
@@ -279,9 +278,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                 'entity.status.kubernetes': _create_k8s_software_string(
                     template[LocalTemplateKey.KUBERNETES],
                     template[LocalTemplateKey.KUBERNETES_VERSION]),
-                'entity.status.cni': _create_k8s_software_string(
-                    CNI_NAME,
-                    ANTREA_CNI_VERSION),
+                'entity.status.cni': CNI_NAME,
                 'entity.status.os': template[LocalTemplateKey.OS],
                 'entity.status.cloud_properties': cloud_properties,
                 'entity.status.uid': entity_id,
@@ -794,7 +791,6 @@ class ClusterService(abstract_broker.AbstractBroker):
                 ClusterMetadataKey.KUBERNETES: template[LocalTemplateKey.KUBERNETES],  # noqa: E501
                 ClusterMetadataKey.KUBERNETES_VERSION: template[LocalTemplateKey.KUBERNETES_VERSION],  # noqa: E501
                 ClusterMetadataKey.CNI: CNI_NAME,
-                ClusterMetadataKey.CNI_VERSION: ANTREA_CNI_VERSION  # noqa: E501
             }
 
             sysadmin_client_v36 = self.context.get_sysadmin_client(
@@ -923,10 +919,7 @@ class ClusterService(abstract_broker.AbstractBroker):
                     )
                 ),
                 'entity.status.nodes': _get_nodes_details(vapp),
-                'entity.status.cni': _create_k8s_software_string(
-                    CNI_NAME,
-                    ANTREA_CNI_VERSION,
-                ),
+                'entity.status.cni': CNI_NAME,
                 'entity.status.cloud_properties.distribution.''template_name':
                     tags[ClusterMetadataKey.TEMPLATE_NAME],
                 'entity.status.cloud_properties.distribution.''template_revision':  # noqa: E501
@@ -2231,7 +2224,6 @@ def _add_control_plane_nodes(
                 vm_host_name=spec['target_vm_name'],
                 service_cidr=k8s_svc_cidr,
                 pod_cidr=k8s_pod_cidr,
-                antrea_cni_version=ANTREA_CNI_VERSION,
                 cpi_version=CPI_VERSION,
                 csi_version=CSI_VERSION,
                 ssh_key=ssh_key if ssh_key else '',
@@ -2306,7 +2298,6 @@ def _add_control_plane_nodes(
                 vm_host_name=spec['target_vm_name'],
                 service_cidr=k8s_svc_cidr,
                 pod_cidr=k8s_pod_cidr,
-                antrea_cni_version=ANTREA_CNI_VERSION,
                 cpi_version=CPI_VERSION,
                 csi_version=CSI_VERSION,
                 ssh_key=ssh_key if ssh_key else '',

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -2305,6 +2305,12 @@ def _add_control_plane_nodes(
                 base64_encoded_refresh_token=base64_refresh_token.decode("utf-8"),  # noqa: E501
                 **proxy_config
             )
+
+            # place bash open and close brackets after the python template
+            # function
+            cloud_init_spec = cloud_init_spec.replace("OPEN_BRACKET", "{")
+            cloud_init_spec = cloud_init_spec.replace("CLOSE_BRACKET", "}")
+
             # create a cloud-init spec and update the VMs with it
             _set_cloud_init_spec(sysadmin_client, vapp, vm, cloud_init_spec)
 


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

- (Required) Short description of changes in the PR topic line
- Using TKR bom to get antrea version for R1 TKGm clusters
- R1 RDE should only specify "antrea" as the cni and not the version since we do not currently support the vm to update the cni version

- (Required) Detailed description of changes include tests and
  documentation.  If the pull request contains multiple commits with 
  detailed messages, refer to those instead
Tested with 1.3.0 (no antrea in bom), 1.4.0 (antrea 0.11.3 in bom ), and 1.4.1 (antrea 0.13.3 in bom) ovas
Verified RDE only shows "antrea"

- (Optional) Names of reviewers using @ sign + name
- @Anirudh9794 @arunmk @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1308)
<!-- Reviewable:end -->
