### PR TITLE
Fix cpu,memory size defaults to Tkgm node size; Fix vm update issues

### DIFF
--- a/container_service_extension/common/constants/server_constants.py
+++ b/container_service_extension/common/constants/server_constants.py
@@ -861,3 +861,29 @@ CPI_NAME = "cloud-provider-for-cloud-director"
 CPI_DEFAULT_VERSION = "1.1.1"
 CSI_NAME = "cloud-director-named-disk-csi-driver"
 CSI_DEFAULT_VERSION = "1.1.1"
+
+
+@unique
+class TkgmNodeSizing(Enum):
+    """Predefined configuration for TKGm cluster node size.
+
+    1.cpu - number of cpus
+    2.memory - cpu memory size in mb
+    """
+
+    def __init__(self, cpu, memory):
+        self._cpu = cpu
+        self._memory = memory
+
+    @property
+    def cpu(self):
+        return self._cpu
+
+    @property
+    def memory(self):
+        return self._memory
+
+    SMALL = (2, 4096)
+    MEDIUM = (2, 8192)
+    LARGE = (4, 16384)
+    EXTRA_LARGE = (8, 32768)

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -44,8 +44,8 @@ from container_service_extension.common.constants.server_constants import PostCu
 from container_service_extension.common.constants.server_constants import PostCustomizationVersions  # noqa: E501
 from container_service_extension.common.constants.server_constants import ThreadLocalData  # noqa: E501
 from container_service_extension.common.constants.server_constants import TKGM_DEFAULT_POD_NETWORK_CIDR  # noqa: E501
-from container_service_extension.common.constants.server_constants import TkgmNodeSizing # noqa: E501
 from container_service_extension.common.constants.server_constants import TKGM_DEFAULT_SERVICE_CIDR  # noqa: E501
+from container_service_extension.common.constants.server_constants import TkgmNodeSizing # noqa: E501
 from container_service_extension.common.constants.server_constants import TKGmProxyKey  # noqa: E501
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
 from container_service_extension.common.constants.shared_constants import \
@@ -2413,35 +2413,26 @@ def _add_control_plane_nodes(
                     # functionality fails.
                     raise
 
-            # modify CPU and memory if needed
+            task = None
+            # updating cpu count on the VM
             if cpu_count and cpu_count > 0:
-                # updating cpu count on the VM
                 task = vm.modify_cpu(cpu_count)
-                sysadmin_client.get_task_monitor().wait_for_status(
-                    task,
-                    callback=wait_for_cpu_update)
-                vm.reload()
-                vapp.reload()
-
-            if memory_mb and memory_mb > 0:
-                # updating memory
-                task = vm.modify_memory(memory_mb)
-                sysadmin_client.get_task_monitor().wait_for_status(
-                    task,
-                    callback=wait_for_memory_update)
-                vm.reload()
-                vapp.reload()
-
-            if not (cpu_count and cpu_count > 0) and not sizing_class_name:
+            elif not sizing_class_name:
                 task = vm.modify_cpu(TkgmNodeSizing.SMALL.cpu)
+            if task:
                 sysadmin_client.get_task_monitor().wait_for_status(
                     task,
                     callback=wait_for_cpu_update)
                 vm.reload()
                 vapp.reload()
 
-            if not (memory_mb and memory_mb > 0) and not sizing_class_name:
+            task = None
+            # updating memory
+            if memory_mb and memory_mb > 0:
+                task = vm.modify_memory(memory_mb)
+            elif not sizing_class_name:
                 task = vm.modify_memory(TkgmNodeSizing.SMALL.memory)
+            if task:
                 sysadmin_client.get_task_monitor().wait_for_status(
                     task,
                     callback=wait_for_memory_update)
@@ -2661,35 +2652,26 @@ def _add_worker_nodes(sysadmin_client, num_nodes, org, vdc, vapp,
             vm_resource = vapp.get_vm(vm_name)
             vm = vcd_vm.VM(sysadmin_client, resource=vm_resource)
 
-            # modify CPU and memory if needed
+            task = None
+            # updating cpu count on the VM
             if cpu_count and cpu_count > 0:
-                # updating cpu count on the VM
                 task = vm.modify_cpu(cpu_count)
-                sysadmin_client.get_task_monitor().wait_for_status(
-                    task,
-                    callback=wait_for_cpu_update)
-                vm.reload()
-                vapp.reload()
-
-            if memory_mb and memory_mb > 0:
-                # updating memory
-                task = vm.modify_memory(memory_mb)
-                sysadmin_client.get_task_monitor().wait_for_status(
-                    task,
-                    callback=wait_for_memory_update)
-                vm.reload()
-                vapp.reload()
-
-            if not (cpu_count and cpu_count > 0) and not sizing_class_name:
+            elif not sizing_class_name:
                 task = vm.modify_cpu(TkgmNodeSizing.SMALL.cpu)
+            if task:
                 sysadmin_client.get_task_monitor().wait_for_status(
                     task,
                     callback=wait_for_cpu_update)
                 vm.reload()
                 vapp.reload()
 
-            if not (memory_mb and memory_mb > 0) and not sizing_class_name:
+            task = None
+            # updating memory
+            if memory_mb and memory_mb > 0:
+                task = vm.modify_memory(memory_mb)
+            elif not sizing_class_name:
                 task = vm.modify_memory(TkgmNodeSizing.SMALL.memory)
+            if task:
                 sysadmin_client.get_task_monitor().wait_for_status(
                     task,
                     callback=wait_for_memory_update)

--- a/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
+++ b/container_service_extension/rde/backend/cluster_service_2_x_tkgm.py
@@ -44,6 +44,7 @@ from container_service_extension.common.constants.server_constants import PostCu
 from container_service_extension.common.constants.server_constants import PostCustomizationVersions  # noqa: E501
 from container_service_extension.common.constants.server_constants import ThreadLocalData  # noqa: E501
 from container_service_extension.common.constants.server_constants import TKGM_DEFAULT_POD_NETWORK_CIDR  # noqa: E501
+from container_service_extension.common.constants.server_constants import TkgmNodeSizing # noqa: E501
 from container_service_extension.common.constants.server_constants import TKGM_DEFAULT_SERVICE_CIDR  # noqa: E501
 from container_service_extension.common.constants.server_constants import TKGmProxyKey  # noqa: E501
 import container_service_extension.common.constants.shared_constants as shared_constants  # noqa: E501
@@ -2419,12 +2420,33 @@ def _add_control_plane_nodes(
                 sysadmin_client.get_task_monitor().wait_for_status(
                     task,
                     callback=wait_for_cpu_update)
+                vm.reload()
+                vapp.reload()
+
             if memory_mb and memory_mb > 0:
                 # updating memory
                 task = vm.modify_memory(memory_mb)
                 sysadmin_client.get_task_monitor().wait_for_status(
                     task,
                     callback=wait_for_memory_update)
+                vm.reload()
+                vapp.reload()
+
+            if not (cpu_count and cpu_count > 0) and not sizing_class_name:
+                task = vm.modify_cpu(TkgmNodeSizing.SMALL.cpu)
+                sysadmin_client.get_task_monitor().wait_for_status(
+                    task,
+                    callback=wait_for_cpu_update)
+                vm.reload()
+                vapp.reload()
+
+            if not (memory_mb and memory_mb > 0) and not sizing_class_name:
+                task = vm.modify_memory(TkgmNodeSizing.SMALL.memory)
+                sysadmin_client.get_task_monitor().wait_for_status(
+                    task,
+                    callback=wait_for_memory_update)
+                vm.reload()
+                vapp.reload()
 
             # If expose is set, control_plane_endpoint is exposed ip
             # Else control_plane_endpoint is internal_ip
@@ -2646,12 +2668,33 @@ def _add_worker_nodes(sysadmin_client, num_nodes, org, vdc, vapp,
                 sysadmin_client.get_task_monitor().wait_for_status(
                     task,
                     callback=wait_for_cpu_update)
+                vm.reload()
+                vapp.reload()
+
             if memory_mb and memory_mb > 0:
                 # updating memory
                 task = vm.modify_memory(memory_mb)
                 sysadmin_client.get_task_monitor().wait_for_status(
                     task,
                     callback=wait_for_memory_update)
+                vm.reload()
+                vapp.reload()
+
+            if not (cpu_count and cpu_count > 0) and not sizing_class_name:
+                task = vm.modify_cpu(TkgmNodeSizing.SMALL.cpu)
+                sysadmin_client.get_task_monitor().wait_for_status(
+                    task,
+                    callback=wait_for_cpu_update)
+                vm.reload()
+                vapp.reload()
+
+            if not (memory_mb and memory_mb > 0) and not sizing_class_name:
+                task = vm.modify_memory(TkgmNodeSizing.SMALL.memory)
+                sysadmin_client.get_task_monitor().wait_for_status(
+                    task,
+                    callback=wait_for_memory_update)
+                vm.reload()
+                vapp.reload()
 
             # create a cloud-init spec and update the VMs with it
             _set_cloud_init_spec(sysadmin_client, vapp, vm, spec['cloudinit_node_spec'])  # noqa: E501


### PR DESCRIPTION
- Fix cpu,memory size defaults to Tkgm node size; 
- Fix vm update to change cpu, memory
- VCDA-3565,VCDA-3569
- Tested with defaults 
- Tested with memory, cpu in cluster specifction
- Tested with sizingClass in cluster specification

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1344)
<!-- Reviewable:end -->
