### PR TITLE
[VCDA-3485] Update TKGm template metadata if it is renamed in VCD

### DIFF
--- a/container_service_extension/installer/templates/tkgm_template_manager.py
+++ b/container_service_extension/installer/templates/tkgm_template_manager.py
@@ -149,13 +149,30 @@ def read_all_tkgm_template(
         filtered_dict = {}
         kind = metadata_dict.get(server_constants.TKGmTemplateKey.KIND)
         if kind == shared_constants.ClusterEntityKind.TKG_M.value:
-            msg = f"Found TKGm template {item_name}."
+            msg = f"Found catalog item `{item_name}`."
             logger.debug(msg)
             msg_update_callback.general(msg)
-            for item in server_constants.TKGmTemplateKey:
-                key = item.value
+            for entry in server_constants.TKGmTemplateKey:
+                key = entry.value
                 value = metadata_dict.get(key, '')
+                # If catalog item has been renamed directly in VCD,
+                # update the `name` metadata field.
+                if entry == server_constants.TKGmTemplateKey.NAME and value != item_name:  # noqa: E501
+                    msg = f"Template `{value}` has been " \
+                          "renamed outside of CSE. Attempting to fix."
+                    logger.debug(msg)
+                    msg_update_callback.general(msg)
+                    org.set_metadata_on_catalog_item(
+                        catalog_name=catalog_name,
+                        item_name=item_name,
+                        key=key,
+                        value=item_name
+                    )
+                    value = item_name
                 filtered_dict[key] = value
+            msg = f"Template `{item_name}` successfully loaded."
+            logger.debug(msg)
+            msg_update_callback.general(msg)
             templates.append(filtered_dict)
 
     return templates


### PR DESCRIPTION
If the underlying catalog item of a TKGm template is renamed in VCD, the metadata on the catalog item goes out of sync, specifically the field `name`. This leads to the issue where CSE is unable to locate the affected template during cluster creation. To fix this issue, CSE will detect such name changes and automatically update the metadata. The operation will be done only for TKGm templates and will be triggered during CSE startup and whenever the template definition held in CSE server's memory is refreshed via REST api.

Testing Done:
Renamed TKGm template in vCD and started up CSE server.

The output on the console during startup.
```Skipping loading k8s template definition from catalog since `No communication with VCenter` mode is on.
Loading TKGm template definition from catalog
Found catalog item `ubuntu-2004-kube-v1.21.2+vmware.1-tkg.2-14542111852555356776-abc`.
Template `ubuntu-2004-kube-v1.21.2+vmware.1-tkg.2-14542111852555356776`'s catalog item has been renamed outside CSE. Attempting to fix.
Template `ubuntu-2004-kube-v1.21.2+vmware.1-tkg.2-14542111852555356776-abc` successfully loaded.```

Verified that the new template name shows up in the UI's template selection page.

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1331)
<!-- Reviewable:end -->
