### PR TITLE
VCDA-6112 Disable delete-nfs test

### DIFF
--- a/system_tests_v2/test_cse_client.py
+++ b/system_tests_v2/test_cse_client.py
@@ -1187,6 +1187,7 @@ def cluster_delete_nfs_param(request):
     yield username
 
 
+@pytest.mark.skip(reason='Test disabled')
 @pytest.mark.parametrize('cluster_delete_nfs_param',
                          [env.SYS_ADMIN_NAME,
                           env.CLUSTER_AUTHOR_NAME,


### PR DESCRIPTION
-  Disable delete-nfs test 
-  This unblocks ctot failure that fails on delete-nfs in test environment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension/1423)
<!-- Reviewable:end -->
