### PR TITLE
[VCDA-3455] Document known issue - cluster create task running forever due to failure to get API token

### DIFF
--- a/docs/cse3_1/KNOWN_ISSUES.md
+++ b/docs/cse3_1/KNOWN_ISSUES.md
@@ -237,5 +237,7 @@ Kubernetes version has to be specified within the configuration file itself,
 since `--kubernetes-version` and `--config` are incompatible.
 
 ### Task for create cluster goes on forever even when cluster create has failed in CSE server
-CSE server with versions 3.1.1, 3.1.2, 3.1.3 and 3.1.4 are impacted. The issue will happen when the user's role used to deploy a TKGm kubernetes cluster is missing "Manage user's own API token" right. The cluster create task will not be marked as "failed" even when CSE server logs indicate that the cluster creation has failed.
-Adding the missing "Manage user's own API token" right to the user's role and re-attemplting the cluster creation should fix the issue.
+CSE server versions 3.1.1, 3.1.2, 3.1.3 and 3.1.4 are impacted.
+This issue will be observed, if the user used to deploy the TKGm kubernetes cluster is missing "Manage user's own API token" right from their role.
+The cluster create task will not be marked as "failed" even though CSE server logs will indicate that the cluster creation has failed.
+Adding the missing right viz. "Manage user's own API token" to the user's role and reattempting the cluster creation operation should fix the issue.

--- a/docs/cse3_1/KNOWN_ISSUES.md
+++ b/docs/cse3_1/KNOWN_ISSUES.md
@@ -235,3 +235,7 @@ to
 
 Kubernetes version has to be specified within the configuration file itself,
 since `--kubernetes-version` and `--config` are incompatible.
+
+### Task for create cluster goes on forever even when cluster create has failed in CSE server
+CSE server with versions 3.1.1, 3.1.2, 3.1.3 and 3.1.4 are impacted. The issue will happen when the user's role used to deploy a TKGm kubernetes cluster is missing "Manage user's own API token" right. The cluster create task will not be marked as "failed" even when CSE server logs indicate that the cluster creation has failed.
+Adding the missing "Manage user's own API token" right to the user's role and re-attemplting the cluster creation should fix the issue.


### PR DESCRIPTION

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

- If there is an error in getting API token for a TKGm cluster, the cluster create task will run forever.
- This should be documented as a known issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1407)
<!-- Reviewable:end -->
