### PR TITLE
[VCDA-3458] remove conditional check for DNAT rule removal on Force Delete

### DIFF
--- a/container_service_extension/rde/backend/cluster_service_2_x.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x.py
@@ -2037,27 +2037,25 @@ class ClusterService(abstract_broker.AbstractBroker):
 
             native_entity: rde_2_x.NativeEntity = rde_entity.entity
             cluster_spec = native_entity.spec
-            exposed: bool = native_entity.status.cloud_properties.exposed
 
-            if exposed:
-                msg = f"Deleting dnat rule of '{cluster_name}'"
+            msg = f"Deleting dnat rule of '{cluster_name}'"
+            self._update_task_with_no_behavior(vcd_client.TaskStatus.RUNNING, message=msg)  # noqa: E501
+            network_name: str = cluster_spec.settings.ovdc_network
+            try:
+                nw_exp_helper.handle_delete_expose_dnat_rule(
+                    client=user_client,
+                    org_name=org_name,
+                    network_name=network_name,
+                    cluster_name=cluster_name,
+                    cluster_id=entity_id)
+            except Exception as err:
+                msg = f"Delete dnat rule of of cluster '{cluster_name}' status:{err}"  # noqa: E501
+                LOGGER.error(msg, exc_info=True)
                 self._update_task_with_no_behavior(vcd_client.TaskStatus.RUNNING, message=msg)  # noqa: E501
-                network_name: str = cluster_spec.settings.ovdc_network
-                try:
-                    nw_exp_helper.handle_delete_expose_dnat_rule(
-                        client=user_client,
-                        org_name=org_name,
-                        network_name=network_name,
-                        cluster_name=cluster_name,
-                        cluster_id=entity_id)
-                except Exception as err:
-                    msg = f"Delete dnat rule of of cluster '{cluster_name}' status:{err}"  # noqa: E501
-                    LOGGER.error(msg, exc_info=True)
-                    self._update_task_with_no_behavior(vcd_client.TaskStatus.RUNNING, message=msg)  # noqa: E501
-                else:
-                    msg = f"Delete dnat rule of cluster '{cluster_name}' status:success "  # noqa: E501
-                    LOGGER.info(msg)
-                    self._update_task_with_no_behavior(vcd_client.TaskStatus.RUNNING, message=msg)  # noqa: E501
+            else:
+                msg = f"Delete dnat rule of cluster '{cluster_name}' status:success "  # noqa: E501
+                LOGGER.info(msg)
+                self._update_task_with_no_behavior(vcd_client.TaskStatus.RUNNING, message=msg)  # noqa: E501
 
             try:
                 msg = f"Deleting rde of '{cluster_name}'"

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -1946,27 +1946,25 @@ class ClusterService(abstract_broker.AbstractBroker):
 
             native_entity: rde_2_x.NativeEntity = rde_entity.entity
             cluster_spec = native_entity.spec
-            exposed: bool = native_entity.status.cloud_properties.exposed
 
-            if exposed:
-                msg = f"Deleting dnat rule of '{cluster_name}'"
+            msg = f"Deleting dnat rule of '{cluster_name}'"
+            self._update_task_with_no_behavior(vcd_client.TaskStatus.RUNNING, message=msg)  # noqa: E501
+            network_name: str = cluster_spec.settings.ovdc_network
+            try:
+                nw_exp_helper.handle_delete_expose_dnat_rule(
+                    client=user_client,
+                    org_name=org_name,
+                    network_name=network_name,
+                    cluster_name=cluster_name,
+                    cluster_id=entity_id)
+            except Exception as err:
+                msg = f"Delete dnat rule of of cluster '{cluster_name}' status:{err}"  # noqa: E501
+                LOGGER.error(msg, exc_info=True)
                 self._update_task_with_no_behavior(vcd_client.TaskStatus.RUNNING, message=msg)  # noqa: E501
-                network_name: str = cluster_spec.settings.ovdc_network
-                try:
-                    nw_exp_helper.handle_delete_expose_dnat_rule(
-                        client=user_client,
-                        org_name=org_name,
-                        network_name=network_name,
-                        cluster_name=cluster_name,
-                        cluster_id=entity_id)
-                except Exception as err:
-                    msg = f"Delete dnat rule of of cluster '{cluster_name}' status:{err}"  # noqa: E501
-                    LOGGER.error(msg, exc_info=True)
-                    self._update_task_with_no_behavior(vcd_client.TaskStatus.RUNNING, message=msg)  # noqa: E501
-                else:
-                    msg = f"Delete dnat rule of cluster '{cluster_name}' status:success "  # noqa: E501
-                    LOGGER.info(msg)
-                    self._update_task_with_no_behavior(vcd_client.TaskStatus.RUNNING, message=msg)  # noqa: E501
+            else:
+                msg = f"Delete dnat rule of cluster '{cluster_name}' status:success "  # noqa: E501
+                LOGGER.info(msg)
+                self._update_task_with_no_behavior(vcd_client.TaskStatus.RUNNING, message=msg)  # noqa: E501
 
             try:
                 msg = f"Deleting rde of '{cluster_name}'"


### PR DESCRIPTION
- Remove DNAT rule unconditionally
- Force deleting a cluster should not check status of `exposed` on the cluster. Often, cluster failures do not set the RDE status to the actual values. This causes missed DNAT rule deletion and IP address consumption and blocks and require manual deletion of DNAT to release the IP
- Tested on TKGm and verified

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1339)
<!-- Reviewable:end -->
