### PR TITLE
Fix vcd cse cluster delete for legacy cluster

### DIFF
--- a/container_service_extension/client/cluster_commands.py
+++ b/container_service_extension/client/cluster_commands.py
@@ -145,7 +145,7 @@ Examples
     help="ID of the cluster which needs to be deleted;"
          "Supported only for CSE api version >= 35."
          "ID gets precedence over cluster name.")
-def cluster_delete(ctx, name, force, vdc, org, k8_runtime=None, cluster_id=None):  # noqa: E501
+def cluster_delete(ctx, name, vdc, org, force=False, k8_runtime=None, cluster_id=None):  # noqa: E501
     """Delete a Kubernetes cluster.
 
 \b


### PR DESCRIPTION
- Fixed `vcd cse cluster delete ` for legacy cluster
- Force delete is not supported for legacy cluster. Since this option is made hidden, the handler method in CLI needs to set defult value for --force option. 
- Error message: `TypeError: cluster_delete() missing 1 required positional argument: 'force'`
- Tested for both legacy, native and tkgm cluster delete
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1334)
<!-- Reviewable:end -->
