### PR TITLE
[VCDA-3410] Retry creation of DNAT rule on failure

### DIFF
--- a/container_service_extension/lib/nsxt/nsxt_backed_gateway_service.py
+++ b/container_service_extension/lib/nsxt/nsxt_backed_gateway_service.py
@@ -18,7 +18,7 @@ import container_service_extension.common.utils.pyvcloud_utils as pyvcloud_utils
 import container_service_extension.lib.cloudapi.constants as cloudapi_constants
 import container_service_extension.lib.nsxt.constants as nsxt_constants
 from container_service_extension.lib.nsxt.constants import \
-    NsxtGatewayRequestKey, NsxtNATRuleKey, DNAT_EXTERNAL_PORT
+    DNAT_EXTERNAL_PORT, NsxtGatewayRequestKey, NsxtNATRuleKey
 from container_service_extension.logging.logger import NULL_LOGGER
 from container_service_extension.logging.logger import SERVER_LOGGER
 

--- a/container_service_extension/rde/backend/common/network_expose_helper.py
+++ b/container_service_extension/rde/backend/common/network_expose_helper.py
@@ -200,7 +200,10 @@ def expose_cluster(client: vcd_client.Client, org_name: str,
         nsxt_gateway_svc.add_dnat_rule(
             name=dnat_rule_name,
             internal_address=internal_ip,
-            external_address=expose_ip)
+            external_address=expose_ip,
+            num_retry_if_gateway_busy=3
+        )
+
     except Exception as err:
         raise Exception(f"Unable to add dnat rule with error: {str(err)}")
     return expose_ip


### PR DESCRIPTION
If multiple exposed clusters are being deployed by CSE is parallel, they can easily run into a state where DNAT rule creation for one cluster, puts the gateway in BUSY state and as a result the other DNAT rule creation operation fails. In this PR we have added few retries while adding the DNAT rule to potentially alleviate the gateway lock-up state.

Testing Done:
Wrote a script that calls the method nsxt_gateway_svc.add_dnat_rule() from two different threads simultaneously to create two DNAT rules on the same edge gateway. Verified from logs that the second operation fails because of BUSY gateway and is retried by the fixed code. Both DNAT rules were created successfully after a small delay.

22-03-30 22:35:25 | nsxt_backed_gateway_service:175 - add_dnat_rule | ERROR :: Error creating dnat rule, underlying gateway might be in busy state.
22-03-30 22:35:25 | nsxt_backed_gateway_service:180 - add_dnat_rule | ERROR :: Retrying operation. Attempt#1.

In the wire logs three calls to POST https://[vcd]/cloudapi/1.0.0/edgeGateways/urn:vcloud:gateway:ad794f5a-3289-4c91-8e98-0492566bf8cf/nat/rules were recorded.
22-03-30 22:35:24 - 1st call (thread1) - status 202 (success)
22-03-30 22:35:24 - 2nd call (thread2) - status 400 (failure - Gateway busy)
22-03-30 22:35:55 - 3rd call (thread2) - status 202 (success) 

Signed-off-by: rocknes <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1333)
<!-- Reviewable:end -->
