### PR TITLE
Fix for using tkr k8s version in node script

### DIFF
--- a/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
+++ b/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
@@ -179,6 +179,9 @@ write_files:
           break
         fi
       done
+      # This version is written into the extra config for worker nodes to use for tanzu-cli.
+      # Note: this approach can be done in R1 clusters since there are no rolling upgrade.
+      # However, this approach should not be done in capvcd clusters due to rolling upgrades.
       vmtoolsd --cmd "info-set guestinfo.postcustomization.tkr.get_versions.k8s $k8s_version"
 
       mv $bom_path/*.yaml $components_path

--- a/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
+++ b/cluster_scripts/v2_x_tkgm/cloud_init_control_plane.yaml
@@ -179,6 +179,7 @@ write_files:
           break
         fi
       done
+      vmtoolsd --cmd "info-set guestinfo.postcustomization.tkr.get_versions.k8s $k8s_version"
 
       mv $bom_path/*.yaml $components_path
       # download yq for yaml parsing

--- a/cluster_scripts/v2_x_tkgm/cloud_init_node.yaml
+++ b/cluster_scripts/v2_x_tkgm/cloud_init_node.yaml
@@ -143,7 +143,7 @@ write_files:
         kapp_controller_namespace=$(kubectl get pods -l=app='kapp-controller' -A -o jsonpath='OPENBRACKET.items[*].metadata.namespaceCLOSEBRACKET')
         kapp_controller_ready_path=/root/kapp_controller_ready.txt
         kapp_controller_ready=false
-        kubectl wait --for=condition=Ready pod/$OPENBRACKETkapp_controller_podCLOSEBRACKET -n $kapp_controller_namespace --timeout=8m > $kapp_controller_ready_path
+        kubectl wait --for=condition=Ready pod/$OPENBRACKETkapp_controller_podCLOSEBRACKET -n $kapp_controller_namespace --timeout=10m > $kapp_controller_ready_path
         if [[ -f "$kapp_controller_ready_path" && -s $kapp_controller_ready_path ]]; then
           kapp_controller_ready=true
         else
@@ -161,9 +161,8 @@ write_files:
           export HOME=/root
           tanzu plugin install package
 
-          xml_version_property=$(vmtoolsd --cmd "info-get guestinfo.ovfenv" | grep "oe:key=\"VERSION\"")
-          init_k8s_version=$(echo $xml_version_property | sed 's/.*oe:value=\"//; s/\(.*\)-.*/\1/')
           k8s_version=$(echo $init_k8s_version | tr -s "+" "_")
+          k8s_version="{k8s_version}"
           export KUBECONFIG=$kubeconfig_path
           tanzu package repository add tanzu-core --namespace tkg-system --create-namespace --url projects.registry.vmware.com/tkg/packages/core/repo:$OPENBRACKETk8s_versionCLOSEBRACKET
 

--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -823,7 +823,7 @@ class PostCustomizationPhase(Enum):
 @unique
 class PostCustomizationVersions(Enum):
     TKR_KAPP_CONTROLLER_VERSION_TO_INSTALL = 'guestinfo.postcustomization.tkr.get_versions.kapp_controller'  # noqa: E501
-    TKR_METRICS_SERVER_VERSION_TO_INSTALL = 'guestinfo.postcustomization.tkr.get_versions.metrics_server'  # noqa: E501
+    TKR_K8S_VERSION = 'guestinfo.postcustomization.tkr.get_versions.k8s'
     INSTALLED_VERSION_OF_KAPP_CONTROLLER = 'guestinfo.postcustomization.core_packages.kapp_controller_version'  # noqa: E501
     INSTALLED_VERSION_OF_METRICS_SERVER = 'guestinfo.postcustomization.core_packages.metrics_server_version'  # noqa: E501
     INSTALLED_VERSION_OF_ANTREA = 'guestinfo.postcustomization.core_packages.antrea_version'  # noqa: E501
@@ -834,6 +834,7 @@ class CorePkgVersionKeys(Enum):
     KAPP_CONTROLLER = 'kapp-controller'
     METRICS_SERVER = 'metrics-server'
     ANTREA = 'antrea'
+    K8S = 'k8s'
 
 
 PostCustomizationKubeconfig = 'guestinfo.postcustomization.control_plane.kubeconfig'  # noqa: E501


### PR DESCRIPTION
Signed-off-by: ltimothy7 <66969084+ltimothy7@users.noreply.github.com>

To help us process your pull request efficiently, please include: 

- (Required) Detailed description of changes include tests and
  documentation.  If the pull request contains multiple commits with 
  detailed messages, refer to those instead
Tanzu-cli on the worker node needs the tkr k8s version to use. Previously, this version was retrieved in the control plane node, but it was not written to the control plane extra config to be used in the worker node when installing tanzu cli.

This issue fixes the cluster creation failure seen in the TKGm 1.5.1 k8s 1.22 ova.

- (Optional) Names of reviewers using @ sign + name
@arunmk @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1338)
<!-- Reviewable:end -->
