### PR TITLE
[VCDA-3435] update pkg_resources.open_text() calls to be made with string arguments

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_1_x.py
+++ b/container_service_extension/rde/backend/cluster_service_1_x.py
@@ -2321,7 +2321,8 @@ def _init_cluster(sysadmin_client: vcd_client.Client, vapp, cluster_kind,
 
     try:
         templated_script = get_cluster_script_file_contents(
-            ClusterScriptFile.CONTROL_PLANE, ClusterScriptFile.VERSION_1_X)
+            ClusterScriptFile.CONTROL_PLANE.value,
+            ClusterScriptFile.VERSION_1_X.value)
         script = templated_script.format(
             cluster_kind=cluster_kind,
             k8s_version=k8s_version,
@@ -2376,7 +2377,7 @@ def _join_cluster(sysadmin_client: vcd_client.Client, vapp, target_nodes=None):
         local_ip_port = f"{join_info[7]}:6443"
 
         templated_script = get_cluster_script_file_contents(
-            ClusterScriptFile.NODE, ClusterScriptFile.VERSION_1_X)
+            ClusterScriptFile.NODE.value, ClusterScriptFile.VERSION_1_X.value)
         script = templated_script.format(
             ip_port=local_ip_port,
             token=join_info[4],

--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -2722,7 +2722,8 @@ def _init_cluster(sysadmin_client: vcd_client.Client, vapp, cluster_kind,
 
     try:
         templated_script = get_cluster_script_file_contents(
-            ClusterScriptFile.CONTROL_PLANE, ClusterScriptFile.VERSION_2_X)
+            ClusterScriptFile.CONTROL_PLANE.value,
+            ClusterScriptFile.VERSION_2_X.value)
         script = templated_script.format(
             cluster_kind=cluster_kind,
             k8s_version=k8s_version,
@@ -2778,7 +2779,7 @@ def _join_cluster(sysadmin_client: vcd_client.Client, vapp, target_nodes=None):
         join_info = control_plane_result[0][1].content.decode().split()
 
         templated_script = get_cluster_script_file_contents(
-            ClusterScriptFile.NODE, ClusterScriptFile.VERSION_2_X)
+            ClusterScriptFile.NODE.value, ClusterScriptFile.VERSION_2_X.value)
         script = templated_script.format(
             ip_port=join_info[2],
             token=join_info[4],

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -2278,8 +2278,8 @@ def _add_control_plane_nodes(
             )
 
         templated_script = get_cluster_script_file_contents(
-            ClusterScriptFile.CLOUDINIT_CONTROL_PLANE,
-            ClusterScriptFile.VERSION_2_X_TKGM)
+            ClusterScriptFile.CLOUDINIT_CONTROL_PLANE.value,
+            ClusterScriptFile.VERSION_2_X_TKGM.value)
 
         # Get template with no expose_ip; expose_ip will be computed
         # later when control_plane internal ip is computed below.

--- a/container_service_extension/rde/models/common_models.py
+++ b/container_service_extension/rde/models/common_models.py
@@ -356,7 +356,7 @@ class EntityType(Enum):
     NATIVE_ENTITY_TYPE_1_0_0 = DefEntityType(
         name='nativeClusterEntityType',
         id=f"{DEF_ENTITY_TYPE_ID_PREFIX}:{Vendor.CSE.value}:{Nss.NATIVE_CLUSTER}:1.0.0",  # noqa: E501
-        schema=load_rde_schema(SchemaFile.SCHEMA_1_0_0),
+        schema=load_rde_schema(SchemaFile.SCHEMA_1_0_0.value),
         interfaces=[K8Interface.VCD_INTERFACE.value.id],
         version='1.0.0',
         vendor=Vendor.CSE.value,
@@ -366,7 +366,7 @@ class EntityType(Enum):
     NATIVE_ENTITY_TYPE_2_1_0 = DefEntityType2_0(
         name='nativeClusterEntityType',
         id=f"{DEF_ENTITY_TYPE_ID_PREFIX}:{Vendor.CSE.value}:{Nss.NATIVE_CLUSTER}:2.1.0",# noqa: E501
-        schema=load_rde_schema(SchemaFile.SCHEMA_2_1_0),
+        schema=load_rde_schema(SchemaFile.SCHEMA_2_1_0.value),
         interfaces=[
             K8Interface.VCD_INTERFACE.value.id,
             K8Interface.CSE_INTERFACE.value.id
@@ -394,7 +394,7 @@ class EntityType(Enum):
     CAPVCD_ENTITY_TYPE_1_0_0 = DefEntityType(
         name='CAPVCD Cluster',
         id=f"{DEF_ENTITY_TYPE_ID_PREFIX}:{Vendor.VMWARE.value}:{Nss.CAPVCD}:1.0.0",  # noqa: E501
-        schema=load_rde_schema(SchemaFile.CAPVCD_1_0_0),
+        schema=load_rde_schema(SchemaFile.CAPVCD_1_0_0.value),
         interfaces=[K8Interface.VCD_INTERFACE.value.id],
         version='1.0.0',
         vendor=Vendor.VMWARE.value,


### PR DESCRIPTION

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>
Description:
* to suport python3.10, pkg_resources.open_text() should receive string arguments
* `pkg_resources` uses modules which are shipped along with python
* previous versions of python used to work with the existing code because the Enums were converted to a string within the function `pkg_resources.open_text()`.

Testing done:
* Start the server (makes sure the schema is loaded using `load_rde_schema()`)
* Create TKGm cluster with 1 control plane and 1 worker. (makes sure code in cluster_service_2_x_tkgm.py is executed)
* Create cluster with native template and 2.0 RDE (makes sure code in cluster_service_2_x.py is executed)
* Create cluster with native template and 1.0 RDE (makes sure code in cluster_service_1_x.py is executed)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1328)
<!-- Reviewable:end -->
