### PR TITLE
Fix warning message on importing TKG ova template 

### DIFF
--- a/container_service_extension/installer/templates/tkgm_template_manager.py
+++ b/container_service_extension/installer/templates/tkgm_template_manager.py
@@ -22,7 +22,9 @@ def parse_tkgm_template_name(ova_file_name):
     # ubuntu-2004-kube-v1.19.8-vmware.1-tkg.0-18171857641727074969.ova
     # ubuntu-2004-kube-v1.18.16-vmware.1-tkg.0-14744207219736322255.ova
     # ubuntu-2004-kube-v1.21.2+vmware.1-tkg.1-7832907791984498322.ova
-    name_regex = re.compile(r"ubuntu-([\d]+)-kube-v([\d]+[.][\d]+[.][\d]+[-|+][vmware.[\d]*]*)-tkg[.][-|\d]*[.]ova")  # noqa: E501
+    # ubuntu-2004-kube-v1.20.14+vmware.1-tkg.2-5a5027ce2528a6229acb35b38ff8084e.ova
+    # ubuntu-2004-kube-v1.22.5+vmware.1-tkg.2-f838b27ca494fee7083c0340e11ce243.ova
+    name_regex = re.compile(r"ubuntu-([\d]+)-kube-v([\d]+[.][\d]+[.][\d]+[-|+][vmware.[\d]*]*)-tkg[.][-|a-z0-9]*[.]ova")  # noqa: E501
     m = name_regex.match(ova_file_name)
     os_version = None
     kubernetes_version = None


### PR DESCRIPTION
- Fixes the warning message for the valid TKGm Ova(s) that were shipped recently
- The latest version of the TKGm OVA (shipped with 1.4.2 and 1.5.1) have a different name pattern. CSE server CLI has a check on valid names based on allowed pattern. This pattern has been updated in this fix to include new naming of TKGm as a valid name
- Tested the import with new OVAs. Verfied that no more warning messages on these names

```
cse template import -F ~/Downloads/ubuntu-2004-kube-v1.20.14+vmware.1-tkg.2-5a5027ce2528a6229acb35b38ff8084e.ova 

cse template import -F ~/Downloads/ubuntu-2004-kube-v1.22.5+vmware.1-tkg.2-f838b27ca494fee7083c0340e11ce243.ova 
```

@Anirudh9794 @ltimothy7 @arunmk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1320)
<!-- Reviewable:end -->
